### PR TITLE
feat(js/ai/agent): assemble agent messages from streamed chunks

### DIFF
--- a/js/ai/src/agent-core.ts
+++ b/js/ai/src/agent-core.ts
@@ -433,9 +433,11 @@ class MessageAssembler {
 
   /** Folds one streamed model chunk into the accumulating messages. */
   add(chunk: ModelChunk): void {
+    const hasIndex = chunk.index !== undefined;
     const index = chunk.index ?? this.lastIndex;
     this.lastIndex = index;
     let entry = this.byIndex.get(index);
+    const isNewEntry = !entry;
     if (!entry) {
       entry = {
         role: (chunk.role ?? 'model') as MessageData['role'],
@@ -443,6 +445,16 @@ class MessageAssembler {
       };
       this.byIndex.set(index, entry);
       this.order.push(index);
+    }
+    // An index-less chunk that folds into an already-seen message is a trailing
+    // signal frame - e.g. the `role: 'tool'` interrupt frame `agentFromPrompt`
+    // emits after the model message has already streamed. Its tool requests are
+    // already present in the target message, so merging would duplicate them and
+    // its role would wrongly override the established message role. Ignore it;
+    // the authoritative final message is reconciled from `raw.message` once the
+    // turn resolves (see `AgentChatImpl.applyOutput`).
+    if (!hasIndex && !isNewEntry) {
+      return;
     }
     if (chunk.role) {
       entry.role = chunk.role;
@@ -869,7 +881,8 @@ export class AgentChatImpl<State = unknown> implements AgentChat<State> {
   private buildResponse(
     output: Promise<AgentOutput>,
     isAborted: () => boolean,
-    messageCountBeforeTurn: number
+    messageCountBeforeTurn: number,
+    turnPrefixLength: number
   ): Promise<AgentResponse<State>> {
     return (async (): Promise<AgentResponse<State>> => {
       let raw: AgentOutput<State>;
@@ -895,6 +908,21 @@ export class AgentChatImpl<State = unknown> implements AgentChat<State> {
         this.messages.length = messageCountBeforeTurn;
       }
       this.applyOutput(raw);
+      // Server-managed turns stream the turn's intermediate messages (assembled
+      // via `MessageAssembler`) but return only the authoritative final message
+      // on the wire (`raw.message`; no `state.messages`). Overwrite the last
+      // assembled message with it so redundant trailing stream frames - e.g. the
+      // `role: 'tool'` interrupt frame `agentFromPrompt` emits - cannot leave a
+      // corrupted final entry, and so metadata present only on the stored message
+      // (e.g. interrupt metadata) is preserved. Client-managed turns carry
+      // authoritative `state.messages` and are replaced wholesale in `applyOutput`.
+      if (raw.state?.messages === undefined && raw.message) {
+        if (this.messages.length > turnPrefixLength) {
+          this.messages[this.messages.length - 1] = raw.message;
+        } else {
+          this.messages.push(raw.message);
+        }
+      }
       const response = new AgentResponseImpl<State>(
         raw,
         () => [...this.messages],
@@ -995,7 +1023,8 @@ export class AgentChatImpl<State = unknown> implements AgentChat<State> {
     const responsePromise = this.buildResponse(
       output,
       isAborted,
-      messageCountBeforeTurn
+      messageCountBeforeTurn,
+      turnPrefixLength
     );
     // Avoid unhandled-rejection warnings when only the stream is consumed.
     responsePromise.catch(() => {});

--- a/js/ai/src/agent-core.ts
+++ b/js/ai/src/agent-core.ts
@@ -349,6 +349,118 @@ function toolRequestParts(parts?: Part[]): ToolRequestPart[] {
   return (parts ?? []).filter((p) => !!p.toolRequest) as ToolRequestPart[];
 }
 
+// ── Stream → message assembly helpers ──────────────────────────────────────
+
+/** A streamed model chunk (the `modelChunk` field of an {@link AgentStreamChunk}). */
+type ModelChunk = NonNullable<AgentStreamChunk['modelChunk']>;
+
+/**
+ * Returns `true` for a part that carries only streamed `text` (no tool
+ * request/response, media, data, or reasoning). Consecutive text-only parts are
+ * coalesced into a single part when assembling a message from stream chunks so
+ * the reconstructed message mirrors the server's stored, concatenated form.
+ */
+function isTextOnlyPart(part: Part): boolean {
+  return (
+    part.text !== undefined &&
+    part.reasoning === undefined &&
+    !part.toolRequest &&
+    !part.toolResponse &&
+    !part.media &&
+    part.data === undefined
+  );
+}
+
+/** As {@link isTextOnlyPart} but for `reasoning`-only parts. */
+function isReasoningOnlyPart(part: Part): boolean {
+  return (
+    part.reasoning !== undefined &&
+    part.text === undefined &&
+    !part.toolRequest &&
+    !part.toolResponse &&
+    !part.media &&
+    part.data === undefined
+  );
+}
+
+/**
+ * Merges incremental streamed `incoming` parts into an accumulating `existing`
+ * part list, coalescing consecutive text-only / reasoning-only deltas into a
+ * single part. Other parts (tool requests/responses, media, data) pass through
+ * unchanged.
+ */
+function mergeParts(existing: Part[], incoming: Part[]): Part[] {
+  const out = [...existing];
+  for (const part of incoming) {
+    const last = out[out.length - 1];
+    if (last && isTextOnlyPart(last) && isTextOnlyPart(part)) {
+      out[out.length - 1] = {
+        ...last,
+        text: (last.text ?? '') + part.text,
+      } as Part;
+    } else if (last && isReasoningOnlyPart(last) && isReasoningOnlyPart(part)) {
+      out[out.length - 1] = {
+        ...last,
+        reasoning: (last.reasoning ?? '') + part.reasoning,
+      } as Part;
+    } else {
+      out.push(part);
+    }
+  }
+  return out;
+}
+
+/**
+ * Reconstructs a turn's message list from its streamed `modelChunk` frames.
+ *
+ * Server-managed agents (with a store) return only the final response message
+ * on the wire; the intermediate messages a turn produces - the assistant
+ * message that issued tool requests, the `role: 'tool'` responses, reasoning -
+ * exist only as streamed chunks. Each chunk carries an `index` identifying the
+ * message it belongs to (bumped by the server when generation advances to a new
+ * message), so we bucket chunks by index and merge their parts to rebuild the
+ * per-turn messages in order.
+ */
+class MessageAssembler {
+  private readonly byIndex = new Map<
+    number,
+    { role: MessageData['role']; content: Part[] }
+  >();
+  private readonly order: number[] = [];
+  /** Index to attribute a chunk to when it omits `index` (e.g. the trailing
+   * interrupt `tool` chunk); defaults to the most recently seen index. */
+  private lastIndex = 0;
+
+  /** Folds one streamed model chunk into the accumulating messages. */
+  add(chunk: ModelChunk): void {
+    const index = chunk.index ?? this.lastIndex;
+    this.lastIndex = index;
+    let entry = this.byIndex.get(index);
+    if (!entry) {
+      entry = { role: (chunk.role ?? 'model') as MessageData['role'], content: [] };
+      this.byIndex.set(index, entry);
+      this.order.push(index);
+    }
+    if (chunk.role) {
+      entry.role = chunk.role;
+    }
+    const content = (chunk.content ?? []) as Part[];
+    // An `aggregated` chunk already contains all data from previous chunks of
+    // its message, so replace rather than merge.
+    entry.content = chunk.aggregated
+      ? [...content]
+      : mergeParts(entry.content, content);
+  }
+
+  /** The assembled messages, in the order their indices first appeared. */
+  get messages(): MessageData[] {
+    return this.order.map((i) => {
+      const e = this.byIndex.get(i)!;
+      return { role: e.role, content: e.content } as MessageData;
+    });
+  }
+}
+
 // ---------------------------------------------------------------------------
 // AgentInterrupt
 // ---------------------------------------------------------------------------
@@ -396,7 +508,15 @@ class AgentResponseImpl<State = unknown, O = unknown>
 {
   constructor(
     private readonly _raw: AgentOutput<State>,
-    private readonly _messages: MessageData[],
+    /**
+     * Live messages getter. Server-managed agents assemble the turn's
+     * intermediate messages (tool requests/responses, reasoning) from the
+     * stream, which may still be draining when this response is first
+     * constructed. Reading through a getter (rather than snapshotting an array)
+     * ensures `res.messages` reflects the fully-assembled list at read time and
+     * stays consistent with {@link AgentChat.messages}.
+     */
+    private readonly _messages: () => MessageData[],
     /**
      * Fallback custom-state getter. Server-managed agents (with a store) do not
      * return `state` on the wire - they return a `snapshotId` and the chat
@@ -444,7 +564,7 @@ class AgentResponseImpl<State = unknown, O = unknown>
   }
 
   get messages(): MessageData[] {
-    return this._messages;
+    return this._messages();
   }
 
   get finishReason(): AgentFinishReason {
@@ -684,10 +804,15 @@ export class AgentChatImpl<State = unknown> implements AgentChat<State> {
         this.transport.stateManagement = 'client';
       }
     }
+    // Client-managed agents round-trip the full authoritative history on the
+    // wire, so replace `this.messages` wholesale. Server-managed agents return
+    // only the final response message here (no `state.messages`); their
+    // per-turn messages - including intermediate tool-request/response and
+    // reasoning messages, and the final message - are assembled from the
+    // streamed `modelChunk` frames during `sendStream` (see `MessageAssembler`),
+    // so there is nothing to append here.
     if (raw.state?.messages !== undefined) {
       this.messages = [...raw.state.messages];
-    } else if (raw.message) {
-      this.messages.push(raw.message);
     }
     if (raw.state?.artifacts !== undefined) {
       this.artifacts = [...raw.state.artifacts];
@@ -769,7 +894,7 @@ export class AgentChatImpl<State = unknown> implements AgentChat<State> {
       this.applyOutput(raw);
       const response = new AgentResponseImpl<State>(
         raw,
-        [...this.messages],
+        () => [...this.messages],
         () => this.state,
         () => this.sessionId
       );
@@ -824,11 +949,12 @@ export class AgentChatImpl<State = unknown> implements AgentChat<State> {
       const aborted = (async (): Promise<AgentResponse<State>> => {
         return new AgentResponseImpl<State>(
           { finishReason: 'aborted' as AgentFinishReason },
-          [...this.messages],
+          () => [...this.messages],
           () => this.state,
           () => this.sessionId
         );
       })();
+
       aborted.catch(() => {});
       return {
         stream: (async function* (): AsyncIterable<AgentChunk<State>> {})(),
@@ -846,6 +972,13 @@ export class AgentChatImpl<State = unknown> implements AgentChat<State> {
     if (agentInput.message) {
       this.messages.push(agentInput.message);
     }
+    // Length of `this.messages` after the eager user-message push and before
+    // this turn's assistant/tool messages. Server-managed turns return only the
+    // final response message on the wire, so we assemble the turn's intermediate
+    // messages (assistant tool-requests, `role: 'tool'` responses, reasoning)
+    // from the streamed `modelChunk` frames and splice them in starting here.
+    const turnPrefixLength = this.messages.length;
+    const assembler = new MessageAssembler();
     const init = this.buildInit();
 
     const { controller, isAborted } = this.setupAbort(opts);
@@ -880,6 +1013,19 @@ export class AgentChatImpl<State = unknown> implements AgentChat<State> {
           if (raw.customPatch) {
             self.applyCustomPatch(raw.customPatch);
             chunk._setCustom(self.state);
+          }
+          // Reconstruct this turn's messages from the streamed model chunks and
+          // keep `this.messages` live as they arrive. Only the final response
+          // message comes back on the wire for server-managed agents, so the
+          // intermediate messages (assistant tool-requests, `tool` responses,
+          // reasoning) exist only in the stream. We re-splice the whole assembled
+          // block each time (cheap; turns have few messages). For client-managed
+          // agents this is provisional - `applyOutput` later replaces
+          // `this.messages` wholesale with the authoritative `state.messages`.
+          if (raw.modelChunk) {
+            assembler.add(raw.modelChunk);
+            self.messages.length = turnPrefixLength;
+            self.messages.push(...assembler.messages);
           }
           yield chunk;
         }
@@ -978,7 +1124,7 @@ export class AgentChatImpl<State = unknown> implements AgentChat<State> {
     };
     const response = new AgentResponseImpl<State>(
       raw,
-      [...this.messages],
+      () => [...this.messages],
       () => this.clientState?.custom as State | undefined,
       () => this.sessionId
     );

--- a/js/ai/src/agent-core.ts
+++ b/js/ai/src/agent-core.ts
@@ -451,7 +451,7 @@ class MessageAssembler {
     // An `aggregated` chunk already contains all data from previous chunks of
     // its message, so replace rather than merge.
     entry.content = chunk.aggregated
-      ? [...content]
+      ? mergeParts([], content)
       : mergeParts(entry.content, content);
   }
 

--- a/js/ai/src/agent-core.ts
+++ b/js/ai/src/agent-core.ts
@@ -437,7 +437,10 @@ class MessageAssembler {
     this.lastIndex = index;
     let entry = this.byIndex.get(index);
     if (!entry) {
-      entry = { role: (chunk.role ?? 'model') as MessageData['role'], content: [] };
+      entry = {
+        role: (chunk.role ?? 'model') as MessageData['role'],
+        content: [],
+      };
       this.byIndex.set(index, entry);
       this.order.push(index);
     }

--- a/js/ai/tests/agent_test.ts
+++ b/js/ai/tests/agent_test.ts
@@ -4147,5 +4147,199 @@ Now respond to the latest message.`,
       const snap = await task.wait({ intervalMs: 1 });
       assert.ok(snap.status);
     });
+
+    it('assembles intermediate messages from the stream (server-managed tool loop)', async () => {
+      // Server-managed agents (with a store) return only the final response
+      // message on the wire; the intermediate messages a turn produces (the
+      // assistant message issuing tool requests, the `tool` response, and the
+      // final text) exist only as streamed `modelChunk` frames, each carrying
+      // an `index` marking the message it belongs to. The client must rebuild
+      // the full per-turn message list from those chunks.
+      const store = new InMemorySessionStore<{}>();
+      const agent = defineCustomAgent<{}>(
+        new Registry(),
+        { name: 'apiToolLoop', store },
+        async (sess, { sendChunk }) => {
+          await sess.run(async () => {
+            // Message 0: assistant issues a tool request.
+            sendChunk({
+              modelChunk: {
+                role: 'model',
+                index: 0,
+                content: [
+                  {
+                    toolRequest: { name: 'getWeather', input: { city: 'SF' } },
+                  },
+                ],
+              },
+            });
+            // Message 1: the tool response (streamed as a whole message).
+            sendChunk({
+              modelChunk: {
+                role: 'tool',
+                index: 1,
+                content: [
+                  {
+                    toolResponse: { name: 'getWeather', output: 'sunny' },
+                  },
+                ],
+              },
+            });
+            // Message 2: the final assistant text, in two incremental deltas.
+            sendChunk({
+              modelChunk: { role: 'model', index: 2, content: [{ text: "It's " }] },
+            });
+            sendChunk({
+              modelChunk: { role: 'model', index: 2, content: [{ text: 'sunny' }] },
+            });
+            return { finishReason: 'stop' as const };
+          });
+          return {
+            message: { role: 'model', content: [{ text: "It's sunny" }] },
+            finishReason: 'stop' as const,
+          };
+        }
+      );
+
+      const chat = agent.chat();
+      const turn = chat.sendStream('weather?');
+      for await (const _ of turn.stream) {
+      }
+      const res = await turn.response;
+
+      const expected = [
+        { role: 'user', content: [{ text: 'weather?' }] },
+        {
+          role: 'model',
+          content: [
+            { toolRequest: { name: 'getWeather', input: { city: 'SF' } } },
+          ],
+        },
+        {
+          role: 'tool',
+          content: [{ toolResponse: { name: 'getWeather', output: 'sunny' } }],
+        },
+        { role: 'model', content: [{ text: "It's sunny" }] },
+      ];
+      assert.deepEqual(chat.messages, expected);
+      // res.messages reads through a live getter and mirrors chat.messages.
+      assert.deepEqual(res.messages, expected);
+    });
+
+    it('assembles messages up to an interrupt (server-managed)', async () => {
+      const store = new InMemorySessionStore<{}>();
+      const agent = defineCustomAgent<{}>(
+        new Registry(),
+        { name: 'apiToolLoopInterrupt', store },
+        async (sess, { sendChunk }) => {
+          await sess.run(async () => {
+            sendChunk({
+              modelChunk: {
+                role: 'model',
+                index: 0,
+                content: [
+                  {
+                    toolRequest: {
+                      name: 'userApproval',
+                      ref: 'r1',
+                      input: { action: 'transfer' },
+                    },
+                    metadata: { interrupt: true },
+                  },
+                ],
+              },
+            });
+            return { finishReason: 'interrupted' as const };
+          });
+          return {
+            message: {
+              role: 'model',
+              content: [
+                {
+                  toolRequest: {
+                    name: 'userApproval',
+                    ref: 'r1',
+                    input: { action: 'transfer' },
+                  },
+                  metadata: { interrupt: true },
+                },
+              ],
+            },
+            finishReason: 'interrupted' as const,
+          };
+        }
+      );
+
+      const chat = agent.chat();
+      const turn = chat.sendStream('Transfer $500');
+      for await (const _ of turn.stream) {
+      }
+      const res = await turn.response;
+
+      assert.strictEqual(res.finishReason, 'interrupted');
+      assert.deepEqual(chat.messages, [
+        { role: 'user', content: [{ text: 'Transfer $500' }] },
+        {
+          role: 'model',
+          content: [
+            {
+              toolRequest: {
+                name: 'userApproval',
+                ref: 'r1',
+                input: { action: 'transfer' },
+              },
+              metadata: { interrupt: true },
+            },
+          ],
+        },
+      ]);
+    });
+
+    it('replaces messages wholesale with authoritative history (client-managed)', async () => {
+      // Client-managed agents round-trip the full authoritative history on the
+      // wire, so `applyOutput` replaces `chat.messages` wholesale - any
+      // provisional messages assembled from the stream are overwritten. Here the
+      // stream carries a "provisional" model message, but the agent stores a
+      // different authoritative message; `chat.messages` must reflect the
+      // authoritative one, not the streamed provisional.
+      const agent = defineCustomAgent(
+        new Registry(),
+        { name: 'apiClientMessages' },
+        async (sess, { sendChunk }) => {
+          await sess.run(async () => {
+            sendChunk({
+              modelChunk: {
+                role: 'model',
+                index: 0,
+                content: [{ text: 'provisional' }],
+              },
+            });
+            // Store an authoritative model reply that differs from the stream.
+            sess.session.addMessages([
+              { role: 'model', content: [{ text: 'authoritative' }] },
+            ]);
+            return { finishReason: 'stop' as const };
+          });
+          return {
+            message: { role: 'model', content: [{ text: 'authoritative' }] },
+            finishReason: 'stop' as const,
+          };
+        }
+      );
+
+      const chat = agent.chat();
+      const turn = chat.sendStream('hello');
+      for await (const _ of turn.stream) {
+      }
+      await turn.response;
+
+      // The authoritative client-managed history wins over the streamed
+      // provisional model message.
+      assert.deepEqual(chat.messages, [
+        { role: 'user', content: [{ text: 'hello' }] },
+        { role: 'model', content: [{ text: 'authoritative' }] },
+      ]);
+    });
   });
 });
+

--- a/js/ai/tests/agent_test.ts
+++ b/js/ai/tests/agent_test.ts
@@ -4187,10 +4187,18 @@ Now respond to the latest message.`,
             });
             // Message 2: the final assistant text, in two incremental deltas.
             sendChunk({
-              modelChunk: { role: 'model', index: 2, content: [{ text: "It's " }] },
+              modelChunk: {
+                role: 'model',
+                index: 2,
+                content: [{ text: "It's " }],
+              },
             });
             sendChunk({
-              modelChunk: { role: 'model', index: 2, content: [{ text: 'sunny' }] },
+              modelChunk: {
+                role: 'model',
+                index: 2,
+                content: [{ text: 'sunny' }],
+              },
             });
             return { finishReason: 'stop' as const };
           });
@@ -4342,4 +4350,3 @@ Now respond to the latest message.`,
     });
   });
 });
-

--- a/js/ai/tests/agent_test.ts
+++ b/js/ai/tests/agent_test.ts
@@ -4303,6 +4303,103 @@ Now respond to the latest message.`,
       ]);
     });
 
+    it('does not corrupt the final message when a trailing index-less interrupt frame streams (server-managed)', async () => {
+      // On interrupt, `agentFromPrompt` streams the model message
+      // (with an `index`) and then emits an extra `role: 'tool'` frame with no
+      // `index` carrying the same tool requests. A naive assembler folds that
+      // index-less frame into the model message's bucket, flipping its role to
+      // `tool` and duplicating the tool request. The final message must stay the
+      // authoritative `role: 'model'` message (with interrupt metadata), with no
+      // duplicated tool request.
+      const store = new InMemorySessionStore<{}>();
+      const agent = defineCustomAgent<{}>(
+        new Registry(),
+        { name: 'apiTrailingInterruptFrame', store },
+        async (sess, { sendChunk }) => {
+          await sess.run(async () => {
+            // The model message that issued the interrupt tool request.
+            sendChunk({
+              modelChunk: {
+                role: 'model',
+                index: 0,
+                content: [
+                  {
+                    toolRequest: {
+                      name: 'userApproval',
+                      ref: 'r1',
+                      input: { action: 'transfer' },
+                    },
+                    metadata: { interrupt: true },
+                  },
+                ],
+              },
+            });
+            // The trailing, index-less `tool` frame emitted on interrupt.
+            sendChunk({
+              modelChunk: {
+                role: 'tool',
+                content: [
+                  {
+                    toolRequest: {
+                      name: 'userApproval',
+                      ref: 'r1',
+                      input: { action: 'transfer' },
+                    },
+                    metadata: { interrupt: true },
+                  },
+                ],
+              },
+            });
+            return { finishReason: 'interrupted' as const };
+          });
+          return {
+            message: {
+              role: 'model',
+              content: [
+                {
+                  toolRequest: {
+                    name: 'userApproval',
+                    ref: 'r1',
+                    input: { action: 'transfer' },
+                  },
+                  metadata: { interrupt: true },
+                },
+              ],
+            },
+            finishReason: 'interrupted' as const,
+          };
+        }
+      );
+
+      const chat = agent.chat();
+      const turn = chat.sendStream('Transfer $500');
+      for await (const _ of turn.stream) {
+      }
+      const res = await turn.response;
+
+      assert.strictEqual(res.finishReason, 'interrupted');
+      const expected = [
+        { role: 'user', content: [{ text: 'Transfer $500' }] },
+        {
+          role: 'model',
+          content: [
+            {
+              toolRequest: {
+                name: 'userApproval',
+                ref: 'r1',
+                input: { action: 'transfer' },
+              },
+              metadata: { interrupt: true },
+            },
+          ],
+        },
+      ];
+      // The trailing index-less frame must not flip the role to `tool` nor
+      // duplicate the tool request.
+      assert.deepEqual(chat.messages, expected);
+      assert.deepEqual(res.messages, expected);
+    });
+
     it('replaces messages wholesale with authoritative history (client-managed)', async () => {
       // Client-managed agents round-trip the full authoritative history on the
       // wire, so `applyOutput` replaces `chat.messages` wholesale - any


### PR DESCRIPTION
Add stream-to-message assembly helpers to reconstruct a turn's intermediate messages from streamed `modelChunk` frames. Server-managed agents only return the final response on the wire, so intermediate messages (tool requests/responses, reasoning) must be rebuilt from chunks bucketed by index, coalescing consecutive text-only and reasoning-only deltas.

Also switch `AgentResponseImpl` to a live messages getter so responses reflect the stream that may still be draining when first constructed.
