### PR TITLE
feat(js/plugins/compat-oai): add strict structured outputs support

### DIFF
--- a/js/plugins/compat-oai/README.md
+++ b/js/plugins/compat-oai/README.md
@@ -54,6 +54,35 @@ const response = await ai.generate({
 console.log(response.text);
 ```
 
+### Structured Outputs
+
+Use `config.strict: true` with an output schema on a model that supports OpenAI Structured Outputs:
+
+```typescript
+import { z } from 'genkit';
+import { openAI } from '@genkit-ai/compat-oai/openai';
+
+const response = await ai.generate({
+  model: openAI.model('gpt-5'),
+  prompt: 'Extract the answer from the text.',
+  output: {
+    schema: z
+      .object({
+        answer: z.string(),
+      })
+      .strict(),
+  },
+  config: {
+    strict: true,
+  },
+});
+
+console.log(response.output);
+```
+
+Apply `.strict()` to every object in the schema; Genkit does not automatically set `additionalProperties: false`.
+See the [Structured Outputs guide](https://developers.openai.com/api/docs/guides/structured-outputs).
+
 ### Multi-modal prompt
 
 ```typescript

--- a/js/plugins/compat-oai/src/model.ts
+++ b/js/plugins/compat-oai/src/model.ts
@@ -578,6 +578,7 @@ export function toOpenAIRequestBody(
     version: modelVersion,
     tools: toolsFromConfig,
     apiKey,
+    strict,
     ...restOfConfig
   } = request.config ?? {};
 
@@ -605,6 +606,16 @@ export function toOpenAIRequestBody(
     body = { ...body, ...restOfConfig }; // passthrough for other config
   }
   const response_format = request.output?.format;
+  if (
+    strict === true &&
+    (response_format !== 'json' || !request.output?.schema)
+  ) {
+    throw new GenkitError({
+      status: 'INVALID_ARGUMENT',
+      message:
+        'OpenAI strict output requires output.format="json" and an output schema.',
+    });
+  }
   if (response_format === 'json') {
     if (request.output?.schema) {
       body.response_format = {
@@ -612,6 +623,7 @@ export function toOpenAIRequestBody(
         json_schema: {
           name: 'output',
           schema: request.output!.schema,
+          ...(strict !== undefined ? { strict } : {}),
         },
       };
     } else {

--- a/js/plugins/compat-oai/src/openai/gpt.ts
+++ b/js/plugins/compat-oai/src/openai/gpt.ts
@@ -250,6 +250,7 @@ const gpt5ChatLatest = openAIModelRef({
       ...GPT_5_MODEL_INFO.supports,
       tools: false,
       output: ['text'],
+      constrained: undefined,
     },
   },
 });

--- a/js/plugins/compat-oai/src/openai/gpt.ts
+++ b/js/plugins/compat-oai/src/openai/gpt.ts
@@ -37,6 +37,7 @@ const MULTIMODAL_MODEL_INFO: ModelInfo = {
 export const OpenAIChatCompletionConfigSchema =
   ChatCompletionCommonConfigSchema.extend({
     store: z.boolean().optional(),
+    strict: z.boolean().optional(),
   });
 
 /** OpenAI ModelRef helper, with OpenAI specific config. */
@@ -227,6 +228,7 @@ const GPT_5_MODEL_INFO: ModelInfo = {
     media: true,
     systemRole: true,
     output: ['text', 'json'],
+    constrained: 'all',
   },
 };
 const gpt5 = openAIModelRef({

--- a/js/plugins/compat-oai/tests/compat_oai_test.ts
+++ b/js/plugins/compat-oai/tests/compat_oai_test.ts
@@ -1500,6 +1500,63 @@ describe('toOpenAiRequestBody', () => {
       },
     });
   });
+
+  it('sets strict inside json_schema when configured', () => {
+    const schema = {
+      type: 'object',
+      properties: { foo: { type: 'string' } },
+      required: ['foo'],
+      additionalProperties: false,
+    };
+    const request = {
+      messages: [{ role: 'user', content: [{ text: 'hello' }] }],
+      config: { strict: true },
+      output: { format: 'json', schema },
+    } as unknown as GenerateRequest;
+
+    const actualOutput = toOpenAIRequestBody('gpt-5', request) as any;
+
+    expect(actualOutput.response_format).toStrictEqual({
+      type: 'json_schema',
+      json_schema: {
+        name: 'output',
+        schema,
+        strict: true,
+      },
+    });
+    expect(actualOutput.strict).toBeUndefined();
+  });
+
+  it('preserves strict false inside json_schema', () => {
+    const schema = {
+      type: 'object',
+      properties: { foo: { type: 'string' } },
+      required: ['foo'],
+      additionalProperties: false,
+    };
+    const request = {
+      messages: [{ role: 'user', content: [{ text: 'hello' }] }],
+      config: { strict: false },
+      output: { format: 'json', schema },
+    } as unknown as GenerateRequest;
+
+    const actualOutput = toOpenAIRequestBody('gpt-5', request) as any;
+
+    expect(actualOutput.response_format.json_schema.strict).toBe(false);
+    expect(actualOutput.strict).toBeUndefined();
+  });
+
+  it('rejects strict output without a JSON schema', () => {
+    const request = {
+      messages: [{ role: 'user', content: [{ text: 'hello' }] }],
+      config: { strict: true },
+      output: { format: 'json' },
+    } as unknown as GenerateRequest;
+
+    expect(() => toOpenAIRequestBody('gpt-5', request)).toThrow(
+      'OpenAI strict output requires output.format="json" and an output schema.'
+    );
+  });
 });
 
 describe('openAIModelRunner', () => {

--- a/js/plugins/compat-oai/tests/openai_test.ts
+++ b/js/plugins/compat-oai/tests/openai_test.ts
@@ -110,7 +110,7 @@ describe('gptModel', () => {
     });
   });
 
-  it('should correctly define gpt-5 and gpt-5-chat-latest', () => {
+  it('should correctly define gpt-5', () => {
     const gpt5 = defineCompatOpenAIModel({
       name: 'openai/gpt-5',
       client: {} as OpenAI,

--- a/js/plugins/compat-oai/tests/openai_test.ts
+++ b/js/plugins/compat-oai/tests/openai_test.ts
@@ -23,6 +23,7 @@ import {
   defineCompatOpenAIModel,
   toOpenAIRequestBody,
 } from '../src/model';
+import { SUPPORTED_GPT_MODELS } from '../src/openai/gpt';
 
 describe('gptModel', () => {
   afterEach(() => {
@@ -105,6 +106,28 @@ describe('gptModel', () => {
         media: true,
         systemRole: true,
         output: ['text', 'json'],
+      },
+    });
+  });
+
+  it('should correctly define gpt-5 and gpt-5-chat-latest', () => {
+    const gpt5 = defineCompatOpenAIModel({
+      name: 'openai/gpt-5',
+      client: {} as OpenAI,
+      modelRef: SUPPORTED_GPT_MODELS['gpt-5'],
+    });
+    expect({
+      name: gpt5.__action.name,
+      supports: gpt5.__action.metadata?.model.supports,
+    }).toStrictEqual({
+      name: 'openai/gpt-5',
+      supports: {
+        multiturn: true,
+        tools: true,
+        media: true,
+        systemRole: true,
+        output: ['text', 'json'],
+        constrained: 'all',
       },
     });
   });

--- a/js/testapps/compat-oai/src/index.ts
+++ b/js/testapps/compat-oai/src/index.ts
@@ -267,6 +267,33 @@ const RpgCharacterSchema = z.object({
   class: z.enum(['RANGER', 'WIZZARD', 'TANK', 'HEALER', 'ENGINEER']),
 });
 
+const StrictStructuredOutputSchema = z
+  .object({
+    answer: z.string(),
+    confidence: z.number(),
+  })
+  .strict();
+
+export const strictStructuredOutputFlow = ai.defineFlow(
+  {
+    name: 'strict-structured-output',
+    inputSchema: z
+      .string()
+      .default('Genkit is a framework for AI applications.'),
+    outputSchema: StrictStructuredOutputSchema,
+  },
+  async (text) => {
+    const { output } = await ai.generate({
+      model: openAI.model('gpt-5'),
+      prompt: `Summarize this statement and estimate your confidence from 0 to 1:\n${text}`,
+      output: { schema: StrictStructuredOutputSchema },
+      config: { strict: true },
+    });
+
+    return output!;
+  }
+);
+
 // A simple example of structured output.
 ai.defineFlow(
   {
@@ -439,5 +466,5 @@ ai.defineFlow(
 );
 
 startFlowServer({
-  flows: [jokeFlow, embedFlow],
+  flows: [jokeFlow, embedFlow, strictStructuredOutputFlow],
 });


### PR DESCRIPTION
Description here... Help the reviewer by:
 - Add OpenAI-specific `strict` configuration support.
 - Map `strict` to `response_format.json_schema.strict`.
 - Validate that strict output requires a JSON schema.
 - Update GPT-5 capability metadata.
 - Add tests, documentation, and a strict output example flow.
 - [https://developers.openai.com/api/docs/guides/structured-outputs](https://developers.openai.com/api/docs/guides/structured-outputs)

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [x] Docs updated (updated docs or a docs bug required)
