### PR TITLE
fix(compat-oai): stop visualDetailLevel leaking into OpenAI request body

### DIFF
--- a/js/plugins/compat-oai/src/model.ts
+++ b/js/plugins/compat-oai/src/model.ts
@@ -82,6 +82,11 @@ export const ChatCompletionCommonConfigSchema =
     logProbs: z.boolean().optional(),
     presencePenalty: z.number().min(-2).max(2).optional(),
     topLogProbs: z.number().int().min(0).max(20).optional(),
+    visualDetailLevel: VisualDetailLevelSchema.describe(
+      'Controls the `detail` level used for image content parts ' +
+        '(see OpenAI vision docs). Consumed when building messages and ' +
+        'never sent as a top-level request parameter.'
+    ),
   });
 
 export function toOpenAIRole(role: Role): ChatCompletionRole {
@@ -481,10 +486,6 @@ export function toOpenAIRequestBody(
   request: GenerateRequest,
   requestBuilder?: ModelRequestBuilder
 ) {
-  const messages = toOpenAIMessages(
-    request.messages,
-    request.config?.visualDetailLevel
-  );
   const {
     temperature,
     maxOutputTokens, // unused
@@ -498,8 +499,10 @@ export function toOpenAIRequestBody(
     version: modelVersion,
     tools: toolsFromConfig,
     apiKey,
+    visualDetailLevel, // consumed below; not a top-level OpenAI request param
     ...restOfConfig
   } = request.config ?? {};
+  const messages = toOpenAIMessages(request.messages, visualDetailLevel);
 
   const tools: ChatCompletionTool[] = request.tools?.map(toOpenAITool) ?? [];
   if (toolsFromConfig) {

--- a/js/plugins/compat-oai/tests/compat_oai_test.ts
+++ b/js/plugins/compat-oai/tests/compat_oai_test.ts
@@ -1149,6 +1149,47 @@ describe('toOpenAiRequestBody', () => {
     });
   }
 
+  it('applies visualDetailLevel to image parts without leaking it into the request body', () => {
+    const actualOutput = toOpenAIRequestBody('gpt-4o', {
+      messages: [
+        {
+          role: 'user',
+          content: [
+            {
+              media: {
+                contentType: 'image/png',
+                url: 'https://example.com/image.png',
+              },
+            },
+          ],
+        },
+      ],
+      config: {
+        seed: 42,
+        visualDetailLevel: 'high',
+      },
+    } as GenerateRequest) as any;
+
+    // visualDetailLevel is consumed when building messages, not forwarded to OpenAI.
+    expect(actualOutput.visualDetailLevel).toBeUndefined();
+    // Genuine passthrough config is still forwarded.
+    expect(actualOutput.seed).toBe(42);
+    expect(actualOutput.messages).toStrictEqual([
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'image_url',
+            image_url: {
+              url: 'https://example.com/image.png',
+              detail: 'high',
+            },
+          },
+        ],
+      },
+    ]);
+  });
+
   it('(gpt4) does NOT set response_format in openai request body', () => {
     // In either case - output.format='json' or output.format='text' - do NOT set response_format in the OpenAI request body explicitly.
     const modelName = 'gpt-4';


### PR DESCRIPTION
Fixes #4592.

## Problem
`@genkit-ai/compat-oai` reads `config.visualDetailLevel` to set the `detail` field on image content parts in `toOpenAIMessages()`, but `toOpenAIRequestBody()` never destructures it out of the config. It therefore falls through into `restOfConfig` and gets spread onto the request body:

```ts
body = { ...body, ...restOfConfig }; // visualDetailLevel ends up here
```

OpenAI rejects unknown top-level parameters, so **any** generate call that sets `config.visualDetailLevel` fails outright:

```
400 Unknown parameter: 'visualDetailLevel'
```

## Solution
- Destructure `visualDetailLevel` alongside the other consumed config fields so it is excluded from `restOfConfig`, and feed the local binding into `toOpenAIMessages()` (removing the second `request.config?.visualDetailLevel` read).
- Declare `visualDetailLevel` on `ChatCompletionCommonConfigSchema`. The code already reads this field, but it was never part of the schema — so it was undocumented and untyped for users. Adding it (with a description) makes it a first-class, validated option.

The field still drives the per-image `detail` value exactly as before; it simply no longer escapes into the request body.

## Testing
- Added a regression test asserting that for a request with `config.visualDetailLevel: 'high'`, the produced body has no `visualDetailLevel` key, genuine passthrough config (`seed`) is still forwarded, and the image part carries `detail: 'high'`.
- `pnpm --filter @genkit-ai/compat-oai check` — passes (tsc).
- `pnpm --filter @genkit-ai/compat-oai test` — 96 tests pass.