### PR TITLE
fix(js/ai): persist serializable message data from prompt agents

### DIFF
--- a/js/ai/src/agent.ts
+++ b/js/ai/src/agent.ts
@@ -1560,11 +1560,15 @@ export function definePromptAgent<
           (m) => !m.metadata?.[promptTag]
         );
         if (res.message) {
-          msgs.push(res.message);
+          // Persist the serializable message data, not the `Message` instance:
+          // when the prompt declares an `output` schema the response message
+          // carries a non-cloneable `parser` function, which would break
+          // `structuredClone` when the session state is snapshotted (#5712).
+          msgs.push(res.message.toJSON());
         }
         sess.setMessages(msgs);
       } else if (res.message) {
-        sess.addMessages([res.message]);
+        sess.addMessages([res.message.toJSON()]);
       }
 
       if (res.finishReason === 'interrupted') {

--- a/js/ai/tests/agent_test.ts
+++ b/js/ai/tests/agent_test.ts
@@ -31,6 +31,7 @@ import {
   defineCustomAgent,
   definePromptAgent,
 } from '../src/agent.js';
+import { configureFormats } from '../src/formats/index.js';
 import { definePrompt } from '../src/prompt.js';
 import { InMemorySessionStore } from '../src/session-stores.js';
 import {
@@ -987,6 +988,38 @@ describe('Agent', () => {
 
       const output = await session.output;
       assert.strictEqual(output.message?.role, 'model');
+    });
+
+    it('supports a prompt output schema with a persistent store (#5712)', async () => {
+      // Regression test: a prompt agent whose prompt declares an `output`
+      // schema attaches a non-cloneable `parser` function to the response
+      // message. Persisting that message into session state used to throw
+      // `DataCloneError: ... could not be cloned` when the store snapshotted
+      // the state via `structuredClone`.
+      const registry = new Registry();
+      configureFormats(registry);
+      const pm = defineProgrammableModel(registry);
+      pm.handleResponse = async () => ({
+        message: { role: 'model', content: [{ text: '{"answer":"hello"}' }] },
+        finishReason: 'stop',
+      });
+      definePrompt(registry, {
+        name: 'structuredPrompt',
+        model: 'programmableModel',
+        system: 'You are a test assistant.',
+        output: { schema: z.object({ answer: z.string() }) },
+      });
+
+      const agent = definePromptAgent<unknown, z.ZodTypeAny>(registry, {
+        promptName: 'structuredPrompt',
+        store: new InMemorySessionStore(),
+      });
+
+      const chat = agent.chat({ sessionId: 'structured-output' });
+      const res = await chat.send('hi');
+
+      assert.strictEqual(res.finishReason, 'stop');
+      assert.strictEqual(res.text, '{"answer":"hello"}');
     });
 
     it('should pass promptInput to the prompt template', async () => {


### PR DESCRIPTION
Fixes #5712

### Bug

A prompt agent whose prompt declares an `output` schema throws on the very first `send()`:

```
DataCloneError: (message) => { return extractJson(message.text); } could not be cloned.
```

Removing the `output` schema makes it go away.

### Root cause

When a prompt declares an `output` schema, the generate response's `.message` is a `Message` instance that carries a non-serializable `parser` function (`(message) => extractJson(message.text)`). `definePromptAgent` pushes that instance straight into the session messages, so when the turn snapshots state to the store, `session.getState()`'s `structuredClone` chokes on the function.

### Fix

Persist `res.message.toJSON()` (plain `MessageData`) instead of the `Message` instance — the same serializable form `GenerateResponse.messages` already uses for history persistence. The live response object is untouched, so callers still get `res.text` and normal output parsing.

### Test

Added a regression test in `js/ai/tests/agent_test.ts` (prompt agent + `output` schema + `InMemorySessionStore`). It throws the `could not be cloned` error before the fix and passes after. Full `agent_test` (94 tests), `agents_spec`, and `session` suites pass; `tsc` is clean.

### Checklist
- [x] PR title follows Conventional Commits
- [x] Tested (unit test added + existing suites)
- [ ] Docs updated (n/a — bug fix)