### PR TITLE
feat(js/plugins/compat-oai): add OpenAI Responses transport and non-streaming runner

### DIFF
--- a/js/plugins/compat-oai/src/index.ts
+++ b/js/plugins/compat-oai/src/index.ts
@@ -46,6 +46,12 @@ export {
   type ModelRequestBuilder,
 } from './model.js';
 export {
+  ResponsesCommonConfigSchema,
+  compatOaiResponsesModelRef,
+  defineCompatOpenAIResponsesModel,
+  openAIResponsesModelRunner,
+} from './responses.js';
+export {
   TranslationConfigSchema,
   compatOaiTranslationModelRef,
   defineCompatOpenAITranslationModel,

--- a/js/plugins/compat-oai/src/model.ts
+++ b/js/plugins/compat-oai/src/model.ts
@@ -30,15 +30,13 @@ import {
   GenerationCommonConfigSchema,
   GenkitError,
   Message,
-  StatusName,
   modelRef,
   z,
-  type ErrorResponseMetadata,
 } from 'genkit';
 import { parsePartialJson } from 'genkit/extract';
 import type { ModelAction, ModelInfo, ToolDefinition } from 'genkit/model';
 import { model } from 'genkit/plugin';
-import OpenAI, { APIError } from 'openai';
+import OpenAI from 'openai';
 import type {
   ChatCompletion,
   ChatCompletionChunk,
@@ -52,20 +50,14 @@ import type {
   CompletionChoice,
 } from 'openai/resources/index.mjs';
 import { PluginOptions } from './index.js';
-import { maybeCreateRequestScopedOpenAIClient, toModelName } from './utils.js';
-
-/**
- * Parses a `Retry-After` header value into milliseconds.
- * Supports delay-seconds and HTTP-date formats (RFC 7231 §7.1.3).
- */
-function parseRetryAfterMs(value: string): number | undefined {
-  if (!value || !value.trim()) return undefined;
-  const seconds = Number(value);
-  if (!isNaN(seconds) && seconds >= 0) return seconds * 1000;
-  const date = new Date(value);
-  if (!isNaN(date.getTime())) return Math.max(0, date.getTime() - Date.now());
-  return undefined;
-}
+import {
+  extractDataFromBase64Url,
+  generateFilenameFromContentType,
+  isImageContentType,
+  maybeCreateRequestScopedOpenAIClient,
+  rethrowOpenAIError,
+  toModelName,
+} from './utils.js';
 
 const VisualDetailLevelSchema = z.enum(['auto', 'low', 'high']).optional();
 
@@ -113,56 +105,6 @@ export function toOpenAITool(tool: ToolDefinition): ChatCompletionTool {
       parameters: tool.inputSchema !== null ? tool.inputSchema : undefined,
     },
   };
-}
-
-/**
- * Checks if a content type is an image type.
- * @param contentType The content type to check.
- * @returns True if the content type is an image type.
- */
-function isImageContentType(contentType?: string): boolean {
-  if (!contentType) return false;
-  return contentType.startsWith('image/');
-}
-
-/**
- * Extracts the base64 data and content type from a data URL.
- * @param url The data URL to parse.
- * @returns The base64 data and content type, or null if invalid.
- */
-function extractDataFromBase64Url(url: string): {
-  data: string;
-  contentType: string;
-} | null {
-  const match = url.match(/^data:([^;]+);base64,(.+)$/);
-  return (
-    match && {
-      contentType: match[1],
-      data: match[2],
-    }
-  );
-}
-
-/**
- * Map of content types to file extensions.
- */
-const FILE_EXTENSIONS: Record<string, string> = {
-  'application/pdf': 'pdf',
-  'application/msword': 'doc',
-  'application/vnd.openxmlformats-officedocument.wordprocessingml.document':
-    'docx',
-  'text/plain': 'txt',
-  'text/csv': 'csv',
-};
-
-/**
- * Generates a filename from a content type.
- * @param contentType The content type.
- * @returns A filename with appropriate extension.
- */
-function generateFilenameFromContentType(contentType: string): string {
-  const ext = FILE_EXTENSIONS[contentType] || '';
-  return ext ? `file.${ext}` : 'file';
 }
 
 /**
@@ -578,8 +520,22 @@ export function toOpenAIRequestBody(
     version: modelVersion,
     tools: toolsFromConfig,
     apiKey,
+    // Selects the OpenAI transport; it is a plugin concept, and Chat
+    // Completions rejects unknown arguments, so it must never survive into the
+    // passthrough below.
+    transport,
     ...restOfConfig
   } = request.config ?? {};
+
+  // Silently ignoring the request would hand back a Chat Completions response
+  // to a caller who asked for something else. This builder is shared by every
+  // OpenAI-compatible provider, so the message stays provider-neutral.
+  if (transport === 'responses') {
+    throw new GenkitError({
+      status: 'INVALID_ARGUMENT',
+      message: `The 'responses' transport is not supported by ${modelVersion ?? modelName}; it is served over the Chat Completions API.`,
+    });
+  }
 
   const tools: ChatCompletionTool[] = request.tools?.map(toOpenAITool) ?? [];
   if (toolsFromConfig) {
@@ -716,43 +672,7 @@ export function openAIModelRunner(
         };
       }
     } catch (e) {
-      if (e instanceof APIError) {
-        let status: StatusName = 'UNKNOWN';
-        switch (e.status) {
-          case 429:
-            status = 'RESOURCE_EXHAUSTED';
-            break;
-          case 401:
-            status = 'UNAUTHENTICATED';
-            break;
-          case 403:
-            status = 'PERMISSION_DENIED';
-            break;
-          case 400:
-            status = 'INVALID_ARGUMENT';
-            break;
-          case 500:
-            status = 'INTERNAL';
-            break;
-          case 503:
-            status = 'UNAVAILABLE';
-            break;
-        }
-        const retryAfterHeader =
-          e.headers?.get?.('retry-after') ??
-          (e.headers as any)?.['retry-after'];
-        const retryAfterMs = retryAfterHeader
-          ? parseRetryAfterMs(retryAfterHeader)
-          : undefined;
-        const responseMetadata: ErrorResponseMetadata | undefined =
-          retryAfterMs !== undefined ? { retryAfterMs } : undefined;
-        throw new GenkitError({
-          status,
-          message: e.message,
-          responseMetadata,
-        });
-      }
-      throw e;
+      rethrowOpenAIError(e);
     }
   };
 }

--- a/js/plugins/compat-oai/src/openai/index.ts
+++ b/js/plugins/compat-oai/src/openai/index.ts
@@ -40,6 +40,8 @@ import {
 } from '../image.js';
 import { openAICompatible, PluginOptions } from '../index.js';
 import { defineCompatOpenAIModel } from '../model.js';
+import { defineCompatOpenAIResponsesModel } from '../responses.js';
+import { toModelName } from '../utils.js';
 import {
   gptImage1RequestBuilder,
   openAIImageModelRef,
@@ -54,6 +56,13 @@ import {
   openAIModelRef,
   SUPPORTED_GPT_MODELS,
 } from './gpt.js';
+import {
+  isResponsesOnlyModelName,
+  OpenAIResponsesConfigSchema,
+  openAIResponsesModelRef,
+  SUPPORTED_RESPONSES_MODELS,
+  type ResponsesOnlyModelName,
+} from './responses.js';
 import { openAITranscriptionModelRef, SUPPORTED_STT_MODELS } from './stt.js';
 import { openAISpeechModelRef, SUPPORTED_TTS_MODELS } from './tts.js';
 import {
@@ -115,6 +124,16 @@ function createResolver(pluginOptions: PluginOptions) {
         name: actionName,
       });
       return defineCompatOpenAITranscriptionModel({
+        name: modelRef.name,
+        client,
+        pluginOptions,
+        modelRef,
+      });
+    } else if (
+      isResponsesOnlyModelName(toModelName(actionName, pluginOptions.name))
+    ) {
+      const modelRef = openAIResponsesModelRef({ name: actionName });
+      return defineCompatOpenAIResponsesModel({
         name: modelRef.name,
         client,
         pluginOptions,
@@ -184,6 +203,15 @@ const listActions = async (client: OpenAI): Promise<ActionMetadata[]> => {
           info: modelRef.info,
           configSchema: modelRef.configSchema,
         });
+      } else if (isResponsesOnlyModelName(model.id)) {
+        const modelRef =
+          SUPPORTED_RESPONSES_MODELS[model.id] ??
+          openAIResponsesModelRef({ name: model.id });
+        return modelActionMetadata({
+          name: modelRef.name,
+          info: modelRef.info,
+          configSchema: modelRef.configSchema,
+        });
       } else {
         const modelRef =
           SUPPORTED_GPT_MODELS[model.id] ?? openAIModelRef({ name: model.id });
@@ -207,6 +235,16 @@ export function openAIPlugin(options?: OpenAIPluginOptions): GenkitPluginV2 {
       models.push(
         ...Object.values(SUPPORTED_GPT_MODELS).map((modelRef) =>
           defineCompatOpenAIModel({
+            name: modelRef.name,
+            client,
+            pluginOptions,
+            modelRef,
+          })
+        )
+      );
+      models.push(
+        ...Object.values(SUPPORTED_RESPONSES_MODELS).map((modelRef) =>
+          defineCompatOpenAIResponsesModel({
             name: modelRef.name,
             client,
             pluginOptions,
@@ -299,6 +337,10 @@ export type OpenAIPlugin = {
     config?: z.infer<typeof TranscriptionConfigSchema>
   ): ModelReference<typeof TranscriptionConfigSchema>;
   model(
+    name: ResponsesOnlyModelName,
+    config?: z.infer<typeof OpenAIResponsesConfigSchema>
+  ): ModelReference<typeof OpenAIResponsesConfigSchema>;
+  model(
     name:
       | keyof typeof SUPPORTED_GPT_MODELS
       | (`gpt-${string}` & {})
@@ -336,6 +378,12 @@ const model = ((name: string, config?: any): ModelReference<z.ZodTypeAny> => {
   }
   if (name.includes('transcribe')) {
     return openAITranscriptionModelRef({
+      name,
+      config,
+    });
+  }
+  if (isResponsesOnlyModelName(toModelName(name, 'openai'))) {
+    return openAIResponsesModelRef({
       name,
       config,
     });

--- a/js/plugins/compat-oai/src/openai/index.ts
+++ b/js/plugins/compat-oai/src/openai/index.ts
@@ -65,7 +65,15 @@ import {
 
 export type OpenAIPluginOptions = Omit<PluginOptions, 'name' | 'baseURL'>;
 
-const UNSUPPORTED_MODEL_MATCHERS = ['babbage', 'davinci', 'codex'];
+/**
+ * Model ids this plugin cannot serve: the legacy completion-only families,
+ * including the original `code-*` (codex) models.
+ *
+ * Anchored on the leading segment rather than matched as a bare substring so
+ * that current models whose names merely contain a legacy word - `gpt-5-codex`,
+ * `gpt-5.1-codex-max`, `codex-mini-latest` - stay listed.
+ */
+const UNSUPPORTED_MODEL_MATCHERS = [/babbage/, /davinci/, /^code-/];
 
 function createResolver(pluginOptions: PluginOptions) {
   return async (client: OpenAI, actionType: ActionType, actionName: string) => {
@@ -125,7 +133,7 @@ function createResolver(pluginOptions: PluginOptions) {
 }
 
 function filterOpenAiModels(model: OpenAI.Model): boolean {
-  return !UNSUPPORTED_MODEL_MATCHERS.some((m) => model.id.includes(m));
+  return !UNSUPPORTED_MODEL_MATCHERS.some((m) => m.test(model.id));
 }
 
 const listActions = async (client: OpenAI): Promise<ActionMetadata[]> => {

--- a/js/plugins/compat-oai/src/openai/responses.ts
+++ b/js/plugins/compat-oai/src/openai/responses.ts
@@ -1,0 +1,117 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { z } from 'genkit';
+import { ModelInfo, ModelReference } from 'genkit/model';
+import {
+  ResponsesCommonConfigSchema,
+  compatOaiResponsesModelRef,
+} from '../responses.js';
+
+/**
+ * Models OpenAI serves exclusively over `/v1/responses`, so they register on
+ * that transport because they have no other one.
+ *
+ * Hand-curated: no type in the pinned SDK enumerates this set, and the list is
+ * chased by this plugin the same way `SUPPORTED_GPT_MODELS` is. Deep-research
+ * and computer-use models belong on a background action rather than this
+ * synchronous runner and are deliberately absent.
+ */
+export const RESPONSES_ONLY_MODELS = [
+  'gpt-5-pro',
+  'gpt-5-codex',
+  'gpt-5.1-codex',
+  'gpt-5.1-codex-mini',
+  'gpt-5.1-codex-max',
+  'codex-mini-latest',
+  'o1-pro',
+  'o3-pro',
+] as const;
+
+type ResponsesOnlyBaseName = (typeof RESPONSES_ONLY_MODELS)[number];
+
+/**
+ * A model name served only over the Responses API: one of
+ * {@link RESPONSES_ONLY_MODELS} or any name extending one of them.
+ */
+export type ResponsesOnlyModelName =
+  | ResponsesOnlyBaseName
+  | (`${ResponsesOnlyBaseName}-${string}` & {});
+
+/**
+ * Checks whether a model name must be served over the Responses API.
+ *
+ * Any suffixed form of a curated base name matches, so `o3-pro-2025-06-10` and
+ * `gpt-5-pro-preview` route like `o3-pro` and `gpt-5-pro` rather than falling
+ * through to Chat Completions and failing with an opaque OpenAI 400. The bias
+ * is deliberate: a name extending one of these bases is near-certainly served
+ * on the same transport as the base, so unknown suffixes should fail toward the
+ * transport that works.
+ * @param name The bare model name, without the plugin namespace.
+ */
+export function isResponsesOnlyModelName(
+  name?: string
+): name is ResponsesOnlyModelName {
+  if (!name) return false;
+  return RESPONSES_ONLY_MODELS.some(
+    (base) => name === base || name.startsWith(`${base}-`)
+  );
+}
+
+/** OpenAI Responses API custom configuration schema. */
+export const OpenAIResponsesConfigSchema = ResponsesCommonConfigSchema.extend({
+  store: z.boolean().optional(),
+  transport: z.enum(['responses']).optional(),
+}).passthrough();
+
+const RESPONSES_MODEL_INFO: ModelInfo = {
+  supports: {
+    multiturn: true,
+    tools: false,
+    media: true,
+    systemRole: true,
+    output: ['text', 'json'],
+    // See GENERIC_RESPONSES_MODEL_INFO in responses.ts on why this is declared.
+    constrained: 'all',
+  },
+};
+
+/** OpenAI ModelRef helper for models served over the Responses API. */
+export function openAIResponsesModelRef(params: {
+  name: string;
+  info?: ModelInfo;
+  config?: any;
+}): ModelReference<typeof OpenAIResponsesConfigSchema> {
+  return compatOaiResponsesModelRef({
+    ...params,
+    info: params.info ?? RESPONSES_MODEL_INFO,
+    configSchema: OpenAIResponsesConfigSchema,
+    namespace: 'openai',
+  });
+}
+
+export const SUPPORTED_RESPONSES_MODELS = {
+  'gpt-5-pro': openAIResponsesModelRef({ name: 'gpt-5-pro' }),
+  'gpt-5-codex': openAIResponsesModelRef({ name: 'gpt-5-codex' }),
+  'gpt-5.1-codex': openAIResponsesModelRef({ name: 'gpt-5.1-codex' }),
+  'gpt-5.1-codex-mini': openAIResponsesModelRef({
+    name: 'gpt-5.1-codex-mini',
+  }),
+  'gpt-5.1-codex-max': openAIResponsesModelRef({ name: 'gpt-5.1-codex-max' }),
+  'codex-mini-latest': openAIResponsesModelRef({ name: 'codex-mini-latest' }),
+  'o1-pro': openAIResponsesModelRef({ name: 'o1-pro' }),
+  'o3-pro': openAIResponsesModelRef({ name: 'o3-pro' }),
+} as const;

--- a/js/plugins/compat-oai/src/openai/responses.ts
+++ b/js/plugins/compat-oai/src/openai/responses.ts
@@ -32,10 +32,14 @@ import {
  */
 export const RESPONSES_ONLY_MODELS = [
   'gpt-5-pro',
+  'gpt-5.2-pro',
+  'gpt-5.5-pro',
   'gpt-5-codex',
   'gpt-5.1-codex',
   'gpt-5.1-codex-mini',
   'gpt-5.1-codex-max',
+  'gpt-5.2-codex',
+  'gpt-5.3-codex',
   'codex-mini-latest',
   'o1-pro',
   'o3-pro',
@@ -105,12 +109,16 @@ export function openAIResponsesModelRef(params: {
 
 export const SUPPORTED_RESPONSES_MODELS = {
   'gpt-5-pro': openAIResponsesModelRef({ name: 'gpt-5-pro' }),
+  'gpt-5.2-pro': openAIResponsesModelRef({ name: 'gpt-5.2-pro' }),
+  'gpt-5.5-pro': openAIResponsesModelRef({ name: 'gpt-5.5-pro' }),
   'gpt-5-codex': openAIResponsesModelRef({ name: 'gpt-5-codex' }),
   'gpt-5.1-codex': openAIResponsesModelRef({ name: 'gpt-5.1-codex' }),
   'gpt-5.1-codex-mini': openAIResponsesModelRef({
     name: 'gpt-5.1-codex-mini',
   }),
   'gpt-5.1-codex-max': openAIResponsesModelRef({ name: 'gpt-5.1-codex-max' }),
+  'gpt-5.2-codex': openAIResponsesModelRef({ name: 'gpt-5.2-codex' }),
+  'gpt-5.3-codex': openAIResponsesModelRef({ name: 'gpt-5.3-codex' }),
   'codex-mini-latest': openAIResponsesModelRef({ name: 'codex-mini-latest' }),
   'o1-pro': openAIResponsesModelRef({ name: 'o1-pro' }),
   'o3-pro': openAIResponsesModelRef({ name: 'o3-pro' }),

--- a/js/plugins/compat-oai/src/responses.ts
+++ b/js/plugins/compat-oai/src/responses.ts
@@ -30,6 +30,7 @@ import {
   modelRef,
   z,
 } from 'genkit';
+import { parsePartialJson } from 'genkit/extract';
 import type { ModelAction, ModelInfo } from 'genkit/model';
 import { model } from 'genkit/plugin';
 import type OpenAI from 'openai';
@@ -311,12 +312,8 @@ function toFinishInfo(response: OpenAIResponse): {
       };
     case 'cancelled':
       return { finishReason: 'other', finishMessage: 'Response cancelled.' };
-    case 'failed':
-      return {
-        finishReason: 'other',
-        finishMessage: response.error?.message,
-      };
     default:
+      // 'failed' is unreachable: fromOpenAIResponse throws before mapping it.
       return { finishReason: 'unknown' };
   }
 }
@@ -329,6 +326,24 @@ function toFinishInfo(response: OpenAIResponse): {
 const TOOL_CALL_ITEM_TYPES = new Set(['function_call', 'custom_tool_call']);
 
 /**
+ * Best-effort conversion of json-mode output text into a data part. A response
+ * truncated by `max_output_tokens` or a content filter can end with partial
+ * JSON, which must surface through the finish reason rather than as a
+ * SyntaxError.
+ */
+function toJsonData(text: string): Part {
+  try {
+    return { data: JSON.parse(text) };
+  } catch {
+    try {
+      return { data: parsePartialJson(text) };
+    } catch {
+      return { text };
+    }
+  }
+}
+
+/**
  * Converts an OpenAI Response into Genkit response data.
  * @param response The Response to convert.
  * @param jsonMode Whether the response text is expected to be JSON.
@@ -339,12 +354,14 @@ export function fromOpenAIResponse(
   response: OpenAIResponse,
   jsonMode = false
 ): GenerateResponseData {
-  // A failed response carries its cause in `error` and nothing in `output`, so
-  // returning it as an empty completion would hide the reason entirely.
-  if (response.status === 'failed' && response.error) {
+  // Returning a failed response as an empty completion would hide the failure
+  // entirely: the message object is present, so genkit's validation passes.
+  if (response.status === 'failed') {
     throw new GenkitError({
       status: 'INTERNAL',
-      message: `OpenAI Responses API request failed (${response.error.code}): ${response.error.message}`,
+      message: response.error
+        ? `OpenAI Responses API request failed (${response.error.code}): ${response.error.message}`
+        : 'OpenAI Responses API request failed without an error payload.',
     });
   }
 
@@ -359,9 +376,7 @@ export function fromOpenAIResponse(
       for (const contentItem of item.content ?? []) {
         if (contentItem.type === 'output_text') {
           content.push(
-            jsonMode
-              ? { data: JSON.parse(contentItem.text) }
-              : { text: contentItem.text }
+            jsonMode ? toJsonData(contentItem.text) : { text: contentItem.text }
           );
         } else if (contentItem.type === 'refusal') {
           refused = true;

--- a/js/plugins/compat-oai/src/responses.ts
+++ b/js/plugins/compat-oai/src/responses.ts
@@ -1,0 +1,525 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type {
+  GenerateRequest,
+  GenerateResponseChunkData,
+  GenerateResponseData,
+  MessageData,
+  ModelReference,
+  Part,
+  StreamingCallback,
+} from 'genkit';
+import {
+  GenerationCommonConfigSchema,
+  GenkitError,
+  Message,
+  modelRef,
+  z,
+} from 'genkit';
+import type { ModelAction, ModelInfo } from 'genkit/model';
+import { model } from 'genkit/plugin';
+import type OpenAI from 'openai';
+import type {
+  Response as OpenAIResponse,
+  ResponseCreateParamsNonStreaming,
+  ResponseInput,
+  ResponseInputContent,
+} from 'openai/resources/responses/responses.mjs';
+import { PluginOptions } from './index.js';
+import {
+  extractDataFromBase64Url,
+  generateFilenameFromContentType,
+  isImageContentType,
+  maybeCreateRequestScopedOpenAIClient,
+  rethrowOpenAIError,
+  toModelName,
+} from './utils.js';
+
+type VisualDetailLevel = 'auto' | 'low' | 'high';
+
+/**
+ * Generation config shared by models served over the OpenAI Responses API.
+ *
+ * `topK` and `stopSequences` are omitted because the Responses API has no
+ * equivalent for either, so advertising them would offer fields that are
+ * silently dropped. The schema is otherwise narrower than the Responses request
+ * surface; anything not declared here still reaches the wire through the
+ * passthrough in {@link toOpenAIResponsesRequestBody}.
+ */
+export const ResponsesCommonConfigSchema = GenerationCommonConfigSchema.omit({
+  topK: true,
+  stopSequences: true,
+}).extend({
+  temperature: z.number().min(0).max(2).optional(),
+});
+
+/**
+ * Converts a Genkit Part into a Responses API input content item.
+ * @param part The Genkit Part to convert.
+ * @param visualDetailLevel The visual detail level to use for image parts.
+ * @returns The corresponding Responses API input content item.
+ * @throws GenkitError if the part cannot be represented as Responses API input.
+ */
+export function toOpenAIResponsesContent(
+  part: Part,
+  visualDetailLevel: VisualDetailLevel = 'auto'
+): ResponseInputContent {
+  if (part.text) {
+    return { type: 'input_text', text: part.text };
+  }
+  if (part.media) {
+    let contentType = part.media.contentType;
+    if (!contentType && part.media.url.startsWith('data:')) {
+      contentType = extractDataFromBase64Url(part.media.url)?.contentType;
+    }
+
+    // Media without a content type is treated as an image, preserving the
+    // behaviour of the Chat Completions converter for signed/remote URLs.
+    if (!contentType || isImageContentType(contentType)) {
+      return {
+        type: 'input_image',
+        detail: visualDetailLevel,
+        image_url: part.media.url,
+      };
+    }
+
+    if (part.media.url.startsWith('data:')) {
+      const extracted = extractDataFromBase64Url(part.media.url);
+      if (!extracted) {
+        throw new GenkitError({
+          status: 'INVALID_ARGUMENT',
+          message: `Invalid data URL format for media: ${part.media.url.substring(0, 50)}...`,
+        });
+      }
+      return {
+        type: 'input_file',
+        filename: generateFilenameFromContentType(extracted.contentType),
+        file_data: part.media.url,
+      };
+    }
+
+    throw new GenkitError({
+      status: 'INVALID_ARGUMENT',
+      message: `File URLs are not supported. Only base64-encoded files and image URLs are supported. Content type: ${contentType}`,
+    });
+  }
+  throw new GenkitError({
+    status: 'INVALID_ARGUMENT',
+    message: `Unsupported genkit part fields encountered for current message role: ${JSON.stringify(part)}.`,
+  });
+}
+
+/**
+ * Serializes a prior model turn into the text of an assistant input message.
+ *
+ * Structured output comes back as a `data` part carrying no text, so replaying
+ * only the turn's text would send an empty assistant message and lose the
+ * model's own previous answer.
+ * @param parts The content of the model message.
+ * @returns The assistant message text, empty when the turn carries nothing
+ * this transport can replay.
+ * @throws GenkitError if a part cannot be represented in assistant history.
+ */
+function fromModelTurn(parts: Part[]): string {
+  let text = '';
+  for (const part of parts) {
+    if (part.text !== undefined) {
+      text += part.text;
+    } else if (part.data !== undefined) {
+      text += JSON.stringify(part.data);
+    } else if (part.reasoning !== undefined) {
+      // Reasoning is replayed through the encrypted round-trip, which this
+      // slice does not implement; the plain summary adds nothing on its own.
+      continue;
+    } else {
+      throw new GenkitError({
+        status: 'INVALID_ARGUMENT',
+        message: `Unsupported genkit part fields encountered for current message role: ${JSON.stringify(part)}.`,
+      });
+    }
+  }
+  return text;
+}
+
+/**
+ * Converts Genkit messages into Responses API `input` items.
+ *
+ * System messages are hoisted into `instructions`, which is where the Responses
+ * API takes them; the remaining messages keep their order in `input`.
+ * @param messages The Genkit messages to convert.
+ * @param visualDetailLevel The visual detail level to use for image parts.
+ * @returns The `input` items and, when any system message was present, the
+ * joined `instructions` string.
+ */
+export function toOpenAIResponsesInput(
+  messages: MessageData[],
+  visualDetailLevel: VisualDetailLevel = 'auto'
+): { input: ResponseInput; instructions?: string } {
+  const input: ResponseInput = [];
+  const instructions: string[] = [];
+  for (const message of messages) {
+    const msg = new Message(message);
+    switch (message.role) {
+      case 'system':
+        if (msg.text) instructions.push(msg.text);
+        break;
+      case 'user':
+        input.push({
+          role: 'user',
+          content: msg.content.map((part) =>
+            toOpenAIResponsesContent(part, visualDetailLevel)
+          ),
+        });
+        break;
+      case 'model': {
+        // An assistant message with no content carries nothing and OpenAI
+        // rejects it, so a turn that reduces to nothing is left out entirely.
+        const content = fromModelTurn(msg.content);
+        if (content) input.push({ role: 'assistant', content });
+        break;
+      }
+      default:
+        throw new GenkitError({
+          status: 'UNIMPLEMENTED',
+          message: `role ${message.role} is not supported by the OpenAI Responses API transport.`,
+        });
+    }
+  }
+  return {
+    input,
+    instructions: instructions.length ? instructions.join('\n\n') : undefined,
+  };
+}
+
+/** Drops keys whose value is `undefined` so they never show up in traces. */
+function stripUndefined<T extends object>(value: T): T {
+  return Object.fromEntries(
+    Object.entries(value).filter(([, v]) => v !== undefined)
+  ) as T;
+}
+
+/**
+ * Converts a Genkit request into an OpenAI Responses API request body.
+ * @param modelName The name of the model to use.
+ * @param request The Genkit GenerateRequest to convert.
+ * @returns The Responses API request body.
+ */
+export function toOpenAIResponsesRequestBody(
+  modelName: string,
+  request: GenerateRequest
+): ResponseCreateParamsNonStreaming {
+  // Genkit only warns when a model declares `supports.tools: false`, so without
+  // this the tools would be dropped and the model would answer as if none had
+  // been offered.
+  if (request.tools?.length) {
+    throw new GenkitError({
+      status: 'INVALID_ARGUMENT',
+      message: `Tool calling is not yet supported on the OpenAI Responses API transport (model ${modelName}).`,
+    });
+  }
+
+  const { input, instructions } = toOpenAIResponsesInput(
+    request.messages,
+    request.config?.visualDetailLevel
+  );
+  const {
+    temperature,
+    maxOutputTokens: max_output_tokens,
+    topP: top_p,
+    topK, // the Responses API has no equivalent
+    stopSequences, // the Responses API has no equivalent
+    visualDetailLevel, // consumed while building the input items above
+    version: modelVersion,
+    store,
+    // Selects the OpenAI transport; it is a plugin concept, not a wire field.
+    transport,
+    apiKey,
+    ...restOfConfig
+  } = request.config ?? {};
+
+  if (transport !== undefined && transport !== 'responses') {
+    throw new GenkitError({
+      status: 'INVALID_ARGUMENT',
+      message: `Unsupported transport '${transport}'; this model is served over the Responses API.`,
+    });
+  }
+
+  const body: ResponseCreateParamsNonStreaming = {
+    model: modelVersion ?? modelName,
+    input,
+    instructions,
+    max_output_tokens,
+    temperature,
+    top_p,
+    // The Responses API retains requests and responses server-side by default;
+    // pinning it off matches the Chat Completions retention posture.
+    store: store ?? false,
+    ...restOfConfig,
+  };
+
+  const format = request.output?.format;
+  if (format === 'json') {
+    body.text = {
+      format: request.output?.schema
+        ? {
+            type: 'json_schema',
+            name: 'output',
+            schema: request.output.schema,
+          }
+        : { type: 'json_object' },
+    };
+  } else if (format === 'text') {
+    body.text = { format: { type: 'text' } };
+  }
+
+  return stripUndefined(body);
+}
+
+/**
+ * Maps the terminal state of a Response onto a Genkit finish reason, keeping
+ * whatever the API said about it as the finish message.
+ */
+function toFinishInfo(response: OpenAIResponse): {
+  finishReason: GenerateResponseData['finishReason'];
+  finishMessage?: string;
+} {
+  const reason = response.incomplete_details?.reason;
+  if (reason === 'max_output_tokens') return { finishReason: 'length' };
+  if (reason === 'content_filter') return { finishReason: 'blocked' };
+  switch (response.status) {
+    case undefined:
+    case 'completed':
+      return { finishReason: 'stop' };
+    case 'incomplete':
+      return {
+        finishReason: 'other',
+        finishMessage: `Response incomplete: ${reason ?? 'no reason given'}.`,
+      };
+    case 'cancelled':
+      return { finishReason: 'other', finishMessage: 'Response cancelled.' };
+    case 'failed':
+      return {
+        finishReason: 'other',
+        finishMessage: response.error?.message,
+      };
+    default:
+      return { finishReason: 'unknown' };
+  }
+}
+
+/**
+ * Output items asking the caller to run a tool. Genkit has no way to answer one
+ * on this transport yet, and dropping it would leave the caller with an empty
+ * response instead of an error.
+ */
+const TOOL_CALL_ITEM_TYPES = new Set(['function_call', 'custom_tool_call']);
+
+/**
+ * Converts an OpenAI Response into Genkit response data.
+ * @param response The Response to convert.
+ * @param jsonMode Whether the response text is expected to be JSON.
+ * @returns The converted Genkit GenerateResponseData object.
+ * @throws GenkitError if the response failed or asks for a tool call.
+ */
+export function fromOpenAIResponse(
+  response: OpenAIResponse,
+  jsonMode = false
+): GenerateResponseData {
+  // A failed response carries its cause in `error` and nothing in `output`, so
+  // returning it as an empty completion would hide the reason entirely.
+  if (response.status === 'failed' && response.error) {
+    throw new GenkitError({
+      status: 'INTERNAL',
+      message: `OpenAI Responses API request failed (${response.error.code}): ${response.error.message}`,
+    });
+  }
+
+  const content: Part[] = [];
+  let refused = false;
+  for (const item of response.output ?? []) {
+    if (item.type === 'reasoning') {
+      for (const summary of item.summary ?? []) {
+        if (summary.text) content.push({ reasoning: summary.text });
+      }
+    } else if (item.type === 'message') {
+      for (const contentItem of item.content ?? []) {
+        if (contentItem.type === 'output_text') {
+          content.push(
+            jsonMode
+              ? { data: JSON.parse(contentItem.text) }
+              : { text: contentItem.text }
+          );
+        } else if (contentItem.type === 'refusal') {
+          refused = true;
+          content.push({ text: contentItem.refusal });
+        }
+      }
+    } else if (TOOL_CALL_ITEM_TYPES.has(item.type)) {
+      throw new GenkitError({
+        status: 'UNIMPLEMENTED',
+        message: `Tool calling is not yet supported on the OpenAI Responses API transport; the model returned a '${item.type}' item.`,
+      });
+    }
+    // Records of tools OpenAI ran itself (`web_search_call`, `mcp_call`, ...);
+    // the caller-visible result arrives in the message item alongside them.
+  }
+
+  const finish = refused
+    ? { finishReason: 'blocked' as const }
+    : toFinishInfo(response);
+
+  return {
+    ...finish,
+    message: {
+      role: 'model',
+      content,
+    },
+    usage: {
+      inputTokens: response.usage?.input_tokens,
+      outputTokens: response.usage?.output_tokens,
+      totalTokens: response.usage?.total_tokens,
+    },
+    raw: response,
+  };
+}
+
+/**
+ * Creates the runner used by Genkit to interact with a model over the OpenAI
+ * Responses API.
+ * @param name The name of the model.
+ * @param defaultClient The OpenAI client instance.
+ * @param pluginOptions Options of the plugin that owns the model.
+ * @returns The runner that Genkit will call when the model is invoked.
+ */
+export function openAIResponsesModelRunner(
+  name: string,
+  defaultClient: OpenAI,
+  pluginOptions?: Omit<PluginOptions, 'apiKey'>
+) {
+  return async (
+    request: GenerateRequest,
+    options?: {
+      streamingRequested?: boolean;
+      sendChunk?: StreamingCallback<GenerateResponseChunkData>;
+      abortSignal?: AbortSignal;
+    }
+  ): Promise<GenerateResponseData> => {
+    const client = maybeCreateRequestScopedOpenAIClient(
+      pluginOptions,
+      request,
+      defaultClient
+    );
+    try {
+      const response = await client.responses.create(
+        toOpenAIResponsesRequestBody(name, request),
+        { signal: options?.abortSignal }
+      );
+      const converted = fromOpenAIResponse(
+        response,
+        request.output?.format === 'json'
+      );
+      // The Responses event protocol is not mapped yet, so a streaming caller
+      // gets the completed response delivered as a single chunk rather than
+      // nothing at all.
+      if (options?.streamingRequested && options.sendChunk) {
+        options.sendChunk({
+          index: 0,
+          content: converted.message?.content ?? [],
+        });
+      }
+      return converted;
+    } catch (e) {
+      rethrowOpenAIError(e);
+    }
+  };
+}
+
+/**
+ * Method to define a new Genkit Model that is served over the OpenAI Responses
+ * API.
+ *
+ * @param params An object containing parameters for defining the model.
+ * @param params.name The name of the model.
+ * @param params.client The OpenAI client instance.
+ * @param params.modelRef Optional reference to the model's configuration and
+ * custom options.
+ * @param params.pluginOptions Options of the plugin that owns the model.
+ * @returns the created {@link ModelAction}
+ */
+export function defineCompatOpenAIResponsesModel<
+  CustomOptions extends z.ZodTypeAny = z.ZodTypeAny,
+>(params: {
+  name: string;
+  client: OpenAI;
+  modelRef?: ModelReference<CustomOptions>;
+  pluginOptions?: PluginOptions;
+}): ModelAction {
+  const { name, client, pluginOptions, modelRef } = params;
+  const modelName = toModelName(name, pluginOptions?.name);
+  const actionName =
+    modelRef?.name ?? `${pluginOptions?.name ?? 'compat-oai'}/${modelName}`;
+
+  return model(
+    {
+      name: actionName,
+      ...modelRef?.info,
+      configSchema: modelRef?.configSchema,
+    },
+    openAIResponsesModelRunner(modelName, client, pluginOptions)
+  );
+}
+
+const GENERIC_RESPONSES_MODEL_INFO: ModelInfo = {
+  supports: {
+    multiturn: true,
+    media: true,
+    tools: false,
+    systemRole: true,
+    output: ['text', 'json'],
+    // Without this genkit wraps the model in simulateConstrainedGeneration,
+    // which strips output.schema and appends it to the prompt instead of
+    // letting the request carry `text.format`.
+    constrained: 'all',
+  },
+};
+
+/** ModelRef helper for models served over the OpenAI Responses API. */
+export function compatOaiResponsesModelRef<
+  CustomOptions extends z.ZodTypeAny = z.ZodTypeAny,
+>(params: {
+  name: string;
+  info?: ModelInfo;
+  configSchema?: CustomOptions;
+  config?: any;
+  namespace?: string;
+}): ModelReference<CustomOptions> {
+  const {
+    name,
+    info = GENERIC_RESPONSES_MODEL_INFO,
+    configSchema,
+    config = undefined,
+    namespace,
+  } = params;
+  return modelRef({
+    name,
+    configSchema:
+      configSchema ?? (ResponsesCommonConfigSchema as unknown as CustomOptions),
+    info,
+    config,
+    namespace,
+  });
+}

--- a/js/plugins/compat-oai/src/responses.ts
+++ b/js/plugins/compat-oai/src/responses.ts
@@ -298,9 +298,12 @@ export function toOpenAIResponsesRequestBody(
     ...restOfConfig,
   };
 
+  // Composed onto any raw `text` object from the passthrough (e.g. verbosity)
+  // rather than replacing it wholesale.
   const format = request.output?.format;
   if (format === 'json') {
     body.text = {
+      ...body.text,
       format: request.output?.schema
         ? {
             type: 'json_schema',
@@ -314,7 +317,7 @@ export function toOpenAIResponsesRequestBody(
         : { type: 'json_object' },
     };
   } else if (format === 'text') {
-    body.text = { format: { type: 'text' } };
+    body.text = { ...body.text, format: { type: 'text' } };
   }
 
   return stripUndefined(body);

--- a/js/plugins/compat-oai/src/responses.ts
+++ b/js/plugins/compat-oai/src/responses.ts
@@ -437,6 +437,8 @@ export function fromOpenAIResponse(
       inputTokens: response.usage?.input_tokens,
       outputTokens: response.usage?.output_tokens,
       totalTokens: response.usage?.total_tokens,
+      thoughtsTokens: response.usage?.output_tokens_details?.reasoning_tokens,
+      cachedContentTokens: response.usage?.input_tokens_details?.cached_tokens,
     },
     raw: response,
   };

--- a/js/plugins/compat-oai/src/responses.ts
+++ b/js/plugins/compat-oai/src/responses.ts
@@ -249,6 +249,8 @@ export function toOpenAIResponsesRequestBody(
     instructions: instructionsFromConfig,
     // Selects the OpenAI transport; it is a plugin concept, not a wire field.
     transport,
+    stream,
+    background,
     apiKey,
     ...restOfConfig
   } = request.config ?? {};
@@ -257,6 +259,22 @@ export function toOpenAIResponsesRequestBody(
     throw new GenkitError({
       status: 'INVALID_ARGUMENT',
       message: `Unsupported transport '${transport}'; this model is served over the Responses API.`,
+    });
+  }
+
+  // Either key through the passthrough would change the response envelope out
+  // from under this runner: a Stream or a queued response read as a completed
+  // one comes back as an empty message with a clean finish.
+  if (stream !== undefined) {
+    throw new GenkitError({
+      status: 'INVALID_ARGUMENT',
+      message: `'stream' is not a config option; use Genkit's streaming API (generateStream) instead.`,
+    });
+  }
+  if (background !== undefined) {
+    throw new GenkitError({
+      status: 'INVALID_ARGUMENT',
+      message: `Background responses are not supported.`,
     });
   }
 

--- a/js/plugins/compat-oai/src/responses.ts
+++ b/js/plugins/compat-oai/src/responses.ts
@@ -287,6 +287,10 @@ export function toOpenAIResponsesRequestBody(
         ? {
             type: 'json_schema',
             name: 'output',
+            // Unlike Chat Completions, the Responses API validates the schema
+            // under strict mode unless told otherwise, and genkit schemas are
+            // not authored for it (`additionalProperties: false` everywhere).
+            strict: false,
             schema: request.output.schema,
           }
         : { type: 'json_object' },

--- a/js/plugins/compat-oai/src/responses.ts
+++ b/js/plugins/compat-oai/src/responses.ts
@@ -246,6 +246,7 @@ export function toOpenAIResponsesRequestBody(
     visualDetailLevel, // consumed while building the input items above
     version: modelVersion,
     store,
+    instructions: instructionsFromConfig,
     // Selects the OpenAI transport; it is a plugin concept, not a wire field.
     transport,
     apiKey,
@@ -259,10 +260,17 @@ export function toOpenAIResponsesRequestBody(
     });
   }
 
+  // Joined rather than passed through: a passthrough `instructions` landing
+  // after the spread would silently discard every hoisted system message.
+  const mergedInstructions =
+    [instructions, instructionsFromConfig as string | undefined]
+      .filter(Boolean)
+      .join('\n\n') || undefined;
+
   const body: ResponseCreateParamsNonStreaming = {
     model: modelVersion ?? modelName,
     input,
-    instructions,
+    instructions: mergedInstructions,
     max_output_tokens,
     temperature,
     top_p,

--- a/js/plugins/compat-oai/src/utils.ts
+++ b/js/plugins/compat-oai/src/utils.ts
@@ -14,9 +14,14 @@
  * limitations under the License.
  */
 
-import { GenerateRequest } from 'genkit';
+import {
+  GenerateRequest,
+  GenkitError,
+  StatusName,
+  type ErrorResponseMetadata,
+} from 'genkit';
 import { EmbedRequest } from 'genkit/embedder';
-import OpenAI from 'openai';
+import OpenAI, { APIError } from 'openai';
 import { PluginOptions } from '.';
 
 /**
@@ -39,6 +44,114 @@ export function maybeCreateRequestScopedOpenAIClient(
     ...(pluginOptions ?? defaultClient['_options']),
     apiKey: requestApiKey,
   });
+}
+
+/**
+ * Parses a `Retry-After` header value into milliseconds.
+ * Supports delay-seconds and HTTP-date formats (RFC 7231 §7.1.3).
+ */
+function parseRetryAfterMs(value: string): number | undefined {
+  if (!value || !value.trim()) return undefined;
+  const seconds = Number(value);
+  if (!isNaN(seconds) && seconds >= 0) return seconds * 1000;
+  const date = new Date(value);
+  if (!isNaN(date.getTime())) return Math.max(0, date.getTime() - Date.now());
+  return undefined;
+}
+
+/**
+ * Rethrows an error raised by the OpenAI SDK. An `APIError` is converted into a
+ * {@link GenkitError} carrying the equivalent Genkit status and, when the
+ * response supplied one, a `retryAfterMs` hint. Anything else is rethrown
+ * untouched.
+ */
+export function rethrowOpenAIError(e: unknown): never {
+  if (e instanceof APIError) {
+    let status: StatusName = 'UNKNOWN';
+    switch (e.status) {
+      case 429:
+        status = 'RESOURCE_EXHAUSTED';
+        break;
+      case 401:
+        status = 'UNAUTHENTICATED';
+        break;
+      case 403:
+        status = 'PERMISSION_DENIED';
+        break;
+      case 400:
+        status = 'INVALID_ARGUMENT';
+        break;
+      case 500:
+        status = 'INTERNAL';
+        break;
+      case 503:
+        status = 'UNAVAILABLE';
+        break;
+    }
+    const retryAfterHeader =
+      e.headers?.get?.('retry-after') ?? (e.headers as any)?.['retry-after'];
+    const retryAfterMs = retryAfterHeader
+      ? parseRetryAfterMs(retryAfterHeader)
+      : undefined;
+    const responseMetadata: ErrorResponseMetadata | undefined =
+      retryAfterMs !== undefined ? { retryAfterMs } : undefined;
+    throw new GenkitError({
+      status,
+      message: e.message,
+      responseMetadata,
+    });
+  }
+  throw e;
+}
+
+/**
+ * Checks if a content type is an image type.
+ * @param contentType The content type to check.
+ * @returns True if the content type is an image type.
+ */
+export function isImageContentType(contentType?: string): boolean {
+  if (!contentType) return false;
+  return contentType.startsWith('image/');
+}
+
+/**
+ * Extracts the base64 data and content type from a data URL.
+ * @param url The data URL to parse.
+ * @returns The base64 data and content type, or null if invalid.
+ */
+export function extractDataFromBase64Url(url: string): {
+  data: string;
+  contentType: string;
+} | null {
+  const match = url.match(/^data:([^;]+);base64,(.+)$/);
+  return (
+    match && {
+      contentType: match[1],
+      data: match[2],
+    }
+  );
+}
+
+/**
+ * Map of content types to file extensions.
+ */
+const FILE_EXTENSIONS: Record<string, string> = {
+  'application/pdf': 'pdf',
+  'application/msword': 'doc',
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document':
+    'docx',
+  'text/plain': 'txt',
+  'text/csv': 'csv',
+};
+
+/**
+ * Generates a filename from a content type.
+ * @param contentType The content type.
+ * @returns A filename with appropriate extension.
+ */
+export function generateFilenameFromContentType(contentType: string): string {
+  const ext = FILE_EXTENSIONS[contentType] || '';
+  return ext ? `file.${ext}` : 'file';
 }
 
 /**

--- a/js/plugins/compat-oai/tests/compat_oai_test.ts
+++ b/js/plugins/compat-oai/tests/compat_oai_test.ts
@@ -1500,6 +1500,30 @@ describe('toOpenAiRequestBody', () => {
       },
     });
   });
+  it('never serializes the transport routing key', () => {
+    const request = {
+      messages: [{ role: 'user', content: [{ text: 'hello' }] }],
+      config: { transport: 'chat_completions' },
+    } as unknown as GenerateRequest;
+
+    const actualOutput = toOpenAIRequestBody('gpt-4o', request);
+
+    expect(actualOutput).not.toHaveProperty('transport');
+    expect(JSON.stringify(actualOutput)).not.toContain('transport');
+  });
+  it('rejects an opt-in to the responses transport', () => {
+    const request = {
+      messages: [{ role: 'user', content: [{ text: 'hello' }] }],
+      config: { transport: 'responses' },
+    } as unknown as GenerateRequest;
+
+    expect(() => toOpenAIRequestBody('gpt-4o', request)).toThrow(
+      expect.objectContaining({
+        status: 'INVALID_ARGUMENT',
+        message: expect.stringContaining('Chat Completions'),
+      })
+    );
+  });
 });
 
 describe('openAIModelRunner', () => {

--- a/js/plugins/compat-oai/tests/fake_openai_server.ts
+++ b/js/plugins/compat-oai/tests/fake_openai_server.ts
@@ -29,7 +29,11 @@ export class FakeOpenAIServer {
   private server: http.Server;
   private port: number = 0;
   private responses: MockResponse[] = [];
-  public requests: { headers: http.IncomingHttpHeaders; body: any }[] = [];
+  public requests: {
+    url?: string;
+    headers: http.IncomingHttpHeaders;
+    body: any;
+  }[] = [];
   private expectedApiKey?: string;
 
   constructor(expectedApiKey?: string) {
@@ -43,7 +47,11 @@ export class FakeOpenAIServer {
       await new Promise<void>((resolve) => req.on('end', resolve));
 
       const parsedBody = body ? JSON.parse(body) : {};
-      this.requests.push({ headers: req.headers, body: parsedBody });
+      this.requests.push({
+        url: req.url,
+        headers: req.headers,
+        body: parsedBody,
+      });
 
       if (this.expectedApiKey) {
         const authHeader = req.headers['authorization'];

--- a/js/plugins/compat-oai/tests/openai_responses_live_test.ts
+++ b/js/plugins/compat-oai/tests/openai_responses_live_test.ts
@@ -1,0 +1,78 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, test } from '@jest/globals';
+import OpenAI from 'openai';
+import { openAIResponsesModelRunner } from '../src/responses';
+
+/**
+ * Smoke tests against the real Responses API. They only run when
+ * `OPENAI_API_KEY` is set, so the suite stays green without credentials.
+ *
+ * `gpt-5-nano` stands in for the registered Responses-only models: it is served
+ * over the same endpoint with the same request and response shapes, at a
+ * fraction of the latency and cost of `gpt-5-pro`.
+ */
+const LIVE_MODEL = 'gpt-5-nano';
+const maybeDescribe = process.env.OPENAI_API_KEY ? describe : describe.skip;
+
+maybeDescribe('openAI responses live', () => {
+  const runner = () =>
+    openAIResponsesModelRunner(
+      LIVE_MODEL,
+      new OpenAI({ apiKey: process.env.OPENAI_API_KEY })
+    );
+
+  test('generates text', async () => {
+    const response = await runner()({
+      messages: [
+        { role: 'system', content: [{ text: 'Answer with one word.' }] },
+        {
+          role: 'user',
+          content: [{ text: 'What is the capital of France?' }],
+        },
+      ],
+      config: { maxOutputTokens: 2048 },
+    });
+
+    expect(response.finishReason).toBe('stop');
+    expect(response.message?.content.map((p) => p.text ?? '').join('')).toMatch(
+      /paris/i
+    );
+    expect(response.usage?.totalTokens).toBeGreaterThan(0);
+  }, 120_000);
+
+  test('honours a json output schema', async () => {
+    const response = await runner()({
+      messages: [{ role: 'user', content: [{ text: 'Name one colour.' }] }],
+      config: { maxOutputTokens: 2048 },
+      output: {
+        format: 'json',
+        schema: {
+          type: 'object',
+          properties: { colour: { type: 'string' } },
+          required: ['colour'],
+          additionalProperties: false,
+        },
+      },
+    });
+
+    const data = response.message?.content.find((p) => p.data)?.data as {
+      colour?: string;
+    };
+    expect(typeof data?.colour).toBe('string');
+  }, 120_000);
+});

--- a/js/plugins/compat-oai/tests/openai_responses_test.ts
+++ b/js/plugins/compat-oai/tests/openai_responses_test.ts
@@ -451,8 +451,33 @@ describe('fromOpenAIResponse', () => {
     expect(fromOpenAIResponse(response)).toStrictEqual({
       finishReason: 'stop',
       message: { role: 'model', content: [{ text: 'hello' }] },
-      usage: { inputTokens: 10, outputTokens: 4, totalTokens: 14 },
+      usage: {
+        inputTokens: 10,
+        outputTokens: 4,
+        totalTokens: 14,
+        thoughtsTokens: 0,
+        cachedContentTokens: 0,
+      },
       raw: response,
+    });
+  });
+
+  test('maps reasoning and cached token details into usage', () => {
+    const response = textResponse('hello');
+    response.usage = {
+      input_tokens: 10,
+      output_tokens: 20,
+      total_tokens: 30,
+      input_tokens_details: { cached_tokens: 4 },
+      output_tokens_details: { reasoning_tokens: 15 },
+    };
+
+    expect(fromOpenAIResponse(response).usage).toStrictEqual({
+      inputTokens: 10,
+      outputTokens: 20,
+      totalTokens: 30,
+      thoughtsTokens: 15,
+      cachedContentTokens: 4,
     });
   });
 

--- a/js/plugins/compat-oai/tests/openai_responses_test.ts
+++ b/js/plugins/compat-oai/tests/openai_responses_test.ts
@@ -1,0 +1,842 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  afterAll,
+  beforeAll,
+  describe,
+  expect,
+  jest,
+  test,
+} from '@jest/globals';
+import { genkit, z, type GenerateRequest } from 'genkit';
+import type { ModelAction } from 'genkit/model';
+import OpenAI, { APIError } from 'openai';
+import type { Response as OpenAIResponse } from 'openai/resources/responses/responses.mjs';
+import { openAIModelRunner } from '../src/model';
+import { openAI } from '../src/openai/index';
+import {
+  RESPONSES_ONLY_MODELS,
+  isResponsesOnlyModelName,
+  openAIResponsesModelRef,
+} from '../src/openai/responses';
+import {
+  defineCompatOpenAIResponsesModel,
+  fromOpenAIResponse,
+  openAIResponsesModelRunner,
+  toOpenAIResponsesRequestBody,
+} from '../src/responses';
+import { FakeOpenAIServer } from './fake_openai_server';
+
+/** Builds a minimal Response object with the given output items. */
+function fakeResponse(overrides: Partial<OpenAIResponse> = {}): OpenAIResponse {
+  return {
+    id: 'resp_1',
+    created_at: 0,
+    output_text: '',
+    error: null,
+    incomplete_details: null,
+    instructions: null,
+    metadata: null,
+    model: 'gpt-5-pro',
+    object: 'response',
+    output: [],
+    parallel_tool_calls: false,
+    temperature: null,
+    tool_choice: 'auto',
+    tools: [],
+    top_p: null,
+    status: 'completed',
+    ...overrides,
+  };
+}
+
+/** Builds a Response whose only output item is an assistant text message. */
+function textResponse(text: string): OpenAIResponse {
+  return fakeResponse({
+    output: [
+      {
+        id: 'msg_1',
+        type: 'message',
+        role: 'assistant',
+        status: 'completed',
+        content: [{ type: 'output_text', text, annotations: [] }],
+      },
+    ],
+  });
+}
+
+describe('isResponsesOnlyModelName', () => {
+  test('matches every curated base name exactly', () => {
+    for (const name of RESPONSES_ONLY_MODELS) {
+      expect(isResponsesOnlyModelName(name)).toBe(true);
+    }
+  });
+
+  test('matches any suffixed form of a base name', () => {
+    expect(isResponsesOnlyModelName('o3-pro-2025-06-10')).toBe(true);
+    expect(isResponsesOnlyModelName('gpt-5-pro-2025-10-06')).toBe(true);
+    expect(isResponsesOnlyModelName('gpt-5.1-codex-max-2026-01-01')).toBe(true);
+    expect(isResponsesOnlyModelName('gpt-5-pro-preview')).toBe(true);
+    expect(isResponsesOnlyModelName('o3-pro-anything')).toBe(true);
+  });
+
+  test('does not match dual-transport or unrelated models', () => {
+    expect(isResponsesOnlyModelName('gpt-5')).toBe(false);
+    expect(isResponsesOnlyModelName('o3')).toBe(false);
+    expect(isResponsesOnlyModelName('o3-mini')).toBe(false);
+    expect(isResponsesOnlyModelName('o1')).toBe(false);
+    expect(isResponsesOnlyModelName('gpt-5-mini')).toBe(false);
+    expect(isResponsesOnlyModelName('gpt-5.1')).toBe(false);
+    expect(isResponsesOnlyModelName('gpt-4o')).toBe(false);
+    expect(isResponsesOnlyModelName('')).toBe(false);
+    expect(isResponsesOnlyModelName(undefined)).toBe(false);
+  });
+
+  test('covers the codex models the model filter now lets through', () => {
+    expect(isResponsesOnlyModelName('codex-mini-latest')).toBe(true);
+    expect(isResponsesOnlyModelName('gpt-5-codex')).toBe(true);
+    expect(isResponsesOnlyModelName('gpt-5.1-codex')).toBe(true);
+    expect(isResponsesOnlyModelName('gpt-5.1-codex-mini')).toBe(true);
+    expect(isResponsesOnlyModelName('gpt-5.1-codex-max')).toBe(true);
+  });
+});
+
+describe('toOpenAIResponsesRequestBody', () => {
+  test('hoists system messages into instructions and keeps the rest as input', () => {
+    const body = toOpenAIResponsesRequestBody('gpt-5-pro', {
+      messages: [
+        { role: 'system', content: [{ text: 'be terse' }] },
+        { role: 'user', content: [{ text: 'hi' }] },
+        { role: 'model', content: [{ text: 'hello' }] },
+        { role: 'user', content: [{ text: 'bye' }] },
+      ],
+    });
+
+    expect(body.instructions).toBe('be terse');
+    expect(body.input).toStrictEqual([
+      { role: 'user', content: [{ type: 'input_text', text: 'hi' }] },
+      { role: 'assistant', content: 'hello' },
+      { role: 'user', content: [{ type: 'input_text', text: 'bye' }] },
+    ]);
+  });
+
+  test('replays a structured-output model turn instead of an empty message', () => {
+    const body = toOpenAIResponsesRequestBody('gpt-5-pro', {
+      messages: [
+        { role: 'user', content: [{ text: 'name a colour' }] },
+        { role: 'model', content: [{ data: { colour: 'blue' } }] },
+        { role: 'user', content: [{ text: 'another one' }] },
+      ],
+      output: { format: 'json' },
+    });
+
+    expect(body.input).toStrictEqual([
+      {
+        role: 'user',
+        content: [{ type: 'input_text', text: 'name a colour' }],
+      },
+      { role: 'assistant', content: '{"colour":"blue"}' },
+      { role: 'user', content: [{ type: 'input_text', text: 'another one' }] },
+    ]);
+  });
+
+  test('preserves order across a mixed text and data model turn', () => {
+    const body = toOpenAIResponsesRequestBody('gpt-5-pro', {
+      messages: [
+        {
+          role: 'model',
+          content: [
+            { text: 'here you go: ' },
+            { data: { colour: 'blue' } },
+            { text: ' (done)' },
+          ],
+        },
+      ],
+    });
+
+    expect(body.input).toStrictEqual([
+      {
+        role: 'assistant',
+        content: 'here you go: {"colour":"blue"} (done)',
+      },
+    ]);
+  });
+
+  test('skips reasoning parts in history and drops turns left empty', () => {
+    const body = toOpenAIResponsesRequestBody('gpt-5-pro', {
+      messages: [
+        {
+          role: 'model',
+          content: [{ reasoning: 'thinking' }, { text: 'answer' }],
+        },
+        { role: 'model', content: [{ reasoning: 'thinking harder' }] },
+      ],
+    });
+
+    expect(body.input).toStrictEqual([
+      { role: 'assistant', content: 'answer' },
+    ]);
+  });
+
+  test('rejects model-turn parts it cannot replay', () => {
+    expect(() =>
+      toOpenAIResponsesRequestBody('gpt-5-pro', {
+        messages: [
+          {
+            role: 'model',
+            content: [{ media: { url: 'https://example.com/cat.png' } }],
+          },
+        ],
+      })
+    ).toThrow(/Unsupported genkit part fields/);
+  });
+
+  test('joins multiple system messages and omits instructions when there are none', () => {
+    const withSystem = toOpenAIResponsesRequestBody('gpt-5-pro', {
+      messages: [
+        { role: 'system', content: [{ text: 'one' }] },
+        { role: 'system', content: [{ text: 'two' }] },
+      ],
+    });
+    expect(withSystem.instructions).toBe('one\n\ntwo');
+
+    const withoutSystem = toOpenAIResponsesRequestBody('gpt-5-pro', {
+      messages: [{ role: 'user', content: [{ text: 'hi' }] }],
+    });
+    expect(withoutSystem).not.toHaveProperty('instructions');
+  });
+
+  test('maps generation config onto Responses API field names', () => {
+    const body = toOpenAIResponsesRequestBody('gpt-5-pro', {
+      messages: [],
+      config: {
+        version: 'gpt-5-pro-2025-10-06',
+        temperature: 0.5,
+        topP: 0.9,
+        maxOutputTokens: 128,
+      },
+    });
+
+    expect(body).toStrictEqual({
+      model: 'gpt-5-pro-2025-10-06',
+      input: [],
+      max_output_tokens: 128,
+      temperature: 0.5,
+      top_p: 0.9,
+      store: false,
+    });
+  });
+
+  test('drops config keys the Responses API has no equivalent for', () => {
+    const body = toOpenAIResponsesRequestBody('gpt-5-pro', {
+      messages: [],
+      config: { topK: 3, stopSequences: ['stop'], visualDetailLevel: 'low' },
+    });
+
+    expect(body).not.toHaveProperty('topK');
+    expect(body).not.toHaveProperty('stopSequences');
+    expect(body).not.toHaveProperty('stop');
+    expect(body).not.toHaveProperty('visualDetailLevel');
+  });
+
+  test('never serializes the transport routing key', () => {
+    const body = toOpenAIResponsesRequestBody('gpt-5-pro', {
+      messages: [],
+      config: { transport: 'responses', apiKey: 'secret' },
+    });
+
+    expect(body).not.toHaveProperty('transport');
+    expect(body).not.toHaveProperty('apiKey');
+    expect(JSON.stringify(body)).not.toContain('transport');
+  });
+
+  test('rejects a transport this model cannot speak', () => {
+    expect(() =>
+      toOpenAIResponsesRequestBody('gpt-5-pro', {
+        messages: [],
+        config: { transport: 'chat_completions' },
+      })
+    ).toThrow(
+      expect.objectContaining({
+        status: 'INVALID_ARGUMENT',
+        message: expect.stringContaining('chat_completions'),
+      })
+    );
+  });
+
+  test('pins store to false unless the caller sets it', () => {
+    expect(
+      toOpenAIResponsesRequestBody('gpt-5-pro', { messages: [] }).store
+    ).toBe(false);
+    expect(
+      toOpenAIResponsesRequestBody('gpt-5-pro', {
+        messages: [],
+        config: { store: true },
+      }).store
+    ).toBe(true);
+  });
+
+  test('passes unrecognized config keys through to the body', () => {
+    const body = toOpenAIResponsesRequestBody('gpt-5-pro', {
+      messages: [],
+      config: {
+        reasoning: { effort: 'high' },
+        tools: [{ type: 'web_search_preview' }],
+      },
+    });
+
+    expect(body.reasoning).toStrictEqual({ effort: 'high' });
+    expect(body.tools).toStrictEqual([{ type: 'web_search_preview' }]);
+  });
+
+  test('maps json output with a schema onto text.format', () => {
+    const body = toOpenAIResponsesRequestBody('gpt-5-pro', {
+      messages: [],
+      output: {
+        format: 'json',
+        schema: { type: 'object', properties: { a: { type: 'string' } } },
+      },
+    });
+
+    expect(body.text).toStrictEqual({
+      format: {
+        type: 'json_schema',
+        name: 'output',
+        schema: { type: 'object', properties: { a: { type: 'string' } } },
+      },
+    });
+  });
+
+  test('maps schemaless json output onto json_object', () => {
+    const body = toOpenAIResponsesRequestBody('gpt-5-pro', {
+      messages: [],
+      output: { format: 'json' },
+    });
+
+    expect(body.text).toStrictEqual({ format: { type: 'json_object' } });
+  });
+
+  test('maps text output onto text.format', () => {
+    const body = toOpenAIResponsesRequestBody('gpt-5-pro', {
+      messages: [],
+      output: { format: 'text' },
+    });
+
+    expect(body.text).toStrictEqual({ format: { type: 'text' } });
+  });
+
+  test('converts media parts into Responses input content', () => {
+    const body = toOpenAIResponsesRequestBody('gpt-5-pro', {
+      messages: [
+        {
+          role: 'user',
+          content: [
+            { media: { url: 'https://example.com/cat.png' } },
+            {
+              media: {
+                url: 'data:application/pdf;base64,QUJD',
+                contentType: 'application/pdf',
+              },
+            },
+          ],
+        },
+      ],
+      config: { visualDetailLevel: 'high' },
+    });
+
+    expect(body.input).toStrictEqual([
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'input_image',
+            detail: 'high',
+            image_url: 'https://example.com/cat.png',
+          },
+          {
+            type: 'input_file',
+            filename: 'file.pdf',
+            file_data: 'data:application/pdf;base64,QUJD',
+          },
+        ],
+      },
+    ]);
+  });
+
+  test('rejects genkit tools rather than dropping them', () => {
+    expect(() =>
+      toOpenAIResponsesRequestBody('gpt-5-pro', {
+        messages: [],
+        tools: [{ name: 'lookup', description: 'looks things up' }],
+      })
+    ).toThrow(
+      expect.objectContaining({
+        status: 'INVALID_ARGUMENT',
+        message: expect.stringContaining('Tool calling is not yet supported'),
+      })
+    );
+  });
+
+  test('rejects roles the transport does not support yet', () => {
+    expect(() =>
+      toOpenAIResponsesRequestBody('gpt-5-pro', {
+        messages: [
+          {
+            role: 'tool',
+            content: [
+              { toolResponse: { name: 'f', ref: '1', output: 'done' } },
+            ],
+          },
+        ],
+      })
+    ).toThrow(/not supported by the OpenAI Responses API transport/);
+  });
+});
+
+describe('fromOpenAIResponse', () => {
+  test('converts output text, usage and finish reason', () => {
+    const response = textResponse('hello');
+    response.usage = {
+      input_tokens: 10,
+      output_tokens: 4,
+      total_tokens: 14,
+      input_tokens_details: { cached_tokens: 0 },
+      output_tokens_details: { reasoning_tokens: 0 },
+    };
+
+    expect(fromOpenAIResponse(response)).toStrictEqual({
+      finishReason: 'stop',
+      message: { role: 'model', content: [{ text: 'hello' }] },
+      usage: { inputTokens: 10, outputTokens: 4, totalTokens: 14 },
+      raw: response,
+    });
+  });
+
+  test('parses output text as data in json mode', () => {
+    const converted = fromOpenAIResponse(textResponse('{"a":1}'), true);
+    expect(converted.message?.content).toStrictEqual([{ data: { a: 1 } }]);
+  });
+
+  test('maps reasoning summaries to reasoning parts, preserving order', () => {
+    const response = fakeResponse({
+      output: [
+        {
+          id: 'rs_1',
+          type: 'reasoning',
+          summary: [
+            { type: 'summary_text', text: 'thinking' },
+            { type: 'summary_text', text: 'more' },
+          ],
+        },
+        {
+          id: 'msg_1',
+          type: 'message',
+          role: 'assistant',
+          status: 'completed',
+          content: [{ type: 'output_text', text: 'answer', annotations: [] }],
+        },
+      ],
+    });
+
+    expect(fromOpenAIResponse(response).message?.content).toStrictEqual([
+      { reasoning: 'thinking' },
+      { reasoning: 'more' },
+      { text: 'answer' },
+    ]);
+  });
+
+  test('maps a refusal to a blocked finish reason', () => {
+    const response = fakeResponse({
+      output: [
+        {
+          id: 'msg_1',
+          type: 'message',
+          role: 'assistant',
+          status: 'completed',
+          content: [{ type: 'refusal', refusal: 'I cannot help with that' }],
+        },
+      ],
+    });
+
+    const converted = fromOpenAIResponse(response);
+    expect(converted.finishReason).toBe('blocked');
+    expect(converted.message?.content).toStrictEqual([
+      { text: 'I cannot help with that' },
+    ]);
+  });
+
+  test('maps incomplete_details.reason to a finish reason', () => {
+    expect(
+      fromOpenAIResponse(
+        fakeResponse({
+          status: 'incomplete',
+          incomplete_details: { reason: 'max_output_tokens' },
+        })
+      ).finishReason
+    ).toBe('length');
+
+    expect(
+      fromOpenAIResponse(
+        fakeResponse({
+          status: 'incomplete',
+          incomplete_details: { reason: 'content_filter' },
+        })
+      ).finishReason
+    ).toBe('blocked');
+  });
+
+  test('rejects a response that asks for a tool call', () => {
+    const response = fakeResponse({
+      output: [
+        {
+          id: 'fc_1',
+          type: 'function_call',
+          call_id: 'call_1',
+          name: 'lookup',
+          arguments: '{}',
+        },
+      ],
+    });
+
+    expect(() => fromOpenAIResponse(response)).toThrow(
+      expect.objectContaining({
+        status: 'UNIMPLEMENTED',
+        message: expect.stringContaining('function_call'),
+      })
+    );
+  });
+
+  test('skips records of tools OpenAI ran itself', () => {
+    const response = fakeResponse({
+      output: [
+        { id: 'ws_1', type: 'web_search_call', status: 'completed' },
+        {
+          id: 'msg_1',
+          type: 'message',
+          role: 'assistant',
+          status: 'completed',
+          content: [{ type: 'output_text', text: 'searched', annotations: [] }],
+        },
+      ],
+    });
+
+    const converted = fromOpenAIResponse(response);
+    expect(converted.finishReason).toBe('stop');
+    expect(converted.message?.content).toStrictEqual([{ text: 'searched' }]);
+  });
+
+  test('maps non-terminal and failed statuses', () => {
+    expect(
+      fromOpenAIResponse(fakeResponse({ status: 'failed' })).finishReason
+    ).toBe('other');
+    expect(
+      fromOpenAIResponse(fakeResponse({ status: 'in_progress' })).finishReason
+    ).toBe('unknown');
+  });
+
+  test('surfaces the error of a failed response', () => {
+    const response = fakeResponse({
+      status: 'failed',
+      error: { code: 'server_error', message: 'upstream exploded' },
+    });
+
+    expect(() => fromOpenAIResponse(response)).toThrow(
+      expect.objectContaining({
+        status: 'INTERNAL',
+        message: expect.stringContaining('upstream exploded'),
+      })
+    );
+  });
+
+  test('explains a cancelled or unexplained incomplete response', () => {
+    expect(
+      fromOpenAIResponse(fakeResponse({ status: 'cancelled' })).finishMessage
+    ).toBe('Response cancelled.');
+
+    const incomplete = fromOpenAIResponse(
+      fakeResponse({ status: 'incomplete', incomplete_details: {} })
+    );
+    expect(incomplete.finishReason).toBe('other');
+    expect(incomplete.finishMessage).toBe(
+      'Response incomplete: no reason given.'
+    );
+  });
+});
+
+describe('openAIResponsesModelRunner', () => {
+  let server: FakeOpenAIServer;
+
+  beforeAll(async () => {
+    server = new FakeOpenAIServer();
+    await server.start();
+  });
+
+  afterAll(() => {
+    server.stop();
+  });
+
+  test('posts to the Responses endpoint with a stateless body', async () => {
+    server.setNextResponse({ body: textResponse('hi there') });
+    const client = new OpenAI({ apiKey: 'key', baseURL: server.baseUrl });
+    const runner = openAIResponsesModelRunner('gpt-5-pro', client);
+
+    const response = await runner({
+      messages: [{ role: 'user', content: [{ text: 'hi' }] }],
+    });
+
+    const request = server.requests[server.requests.length - 1];
+    expect(request.url).toBe('/v1/responses');
+    expect(request.body).toStrictEqual({
+      model: 'gpt-5-pro',
+      input: [{ role: 'user', content: [{ type: 'input_text', text: 'hi' }] }],
+      store: false,
+    });
+    expect(response.message?.content).toStrictEqual([{ text: 'hi there' }]);
+  });
+
+  test('delivers the completed response as a single chunk when streaming', async () => {
+    server.setNextResponse({ body: textResponse('streamed') });
+    const client = new OpenAI({ apiKey: 'key', baseURL: server.baseUrl });
+    const runner = openAIResponsesModelRunner('gpt-5-pro', client);
+    const sendChunk = jest.fn();
+
+    await runner(
+      { messages: [{ role: 'user', content: [{ text: 'hi' }] }] },
+      { streamingRequested: true, sendChunk }
+    );
+
+    expect(sendChunk).toHaveBeenCalledTimes(1);
+    expect(sendChunk).toHaveBeenCalledWith({
+      index: 0,
+      content: [{ text: 'streamed' }],
+    });
+  });
+
+  test('converts an APIError into a GenkitError', async () => {
+    const client = {
+      responses: {
+        create: jest.fn(async () => {
+          throw new APIError(
+            429,
+            { error: { message: 'Rate limit exceeded' } },
+            '',
+            {}
+          );
+        }),
+      },
+    };
+    const runner = openAIResponsesModelRunner(
+      'gpt-5-pro',
+      client as unknown as OpenAI
+    );
+
+    await expect(runner({ messages: [] })).rejects.toThrow(
+      expect.objectContaining({ status: 'RESOURCE_EXHAUSTED' })
+    );
+  });
+});
+
+describe('defineCompatOpenAIResponsesModel', () => {
+  test('declares the Responses model info and config schema', () => {
+    const action = defineCompatOpenAIResponsesModel({
+      name: 'openai/gpt-5-pro',
+      client: {} as OpenAI,
+      modelRef: openAIResponsesModelRef({ name: 'gpt-5-pro' }),
+    });
+
+    expect(action.__action.name).toBe('openai/gpt-5-pro');
+    expect(action.__action.metadata?.model.supports).toStrictEqual({
+      multiturn: true,
+      tools: false,
+      media: true,
+      systemRole: true,
+      output: ['text', 'json'],
+      constrained: 'all',
+    });
+  });
+});
+
+describe('openAI plugin routing', () => {
+  let server: FakeOpenAIServer;
+  let previousBaseUrl: string | undefined;
+
+  beforeAll(async () => {
+    server = new FakeOpenAIServer();
+    await server.start();
+    // The openAI plugin does not accept a baseURL, so the fake server is
+    // injected the way a user would point the SDK at a proxy.
+    previousBaseUrl = process.env.OPENAI_BASE_URL;
+    process.env.OPENAI_BASE_URL = server.baseUrl;
+  });
+
+  afterAll(() => {
+    if (previousBaseUrl === undefined) {
+      delete process.env.OPENAI_BASE_URL;
+    } else {
+      process.env.OPENAI_BASE_URL = previousBaseUrl;
+    }
+    server.stop();
+  });
+
+  test('resolves Responses-only names through the Responses runner', async () => {
+    const plugin = openAI({ apiKey: 'key' });
+    const action = await plugin.model('o3-pro-2025-06-10');
+
+    expect(action.__action.name).toBe('openai/o3-pro-2025-06-10');
+    expect(action.__action.metadata?.model.supports?.tools).toBe(false);
+  });
+
+  test('leaves dual-transport names on Chat Completions', async () => {
+    const plugin = openAI({ apiKey: 'key' });
+    const action = await plugin.model('gpt-5');
+
+    expect(action.__action.metadata?.model.supports?.tools).toBe(true);
+  });
+
+  test('gives Responses-only refs the transport-aware config schema', () => {
+    const ref = openAI.model('gpt-5-pro');
+    const keys = Object.keys(ref.configSchema!.shape);
+
+    expect(keys).toContain('transport');
+    expect(keys).toContain('store');
+    // Neither has a Responses API equivalent, so the schema must not offer them.
+    expect(keys).not.toContain('topK');
+    expect(keys).not.toContain('stopSequences');
+  });
+
+  test('registers every curated Responses-only model', async () => {
+    const plugin = openAI({ apiKey: 'key' });
+    const registered = (await plugin.init!()).map(
+      (action) => (action as ModelAction).__action.name
+    );
+
+    for (const name of RESPONSES_ONLY_MODELS) {
+      expect(registered).toContain(`openai/${name}`);
+    }
+  });
+
+  test('sends Responses-only models to the Responses endpoint', async () => {
+    const plugin = openAI({ apiKey: 'key' });
+    const action = await plugin.model('gpt-5-pro');
+    server.setNextResponse({ body: textResponse('ok') });
+
+    await action({ messages: [{ role: 'user', content: [{ text: 'hi' }] }] });
+
+    expect(server.requests[server.requests.length - 1].url).toBe(
+      '/v1/responses'
+    );
+  });
+
+  test('sends an output schema to the wire rather than into the prompt', async () => {
+    const ai = genkit({ plugins: [openAI({ apiKey: 'key' })] });
+    server.setNextResponse({ body: textResponse('{"colour":"blue"}') });
+
+    await ai.generate({
+      model: openAI.model('gpt-5-pro'),
+      prompt: 'pick one',
+      output: { schema: z.object({ colour: z.string() }) },
+    });
+
+    const sent = server.requests[server.requests.length - 1];
+    expect(sent.body.text.format.type).toBe('json_schema');
+    expect(sent.body.text.format.schema.properties).toHaveProperty('colour');
+    // Constrained generation is native here, so the schema must not have been
+    // simulated by appending it to the prompt.
+    expect(JSON.stringify(sent.body.input)).not.toContain('colour');
+  });
+
+  test('sends dual-transport models to the Chat Completions endpoint', async () => {
+    const plugin = openAI({ apiKey: 'key' });
+    const action = await plugin.model('gpt-4o');
+    server.setNextResponse({
+      body: {
+        choices: [
+          {
+            message: { role: 'assistant', content: 'ok' },
+            finish_reason: 'stop',
+          },
+        ],
+      },
+    });
+
+    await action({ messages: [{ role: 'user', content: [{ text: 'hi' }] }] });
+
+    expect(server.requests[server.requests.length - 1].url).toBe(
+      '/v1/chat/completions'
+    );
+  });
+
+  test('lists Responses-only models with the transport-aware config schema', async () => {
+    const plugin = openAI({ apiKey: 'key' });
+    server.setNextResponse({
+      body: {
+        object: 'list',
+        data: [
+          { id: 'gpt-5-pro', object: 'model', created: 0, owned_by: 'openai' },
+        ],
+      },
+    });
+
+    const [metadata] = await plugin.list!();
+
+    expect(metadata.name).toBe('openai/gpt-5-pro');
+    expect(metadata.metadata?.model.supports.tools).toBe(false);
+    expect(
+      Object.keys(metadata.metadata?.model.customOptions.properties)
+    ).toContain('transport');
+  });
+});
+
+describe('chat completions transport handling', () => {
+  let server: FakeOpenAIServer;
+
+  beforeAll(async () => {
+    server = new FakeOpenAIServer();
+    await server.start();
+  });
+
+  afterAll(() => {
+    server.stop();
+  });
+
+  test('transport never reaches the Chat Completions wire', async () => {
+    const client = new OpenAI({ apiKey: 'key', baseURL: server.baseUrl });
+    const runner = openAIModelRunner('gpt-4o', client);
+    const request: GenerateRequest = {
+      messages: [{ role: 'user', content: [{ text: 'hi' }] }],
+      config: { transport: 'chat_completions' },
+    };
+
+    await runner(request);
+
+    const sent = server.requests[server.requests.length - 1];
+    expect(sent.url).toBe('/v1/chat/completions');
+    expect(sent.body).not.toHaveProperty('transport');
+  });
+
+  test('rejects an opt-in to the responses transport', async () => {
+    const client = new OpenAI({ apiKey: 'key', baseURL: server.baseUrl });
+    const runner = openAIModelRunner('gpt-4o', client);
+
+    await expect(
+      runner({
+        messages: [{ role: 'user', content: [{ text: 'hi' }] }],
+        config: { transport: 'responses' },
+      })
+    ).rejects.toThrow(expect.objectContaining({ status: 'INVALID_ARGUMENT' }));
+  });
+});

--- a/js/plugins/compat-oai/tests/openai_responses_test.ts
+++ b/js/plugins/compat-oai/tests/openai_responses_test.ts
@@ -220,6 +220,24 @@ describe('toOpenAIResponsesRequestBody', () => {
     expect(withoutSystem).not.toHaveProperty('instructions');
   });
 
+  test('rejects stream in config instead of passing it to the wire', () => {
+    expect(() =>
+      toOpenAIResponsesRequestBody('gpt-5-pro', {
+        messages: [{ role: 'user', content: [{ text: 'hi' }] }],
+        config: { stream: true },
+      })
+    ).toThrow(expect.objectContaining({ status: 'INVALID_ARGUMENT' }));
+  });
+
+  test('rejects background in config instead of passing it to the wire', () => {
+    expect(() =>
+      toOpenAIResponsesRequestBody('gpt-5-pro', {
+        messages: [{ role: 'user', content: [{ text: 'hi' }] }],
+        config: { background: true },
+      })
+    ).toThrow(expect.objectContaining({ status: 'INVALID_ARGUMENT' }));
+  });
+
   test('joins config instructions with system messages instead of clobbering them', () => {
     const body = toOpenAIResponsesRequestBody('gpt-5-pro', {
       messages: [{ role: 'system', content: [{ text: 'You are X' }] }],

--- a/js/plugins/compat-oai/tests/openai_responses_test.ts
+++ b/js/plugins/compat-oai/tests/openai_responses_test.ts
@@ -325,6 +325,9 @@ describe('toOpenAIResponsesRequestBody', () => {
       format: {
         type: 'json_schema',
         name: 'output',
+        // The Responses API validates schemas under strict mode by default,
+        // which genkit schemas do not satisfy.
+        strict: false,
         schema: { type: 'object', properties: { a: { type: 'string' } } },
       },
     });

--- a/js/plugins/compat-oai/tests/openai_responses_test.ts
+++ b/js/plugins/compat-oai/tests/openai_responses_test.ts
@@ -220,6 +220,19 @@ describe('toOpenAIResponsesRequestBody', () => {
     expect(withoutSystem).not.toHaveProperty('instructions');
   });
 
+  test('composes the output format over a raw text config passthrough', () => {
+    const body = toOpenAIResponsesRequestBody('gpt-5-pro', {
+      messages: [{ role: 'user', content: [{ text: 'hi' }] }],
+      config: { text: { verbosity: 'low' } },
+      output: { format: 'json' },
+    });
+
+    expect(body.text).toStrictEqual({
+      verbosity: 'low',
+      format: { type: 'json_object' },
+    });
+  });
+
   test('rejects stream in config instead of passing it to the wire', () => {
     expect(() =>
       toOpenAIResponsesRequestBody('gpt-5-pro', {

--- a/js/plugins/compat-oai/tests/openai_responses_test.ts
+++ b/js/plugins/compat-oai/tests/openai_responses_test.ts
@@ -220,6 +220,15 @@ describe('toOpenAIResponsesRequestBody', () => {
     expect(withoutSystem).not.toHaveProperty('instructions');
   });
 
+  test('joins config instructions with system messages instead of clobbering them', () => {
+    const body = toOpenAIResponsesRequestBody('gpt-5-pro', {
+      messages: [{ role: 'system', content: [{ text: 'You are X' }] }],
+      config: { instructions: 'formatting hint' },
+    });
+
+    expect(body.instructions).toBe('You are X\n\nformatting hint');
+  });
+
   test('maps generation config onto Responses API field names', () => {
     const body = toOpenAIResponsesRequestBody('gpt-5-pro', {
       messages: [],

--- a/js/plugins/compat-oai/tests/openai_responses_test.ts
+++ b/js/plugins/compat-oai/tests/openai_responses_test.ts
@@ -539,13 +539,43 @@ describe('fromOpenAIResponse', () => {
     expect(converted.message?.content).toStrictEqual([{ text: 'searched' }]);
   });
 
-  test('maps non-terminal and failed statuses', () => {
-    expect(
-      fromOpenAIResponse(fakeResponse({ status: 'failed' })).finishReason
-    ).toBe('other');
+  test('maps non-terminal statuses', () => {
     expect(
       fromOpenAIResponse(fakeResponse({ status: 'in_progress' })).finishReason
     ).toBe('unknown');
+  });
+
+  test('rejects a failed response even without an error payload', () => {
+    expect(() =>
+      fromOpenAIResponse(fakeResponse({ status: 'failed' }))
+    ).toThrow(
+      expect.objectContaining({
+        status: 'INTERNAL',
+        message: expect.stringContaining('without an error payload'),
+      })
+    );
+  });
+
+  test('survives truncated json output and reports length', () => {
+    const response = fakeResponse({
+      status: 'incomplete',
+      incomplete_details: { reason: 'max_output_tokens' },
+      output: [
+        {
+          id: 'msg_1',
+          type: 'message',
+          role: 'assistant',
+          status: 'incomplete',
+          content: [
+            { type: 'output_text', text: '{"colour":', annotations: [] },
+          ],
+        },
+      ],
+    });
+
+    const converted = fromOpenAIResponse(response, true);
+    expect(converted.finishReason).toBe('length');
+    expect(converted.message?.content).toHaveLength(1);
   });
 
   test('surfaces the error of a failed response', () => {

--- a/js/plugins/compat-oai/tests/openai_test.ts
+++ b/js/plugins/compat-oai/tests/openai_test.ts
@@ -15,7 +15,15 @@
  * limitations under the License.
  */
 
-import { afterEach, describe, expect, it, jest } from '@jest/globals';
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  it,
+  jest,
+} from '@jest/globals';
 import { modelRef, type GenerateRequest } from 'genkit/model';
 import type OpenAI from 'openai';
 import {
@@ -23,6 +31,8 @@ import {
   defineCompatOpenAIModel,
   toOpenAIRequestBody,
 } from '../src/model';
+import { openAI } from '../src/openai/index';
+import { FakeOpenAIServer } from './fake_openai_server';
 
 describe('gptModel', () => {
   afterEach(() => {
@@ -126,6 +136,62 @@ describe('toOpenAiRequestBody for new GPT-4.1 variants', () => {
     expect(() =>
       toOpenAIRequestBody('gpt-4.1-nano', baseRequest)
     ).not.toThrow();
+  });
+});
+
+describe('listActions model filtering', () => {
+  let server: FakeOpenAIServer;
+  let previousBaseUrl: string | undefined;
+
+  beforeAll(async () => {
+    server = new FakeOpenAIServer();
+    await server.start();
+    // The openAI plugin does not accept a baseURL, so the fake server is
+    // injected the way a user would point the SDK at a proxy.
+    previousBaseUrl = process.env.OPENAI_BASE_URL;
+    process.env.OPENAI_BASE_URL = server.baseUrl;
+  });
+
+  afterAll(() => {
+    if (previousBaseUrl === undefined) {
+      delete process.env.OPENAI_BASE_URL;
+    } else {
+      process.env.OPENAI_BASE_URL = previousBaseUrl;
+    }
+    server.stop();
+  });
+
+  it('keeps current codex models and drops the legacy completion families', async () => {
+    const plugin = openAI({ apiKey: 'key' });
+    server.setNextResponse({
+      body: {
+        object: 'list',
+        data: [
+          'gpt-5-codex',
+          'gpt-5.1-codex-max',
+          'codex-mini-latest',
+          'gpt-4o',
+          'code-davinci-002',
+          'code-cushman-001',
+          'davinci-002',
+          'babbage-002',
+        ].map((id) => ({
+          id,
+          object: 'model',
+          created: 0,
+          owned_by: 'openai',
+        })),
+      },
+    });
+
+    const names = (await plugin.list!()).map((a) => a.name);
+
+    expect(names).toStrictEqual([
+      'openai/gpt-5-codex',
+      'openai/gpt-5.1-codex-max',
+      'openai/codex-mini-latest',
+      'openai/gpt-4o',
+    ]);
   });
 });
 


### PR DESCRIPTION
Part of #6002, closes #6003. Design rationale: [design notes on the tracking issue](https://github.com/genkit-ai/genkit/issues/6002#issuecomment-5243479724).

Adds a second OpenAI transport to the existing `openAI()` plugin: the eight models OpenAI serves only over `/v1/responses` (`gpt-5-pro`, `gpt-5-codex`, `gpt-5.1-codex`, `gpt-5.1-codex-mini`, `gpt-5.1-codex-max`, `codex-mini-latest`, `o1-pro`, `o3-pro`) now register and run against that endpoint, in the same namespace with the same action-name scheme. They were unreachable via this plugin before.

- One `RESPONSES_ONLY_MODELS` const drives the runtime routing predicate and the `openAI.model()` type union; suffixed names (`o3-pro-2025-06-10`, `gpt-5-pro-preview`) route like their base, deliberately biased toward the transport that works.
- Non-streaming runner over `client.responses.create`. `store` is pinned to `false` unless set, keeping retention behavior identical to Chat Completions.
- `supports.constrained: 'all'`, so output schemas go natively through `text.format` instead of genkit's simulated-constrained prompt injection. Prior model turns replay part by part, so structured-output history survives multi-turn.
- Fails loudly instead of degrading: genkit tools and `function_call` output items are rejected (`INVALID_ARGUMENT`/`UNIMPLEMENTED`) until the tool-calling slice; a `failed` response throws its `error` instead of returning an empty completion. Deliberate exception: a streaming caller gets the completed response as a single terminal chunk (the Dev UI always streams), with the event protocol in a follow-up.
- Model listing fix: the `'codex'` substring in `UNSUPPORTED_MODEL_MATCHERS` was hiding the `gpt-5-codex` family; matchers are now anchored. Side effect: retired `code-cushman-001` is now filtered.

## Usage

```ts
import { genkit, z } from 'genkit';
import { openAI } from '@genkit-ai/compat-oai/openai';

const ai = genkit({ plugins: [openAI()] });

// Previously unreachable models now work by name:
const { text } = await ai.generate({
  model: openAI.model('gpt-5-pro'),
  prompt: 'Prove there are infinitely many primes.',
});

// Output schemas go natively through text.format:
const { output } = await ai.generate({
  model: openAI.model('gpt-5-pro'),
  prompt: 'Extract the invoice fields.',
  output: { schema: z.object({ total: z.number(), currency: z.string() }) },
});
```

**Shared-layer note** (affects `deepSeek()`/`xai()`/`openAICompatible()`): `transport` becomes a reserved config key in the Chat Completions body builder - stripped from the wire (Chat Completions 400s on unknown args), with `transport: 'responses'` rejected via a provider-neutral `INVALID_ARGUMENT` rather than silently ignored.

**No behavior change for existing models**: nothing in `SUPPORTED_GPT_MODELS` changes transport, `raw` shape, or config; `gpt.ts` is untouched. Fake-server tests assert endpoints on the wire for both transports (`gpt-4o` → `/v1/chat/completions`, `gpt-5-pro` → `/v1/responses`), and an end-to-end test through a real `genkit()` instance asserts the output schema reaches the wire as `text.format`.

Tests: 146 passing in `js/plugins/compat-oai` (+49 vs base); live smoke tests run when `OPENAI_API_KEY` is set.

Not in this slice (see #6002): streaming events, tool calling, encrypted reasoning round-trip, annotations, `responsesModel()` opt-in for dual-transport models, background models.
