### PR TITLE
fix(js/plugins/anthropic): resolveBetaEnabled now checks betas array for beta mode

### DIFF
--- a/js/plugins/anthropic/src/types.ts
+++ b/js/plugins/anthropic/src/types.ts
@@ -236,7 +236,8 @@ export const MEDIA_TYPES = {
  * Priority:
  *   1. request.config.apiVersion (per-request override - explicit stable or beta)
  *   2. pluginDefaultApiVersion (plugin-wide default)
- *   3. otherwise stable
+ *   3. non-empty betas array (enables beta surface for beta feature usage)
+ *   4. otherwise stable
  */
 export function resolveBetaEnabled(
   cfg: ClaudeConfig | undefined,
@@ -246,6 +247,9 @@ export function resolveBetaEnabled(
     return cfg.apiVersion === 'beta';
   }
   if (pluginDefaultApiVersion === 'beta') return true;
+  // If betas array has entries, enable beta API surface
+  const betas = (cfg as Record<string, unknown> | undefined)?.betas;
+  if (Array.isArray(betas) && betas.length > 0) return true;
   return false;
 }
 


### PR DESCRIPTION
## Problem
AnthropicConfigSchema accepts a betas array, but it is silently ignored unless apiVersion is explicitly set to a beta value. The resolveBetaEnabled() function only checks apiVersion and the plugin-wide default, never the betas param itself.

## Solution
Update resolveBetaEnabled() to also return true when the betas array is non-empty. This ensures that specifying beta features via the config actually enables the beta API surface.

## Changes
- js/plugins/anthropic/src/types.ts: Added check for non-empty betas array in resolveBetaEnabled()

## Testing
- Existing unit tests should continue to pass
- The fix is a minimal addition that only affects the beta resolution logic

Fixes #5737