### PR TITLE
docs(py): update package names and import syntax across READMEs

### DIFF
--- a/py/packages/genkit-django/README.md
+++ b/py/packages/genkit-django/README.md
@@ -1,11 +1,11 @@
 # Genkit Django Plugin
 
-`genkit-plugin-django` exposes Genkit flows as HTTP endpoints in a Django application. It mirrors `genkit-plugin-flask` and `genkit-plugin-fastapi`: one decorator turns a `@ai.flow()` into a Django view that speaks the Genkit HTTP protocol (JSON envelope, optional SSE streaming, structured error responses).
+`genkit-django` exposes Genkit flows as HTTP endpoints in a Django application. It mirrors `genkit-flask` and `genkit-fastapi`: one decorator turns a `@ai.flow()` into a Django view that speaks the Genkit HTTP protocol (JSON envelope, optional SSE streaming, structured error responses).
 
 ## Install
 
 ```bash
-pip install genkit-plugin-django
+pip install genkit-django
 ```
 
 ## Usage

--- a/py/packages/genkit-evaluators/README.md
+++ b/py/packages/genkit-evaluators/README.md
@@ -11,7 +11,7 @@ No LLM or API keys required.
 ## Installation
 
 ```bash
-pip install genkit-plugin-evaluators
+pip install genkit-evaluators
 ```
 
 ## Usage

--- a/py/packages/genkit-fastapi/README.md
+++ b/py/packages/genkit-fastapi/README.md
@@ -5,7 +5,7 @@ Serve Genkit flows as FastAPI endpoints.
 ## Installation
 
 ```bash
-pip install genkit-plugin-fastapi
+pip install genkit-fastapi
 ```
 
 ## Usage

--- a/py/packages/genkit-flask/pyproject.toml
+++ b/py/packages/genkit-flask/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
   "pydantic>=2.10.5",
   "flask>=3.1.3",
 ]
-description = "Genkit Firebase Plugin"
+description = "Genkit Flask Plugin"
 keywords = [
   "genkit",
   "ai",

--- a/py/packages/genkit-google-genai/README.md
+++ b/py/packages/genkit-google-genai/README.md
@@ -7,7 +7,7 @@ This Genkit plugin provides a unified interface for Google AI (Gemini) and Verte
 ```bash
 uv venv
 source .venv/bin/activate
-pip install genkit-plugins-google-genai
+pip install genkit-google-genai
 ```
 
 ## Configuration

--- a/py/packages/genkit-middleware/README.md
+++ b/py/packages/genkit-middleware/README.md
@@ -37,7 +37,7 @@ These pre-packaged middlewares will be available to play with in the Dev UI by d
 ## Installation
 
 ```bash
-pip install genkit-plugin-middleware
+pip install genkit-middleware
 ```
 
 ## Usage

--- a/py/packages/genkit/README.md
+++ b/py/packages/genkit/README.md
@@ -12,14 +12,14 @@ you can use Genkit independently of any Google services.
 
 ```bash
 pip install genkit
-pip install genkit-plugin-google-genai
+pip install genkit-google-genai
 ```
 
 
 ```python
 from pydantic import BaseModel, Field
 from genkit import Genkit
-from genkit.plugins.google_genai import GoogleAI
+from genkit_google_genai import GoogleAI
 
 ai = Genkit(
     plugins=[GoogleAI()],

--- a/py/samples/django-hello/README.md
+++ b/py/samples/django-hello/README.md
@@ -1,6 +1,6 @@
 # Django Hello
 
-Serve a Genkit flow through Django and stream the model response back to the client. Mirrors `flask-hello` and `fastapi-bugbot` but uses Django's ASGI server and the `genkit-plugin-django` adaptor.
+Serve a Genkit flow through Django and stream the model response back to the client. Mirrors `flask-hello` and `fastapi-bugbot` but uses Django's ASGI server and the `genkit-django` adaptor.
 
 ```bash
 export GEMINI_API_KEY=your-api-key


### PR DESCRIPTION
### Python SDK README Updates

This PR cleans up outdated package installation instructions and legacy import syntax across package and sample README files, ensuring accurate PyPI landing pages and developer documentation.

#### Key Updates:
- Updated legacy `genkit-plugin-*` package names to their canonical `genkit-*` equivalents across package and sample READMEs.
- Resolved typo in `genkit-google-genai` installation instructions.
- Updated example code in core `genkit` README to use modern import path (`from genkit_google_genai import GoogleAI`).