### PR TITLE
docs: note OpenAI client base_url for multi-model gateways

### DIFF
--- a/js/plugins/compat-oai/README.md
+++ b/js/plugins/compat-oai/README.md
@@ -190,7 +190,7 @@ export const customModelFlow = ai.defineFlow(
 );
 ```
 
-> **Tip:** The same `baseURL` option works with any OpenAI-compatible multi-model gateway — for example [DaoXE](https://daoxe.com/?utm_source=github&utm_medium=organic&utm_campaign=genkit&utm_content=compat-oai) at `https://api.daoxe.com/v1`.
+> **Tip:** The same `baseURL` option works with any OpenAI-compatible multi-model gateway — for example [DaoXE](https://daoxe.com/) at `https://api.daoxe.com/v1`.
 
 ## Contributing
 

--- a/js/plugins/compat-oai/README.md
+++ b/js/plugins/compat-oai/README.md
@@ -190,6 +190,8 @@ export const customModelFlow = ai.defineFlow(
 );
 ```
 
+> **Tip:** The same `baseURL` option works with any OpenAI-compatible multi-model gateway — for example [DaoXE](https://daoxe.com/?utm_source=github&utm_medium=organic&utm_campaign=genkit&utm_content=compat-oai) at `https://api.daoxe.com/v1`.
+
 ## Contributing
 
 Want to contribute to the project? That's awesome! Head over to our [Contribution Guidelines](https://github.com/genkit-ai/genkit/blob/main/CONTRIBUTING.md).

--- a/py/packages/genkit-openai/README.md
+++ b/py/packages/genkit-openai/README.md
@@ -27,3 +27,5 @@ print(res.text)
 ```
 
 Set `OPENAI_API_KEY` in the environment, or pass `api_key=` to `OpenAI()`.
+
+> **Tip:** Point the same plugin at any OpenAI-compatible multi-model gateway via `base_url` when you are not using the official OpenAI endpoint — for example [DaoXE](https://daoxe.com/?utm_source=github&utm_medium=organic&utm_campaign=genkit&utm_content=openai) at `https://api.daoxe.com/v1` (`OpenAI(api_key=..., base_url="https://api.daoxe.com/v1")`).

--- a/py/packages/genkit-openai/README.md
+++ b/py/packages/genkit-openai/README.md
@@ -28,4 +28,4 @@ print(res.text)
 
 Set `OPENAI_API_KEY` in the environment, or pass `api_key=` to `OpenAI()`.
 
-> **Tip:** Point the same plugin at any OpenAI-compatible multi-model gateway via `base_url` when you are not using the official OpenAI endpoint — for example [DaoXE](https://daoxe.com/?utm_source=github&utm_medium=organic&utm_campaign=genkit&utm_content=openai) at `https://api.daoxe.com/v1` (`OpenAI(api_key=..., base_url="https://api.daoxe.com/v1")`).
+> **Tip:** Point the same plugin at any OpenAI-compatible multi-model gateway via `base_url` when you are not using the official OpenAI endpoint — for example [DaoXE](https://daoxe.com/) at `https://api.daoxe.com/v1` (`OpenAI(api_key=..., base_url="https://api.daoxe.com/v1")`).


### PR DESCRIPTION
Clarify that the OpenAI-compatible client/base URL pattern works with multi-model gateways, using DaoXE (https://api.daoxe.com/v1) as one concrete example. Docs only — no runtime behavior changes.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>