### PR TITLE
fix(js/ai): avoid any inference for MiddlewareRef

### DIFF
--- a/js/ai/src/model-types.ts
+++ b/js/ai/src/model-types.ts
@@ -25,9 +25,9 @@ import {
 export { Part, PartSchema };
 
 /** Zod schema for a serializable reference to a registered generate middleware. */
-export const MiddlewareRefSchema: z.ZodTypeAny = z.object({
+export const MiddlewareRefSchema = z.object({
   name: z.string(),
-  config: z.any().optional(),
+  config: z.unknown().optional(),
 });
 /** A serializable reference to a registered generate middleware, identified by name and optional config. */
 export type MiddlewareRef = z.infer<typeof MiddlewareRefSchema>;


### PR DESCRIPTION
Description here... Help the reviewer by:
 - Removed the explicit `z.ZodTypeAny` annotation from `MiddlewareRefSchema` so `MiddlewareRef` is inferred as a concrete object type instead of `any`.

## Explanation
In the case of the previous `genkit/model/middleware` retry middleware, there were no particular issues because the `ModelMiddleware` type was explicitly used.

However, the newly introduced `middlewareRef` was inferred as `any` due to being specified as `z.zodTypeAny`, which triggers a warning. [no-unsafe-assignment](https://typescript-eslint.io/rules/no-unsafe-assignment/)

Although not required, `no-unsafe-assignment` is used in most type-safe projects, so this change is highly important.

This change keeps the serialized middleware boundary flexible while avoiding unnecessary any leakage in public types.

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [ ] Docs updated (updated docs or a docs bug required)
