### PR TITLE
fix(compat-oai): drop empty toolRequest chunks during tool-call streaming

### DIFF
--- a/js/plugins/compat-oai/src/model.ts
+++ b/js/plugins/compat-oai/src/model.ts
@@ -433,9 +433,16 @@ export function fromOpenAIChunkChoice(
   choice: ChatCompletionChunk.Choice,
   jsonMode = false
 ): GenerateResponseData {
-  const toolRequestParts = choice.delta.tool_calls?.map((toolCall) =>
-    fromOpenAIToolCall(toolCall, choice)
-  );
+  // While streaming, OpenAI-compatible models emit the tool call's identity
+  // (id + function.name) only in the first delta; the following deltas carry
+  // incremental `arguments` fragments with no id and no name. Mapping those
+  // continuation deltas produced empty `{ toolRequest: { input: '' } }` chunks
+  // (see #5374). Keep only deltas that start a new tool call — the complete
+  // tool call (with assembled arguments) is reconstructed from the final
+  // response via `stream.finalChatCompletion()`.
+  const toolRequestParts = choice.delta.tool_calls
+    ?.filter((toolCall) => toolCall.id || toolCall.function?.name)
+    .map((toolCall) => fromOpenAIToolCall(toolCall, choice));
 
   // Build content array based on what's present in the delta
   let content: Part[] = [];

--- a/js/plugins/compat-oai/tests/compat_oai_test.ts
+++ b/js/plugins/compat-oai/tests/compat_oai_test.ts
@@ -656,6 +656,68 @@ describe('fromOpenAiChunkChoice', () => {
       },
     },
     {
+      should:
+        'emit a tool request part for the first streaming tool_call delta',
+      chunkChoice: {
+        index: 0,
+        delta: {
+          role: 'assistant',
+          tool_calls: [
+            {
+              index: 0,
+              id: 'call_abc',
+              function: {
+                name: 'list_files',
+                arguments: '',
+              },
+            },
+          ],
+        },
+        finish_reason: null,
+      },
+      expectedOutput: {
+        finishReason: 'unknown',
+        message: {
+          role: 'model',
+          content: [
+            {
+              toolRequest: {
+                name: 'list_files',
+                input: '',
+                ref: 'call_abc',
+              },
+            },
+          ],
+        },
+      },
+    },
+    {
+      should:
+        'skip streaming tool_call argument-continuation deltas (no id, no name)',
+      chunkChoice: {
+        index: 0,
+        delta: {
+          role: 'assistant',
+          tool_calls: [
+            {
+              index: 0,
+              function: {
+                arguments: '{"path":',
+              },
+            },
+          ],
+        } as any,
+        finish_reason: null,
+      },
+      expectedOutput: {
+        finishReason: 'unknown',
+        message: {
+          role: 'model',
+          content: [],
+        },
+      },
+    },
+    {
       should: 'work with reasoning_content',
       chunkChoice: {
         index: 0,


### PR DESCRIPTION
## Problem

Fixes #5374. When streaming a tool call from an OpenAI-compatible model (e.g. gpt-5.5), the model emits the tool call's identity (`id` + `function.name`) **only in the first delta**; every following delta carries an incremental `arguments` fragment with no `id` and no `name`.

`fromOpenAIChunkChoice` mapped *every* `tool_calls` delta to a `toolRequest` part, so those argument-continuation deltas produced a stream of empty chunks:

```
data: {"message":{"modelChunk":{"role":"model","index":0,"content":[{"toolRequest":{"name":"list_files","ref":"call_...","input":""}}]}}}
data: {"message":{"modelChunk":{"role":"model","index":0,"content":[{"toolRequest":{"input":""}}]}}}
data: {"message":{"modelChunk":{"role":"model","index":0,"content":[{"toolRequest":{"input":""}}]}}}
...
```

Each follow-up `{ toolRequest: { input: "" } }` carries no name, no ref, and no input — pure noise in the model chunk stream.

## Solution

In `fromOpenAIChunkChoice`, filter the streamed `tool_calls` deltas to keep only those that start a new tool call (they carry an `id` or a `function.name`). Argument-continuation deltas are skipped, so no empty `toolRequest` part is emitted.

This only touches the streaming path. The complete tool call — with fully assembled arguments — is still reconstructed from the final response via `stream.finalChatCompletion()`, so the final result is unchanged. The non-streaming path (`fromOpenAIChoice`) is untouched.

## Testing

`pnpm --filter @genkit-ai/compat-oai test` — all 55 cases pass, including two new `fromOpenAIChunkChoice` cases:
- the first tool-call delta still emits the identity chunk (`name` + `ref`)
- an argument-continuation delta (no `id`, no `name`) emits no `toolRequest` part