### PR TITLE
docs: s/ai.getAuthContext()/getFlowAuth()

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -81,7 +81,7 @@ import { genkit, z } from 'genkit';
 const ai = genkit({ ... });;
 
 async function readDatabase(uid: string) {
-  const auth = ai.getAuthContext();
+  const auth = getFlowAuth();
   if (auth?.admin) {
     // Do something special if the user is an admin
   } else {


### PR DESCRIPTION
From what I can tell `ai.getAuthContext();` does not exist and we should likely be using getFlowAuth() from the Genkit package instead.

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [ ] Tested (manually, unit tested, etc.)
- [ ] Docs updated (updated docs or a docs bug required)
