### PR TITLE
fix(py): stop telemetry export from stalling generate() and dumping the shared TTY

### DIFF
--- a/py/packages/genkit/src/genkit/_core/_logger.py
+++ b/py/packages/genkit/src/genkit/_core/_logger.py
@@ -35,6 +35,13 @@ QUIET_LOGGERS = (
     'httpcore',
     'uvicorn.access',
     'uvicorn.error',
+    'opentelemetry',
+    'opentelemetry.sdk',
+    'opentelemetry.instrumentation',
+    # google-genai logs "AFC is enabled with max remote calls: N" at INFO on
+    # every tool-using generate — fine for debug, noisy in the shared TTY.
+    'google.genai',
+    'google_genai',
 )
 
 

--- a/py/packages/genkit/src/genkit/_core/_logger.py
+++ b/py/packages/genkit/src/genkit/_core/_logger.py
@@ -28,20 +28,19 @@ _LOG_LEVELS = {
     'fatal': logging.CRITICAL,
 }
 
-# Libraries that log every HTTP request or poll. Under Dev UI, health checks
-# and span exports generate noise unless GENKIT_LOG=debug is explicitly set.
+# Libraries that log every HTTP hop or provider chatter. Under Dev UI those
+# are health checks, span exports, and "AFC is enabled..." on every
+# tool-using generate — useful in GENKIT_LOG=debug, noise otherwise.
 QUIET_LOGGERS = (
     'httpx',
     'httpcore',
     'uvicorn.access',
     'uvicorn.error',
-    'opentelemetry',
-    'opentelemetry.sdk',
+    'opentelemetry.exporter',
     'opentelemetry.instrumentation',
-    # google-genai logs "AFC is enabled with max remote calls: N" at INFO on
-    # every tool-using generate — fine for debug, noisy in the shared TTY.
-    'google.genai',
-    'google_genai',
+    'opentelemetry.sdk.trace.export',
+    # AFC only. Muting google_genai would also hide auth-precedence INFO.
+    'google_genai.models',
 )
 
 

--- a/py/packages/genkit/src/genkit/_core/_logger.py
+++ b/py/packages/genkit/src/genkit/_core/_logger.py
@@ -28,11 +28,15 @@ _LOG_LEVELS = {
     'fatal': logging.CRITICAL,
 }
 
-# Health-check access logs on the reflection server under genkit start.
-# Collector posts use urllib so we do not set the process httpx logger.
+# Shared genkit start TTY. Uvicorn is our reflection health polls. httpx logs
+# INFO on every hop (Gemini generateContent, the app's own clients). Collector
+# POSTs use urllib, so they never hit this logger. GENKIT_LOG=debug turns these
+# back on.
 QUIET_LOGGERS = (
     'uvicorn.access',
     'uvicorn.error',
+    'httpx',
+    'httpcore',
 )
 
 

--- a/py/packages/genkit/src/genkit/_core/_logger.py
+++ b/py/packages/genkit/src/genkit/_core/_logger.py
@@ -28,19 +28,11 @@ _LOG_LEVELS = {
     'fatal': logging.CRITICAL,
 }
 
-# Libraries that log every HTTP hop or provider chatter. Under Dev UI those
-# are health checks, span exports, and "AFC is enabled..." on every
-# tool-using generate — useful in GENKIT_LOG=debug, noise otherwise.
+# Health-check access logs on the reflection server under genkit start.
+# Collector posts use urllib so we do not set the process httpx logger.
 QUIET_LOGGERS = (
-    'httpx',
-    'httpcore',
     'uvicorn.access',
     'uvicorn.error',
-    'opentelemetry.exporter',
-    'opentelemetry.instrumentation',
-    'opentelemetry.sdk.trace.export',
-    # AFC only. Muting google_genai would also hide auth-precedence INFO.
-    'google_genai.models',
 )
 
 
@@ -96,7 +88,7 @@ def configure_structlog_level() -> bool:
 
 
 def configure_logging(*, shared_tty: bool | None = None) -> None:
-    """Configure genkit console logging and mute noisy HTTP/health poll loggers.
+    """Configure genkit console logging and mute reflection access logs on a shared TTY.
 
     Safe to call more than once. Default level is ``info``; override with
     ``GENKIT_LOG=debug|info|warn|error``.

--- a/py/packages/genkit/src/genkit/_core/_trace/_default_exporter.py
+++ b/py/packages/genkit/src/genkit/_core/_trace/_default_exporter.py
@@ -21,12 +21,13 @@ from __future__ import annotations
 import json
 import os
 import threading
+import urllib.error
+import urllib.request
 from collections.abc import Callable, Iterable, Sequence
 from queue import Queue
 from typing import Any, cast
 from urllib.parse import urljoin, urlparse
 
-import httpx
 from opentelemetry import trace as trace_api
 from opentelemetry.sdk.trace import ReadableSpan, SpanProcessor
 from opentelemetry.sdk.trace.export import (
@@ -63,6 +64,20 @@ EXPORT_TIMEOUT_SECONDS = 300
 # is killed, so we give the last span a couple of seconds to land. Ctrl-C of
 # a wedged collector still shouldn't sit for minutes.
 SHUTDOWN_FLUSH_TIMEOUT_MILLIS = 2_000
+
+
+def post_trace(*, url: str, body: str) -> None:
+    """POST one collector document without going through the process httpx logger."""
+    if urlparse(url).scheme not in ('http', 'https'):
+        raise ValueError(f'invalid telemetry server URL {url!r}')
+    request = urllib.request.Request(  # noqa: S310 — scheme checked above
+        url,
+        data=body.encode(),
+        headers=TRACE_HEADERS,
+        method='POST',
+    )
+    with urllib.request.urlopen(request, timeout=EXPORT_TIMEOUT_SECONDS) as response:  # noqa: S310
+        response.read()
 
 
 def resolve_telemetry_server_url(*, telemetry_server_url: str, telemetry_server_endpoint: str) -> str:
@@ -303,16 +318,15 @@ class TraceServerExporter(SpanExporter):
         url = urljoin(self.telemetry_server_url, self.telemetry_server_endpoint)
         try:
             # generate() already returned; this wait lives on the worker.
-            with httpx.Client(timeout=EXPORT_TIMEOUT_SECONDS) as client:
-                for trace_id, body in jobs:
-                    try:
-                        client.post(url, content=body, headers=TRACE_HEADERS)
-                    except (httpx.RequestError, OSError) as error:
-                        self.note_transport_failure(trace_id=trace_id, error=error)
-                        return
-                    self.failed_traces.discard(trace_id)
+            for trace_id, body in jobs:
+                try:
+                    post_trace(url=url, body=body)
+                except (urllib.error.URLError, TimeoutError, OSError) as error:
+                    self.note_transport_failure(trace_id=trace_id, error=error)
+                    return
+                self.failed_traces.discard(trace_id)
             self.last_result = SpanExportResult.SUCCESS
-        except (httpx.RequestError, OSError) as error:
+        except (urllib.error.URLError, TimeoutError, OSError) as error:
             trace_id = jobs[0][0] if jobs else 'unknown'
             self.note_transport_failure(trace_id=trace_id, error=error)
 

--- a/py/packages/genkit/src/genkit/_core/_trace/_default_exporter.py
+++ b/py/packages/genkit/src/genkit/_core/_trace/_default_exporter.py
@@ -23,7 +23,7 @@ import os
 import threading
 import urllib.error
 import urllib.request
-from collections.abc import Callable, Iterable, Sequence
+from collections.abc import Callable, Iterable, Mapping, Sequence
 from queue import Queue
 from typing import Any, cast
 from urllib.parse import urljoin, urlparse
@@ -88,7 +88,7 @@ def resolve_telemetry_server_url(*, telemetry_server_url: str, telemetry_server_
     except ValueError as error:
         raise ValueError(f'invalid telemetry server URL {telemetry_server_url!r}') from error
     parsed = urlparse(joined)
-    if not parsed.scheme or not parsed.netloc:
+    if parsed.scheme not in ('http', 'https') or not parsed.netloc:
         raise ValueError(f'invalid telemetry server URL {telemetry_server_url!r}')
     return url
 
@@ -116,6 +116,22 @@ def _otel_event_attributes_to_json(attrs: object | None) -> dict[str, Any]:
                 out[key] = str(v)
     except (TypeError, ValueError):
         pass
+    return out
+
+
+def json_safe_attributes(*, attrs: Mapping[Any, Any] | None) -> dict[str, Any]:
+    """Drop values the collector cannot store so the rest of the trace still lands."""
+    if not attrs:
+        return {}
+    out: dict[str, Any] = {}
+    for key, value in attrs.items():
+        name = str(key)
+        try:
+            json.dumps(value)
+        except (TypeError, ValueError):
+            logger.warning(f'skipped span attribute {name!r} ({type(value).__name__})')
+            continue
+        out[name] = value
     return out
 
 
@@ -182,9 +198,8 @@ def events_to_time_events(*, span: ReadableSpan) -> TimeEvents:
 def extract_span_data(span: ReadableSpan) -> TraceData:
     """Convert a finished span into the collector document.
 
-    Requires a span context. Encoding happens later on this same thread via
-    ``encode_trace`` so a value the collector cannot store fails in
-    ``export()``, not after generate has moved on.
+    Requires a span context. Values the collector cannot store are dropped
+    so generate() still returns and the rest of the document still POSTs.
     """
     ctx = span.context
     if ctx is None:
@@ -207,7 +222,7 @@ def extract_span_data(span: ReadableSpan) -> TraceData:
         trace_id=trace_id,
         start_time=start,
         end_time=end,
-        attributes=dict(span.attributes or {}),
+        attributes=json_safe_attributes(attrs=span.attributes),
         display_name=span.name,
         span_kind=trace_api.SpanKind(span.kind).name,
         instrumentation_library=INSTRUMENTATION,
@@ -244,11 +259,7 @@ def build_trace_payload(*, spans: Sequence[ReadableSpan]) -> TraceData:
 
 
 def encode_trace(*, trace: TraceData) -> str:
-    """JSON for the collector, with no fallback serializer.
-
-    A bytes or object attribute must raise here so export() is loud.
-    GenkitModel.model_dump would stringify those and hide the bug.
-    """
+    """JSON for the collector. Attributes that cannot encode were already dropped."""
     return json.dumps(BaseModel.model_dump(trace, by_alias=True, exclude_none=True))
 
 
@@ -343,9 +354,8 @@ class TraceServerExporter(SpanExporter):
                 if span.context:
                     filtered_trace_ids.add(format(span.context.trace_id, '032x'))
 
-        # Serialize on this thread so a span that can't encode fails in
-        # export(), not as a silent miss after generate() has moved on.
-        # Group by trace so a batch flush is one POST per flow, not per span.
+        # Encode here so the worker only does I/O. Group by trace so a
+        # batch flush is one POST per flow, not per span.
         by_trace: dict[str, list[ReadableSpan]] = {}
         for span in spans:
             ctx = span.context

--- a/py/packages/genkit/src/genkit/_core/_trace/_default_exporter.py
+++ b/py/packages/genkit/src/genkit/_core/_trace/_default_exporter.py
@@ -24,7 +24,7 @@ import threading
 from collections.abc import Callable, Iterable, Sequence
 from queue import Queue
 from typing import Any, cast
-from urllib.parse import urljoin
+from urllib.parse import urljoin, urlparse
 
 import httpx
 from opentelemetry import trace as trace_api
@@ -47,6 +47,22 @@ logger = get_logger(__name__)
 
 INSTRUMENTATION = {'name': 'genkit-tracer', 'version': 'v1'}
 TRACE_HEADERS = {'Content-Type': 'application/json', 'Accept': 'application/json'}
+# Ctrl-C of a genkit start session shouldn't sit on a wedged collector. A couple
+# of seconds is enough for a healthy local Dev UI to take the last span.
+SHUTDOWN_FLUSH_TIMEOUT_MILLIS = 2_000
+
+
+def resolve_telemetry_server_url(*, telemetry_server_url: str, telemetry_server_endpoint: str) -> str:
+    """A typo'd collector URL should fail when tracing starts, not as missing Dev UI traces later."""
+    url = telemetry_server_url.strip()
+    try:
+        joined = urljoin(url, telemetry_server_endpoint)
+    except ValueError as error:
+        raise ValueError(f'invalid telemetry server URL {telemetry_server_url!r}') from error
+    parsed = urlparse(joined)
+    if not parsed.scheme or not parsed.netloc:
+        raise ValueError(f'invalid telemetry server URL {telemetry_server_url!r}')
+    return url
 
 
 def _ns_to_ms(ns: int | None) -> float:
@@ -216,7 +232,10 @@ class TraceServerExporter(SpanExporter):
         telemetry_server_endpoint: str = '/api/traces',
         filters: dict[str, str] | None = None,
     ) -> None:
-        self.telemetry_server_url = telemetry_server_url
+        self.telemetry_server_url = resolve_telemetry_server_url(
+            telemetry_server_url=telemetry_server_url,
+            telemetry_server_endpoint=telemetry_server_endpoint,
+        )
         self.telemetry_server_endpoint = telemetry_server_endpoint
         self.filters = filters if filters is not None else DEFAULT_SPAN_FILTERS
         self.last_result = SpanExportResult.SUCCESS
@@ -234,7 +253,13 @@ class TraceServerExporter(SpanExporter):
             try:
                 if item is None:
                     return
-                self.post_jobs(jobs=item)
+                try:
+                    self.post_jobs(jobs=item)
+                except Exception as error:
+                    # The worker has to survive a surprise exception or every
+                    # later trace is silently lost and generate() looks fine.
+                    trace_id = item[0][0] if item else 'unknown'
+                    self.note_transport_failure(trace_id=trace_id, error=error)
             finally:
                 self.queue.task_done()
 
@@ -249,6 +274,12 @@ class TraceServerExporter(SpanExporter):
         logger.error(f'Failed to save trace {trace_id}: {error}')
 
     def post_jobs(self, *, jobs: list[tuple[str, str]]) -> None:
+        """POST each serialized trace.
+
+        Saving is not atomic: a transport failure stops the rest of the
+        batch. Traces already sent stay sent; a down collector is one
+        error line, not a retry storm.
+        """
         url = urljoin(self.telemetry_server_url, self.telemetry_server_endpoint)
         try:
             # No timeout: a slow local collector must still get the span.
@@ -315,8 +346,8 @@ class TraceServerExporter(SpanExporter):
 
     @override
     def shutdown(self) -> None:
-        self.force_flush()
         self.stopped = True
+        self.force_flush(timeout_millis=SHUTDOWN_FLUSH_TIMEOUT_MILLIS)
         self.queue.put(None)
 
 
@@ -328,7 +359,11 @@ def init_telemetry_server_exporter() -> SpanExporter | None:
             'GENKIT_TELEMETRY_SERVER is not set. If running with `genkit start`, make sure `genkit-cli` is up to date.'
         )
         return None
-    return TraceServerExporter(telemetry_server_url=url)
+    try:
+        return TraceServerExporter(telemetry_server_url=url)
+    except ValueError as error:
+        logger.error(f'GENKIT_TELEMETRY_SERVER is not a valid URL: {error}')
+        return None
 
 
 def create_span_processor(exporter: SpanExporter) -> SpanProcessor:

--- a/py/packages/genkit/src/genkit/_core/_trace/_default_exporter.py
+++ b/py/packages/genkit/src/genkit/_core/_trace/_default_exporter.py
@@ -47,8 +47,12 @@ logger = get_logger(__name__)
 
 INSTRUMENTATION = {'name': 'genkit-tracer', 'version': 'v1'}
 TRACE_HEADERS = {'Content-Type': 'application/json', 'Accept': 'application/json'}
-# Ctrl-C of a genkit start session shouldn't sit on a wedged collector. A couple
-# of seconds is enough for a healthy local Dev UI to take the last span.
+# Five minutes is long enough for a slow local Dev UI and short enough that a
+# wedged collector eventually gets a Failed to save trace line.
+EXPORT_TIMEOUT_SECONDS = 300
+# The export worker is a daemon: once the interpreter starts tearing down it
+# is killed, so we give the last span a couple of seconds to land. Ctrl-C of
+# a wedged collector still shouldn't sit for minutes.
 SHUTDOWN_FLUSH_TIMEOUT_MILLIS = 2_000
 
 
@@ -282,9 +286,8 @@ class TraceServerExporter(SpanExporter):
         """
         url = urljoin(self.telemetry_server_url, self.telemetry_server_endpoint)
         try:
-            # No timeout: a slow local collector must still get the span.
             # generate() already returned; this wait lives on the worker.
-            with httpx.Client(timeout=None) as client:  # noqa: S113
+            with httpx.Client(timeout=EXPORT_TIMEOUT_SECONDS) as client:
                 for trace_id, body in jobs:
                     try:
                         client.post(url, content=body, headers=TRACE_HEADERS)

--- a/py/packages/genkit/src/genkit/_core/_trace/_default_exporter.py
+++ b/py/packages/genkit/src/genkit/_core/_trace/_default_exporter.py
@@ -18,8 +18,11 @@
 
 from __future__ import annotations
 
+import json
 import os
+import threading
 from collections.abc import Callable, Iterable, Sequence
+from queue import Queue
 from typing import Any, cast
 from urllib.parse import urljoin
 
@@ -180,6 +183,24 @@ def extract_span_data(span: ReadableSpan) -> dict[str, Any]:
     return result
 
 
+def build_trace_payload(spans: Sequence[ReadableSpan]) -> dict[str, Any]:
+    """One collector document for a batch of spans that share a trace id.
+
+    Production uses BatchSpanProcessor, which can flush a whole flow at once.
+    The store keys documents by trace id, so one POST per id is enough.
+    """
+    payload: dict[str, Any] = {'spans': {}}
+    for span in spans:
+        part = extract_span_data(span)
+        payload['traceId'] = part['traceId']
+        payload['spans'].update(part['spans'])
+        if 'displayName' in part:
+            payload['displayName'] = part['displayName']
+            payload['startTime'] = part['startTime']
+            payload['endTime'] = part['endTime']
+    return payload
+
+
 DEFAULT_SPAN_FILTERS: dict[str, str] = {
     # Suppress prompt runner preview traces (triggered on every keystroke in Dev UI)
     Attr.SUBTYPE: Subtype.PROMPT,
@@ -198,9 +219,58 @@ class TraceServerExporter(SpanExporter):
         self.telemetry_server_url = telemetry_server_url
         self.telemetry_server_endpoint = telemetry_server_endpoint
         self.filters = filters if filters is not None else DEFAULT_SPAN_FILTERS
+        self.last_result = SpanExportResult.SUCCESS
+        self.stopped = False
+        self.failed_traces: set[str] = set()
+        # A hung collector holds the HTTP timeout on the worker. generate()
+        # has already returned — traces are best-effort for the Dev UI.
+        self.queue: Queue[list[tuple[str, str]] | None] = Queue()
+        self.worker = threading.Thread(target=self.run_worker, name='genkit-trace-export', daemon=True)
+        self.worker.start()
+
+    def run_worker(self) -> None:
+        while True:
+            item = self.queue.get()
+            try:
+                if item is None:
+                    return
+                self.post_jobs(jobs=item)
+            finally:
+                self.queue.task_done()
+
+    def note_transport_failure(self, *, trace_id: str, error: BaseException) -> None:
+        self.last_result = SpanExportResult.FAILURE
+        # start+end of a 2-span flow is four posts of the same id; one line
+        # is enough to find it without a wall. The reason is so a down
+        # collector doesn't look like their flow crashed.
+        if trace_id in self.failed_traces:
+            return
+        self.failed_traces.add(trace_id)
+        logger.error(f'Failed to save trace {trace_id}: {error}')
+
+    def post_jobs(self, *, jobs: list[tuple[str, str]]) -> None:
+        url = urljoin(self.telemetry_server_url, self.telemetry_server_endpoint)
+        try:
+            # No timeout: a slow local collector must still get the span.
+            # generate() already returned; this wait lives on the worker.
+            with httpx.Client(timeout=None) as client:  # noqa: S113
+                for trace_id, body in jobs:
+                    try:
+                        client.post(url, content=body, headers=TRACE_HEADERS)
+                    except (httpx.RequestError, OSError) as error:
+                        self.note_transport_failure(trace_id=trace_id, error=error)
+                        return
+                    self.failed_traces.discard(trace_id)
+            self.last_result = SpanExportResult.SUCCESS
+        except (httpx.RequestError, OSError) as error:
+            trace_id = jobs[0][0] if jobs else 'unknown'
+            self.note_transport_failure(trace_id=trace_id, error=error)
 
     @override
     def export(self, spans: Sequence[ReadableSpan]) -> SpanExportResult:
+        if self.stopped:
+            return SpanExportResult.FAILURE
+
         # Collect trace IDs that should be filtered out entirely
         filtered_trace_ids: set[str] = set()
         for span in spans:
@@ -209,24 +279,45 @@ class TraceServerExporter(SpanExporter):
                 if span.context:
                     filtered_trace_ids.add(format(span.context.trace_id, '032x'))
 
-        url = urljoin(self.telemetry_server_url, self.telemetry_server_endpoint)
-        headers = {'Content-Type': 'application/json', 'Accept': 'application/json'}
-        try:
-            with httpx.Client() as client:
-                for span in spans:
-                    if span.context and format(span.context.trace_id, '032x') in filtered_trace_ids:
-                        continue
-                    client.post(url, json=extract_span_data(span), headers=headers)
-        except Exception as e:
-            # Network blips / proxy misconfig must not dump httpx tracebacks into
-            # the shared genkit start terminal. Traces are best-effort in dev.
-            logger.debug('Telemetry export failed: %s: %s', type(e).__name__, e)
-            return SpanExportResult.FAILURE
+        # Serialize on this thread so a span that can't encode fails in
+        # export(), not as a silent miss after generate() has moved on.
+        # Group by trace so a batch flush is one POST per flow, not per span.
+        by_trace: dict[str, list[ReadableSpan]] = {}
+        for span in spans:
+            ctx = span.context
+            if ctx is None:
+                extract_span_data(span)
+                raise TypeError('span context is required')
+            trace_id = format(ctx.trace_id, '032x')
+            if trace_id in filtered_trace_ids:
+                continue
+            by_trace.setdefault(trace_id, []).append(span)
+
+        jobs: list[tuple[str, str]] = []
+        for trace_id, group in by_trace.items():
+            jobs.append((trace_id, json.dumps(build_trace_payload(group))))
+
+        if jobs:
+            self.queue.put(jobs)
         return SpanExportResult.SUCCESS
 
     @override
     def force_flush(self, timeout_millis: int = 30000) -> bool:
-        return True
+        finished = threading.Event()
+
+        def wait() -> None:
+            self.queue.join()
+            finished.set()
+
+        waiter = threading.Thread(target=wait, name='genkit-trace-flush', daemon=True)
+        waiter.start()
+        return finished.wait(timeout_millis / 1000.0)
+
+    @override
+    def shutdown(self) -> None:
+        self.force_flush()
+        self.stopped = True
+        self.queue.put(None)
 
 
 def init_telemetry_server_exporter() -> SpanExporter | None:

--- a/py/packages/genkit/src/genkit/_core/_trace/_default_exporter.py
+++ b/py/packages/genkit/src/genkit/_core/_trace/_default_exporter.py
@@ -34,8 +34,9 @@ from opentelemetry.sdk.trace.export import (
     SpanExporter,
     SpanExportResult,
 )
-from opentelemetry.trace import SpanContext
+from pydantic import BaseModel, Field
 
+from genkit._core._base import GenkitModel
 from genkit._core._compat import override
 from genkit._core._environment import is_dev_environment
 from genkit._core._logger import get_logger
@@ -45,7 +46,54 @@ from ._realtime_processor import RealtimeSpanProcessor
 
 logger = get_logger(__name__)
 
-INSTRUMENTATION = {'name': 'genkit-tracer', 'version': 'v1'}
+
+class SpanStatus(GenkitModel):
+    code: int
+    message: str | None = None
+
+
+class EventAnnotation(GenkitModel):
+    description: str
+    attributes: dict[str, Any] = Field(default_factory=dict)
+
+
+class TimeEvent(GenkitModel):
+    time: float
+    annotation: EventAnnotation
+
+
+class TimeEvents(GenkitModel):
+    time_event: list[TimeEvent] = Field(default_factory=list)
+
+
+class InstrumentationLibrary(GenkitModel):
+    name: str
+    version: str | None = None
+
+
+class SpanData(GenkitModel):
+    span_id: str
+    trace_id: str
+    start_time: float
+    end_time: float
+    attributes: dict[str, Any]
+    display_name: str
+    span_kind: str
+    instrumentation_library: InstrumentationLibrary
+    time_events: TimeEvents
+    parent_span_id: str | None = None
+    status: SpanStatus | None = None
+
+
+class TraceData(GenkitModel):
+    trace_id: str
+    spans: dict[str, SpanData]
+    display_name: str | None = None
+    start_time: float | None = None
+    end_time: float | None = None
+
+
+INSTRUMENTATION = InstrumentationLibrary(name='genkit-tracer', version='v1')
 TRACE_HEADERS = {'Content-Type': 'application/json', 'Accept': 'application/json'}
 # Five minutes is long enough for a slow local Dev UI and short enough that a
 # wedged collector eventually gets a Failed to save trace line.
@@ -95,130 +143,133 @@ def _otel_event_attributes_to_json(attrs: object | None) -> dict[str, Any]:
     return out
 
 
-def _ensure_exception_message_for_dev_ui(span_entry: dict[str, Any]) -> None:
-    r"""Ensure exception timeEvents carry exception.message for Dev UI / evaluate.ts.
+def ensure_exception_message(*, span: SpanData) -> None:
+    """Dev UI reads the first exception event's message and shows "Error" if it's missing.
 
-    TraceData SpanStatusSchema uses `message` (not OTel's `description`). Dev UI and
-    evaluate.ts read the first `exception` timeEvent's `exception.message` and fall
-    back to the literal "Error" if missing. Synthesize from status.message or
-    the error attr when events are empty or incomplete.
+    Status uses ``message``, not OTel's ``description``. When the span failed
+    but nobody recorded an exception event, copy the status or error attr onto
+    one so the trace still names what broke.
     """
-    st = span_entry.get('status')
-    if not st or st.get('code') != 2:
+    status = span.status
+    if status is None or status.code != 2:
         return
-    attrs = span_entry.get('attributes') or {}
-    msg = st.get('message') or attrs.get(Attr.ERROR)
-    if not msg:
+    message = status.message or span.attributes.get(Attr.ERROR)
+    if not message:
         return
-    if not st.get('message'):
-        span_entry.setdefault('status', {})['message'] = msg
-    te = span_entry.get('timeEvents')
-    events = (te or {}).get('timeEvent') or []
-    for ev in events:
-        ann = ev.get('annotation') or {}
-        if ann.get('description') != 'exception':
+    if not status.message:
+        status.message = message
+    for event in span.time_events.time_event:
+        if event.annotation.description != 'exception':
             continue
-        ann_attrs = ann.get('attributes') or {}
-        if ann_attrs.get('exception.message'):
+        if event.annotation.attributes.get('exception.message'):
             return
-        ann_attrs['exception.message'] = msg
-        ann['attributes'] = ann_attrs
-        ev['annotation'] = ann
+        event.annotation.attributes['exception.message'] = message
         return
-    if not te:
-        span_entry['timeEvents'] = {'timeEvent': []}
-        te = span_entry['timeEvents']
-    te.setdefault('timeEvent', []).append({
-        'time': span_entry.get('endTime', 0),
-        'annotation': {
-            'description': 'exception',
-            'attributes': {
-                'exception.type': 'Error',
-                'exception.message': msg,
-            },
-        },
-    })
+    span.time_events.time_event.append(
+        TimeEvent(
+            time=span.end_time,
+            annotation=EventAnnotation(
+                description='exception',
+                attributes={
+                    'exception.type': 'Error',
+                    'exception.message': message,
+                },
+            ),
+        )
+    )
 
 
-def _events_to_time_events(span: ReadableSpan) -> dict[str, Any]:
-    """Build Genkit trace `timeEvents` from OTel span events (matches JS TraceServerExporter).
-
-    Always includes `timeEvent` (possibly empty) so the payload matches JS and
-    `_ensure_exception_message_for_dev_ui` can append a synthetic exception event.
-    """
+def events_to_time_events(*, span: ReadableSpan) -> TimeEvents:
+    """Copy OTel events onto the collector document so Dev UI can show them."""
     events = getattr(span, 'events', None) or ()
-    time_event: list[dict[str, Any]] = []
+    time_event: list[TimeEvent] = []
     for ev in events:
         name = getattr(ev, 'name', None) or 'event'
         ts = getattr(ev, 'timestamp', None)
         raw_attrs = getattr(ev, 'attributes', None) or {}
-        time_event.append({
-            'time': _ns_to_ms(ts),
-            'annotation': {
-                'attributes': _otel_event_attributes_to_json(raw_attrs),
-                'description': name,
-            },
-        })
-    return {'timeEvent': time_event}
+        time_event.append(
+            TimeEvent(
+                time=_ns_to_ms(ts),
+                annotation=EventAnnotation(
+                    description=name,
+                    attributes=_otel_event_attributes_to_json(raw_attrs),
+                ),
+            )
+        )
+    return TimeEvents(time_event=time_event)
 
 
-def extract_span_data(span: ReadableSpan) -> dict[str, Any]:
-    """Convert ReadableSpan to Genkit telemetry server JSON format."""
-    ctx = cast(SpanContext, span.context)
+def extract_span_data(span: ReadableSpan) -> TraceData:
+    """Convert a finished span into the collector document.
+
+    Requires a span context. Encoding happens later on this same thread via
+    ``encode_trace`` so a value the collector cannot store fails in
+    ``export()``, not after generate has moved on.
+    """
+    ctx = span.context
+    if ctx is None:
+        raise TypeError('span context is required')
     trace_id = format(ctx.trace_id, '032x')
     span_id = format(ctx.span_id, '016x')
     parent_id = format(span.parent.span_id, '016x') if span.parent else None
     start = _ns_to_ms(span.start_time)
     end = _ns_to_ms(span.end_time)
 
-    span_entry: dict[str, Any] = {
-        'spanId': span_id,
-        'traceId': trace_id,
-        'startTime': start,
-        'endTime': end,
-        'attributes': dict(span.attributes or {}),
-        'displayName': span.name,
-        'spanKind': trace_api.SpanKind(span.kind).name,
-        'instrumentationLibrary': INSTRUMENTATION,
-        'timeEvents': _events_to_time_events(span),
-    }
-    if parent_id:
-        span_entry['parentSpanId'] = parent_id
+    status: SpanStatus | None = None
     if span.status:
-        code = trace_api.StatusCode(span.status.status_code).value
-        desc = span.status.description
-        # SpanStatusSchema only has code + message; omit nulls (Zod rejects null for optional strings).
-        status_obj: dict[str, Any] = {'code': code}
-        if desc is not None:
-            status_obj['message'] = desc
-        span_entry['status'] = status_obj
-    _ensure_exception_message_for_dev_ui(span_entry)
+        status = SpanStatus(
+            code=trace_api.StatusCode(span.status.status_code).value,
+            message=span.status.description,
+        )
 
-    result: dict[str, Any] = {'traceId': trace_id, 'spans': {span_id: span_entry}}
+    entry = SpanData(
+        span_id=span_id,
+        trace_id=trace_id,
+        start_time=start,
+        end_time=end,
+        attributes=dict(span.attributes or {}),
+        display_name=span.name,
+        span_kind=trace_api.SpanKind(span.kind).name,
+        instrumentation_library=INSTRUMENTATION,
+        time_events=events_to_time_events(span=span),
+        parent_span_id=parent_id,
+        status=status,
+    )
+    ensure_exception_message(span=entry)
+
+    result = TraceData(trace_id=trace_id, spans={span_id: entry})
     if not span.parent:
-        result['displayName'] = span.name
-        result['startTime'] = start
-        result['endTime'] = end
-
+        result.display_name = span.name
+        result.start_time = start
+        result.end_time = end
     return result
 
 
-def build_trace_payload(spans: Sequence[ReadableSpan]) -> dict[str, Any]:
+def build_trace_payload(*, spans: Sequence[ReadableSpan]) -> TraceData:
     """One collector document for a batch of spans that share a trace id.
 
-    Production uses BatchSpanProcessor, which can flush a whole flow at once.
-    The store keys documents by trace id, so one POST per id is enough.
+    Production flushes a whole flow at once. The store keys documents by
+    trace id, so one POST per id is enough.
     """
-    payload: dict[str, Any] = {'spans': {}}
+    payload = TraceData(trace_id='', spans={})
     for span in spans:
         part = extract_span_data(span)
-        payload['traceId'] = part['traceId']
-        payload['spans'].update(part['spans'])
-        if 'displayName' in part:
-            payload['displayName'] = part['displayName']
-            payload['startTime'] = part['startTime']
-            payload['endTime'] = part['endTime']
+        payload.trace_id = part.trace_id
+        payload.spans.update(part.spans)
+        if part.display_name is not None:
+            payload.display_name = part.display_name
+            payload.start_time = part.start_time
+            payload.end_time = part.end_time
     return payload
+
+
+def encode_trace(*, trace: TraceData) -> str:
+    """JSON for the collector, with no fallback serializer.
+
+    A bytes or object attribute must raise here so export() is loud.
+    GenkitModel.model_dump would stringify those and hide the bug.
+    """
+    return json.dumps(BaseModel.model_dump(trace, by_alias=True, exclude_none=True))
 
 
 DEFAULT_SPAN_FILTERS: dict[str, str] = {
@@ -320,7 +371,6 @@ class TraceServerExporter(SpanExporter):
         for span in spans:
             ctx = span.context
             if ctx is None:
-                extract_span_data(span)
                 raise TypeError('span context is required')
             trace_id = format(ctx.trace_id, '032x')
             if trace_id in filtered_trace_ids:
@@ -329,7 +379,7 @@ class TraceServerExporter(SpanExporter):
 
         jobs: list[tuple[str, str]] = []
         for trace_id, group in by_trace.items():
-            jobs.append((trace_id, json.dumps(build_trace_payload(group))))
+            jobs.append((trace_id, encode_trace(trace=build_trace_payload(spans=group))))
 
         if jobs:
             self.queue.put(jobs)

--- a/py/packages/genkit/src/genkit/_core/_trace/_default_exporter.py
+++ b/py/packages/genkit/src/genkit/_core/_trace/_default_exporter.py
@@ -34,64 +34,25 @@ from opentelemetry.sdk.trace.export import (
     SpanExporter,
     SpanExportResult,
 )
-from pydantic import BaseModel, Field
+from pydantic import BaseModel
 
-from genkit._core._base import GenkitModel
 from genkit._core._compat import override
 from genkit._core._environment import is_dev_environment
 from genkit._core._logger import get_logger
+from genkit._core._typing import (
+    Annotation,
+    InstrumentationLibrary,
+    SpanData,
+    SpanStatus,
+    TimeEvent,
+    TimeEvents,
+    TraceData,
+)
 
 from ._attrs import Attr, Subtype
 from ._realtime_processor import RealtimeSpanProcessor
 
 logger = get_logger(__name__)
-
-
-class SpanStatus(GenkitModel):
-    code: int
-    message: str | None = None
-
-
-class EventAnnotation(GenkitModel):
-    description: str
-    attributes: dict[str, Any] = Field(default_factory=dict)
-
-
-class TimeEvent(GenkitModel):
-    time: float
-    annotation: EventAnnotation
-
-
-class TimeEvents(GenkitModel):
-    time_event: list[TimeEvent] = Field(default_factory=list)
-
-
-class InstrumentationLibrary(GenkitModel):
-    name: str
-    version: str | None = None
-
-
-class SpanData(GenkitModel):
-    span_id: str
-    trace_id: str
-    start_time: float
-    end_time: float
-    attributes: dict[str, Any]
-    display_name: str
-    span_kind: str
-    instrumentation_library: InstrumentationLibrary
-    time_events: TimeEvents
-    parent_span_id: str | None = None
-    status: SpanStatus | None = None
-
-
-class TraceData(GenkitModel):
-    trace_id: str
-    spans: dict[str, SpanData]
-    display_name: str | None = None
-    start_time: float | None = None
-    end_time: float | None = None
-
 
 INSTRUMENTATION = InstrumentationLibrary(name='genkit-tracer', version='v1')
 TRACE_HEADERS = {'Content-Type': 'application/json', 'Accept': 'application/json'}
@@ -158,17 +119,21 @@ def ensure_exception_message(*, span: SpanData) -> None:
         return
     if not status.message:
         status.message = message
-    for event in span.time_events.time_event:
+    time_events = span.time_events or TimeEvents(time_event=[])
+    span.time_events = time_events
+    event_list = time_events.time_event or []
+    time_events.time_event = event_list
+    for event in event_list:
         if event.annotation.description != 'exception':
             continue
         if event.annotation.attributes.get('exception.message'):
             return
         event.annotation.attributes['exception.message'] = message
         return
-    span.time_events.time_event.append(
+    event_list.append(
         TimeEvent(
             time=span.end_time,
-            annotation=EventAnnotation(
+            annotation=Annotation(
                 description='exception',
                 attributes={
                     'exception.type': 'Error',
@@ -190,7 +155,7 @@ def events_to_time_events(*, span: ReadableSpan) -> TimeEvents:
         time_event.append(
             TimeEvent(
                 time=_ns_to_ms(ts),
-                annotation=EventAnnotation(
+                annotation=Annotation(
                     description=name,
                     attributes=_otel_event_attributes_to_json(raw_attrs),
                 ),

--- a/py/packages/genkit/src/genkit/_core/_trace/_default_exporter.py
+++ b/py/packages/genkit/src/genkit/_core/_trace/_default_exporter.py
@@ -211,11 +211,17 @@ class TraceServerExporter(SpanExporter):
 
         url = urljoin(self.telemetry_server_url, self.telemetry_server_endpoint)
         headers = {'Content-Type': 'application/json', 'Accept': 'application/json'}
-        with httpx.Client() as client:
-            for span in spans:
-                if span.context and format(span.context.trace_id, '032x') in filtered_trace_ids:
-                    continue
-                client.post(url, json=extract_span_data(span), headers=headers)
+        try:
+            with httpx.Client() as client:
+                for span in spans:
+                    if span.context and format(span.context.trace_id, '032x') in filtered_trace_ids:
+                        continue
+                    client.post(url, json=extract_span_data(span), headers=headers)
+        except Exception as e:
+            # Network blips / proxy misconfig must not dump httpx tracebacks into
+            # the shared genkit start terminal. Traces are best-effort in dev.
+            logger.debug('Telemetry export failed: %s: %s', type(e).__name__, e)
+            return SpanExportResult.FAILURE
         return SpanExportResult.SUCCESS
 
     @override

--- a/py/packages/genkit/src/genkit/_core/_trace/_realtime_processor.py
+++ b/py/packages/genkit/src/genkit/_core/_trace/_realtime_processor.py
@@ -21,10 +21,7 @@ from opentelemetry.sdk.trace import ReadableSpan, Span
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 
 from genkit._core._compat import override
-from genkit._core._logger import get_logger
 from genkit._core._trace._suppress import suppress_telemetry
-
-logger = get_logger(__name__)
 
 
 class RealtimeSpanProcessor(SimpleSpanProcessor):
@@ -35,17 +32,9 @@ class RealtimeSpanProcessor(SimpleSpanProcessor):
         """Export span immediately so DevUI can show in-progress traces."""
         if suppress_telemetry.get():
             return
-        try:
-            self.span_exporter.export([span])
-        except Exception as e:  # noqa: BLE001 — must never crash the caller
-            # httpx.ConnectError isn't a builtins.ConnectionError; treat all export
-            # failures as best-effort and keep the shared terminal clean.
-            logger.debug(
-                'RealtimeSpanProcessor: export failed on_start: %s: %s',
-                type(e).__name__,
-                e,
-                exc_info=True,
-            )
+        # Transport failures are handled in the exporter. A broken encoder
+        # has to stay loud so it isn't mistaken for a quiet collector miss.
+        self.span_exporter.export([span])
 
     @override
     def on_end(self, span: ReadableSpan) -> None:

--- a/py/packages/genkit/src/genkit/_core/_trace/_realtime_processor.py
+++ b/py/packages/genkit/src/genkit/_core/_trace/_realtime_processor.py
@@ -37,14 +37,13 @@ class RealtimeSpanProcessor(SimpleSpanProcessor):
             return
         try:
             self.span_exporter.export([span])
-        except ConnectionError:
+        except Exception as e:  # noqa: BLE001 — must never crash the caller
+            # httpx.ConnectError isn't a builtins.ConnectionError; treat all export
+            # failures as best-effort and keep the shared terminal clean.
             logger.debug(
-                'RealtimeSpanProcessor: export failed on_start (collector unreachable)',
-                exc_info=True,
-            )
-        except Exception:  # noqa: BLE001 — must never crash the caller
-            logger.warning(
-                'RealtimeSpanProcessor: unexpected error during export on_start',
+                'RealtimeSpanProcessor: export failed on_start: %s: %s',
+                type(e).__name__,
+                e,
                 exc_info=True,
             )
 

--- a/py/packages/genkit/src/genkit/_core/_trace/_realtime_processor.py
+++ b/py/packages/genkit/src/genkit/_core/_trace/_realtime_processor.py
@@ -32,8 +32,7 @@ class RealtimeSpanProcessor(SimpleSpanProcessor):
         """Export span immediately so DevUI can show in-progress traces."""
         if suppress_telemetry.get():
             return
-        # Transport failures are handled in the exporter. A broken encoder
-        # has to stay loud so it isn't mistaken for a quiet collector miss.
+        # Transport failures stay in the exporter. generate() should still return.
         self.span_exporter.export([span])
 
     @override

--- a/py/packages/genkit/src/genkit/_core/_tracing.py
+++ b/py/packages/genkit/src/genkit/_core/_tracing.py
@@ -98,8 +98,11 @@ def init_provider() -> TracerProvider:
     if tracer_provider is None or not isinstance(tracer_provider, TracerProvider):  # pyright: ignore[reportUnnecessaryComparison]
         tracer_provider = TracerProvider()
         trace_api.set_tracer_provider(tracer_provider)
+        # Correlate logs with spans when someone opts into debug, but don't rewrite
+        # the global log format — that turns every httpx/uvicorn line into a wall
+        # of trace_id/span_id noise in the shared genkit start terminal.
         # pyrefly: ignore[missing-attribute] - LoggingInstrumentor has instrument() method
-        LoggingInstrumentor().instrument(set_logging_format=True)
+        LoggingInstrumentor().instrument(set_logging_format=False)
         logger.debug('Creating a new global tracer provider for telemetry.')
 
     if not isinstance(tracer_provider, TracerProvider):  # pyright: ignore[reportUnnecessaryIsInstance]

--- a/py/packages/genkit/src/genkit/_core/_tracing.py
+++ b/py/packages/genkit/src/genkit/_core/_tracing.py
@@ -98,9 +98,8 @@ def init_provider() -> TracerProvider:
     if tracer_provider is None or not isinstance(tracer_provider, TracerProvider):  # pyright: ignore[reportUnnecessaryComparison]
         tracer_provider = TracerProvider()
         trace_api.set_tracer_provider(tracer_provider)
-        # Correlate logs with spans when someone opts into debug, but don't rewrite
-        # the global log format — that turns every httpx/uvicorn line into a wall
-        # of trace_id/span_id noise in the shared genkit start terminal.
+        # Rewriting the process log format stamps every library line with
+        # trace_id/span_id and turns the shared genkit start terminal into a wall.
         # pyrefly: ignore[missing-attribute] - LoggingInstrumentor has instrument() method
         LoggingInstrumentor().instrument(set_logging_format=False)
         logger.debug('Creating a new global tracer provider for telemetry.')

--- a/py/packages/genkit/src/genkit/_core/_typing.py
+++ b/py/packages/genkit/src/genkit/_core/_typing.py
@@ -100,17 +100,9 @@ class Role(StrEnum):
     TOOL = 'tool'
 
 
-class Schema(GenkitModel):
-    """Model for schema data."""
+Schema = dict[str, Any]  # type alias for schema (typed string map)
 
-    model_config: ClassVar[ConfigDict] = ConfigDict(alias_generator=to_camel, extra='forbid', populate_by_name=True)
-
-
-class ConfigSchema(GenkitModel):
-    """Model for configschema data."""
-
-    model_config: ClassVar[ConfigDict] = ConfigDict(alias_generator=to_camel, extra='forbid', populate_by_name=True)
-
+ConfigSchema = dict[str, Any]  # type alias for configschema (typed string map)
 
 Metadata = dict[str, Any]  # type alias for flexible metadata
 
@@ -959,10 +951,7 @@ class Resume(GenkitModel):
     metadata: Metadata | None = None
 
 
-class StateSchema(GenkitModel):
-    """Model for stateschema data."""
-
-    model_config: ClassVar[ConfigDict] = ConfigDict(alias_generator=to_camel, extra='forbid', populate_by_name=True)
+StateSchema = dict[str, Any]  # type alias for stateschema (typed string map)
 
 
 class Details(GenkitModel):
@@ -1018,17 +1007,9 @@ class Resource(GenkitModel):
     uri: str = Field(...)
 
 
-class Actions(GenkitModel):
-    """Model for actions data."""
+Actions = dict[str, ActionMetadata]  # type alias for actions (typed string map)
 
-    model_config: ClassVar[ConfigDict] = ConfigDict(alias_generator=to_camel, extra='forbid', populate_by_name=True)
-
-
-class Values(GenkitModel):
-    """Model for values data."""
-
-    model_config: ClassVar[ConfigDict] = ConfigDict(alias_generator=to_camel, extra='forbid', populate_by_name=True)
-
+Values = dict[str, Any]  # type alias for values (typed string map)
 
 TelemetryLabels = dict[str, str]  # type alias for telemetrylabels (typed string map)
 
@@ -1040,10 +1021,7 @@ class State(GenkitModel):
     trace_id: str | None = None
 
 
-class Attributes(GenkitModel):
-    """Model for attributes data."""
-
-    model_config: ClassVar[ConfigDict] = ConfigDict(alias_generator=to_camel, extra='forbid', populate_by_name=True)
+Attributes = dict[str, Any]  # type alias for attributes (typed string map)
 
 
 class SameProcessAsParentSpan(GenkitModel):
@@ -1068,10 +1046,7 @@ class Annotation(GenkitModel):
     description: str = Field(...)
 
 
-class Spans(GenkitModel):
-    """Model for spans data."""
-
-    model_config: ClassVar[ConfigDict] = ConfigDict(alias_generator=to_camel, extra='forbid', populate_by_name=True)
+Spans = dict[str, SpanData]  # type alias for spans (typed string map)
 
 
 class DocumentPart(RootModel[TextPart | MediaPart]):

--- a/py/packages/genkit/tests/genkit/core/logger_test.py
+++ b/py/packages/genkit/tests/genkit/core/logger_test.py
@@ -53,11 +53,14 @@ def test_resolve_level() -> None:
         assert resolve_level() == logging.INFO
 
 
-def test_quiet_loggers_are_reflection_access_only() -> None:
-    """Dev UI mutes our reflection access logs, not the app's httpx or provider SDKs."""
-    assert QUIET_LOGGERS == ('uvicorn.access', 'uvicorn.error')
-    assert 'httpx' not in QUIET_LOGGERS
-    assert 'httpcore' not in QUIET_LOGGERS
+def test_quiet_loggers_are_shared_tty_access_noise() -> None:
+    """Dev UI mutes reflection polls and httpx INFO hops, not provider SDKs."""
+    assert QUIET_LOGGERS == (
+        'uvicorn.access',
+        'uvicorn.error',
+        'httpx',
+        'httpcore',
+    )
     assert 'google_genai.models' not in QUIET_LOGGERS
     assert 'opentelemetry.exporter' not in QUIET_LOGGERS
 

--- a/py/packages/genkit/tests/genkit/core/logger_test.py
+++ b/py/packages/genkit/tests/genkit/core/logger_test.py
@@ -53,14 +53,13 @@ def test_resolve_level() -> None:
         assert resolve_level() == logging.INFO
 
 
-def test_quiet_loggers_mute_afc_and_otel_hops_not_auth_precedence() -> None:
-    """AFC and OTel hop INFO are muted; auth-precedence on _api_client is not."""
-    assert 'google_genai.models' in QUIET_LOGGERS
-    assert 'opentelemetry.exporter' in QUIET_LOGGERS
-    assert 'opentelemetry.instrumentation' in QUIET_LOGGERS
-    assert 'google_genai' not in QUIET_LOGGERS
-    assert 'google_genai._api_client' not in QUIET_LOGGERS
-    assert 'google.genai' not in QUIET_LOGGERS
+def test_quiet_loggers_are_reflection_access_only() -> None:
+    """Dev UI mutes our reflection access logs, not the app's httpx or provider SDKs."""
+    assert QUIET_LOGGERS == ('uvicorn.access', 'uvicorn.error')
+    assert 'httpx' not in QUIET_LOGGERS
+    assert 'httpcore' not in QUIET_LOGGERS
+    assert 'google_genai.models' not in QUIET_LOGGERS
+    assert 'opentelemetry.exporter' not in QUIET_LOGGERS
 
 
 def test_configure_logging_mutes_quiet_loggers() -> None:

--- a/py/packages/genkit/tests/genkit/core/logger_test.py
+++ b/py/packages/genkit/tests/genkit/core/logger_test.py
@@ -53,6 +53,16 @@ def test_resolve_level() -> None:
         assert resolve_level() == logging.INFO
 
 
+def test_quiet_loggers_mute_afc_and_otel_hops_not_auth_precedence() -> None:
+    """AFC and OTel hop INFO are muted; auth-precedence on _api_client is not."""
+    assert 'google_genai.models' in QUIET_LOGGERS
+    assert 'opentelemetry.exporter' in QUIET_LOGGERS
+    assert 'opentelemetry.instrumentation' in QUIET_LOGGERS
+    assert 'google_genai' not in QUIET_LOGGERS
+    assert 'google_genai._api_client' not in QUIET_LOGGERS
+    assert 'google.genai' not in QUIET_LOGGERS
+
+
 def test_configure_logging_mutes_quiet_loggers() -> None:
     """Test that configure_logging sets QUIET_LOGGERS to WARNING in dev environment."""
     with (

--- a/py/packages/genkit/tests/genkit/core/trace/default_exporter_test.py
+++ b/py/packages/genkit/tests/genkit/core/trace/default_exporter_test.py
@@ -109,6 +109,18 @@ def test_init_telemetry_server_exporter_returns_none_when_url_not_set() -> None:
         assert exporter is None
 
 
+def test_init_telemetry_server_exporter_returns_none_when_url_is_invalid() -> None:
+    """A typo'd env var must not crash import — just skip the exporter."""
+    with (
+        mock.patch.dict(os.environ, {'GENKIT_TELEMETRY_SERVER': 'http://[::1:4033'}),
+        capture_logs() as entries,
+    ):
+        exporter = init_telemetry_server_exporter()
+
+    assert exporter is None
+    assert any('GENKIT_TELEMETRY_SERVER is not a valid URL' in str(e.get('event', '')) for e in entries)
+
+
 # =============================================================================
 # Tests for TraceServerExporter
 # =============================================================================
@@ -120,6 +132,18 @@ def test_telemetry_server_exporter_init_default_endpoint() -> None:
 
     assert exporter.telemetry_server_url == 'http://localhost:4000'
     assert exporter.telemetry_server_endpoint == '/api/traces'
+
+
+def test_telemetry_server_exporter_rejects_malformed_url() -> None:
+    """A typo'd IPv6 URL must fail on the caller thread, not kill the worker later."""
+    with pytest.raises(ValueError, match='invalid telemetry server URL'):
+        TraceServerExporter(telemetry_server_url='http://[::1:4033')
+
+
+def test_telemetry_server_exporter_strips_url_whitespace() -> None:
+    """A trailing newline in the env var is a common copy-paste, not a bad URL."""
+    exporter = TraceServerExporter(telemetry_server_url='  http://localhost:4000\n')
+    assert exporter.telemetry_server_url == 'http://localhost:4000'
 
 
 def test_telemetry_server_exporter_init_custom_endpoint() -> None:
@@ -287,6 +311,94 @@ def test_export_does_not_stall_on_hung_collector() -> None:
         release.set()
         assert exporter.force_flush(timeout_millis=2000) is True
         assert exporter.last_result == SpanExportResult.FAILURE
+
+
+def test_shutdown_does_not_wait_out_hung_post() -> None:
+    """Process exit must not sit on the full flush timeout for a wedged collector."""
+    started = threading.Event()
+    release = threading.Event()
+
+    def blocking_post(*_args: object, **_kwargs: object) -> MagicMock:
+        started.set()
+        release.wait(timeout=10)
+        return MagicMock()
+
+    with patch('genkit._core._trace._default_exporter.httpx.Client') as mock_client_class:
+        mock_client = MagicMock()
+        mock_client.post.side_effect = blocking_post
+        mock_client_class.return_value.__enter__ = MagicMock(return_value=mock_client)
+        mock_client_class.return_value.__exit__ = MagicMock(return_value=None)
+
+        exporter = TraceServerExporter(telemetry_server_url='http://127.0.0.1:9')
+        exporter.export([create_mock_span()])
+        assert started.wait(timeout=1)
+        t0 = time.perf_counter()
+        exporter.shutdown()
+        elapsed = time.perf_counter() - t0
+        assert elapsed < 5
+        assert exporter.stopped
+        release.set()
+
+
+def test_batch_stops_after_first_trace_failure() -> None:
+    """A transport failure drops the rest of the batch — one error line, not a retry storm."""
+    posts = {'n': 0}
+
+    def flaky_post(*_args: object, **_kwargs: object) -> MagicMock:
+        posts['n'] += 1
+        if posts['n'] == 1:
+            raise httpx.ConnectError('reset by peer')
+        return MagicMock()
+
+    with patch('genkit._core._trace._default_exporter.httpx.Client') as mock_client_class:
+        mock_client = MagicMock()
+        mock_client.post.side_effect = flaky_post
+        mock_client_class.return_value.__enter__ = MagicMock(return_value=mock_client)
+        mock_client_class.return_value.__exit__ = MagicMock(return_value=None)
+
+        exporter = TraceServerExporter(telemetry_server_url='http://localhost:4000')
+        with capture_logs() as entries:
+            exporter.export([
+                create_mock_span(trace_id=0xA, span_id=1),
+                create_mock_span(trace_id=0xB, span_id=2),
+            ])
+            assert exporter.force_flush(timeout_millis=2000) is True
+
+    assert posts['n'] == 1
+    errors = [e for e in entries if 'Failed to save trace' in str(e.get('event', ''))]
+    assert len(errors) == 1
+    assert format(0xA, '032x') in errors[0]['event']
+
+
+def test_worker_survives_unexpected_post_error() -> None:
+    """A non-transport exception must not kill the worker or swallow later traces."""
+    posts = {'n': 0}
+
+    def flaky_post(*_args: object, **_kwargs: object) -> MagicMock:
+        posts['n'] += 1
+        if posts['n'] == 1:
+            raise ValueError('not a transport error')
+        return MagicMock()
+
+    with patch('genkit._core._trace._default_exporter.httpx.Client') as mock_client_class:
+        mock_client = MagicMock()
+        mock_client.post.side_effect = flaky_post
+        mock_client_class.return_value.__enter__ = MagicMock(return_value=mock_client)
+        mock_client_class.return_value.__exit__ = MagicMock(return_value=None)
+
+        exporter = TraceServerExporter(telemetry_server_url='http://localhost:4000')
+        with capture_logs() as entries:
+            exporter.export([create_mock_span(trace_id=0xA)])
+            assert exporter.force_flush(timeout_millis=2000) is True
+            exporter.export([create_mock_span(trace_id=0xB)])
+            assert exporter.force_flush(timeout_millis=2000) is True
+
+    assert exporter.worker.is_alive()
+    assert posts['n'] == 2
+    assert exporter.last_result == SpanExportResult.SUCCESS
+    errors = [e for e in entries if 'Failed to save trace' in str(e.get('event', ''))]
+    assert len(errors) == 1
+    assert format(0xA, '032x') in errors[0]['event']
 
 
 def test_export_encode_bug_is_loud() -> None:

--- a/py/packages/genkit/tests/genkit/core/trace/default_exporter_test.py
+++ b/py/packages/genkit/tests/genkit/core/trace/default_exporter_test.py
@@ -23,13 +23,19 @@ This module tests:
     - init_telemetry_server_exporter: Initializes the telemetry server exporter
 """
 
+import json
 import os
+import threading
+import time
 from unittest import mock
 from unittest.mock import MagicMock, patch
 
+import httpx
+import pytest
 from opentelemetry import trace as trace_api
 from opentelemetry.sdk.trace import Event, ReadableSpan
 from opentelemetry.sdk.trace.export import BatchSpanProcessor, SpanExportResult
+from structlog.testing import capture_logs
 
 from genkit._core._environment import GENKIT_ENV, GenkitEnvironment
 from genkit._core._trace._default_exporter import (
@@ -128,19 +134,35 @@ def test_telemetry_server_exporter_init_custom_endpoint() -> None:
 
 
 def test_telemetry_server_exporter_force_flush_returns_true() -> None:
-    """Test that force_flush always returns True (no buffering)."""
+    """Test that force_flush returns True when the worker queue is empty."""
     exporter = TraceServerExporter(telemetry_server_url='http://localhost:4000')
 
     result = exporter.force_flush()
     assert result is True
 
 
-def test_telemetry_server_exporter_force_flush_ignores_timeout() -> None:
-    """Test that force_flush ignores the timeout parameter."""
-    exporter = TraceServerExporter(telemetry_server_url='http://localhost:4000')
+def test_telemetry_server_exporter_force_flush_respects_timeout() -> None:
+    """Test that force_flush can time out while a post is still in flight."""
+    started = threading.Event()
+    release = threading.Event()
 
-    result = exporter.force_flush(timeout_millis=1)
-    assert result is True
+    def blocking_post(*_args: object, **_kwargs: object) -> MagicMock:
+        started.set()
+        release.wait(timeout=5)
+        return MagicMock()
+
+    with patch('genkit._core._trace._default_exporter.httpx.Client') as mock_client_class:
+        mock_client = MagicMock()
+        mock_client.post.side_effect = blocking_post
+        mock_client_class.return_value.__enter__ = MagicMock(return_value=mock_client)
+        mock_client_class.return_value.__exit__ = MagicMock(return_value=None)
+
+        exporter = TraceServerExporter(telemetry_server_url='http://localhost:4000')
+        exporter.export([create_mock_span()])
+        assert started.wait(timeout=1)
+        assert exporter.force_flush(timeout_millis=20) is False
+        release.set()
+        assert exporter.force_flush(timeout_millis=2000) is True
 
 
 @patch('genkit._core._trace._default_exporter.httpx.Client')
@@ -158,31 +180,135 @@ def test_telemetry_server_exporter_export_sends_http_post(mock_client_class: Mag
 
     # Export
     result = exporter.export([mock_span])
+    assert exporter.force_flush(timeout_millis=2000) is True
 
     # Verify
     assert result == SpanExportResult.SUCCESS
     mock_client.post.assert_called_once()
+    mock_client_class.assert_called_with(timeout=None)
 
 
 @patch('genkit._core._trace._default_exporter.httpx.Client')
-def test_telemetry_server_exporter_export_multiple_spans(mock_client_class: MagicMock) -> None:
-    """Test that export sends HTTP POST for each span in the sequence."""
-    # Setup mock client
+def test_telemetry_server_exporter_export_groups_same_trace(mock_client_class: MagicMock) -> None:
+    """A batch of spans on one trace is one POST — BatchSpanProcessor flushes a whole flow."""
     mock_client = MagicMock()
     mock_client_class.return_value.__enter__ = MagicMock(return_value=mock_client)
     mock_client_class.return_value.__exit__ = MagicMock(return_value=None)
 
     exporter = TraceServerExporter(telemetry_server_url='http://localhost:4000')
+    root = create_mock_span(trace_id=0xABCD, span_id=1, name='root')
+    child_a = create_mock_span(trace_id=0xABCD, span_id=2, name='child-a')
+    child_b = create_mock_span(trace_id=0xABCD, span_id=3, name='child-b')
+    child_a.parent = root.context
+    child_b.parent = root.context
+    mock_spans = [root, child_a, child_b]
 
-    # Create multiple mock spans
-    mock_spans = [create_mock_span() for _ in range(3)]
-
-    # Export
     result = exporter.export(mock_spans)
+    assert exporter.force_flush(timeout_millis=2000) is True
 
-    # Verify
     assert result == SpanExportResult.SUCCESS
-    assert mock_client.post.call_count == 3
+    assert mock_client.post.call_count == 1
+    body = json.loads(mock_client.post.call_args.kwargs['content'])
+    assert body['traceId'] == format(0xABCD, '032x')
+    assert set(body['spans']) == {format(1, '016x'), format(2, '016x'), format(3, '016x')}
+    assert body['displayName'] == 'root'
+
+
+@patch('genkit._core._trace._default_exporter.httpx.Client')
+def test_telemetry_server_exporter_export_posts_once_per_trace(mock_client_class: MagicMock) -> None:
+    """Two traces in one batch are two POSTs, not one per span."""
+    mock_client = MagicMock()
+    mock_client_class.return_value.__enter__ = MagicMock(return_value=mock_client)
+    mock_client_class.return_value.__exit__ = MagicMock(return_value=None)
+
+    exporter = TraceServerExporter(telemetry_server_url='http://localhost:4000')
+    mock_spans = [
+        create_mock_span(trace_id=0xA, span_id=1),
+        create_mock_span(trace_id=0xA, span_id=2),
+        create_mock_span(trace_id=0xB, span_id=3),
+    ]
+
+    result = exporter.export(mock_spans)
+    assert exporter.force_flush(timeout_millis=2000) is True
+
+    assert result == SpanExportResult.SUCCESS
+    assert mock_client.post.call_count == 2
+    posted = {json.loads(c.kwargs['content'])['traceId'] for c in mock_client.post.call_args_list}
+    assert posted == {format(0xA, '032x'), format(0xB, '032x')}
+
+
+def test_export_transport_failure_logs_one_error_and_records_failure() -> None:
+    """A dead collector is one error line that names the trace — not a traceback."""
+    exporter = TraceServerExporter(telemetry_server_url='http://127.0.0.1:1')
+    mock_span = create_mock_span(trace_id=0xABCDEF)
+
+    with capture_logs() as entries:
+        started = time.perf_counter()
+        result = exporter.export([mock_span])
+        elapsed = time.perf_counter() - started
+        assert exporter.force_flush(timeout_millis=2000) is True
+
+    assert result == SpanExportResult.SUCCESS
+    assert elapsed < 0.5
+    assert exporter.last_result == SpanExportResult.FAILURE
+    errors = [e for e in entries if 'Failed to save trace' in str(e.get('event', ''))]
+    assert len(errors) == 1
+    event = errors[0]['event']
+    assert format(0xABCDEF, '032x') in event
+    assert 'Connection refused' in event or 'ConnectError' in event
+    assert 'exception' not in errors[0]
+    assert 'exc_info' not in errors[0]
+
+
+def test_export_does_not_stall_on_hung_collector() -> None:
+    """generate() must return while a collector that accept()s and never reads is still hanging."""
+    started = threading.Event()
+    release = threading.Event()
+
+    def blocking_post(*_args: object, **_kwargs: object) -> MagicMock:
+        started.set()
+        release.wait(timeout=5)
+        raise httpx.ConnectError('hung')
+
+    with patch('genkit._core._trace._default_exporter.httpx.Client') as mock_client_class:
+        mock_client = MagicMock()
+        mock_client.post.side_effect = blocking_post
+        mock_client_class.return_value.__enter__ = MagicMock(return_value=mock_client)
+        mock_client_class.return_value.__exit__ = MagicMock(return_value=None)
+
+        exporter = TraceServerExporter(telemetry_server_url='http://127.0.0.1:9')
+        t0 = time.perf_counter()
+        result = exporter.export([create_mock_span()])
+        elapsed = time.perf_counter() - t0
+
+        assert result == SpanExportResult.SUCCESS
+        assert elapsed < 0.5
+        assert started.wait(timeout=1)
+        release.set()
+        assert exporter.force_flush(timeout_millis=2000) is True
+        assert exporter.last_result == SpanExportResult.FAILURE
+
+
+def test_export_encode_bug_is_loud() -> None:
+    """A span that cannot serialize must raise — not become a quiet FAILURE."""
+    exporter = TraceServerExporter(telemetry_server_url='http://127.0.0.1:1')
+    mock_span = create_mock_span()
+    mock_span.context = None
+
+    with pytest.raises((AttributeError, TypeError)), capture_logs() as entries:
+        exporter.export([mock_span])
+
+    assert exporter.last_result == SpanExportResult.SUCCESS
+    assert not [e for e in entries if 'Failed to save trace' in str(e.get('event', ''))]
+
+
+def test_export_non_json_attribute_is_loud() -> None:
+    """A value httpx cannot JSON-encode must raise on the generate thread."""
+    exporter = TraceServerExporter(telemetry_server_url='http://127.0.0.1:1')
+    mock_span = create_mock_span(attributes={'bad': object()})
+
+    with pytest.raises(TypeError):
+        exporter.export([mock_span])
 
 
 # =============================================================================

--- a/py/packages/genkit/tests/genkit/core/trace/default_exporter_test.py
+++ b/py/packages/genkit/tests/genkit/core/trace/default_exporter_test.py
@@ -27,10 +27,10 @@ import json
 import os
 import threading
 import time
+import urllib.error
 from unittest import mock
 from unittest.mock import MagicMock, patch
 
-import httpx
 import pytest
 from opentelemetry import trace as trace_api
 from opentelemetry.sdk.trace import Event, ReadableSpan
@@ -172,17 +172,15 @@ def test_telemetry_server_exporter_force_flush_respects_timeout() -> None:
     started = threading.Event()
     release = threading.Event()
 
-    def blocking_post(*_args: object, **_kwargs: object) -> MagicMock:
+    def blocking_urlopen(*_args: object, **_kwargs: object) -> MagicMock:
         started.set()
         release.wait(timeout=5)
-        return MagicMock()
+        return mock_urlopen_response()
 
-    with patch('genkit._core._trace._default_exporter.httpx.Client') as mock_client_class:
-        mock_client = MagicMock()
-        mock_client.post.side_effect = blocking_post
-        mock_client_class.return_value.__enter__ = MagicMock(return_value=mock_client)
-        mock_client_class.return_value.__exit__ = MagicMock(return_value=None)
-
+    with patch(
+        'genkit._core._trace._default_exporter.urllib.request.urlopen',
+        side_effect=blocking_urlopen,
+    ):
         exporter = TraceServerExporter(telemetry_server_url='http://localhost:4000')
         exporter.export([create_mock_span()])
         assert started.wait(timeout=1)
@@ -191,35 +189,30 @@ def test_telemetry_server_exporter_force_flush_respects_timeout() -> None:
         assert exporter.force_flush(timeout_millis=2000) is True
 
 
-@patch('genkit._core._trace._default_exporter.httpx.Client')
-def test_telemetry_server_exporter_export_sends_http_post(mock_client_class: MagicMock) -> None:
+@patch('genkit._core._trace._default_exporter.urllib.request.urlopen')
+def test_telemetry_server_exporter_export_sends_http_post(mock_urlopen: MagicMock) -> None:
     """Test that export sends HTTP POST requests for each span."""
-    # Setup mock client
-    mock_client = MagicMock()
-    mock_client_class.return_value.__enter__ = MagicMock(return_value=mock_client)
-    mock_client_class.return_value.__exit__ = MagicMock(return_value=None)
+    mock_urlopen.return_value = mock_urlopen_response()
 
     exporter = TraceServerExporter(telemetry_server_url='http://localhost:4000')
 
-    # Create a mock span
     mock_span = create_mock_span()
 
-    # Export
     result = exporter.export([mock_span])
     assert exporter.force_flush(timeout_millis=2000) is True
 
-    # Verify
     assert result == SpanExportResult.SUCCESS
-    mock_client.post.assert_called_once()
-    mock_client_class.assert_called_with(timeout=EXPORT_TIMEOUT_SECONDS)
+    mock_urlopen.assert_called_once()
+    assert mock_urlopen.call_args.kwargs['timeout'] == EXPORT_TIMEOUT_SECONDS
+    request = mock_urlopen.call_args.args[0]
+    assert request.full_url.startswith('http://localhost:4000')
+    assert request.get_method() == 'POST'
 
 
-@patch('genkit._core._trace._default_exporter.httpx.Client')
-def test_telemetry_server_exporter_export_groups_same_trace(mock_client_class: MagicMock) -> None:
+@patch('genkit._core._trace._default_exporter.urllib.request.urlopen')
+def test_telemetry_server_exporter_export_groups_same_trace(mock_urlopen: MagicMock) -> None:
     """A batch of spans on one trace is one POST — BatchSpanProcessor flushes a whole flow."""
-    mock_client = MagicMock()
-    mock_client_class.return_value.__enter__ = MagicMock(return_value=mock_client)
-    mock_client_class.return_value.__exit__ = MagicMock(return_value=None)
+    mock_urlopen.return_value = mock_urlopen_response()
 
     exporter = TraceServerExporter(telemetry_server_url='http://localhost:4000')
     root = create_mock_span(trace_id=0xABCD, span_id=1, name='root')
@@ -233,19 +226,17 @@ def test_telemetry_server_exporter_export_groups_same_trace(mock_client_class: M
     assert exporter.force_flush(timeout_millis=2000) is True
 
     assert result == SpanExportResult.SUCCESS
-    assert mock_client.post.call_count == 1
-    body = json.loads(mock_client.post.call_args.kwargs['content'])
+    assert mock_urlopen.call_count == 1
+    body = json.loads(mock_urlopen.call_args.args[0].data)
     assert body['traceId'] == format(0xABCD, '032x')
     assert set(body['spans']) == {format(1, '016x'), format(2, '016x'), format(3, '016x')}
     assert body['displayName'] == 'root'
 
 
-@patch('genkit._core._trace._default_exporter.httpx.Client')
-def test_telemetry_server_exporter_export_posts_once_per_trace(mock_client_class: MagicMock) -> None:
+@patch('genkit._core._trace._default_exporter.urllib.request.urlopen')
+def test_telemetry_server_exporter_export_posts_once_per_trace(mock_urlopen: MagicMock) -> None:
     """Two traces in one batch are two POSTs, not one per span."""
-    mock_client = MagicMock()
-    mock_client_class.return_value.__enter__ = MagicMock(return_value=mock_client)
-    mock_client_class.return_value.__exit__ = MagicMock(return_value=None)
+    mock_urlopen.return_value = mock_urlopen_response()
 
     exporter = TraceServerExporter(telemetry_server_url='http://localhost:4000')
     mock_spans = [
@@ -258,8 +249,8 @@ def test_telemetry_server_exporter_export_posts_once_per_trace(mock_client_class
     assert exporter.force_flush(timeout_millis=2000) is True
 
     assert result == SpanExportResult.SUCCESS
-    assert mock_client.post.call_count == 2
-    posted = {json.loads(c.kwargs['content'])['traceId'] for c in mock_client.post.call_args_list}
+    assert mock_urlopen.call_count == 2
+    posted = {json.loads(c.args[0].data)['traceId'] for c in mock_urlopen.call_args_list}
     assert posted == {format(0xA, '032x'), format(0xB, '032x')}
 
 
@@ -281,7 +272,7 @@ def test_export_transport_failure_logs_one_error_and_records_failure() -> None:
     assert len(errors) == 1
     event = errors[0]['event']
     assert format(0xABCDEF, '032x') in event
-    assert 'Connection refused' in event or 'ConnectError' in event
+    assert 'Connection refused' in event or 'URLError' in event
     assert 'exception' not in errors[0]
     assert 'exc_info' not in errors[0]
 
@@ -291,17 +282,15 @@ def test_export_does_not_stall_on_hung_collector() -> None:
     started = threading.Event()
     release = threading.Event()
 
-    def blocking_post(*_args: object, **_kwargs: object) -> MagicMock:
+    def blocking_urlopen(*_args: object, **_kwargs: object) -> MagicMock:
         started.set()
         release.wait(timeout=5)
-        raise httpx.ConnectError('hung')
+        raise urllib.error.URLError('hung')
 
-    with patch('genkit._core._trace._default_exporter.httpx.Client') as mock_client_class:
-        mock_client = MagicMock()
-        mock_client.post.side_effect = blocking_post
-        mock_client_class.return_value.__enter__ = MagicMock(return_value=mock_client)
-        mock_client_class.return_value.__exit__ = MagicMock(return_value=None)
-
+    with patch(
+        'genkit._core._trace._default_exporter.urllib.request.urlopen',
+        side_effect=blocking_urlopen,
+    ):
         exporter = TraceServerExporter(telemetry_server_url='http://127.0.0.1:9')
         t0 = time.perf_counter()
         result = exporter.export([create_mock_span()])
@@ -320,17 +309,15 @@ def test_shutdown_does_not_wait_out_hung_post() -> None:
     started = threading.Event()
     release = threading.Event()
 
-    def blocking_post(*_args: object, **_kwargs: object) -> MagicMock:
+    def blocking_urlopen(*_args: object, **_kwargs: object) -> MagicMock:
         started.set()
         release.wait(timeout=10)
-        return MagicMock()
+        return mock_urlopen_response()
 
-    with patch('genkit._core._trace._default_exporter.httpx.Client') as mock_client_class:
-        mock_client = MagicMock()
-        mock_client.post.side_effect = blocking_post
-        mock_client_class.return_value.__enter__ = MagicMock(return_value=mock_client)
-        mock_client_class.return_value.__exit__ = MagicMock(return_value=None)
-
+    with patch(
+        'genkit._core._trace._default_exporter.urllib.request.urlopen',
+        side_effect=blocking_urlopen,
+    ):
         exporter = TraceServerExporter(telemetry_server_url='http://127.0.0.1:9')
         exporter.export([create_mock_span()])
         assert started.wait(timeout=1)
@@ -346,18 +333,16 @@ def test_batch_stops_after_first_trace_failure() -> None:
     """A transport failure drops the rest of the batch — one error line, not a retry storm."""
     posts = {'n': 0}
 
-    def flaky_post(*_args: object, **_kwargs: object) -> MagicMock:
+    def flaky_urlopen(*_args: object, **_kwargs: object) -> MagicMock:
         posts['n'] += 1
         if posts['n'] == 1:
-            raise httpx.ConnectError('reset by peer')
-        return MagicMock()
+            raise urllib.error.URLError('reset by peer')
+        return mock_urlopen_response()
 
-    with patch('genkit._core._trace._default_exporter.httpx.Client') as mock_client_class:
-        mock_client = MagicMock()
-        mock_client.post.side_effect = flaky_post
-        mock_client_class.return_value.__enter__ = MagicMock(return_value=mock_client)
-        mock_client_class.return_value.__exit__ = MagicMock(return_value=None)
-
+    with patch(
+        'genkit._core._trace._default_exporter.urllib.request.urlopen',
+        side_effect=flaky_urlopen,
+    ):
         exporter = TraceServerExporter(telemetry_server_url='http://localhost:4000')
         with capture_logs() as entries:
             exporter.export([
@@ -376,18 +361,16 @@ def test_worker_survives_unexpected_post_error() -> None:
     """A non-transport exception must not kill the worker or swallow later traces."""
     posts = {'n': 0}
 
-    def flaky_post(*_args: object, **_kwargs: object) -> MagicMock:
+    def flaky_urlopen(*_args: object, **_kwargs: object) -> MagicMock:
         posts['n'] += 1
         if posts['n'] == 1:
             raise ValueError('not a transport error')
-        return MagicMock()
+        return mock_urlopen_response()
 
-    with patch('genkit._core._trace._default_exporter.httpx.Client') as mock_client_class:
-        mock_client = MagicMock()
-        mock_client.post.side_effect = flaky_post
-        mock_client_class.return_value.__enter__ = MagicMock(return_value=mock_client)
-        mock_client_class.return_value.__exit__ = MagicMock(return_value=None)
-
+    with patch(
+        'genkit._core._trace._default_exporter.urllib.request.urlopen',
+        side_effect=flaky_urlopen,
+    ):
         exporter = TraceServerExporter(telemetry_server_url='http://localhost:4000')
         with capture_logs() as entries:
             exporter.export([create_mock_span(trace_id=0xA)])
@@ -417,7 +400,7 @@ def test_export_encode_bug_is_loud() -> None:
 
 
 def test_export_non_json_attribute_is_loud() -> None:
-    """A value httpx cannot JSON-encode must raise on the generate thread."""
+    """A value that cannot JSON-encode must raise on the generate thread."""
     exporter = TraceServerExporter(telemetry_server_url='http://127.0.0.1:1')
     mock_span = create_mock_span(attributes={'bad': object()})
 
@@ -594,6 +577,16 @@ def test_extract_span_data_includes_exception_time_events() -> None:
 # =============================================================================
 # Helper functions
 # =============================================================================
+
+
+def mock_urlopen_response() -> MagicMock:
+    """A urlopen() context manager that drains like a successful POST."""
+    response = MagicMock()
+    response.read.return_value = b''
+    context = MagicMock()
+    context.__enter__.return_value = response
+    context.__exit__.return_value = None
+    return context
 
 
 def create_mock_span(

--- a/py/packages/genkit/tests/genkit/core/trace/default_exporter_test.py
+++ b/py/packages/genkit/tests/genkit/core/trace/default_exporter_test.py
@@ -408,7 +408,7 @@ def test_export_encode_bug_is_loud() -> None:
     mock_span = create_mock_span()
     mock_span.context = None
 
-    with pytest.raises((AttributeError, TypeError)), capture_logs() as entries:
+    with pytest.raises(TypeError, match='span context is required'), capture_logs() as entries:
         exporter.export([mock_span])
 
     assert exporter.last_result == SpanExportResult.SUCCESS
@@ -429,6 +429,14 @@ def test_export_non_json_attribute_is_loud() -> None:
 # =============================================================================
 
 
+def test_extract_span_data_requires_context() -> None:
+    """A span without context is a TypeError, not an AttributeError inside format()."""
+    mock_span = create_mock_span()
+    mock_span.context = None
+    with pytest.raises(TypeError, match='span context is required'):
+        extract_span_data(mock_span)
+
+
 def test_extract_span_data_basic_fields() -> None:
     """Test that extract_span_data extracts basic span fields correctly."""
     mock_span = create_mock_span(
@@ -444,16 +452,15 @@ def test_extract_span_data_basic_fields() -> None:
     trace_id_hex = format(12345, '032x')
     span_id_hex = format(67890, '016x')
 
-    assert data['traceId'] == trace_id_hex
-    assert 'spans' in data
-    assert span_id_hex in data['spans']
+    assert data.trace_id == trace_id_hex
+    assert span_id_hex in data.spans
 
-    span_info = data['spans'][span_id_hex]
-    assert span_info['spanId'] == span_id_hex
-    assert span_info['traceId'] == trace_id_hex
-    assert span_info['displayName'] == 'test-span'
-    assert span_info['startTime'] == 1000.0  # Converted to milliseconds
-    assert span_info['endTime'] == 2000.0  # Converted to milliseconds
+    span_info = data.spans[span_id_hex]
+    assert span_info.span_id == span_id_hex
+    assert span_info.trace_id == trace_id_hex
+    assert span_info.display_name == 'test-span'
+    assert span_info.start_time == 1000.0
+    assert span_info.end_time == 2000.0
 
 
 def test_extract_span_data_with_attributes() -> None:
@@ -463,8 +470,8 @@ def test_extract_span_data_with_attributes() -> None:
     data = extract_span_data(mock_span)
 
     span_id_hex = format(67890, '016x')
-    span_info = data['spans'][span_id_hex]
-    assert span_info['attributes'] == {'key1': 'value1', 'key2': 123}
+    span_info = data.spans[span_id_hex]
+    assert span_info.attributes == {'key1': 'value1', 'key2': 123}
 
 
 def test_extract_span_data_with_parent_span() -> None:
@@ -479,8 +486,8 @@ def test_extract_span_data_with_parent_span() -> None:
 
     span_id_hex = format(67890, '016x')
     parent_span_id_hex = format(11111, '016x')
-    span_info = data['spans'][span_id_hex]
-    assert span_info['parentSpanId'] == parent_span_id_hex
+    span_info = data.spans[span_id_hex]
+    assert span_info.parent_span_id == parent_span_id_hex
 
 
 def test_extract_span_data_without_parent_span() -> None:
@@ -491,11 +498,9 @@ def test_extract_span_data_without_parent_span() -> None:
     data = extract_span_data(mock_span)
 
     span_id_hex = format(67890, '016x')
-    span_info = data['spans'][span_id_hex]
-    assert 'parentSpanId' not in span_info
-
-    # Root span should have displayName, startTime, endTime at top level
-    assert data['displayName'] == 'test-span'
+    span_info = data.spans[span_id_hex]
+    assert span_info.parent_span_id is None
+    assert data.display_name == 'test-span'
 
 
 def test_extract_span_data_includes_status() -> None:
@@ -505,10 +510,10 @@ def test_extract_span_data_includes_status() -> None:
     data = extract_span_data(mock_span)
 
     span_id_hex = format(67890, '016x')
-    span_info = data['spans'][span_id_hex]
-    assert 'status' in span_info
-    assert span_info['status']['code'] == trace_api.StatusCode.OK.value  # OK status is 1
-    assert 'message' not in span_info['status']
+    span_info = data.spans[span_id_hex]
+    assert span_info.status is not None
+    assert span_info.status.code == trace_api.StatusCode.OK.value
+    assert span_info.status.message is None
 
 
 def test_extract_span_data_includes_instrumentation_library() -> None:
@@ -518,11 +523,9 @@ def test_extract_span_data_includes_instrumentation_library() -> None:
     data = extract_span_data(mock_span)
 
     span_id_hex = format(67890, '016x')
-    span_info = data['spans'][span_id_hex]
-    assert span_info['instrumentationLibrary'] == {
-        'name': 'genkit-tracer',
-        'version': 'v1',
-    }
+    span_info = data.spans[span_id_hex]
+    assert span_info.instrumentation_library.name == 'genkit-tracer'
+    assert span_info.instrumentation_library.version == 'v1'
 
 
 def test_extract_span_data_handles_none_times() -> None:
@@ -532,9 +535,9 @@ def test_extract_span_data_handles_none_times() -> None:
     data = extract_span_data(mock_span)
 
     span_id_hex = format(67890, '016x')
-    span_info = data['spans'][span_id_hex]
-    assert span_info['startTime'] == 0
-    assert span_info['endTime'] == 0
+    span_info = data.spans[span_id_hex]
+    assert span_info.start_time == 0
+    assert span_info.end_time == 0
 
 
 def test_extract_span_data_ensures_exception_message_from_status_when_events_empty() -> None:
@@ -548,12 +551,13 @@ def test_extract_span_data_ensures_exception_message_from_status_when_events_emp
 
     data = extract_span_data(mock_span)
     span_id_hex = format(67890, '016x')
-    span_info = data['spans'][span_id_hex]
-    assert span_info['status']['code'] == 2
-    assert span_info['status']['message'] == 'patched from status only'
-    te = span_info['timeEvents']['timeEvent']
-    assert len(te) == 1
-    assert te[0]['annotation']['attributes']['exception.message'] == 'patched from status only'
+    span_info = data.spans[span_id_hex]
+    assert span_info.status is not None
+    assert span_info.status.code == 2
+    assert span_info.status.message == 'patched from status only'
+    events = span_info.time_events.time_event
+    assert len(events) == 1
+    assert events[0].annotation.attributes['exception.message'] == 'patched from status only'
 
 
 def test_extract_span_data_includes_exception_time_events() -> None:
@@ -573,13 +577,12 @@ def test_extract_span_data_includes_exception_time_events() -> None:
     data = extract_span_data(mock_span)
 
     span_id_hex = format(67890, '016x')
-    span_info = data['spans'][span_id_hex]
-    assert 'timeEvents' in span_info
-    te = span_info['timeEvents']['timeEvent']
-    assert len(te) == 1
-    assert te[0]['annotation']['description'] == 'exception'
-    assert te[0]['annotation']['attributes']['exception.message'] == exc_msg
-    assert te[0]['time'] == 1500.0
+    span_info = data.spans[span_id_hex]
+    events = span_info.time_events.time_event
+    assert len(events) == 1
+    assert events[0].annotation.description == 'exception'
+    assert events[0].annotation.attributes['exception.message'] == exc_msg
+    assert events[0].time == 1500.0
 
 
 # =============================================================================

--- a/py/packages/genkit/tests/genkit/core/trace/default_exporter_test.py
+++ b/py/packages/genkit/tests/genkit/core/trace/default_exporter_test.py
@@ -39,6 +39,7 @@ from structlog.testing import capture_logs
 
 from genkit._core._environment import GENKIT_ENV, GenkitEnvironment
 from genkit._core._trace._default_exporter import (
+    EXPORT_TIMEOUT_SECONDS,
     TraceServerExporter,
     create_span_processor,
     extract_span_data,
@@ -209,7 +210,7 @@ def test_telemetry_server_exporter_export_sends_http_post(mock_client_class: Mag
     # Verify
     assert result == SpanExportResult.SUCCESS
     mock_client.post.assert_called_once()
-    mock_client_class.assert_called_with(timeout=None)
+    mock_client_class.assert_called_with(timeout=EXPORT_TIMEOUT_SECONDS)
 
 
 @patch('genkit._core._trace._default_exporter.httpx.Client')

--- a/py/packages/genkit/tests/genkit/core/trace/default_exporter_test.py
+++ b/py/packages/genkit/tests/genkit/core/trace/default_exporter_test.py
@@ -142,6 +142,12 @@ def test_telemetry_server_exporter_rejects_malformed_url() -> None:
         TraceServerExporter(telemetry_server_url='http://[::1:4033')
 
 
+def test_telemetry_server_exporter_rejects_non_http_url() -> None:
+    """A websocket URL must fail at init, not as a missing Dev UI trace later."""
+    with pytest.raises(ValueError, match='invalid telemetry server URL'):
+        TraceServerExporter(telemetry_server_url='ws://localhost:4033')
+
+
 def test_telemetry_server_exporter_strips_url_whitespace() -> None:
     """A trailing newline in the env var is a common copy-paste, not a bad URL."""
     exporter = TraceServerExporter(telemetry_server_url='  http://localhost:4000\n')
@@ -399,13 +405,26 @@ def test_export_encode_bug_is_loud() -> None:
     assert not [e for e in entries if 'Failed to save trace' in str(e.get('event', ''))]
 
 
-def test_export_non_json_attribute_is_loud() -> None:
-    """A value that cannot JSON-encode must raise on the generate thread."""
-    exporter = TraceServerExporter(telemetry_server_url='http://127.0.0.1:1')
-    mock_span = create_mock_span(attributes={'bad': object()})
+@patch('genkit._core._trace._default_exporter.urllib.request.urlopen')
+def test_export_skips_non_json_attribute(mock_urlopen: MagicMock) -> None:
+    """A bytes attribute is dropped; generate() returns and the rest of the trace POSTs."""
+    mock_urlopen.return_value = mock_urlopen_response()
+    exporter = TraceServerExporter(telemetry_server_url='http://localhost:4000')
+    mock_span = create_mock_span(attributes={'ok': 'hi', 'payload': b'secret-bytes'})
 
-    with pytest.raises(TypeError):
-        exporter.export([mock_span])
+    with capture_logs() as entries:
+        result = exporter.export([mock_span])
+        assert exporter.force_flush(timeout_millis=2000) is True
+
+    assert result == SpanExportResult.SUCCESS
+    mock_urlopen.assert_called_once()
+    body = json.loads(mock_urlopen.call_args.args[0].data)
+    span_id = format(67890, '016x')
+    assert body['spans'][span_id]['attributes'] == {'ok': 'hi'}
+    skipped = [e for e in entries if 'skipped span attribute' in str(e.get('event', ''))]
+    assert len(skipped) == 1
+    assert "'payload'" in skipped[0]['event']
+    assert 'bytes' in skipped[0]['event']
 
 
 # =============================================================================
@@ -457,6 +476,22 @@ def test_extract_span_data_with_attributes() -> None:
     span_id_hex = format(67890, '016x')
     span_info = data.spans[span_id_hex]
     assert span_info.attributes == {'key1': 'value1', 'key2': 123}
+
+
+def test_extract_span_data_skips_non_json_attributes() -> None:
+    """A value json.dumps cannot store is dropped; neighbors stay on the document."""
+    mock_span = create_mock_span(
+        attributes={'ok': 'hi', 'payload': b'secret-bytes', 'also': object()},
+    )
+
+    with capture_logs() as entries:
+        data = extract_span_data(mock_span)
+
+    span_id_hex = format(67890, '016x')
+    assert data.spans[span_id_hex].attributes == {'ok': 'hi'}
+    skipped = [e['event'] for e in entries if 'skipped span attribute' in str(e.get('event', ''))]
+    assert any("'payload'" in event and 'bytes' in event for event in skipped)
+    assert any("'also'" in event and 'object' in event for event in skipped)
 
 
 def test_extract_span_data_with_parent_span() -> None:

--- a/py/packages/genkit/tests/genkit/core/trace/default_exporter_test.py
+++ b/py/packages/genkit/tests/genkit/core/trace/default_exporter_test.py
@@ -46,6 +46,7 @@ from genkit._core._trace._default_exporter import (
     init_telemetry_server_exporter,
 )
 from genkit._core._trace._realtime_processor import RealtimeSpanProcessor
+from genkit._core._typing import TraceData
 
 # =============================================================================
 # Tests for create_span_processor
@@ -449,6 +450,7 @@ def test_extract_span_data_basic_fields() -> None:
 
     data = extract_span_data(mock_span)
 
+    assert type(data) is TraceData
     trace_id_hex = format(12345, '032x')
     span_id_hex = format(67890, '016x')
 
@@ -555,7 +557,9 @@ def test_extract_span_data_ensures_exception_message_from_status_when_events_emp
     assert span_info.status is not None
     assert span_info.status.code == 2
     assert span_info.status.message == 'patched from status only'
+    assert span_info.time_events is not None
     events = span_info.time_events.time_event
+    assert events is not None
     assert len(events) == 1
     assert events[0].annotation.attributes['exception.message'] == 'patched from status only'
 
@@ -578,7 +582,9 @@ def test_extract_span_data_includes_exception_time_events() -> None:
 
     span_id_hex = format(67890, '016x')
     span_info = data.spans[span_id_hex]
+    assert span_info.time_events is not None
     events = span_info.time_events.time_event
+    assert events is not None
     assert len(events) == 1
     assert events[0].annotation.description == 'exception'
     assert events[0].annotation.attributes['exception.message'] == exc_msg

--- a/py/packages/genkit/tests/genkit/core/trace/realtime_processor_test.py
+++ b/py/packages/genkit/tests/genkit/core/trace/realtime_processor_test.py
@@ -23,6 +23,7 @@ they start and when they end, enabling real-time trace visualization.
 from collections.abc import Sequence
 from unittest.mock import MagicMock
 
+import pytest
 from opentelemetry.context import Context
 from opentelemetry.sdk.trace import ReadableSpan, Span
 from opentelemetry.sdk.trace.export import SpanExporter, SpanExportResult
@@ -154,6 +155,24 @@ def test_realtime_processor_on_start_with_parent_context() -> None:
     # Verify span was still exported
     assert len(exporter.exported_spans) == 1
     assert list(exporter.exported_spans[0]) == [mock_span]
+
+
+def test_realtime_processor_on_start_does_not_swallow_encode_bugs() -> None:
+    """A broken encoder must stay loud — on_start is not a quiet catch-all."""
+
+    class BrokenExporter(SpanExporter):
+        def export(self, spans: Sequence[ReadableSpan]) -> SpanExportResult:
+            raise TypeError('span context is None')
+
+        def shutdown(self) -> None:
+            return None
+
+        def force_flush(self, timeout_millis: int = 30000) -> bool:
+            return True
+
+    processor = RealtimeSpanProcessor(BrokenExporter())
+    with pytest.raises(TypeError, match='span context is None'):
+        processor.on_start(MagicMock(spec=Span))
 
 
 def test_realtime_processor_multiple_spans() -> None:

--- a/py/packages/genkit/tests/genkit/core/tracing_format_test.py
+++ b/py/packages/genkit/tests/genkit/core/tracing_format_test.py
@@ -1,0 +1,21 @@
+# Copyright 2026 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""LoggingInstrumentor must not rewrite the process log format."""
+
+from unittest.mock import MagicMock, patch
+
+from genkit._core._tracing import init_provider
+
+
+def test_init_provider_does_not_rewrite_log_format() -> None:
+    """The shared TTY stays as the process configured it — no trace_id= wall."""
+    instrumentor = MagicMock()
+    with (
+        patch('genkit._core._tracing.trace_api.get_tracer_provider', return_value=None),
+        patch('genkit._core._tracing.trace_api.set_tracer_provider'),
+        patch('genkit._core._tracing.LoggingInstrumentor', return_value=instrumentor),
+    ):
+        init_provider()
+
+    instrumentor.instrument.assert_called_once_with(set_logging_format=False)

--- a/py/scripts/schema_to_typing.py
+++ b/py/scripts/schema_to_typing.py
@@ -134,23 +134,29 @@ def _models_allowing_extra(schema: dict) -> set[str]:
 
 
 def _typed_map_aliases(defs: dict) -> dict[str, str]:
-    """Inline object schemas with typed scalar ``additionalProperties`` -> Python dict alias.
+    """Object schemas that are only a string-keyed map become a dict alias.
 
-    e.g. ``ReflectionRunActionParams.telemetryLabels``:
-      ``{type: object, additionalProperties: {type: string}}`` -> ``dict[str, str]``.
-
-    Emitting these as type aliases (mirroring ``Metadata`` / ``Custom``) keeps the
-    symbol exported and importable while letting callers pass plain Python dicts —
-    a class with no fields and ``extra='forbid'`` would reject every key on the
-    Dev UI's ``{'genkitx:ignore-trace': 'true'}`` payload.
+    The collector document stores attributes and the spans table as records; a
+    class with no fields and extra='forbid' would drop every key (Dev UI
+    labels, span ids). Scalar maps stay ``dict[str, str]``, open maps become
+    ``dict[str, Any]``, and a ``$ref`` value type becomes ``dict[str, ThatType]``.
     """
 
     result: dict[str, str] = {}
     for name, defn in defs.items():
         if not isinstance(defn, dict) or defn.get('type') != 'object':
             continue
+        if defn.get('properties'):
+            continue
         ap = defn.get('additionalProperties')
+        if ap is True or ap == {}:
+            result[name] = 'dict[str, Any]'
+            continue
         if not isinstance(ap, dict):
+            continue
+        ref = (ap.get('$ref') or '').split('/')[-1]
+        if ref:
+            result[name] = f'dict[str, {_output_name(ref)}]'
             continue
         ap_type = ap.get('type')
         if isinstance(ap_type, str) and ap_type in PRIM:


### PR DESCRIPTION
Under `genkit start`, the Python runtime shares one TTY with the CLI. A dead or hung telemetry collector used to dump `httpx` tracebacks into that terminal and stall `generate()`. `LoggingInstrumentor` also rewrote the process log format with `trace_id=` / `span_id=` on every line.

Traces stay best-effort for the Dev UI. `generate()` still returns if the collector is down or a span attribute cannot encode.

## Summary
- `TraceServerExporter` posts on a background worker. Spans are grouped by trace id (one POST per flow). `generate()` returns without waiting on collector I/O.
- Collector POSTs use `urllib`, so they never hit the process `httpx` logger. A live Dev UI gets traces with no `HTTP Request: POST …/api/traces` line.
- Export builds the collector `SpanData` / `TraceData` types and `json.dumps` on the caller thread. Record-only schema maps (`Attributes`, `Spans`) generate as dict aliases so that dump can hold span ids and labels. A value the collector cannot store is skipped with a warning; the rest of the document still POSTs and `generate()` still returns.
- 300s HTTP timeout for a slow local Dev UI; 2s shutdown flush so Ctrl-C / `atexit` does not sit on a wedged collector.
- Transport failures are one `Failed to save trace <id>: <error>` line, deduped per trace, no traceback.
- A typo'd `GENKIT_TELEMETRY_SERVER` (including `ws://`) fails on the caller thread at init, not as missing Dev UI traces later.
- `LoggingInstrumentor` is instrumented with `set_logging_format=False` so we do not stamp every library line with span ids.
- On a shared TTY (`GENKIT_ENV=dev`), reflection access loggers and `httpx` / `httpcore` are raised to WARNING. That hides our `__health` polls and httpx's `HTTP Request: … generateContent` on every Gemini hop. Collector POSTs are urllib, so this mute is not hiding our traces. `GENKIT_LOG=debug` turns them back on. We do not set OTel exporters or `google_genai.models` (AFC `AFC is enabled…` can still print; that belongs on the Google plugin).