### PR TITLE
feat(py): stream typed chunks

### DIFF
--- a/py/packages/genkit-fastapi/src/genkit_fastapi/handler.py
+++ b/py/packages/genkit-fastapi/src/genkit_fastapi/handler.py
@@ -235,7 +235,7 @@ def genkit_fastapi_handler(
     ai: Genkit,
     context_provider: ContextProvider | None = None,
 ) -> Callable[
-    [Callable[[], Action[InputT, OutputT, ChunkT, InitT]] | Action[InputT, OutputT, ChunkT, InitT]],
+    [Callable[[], Awaitable[Action[InputT, OutputT, ChunkT, InitT]]] | Action[InputT, OutputT, ChunkT, InitT]],
     Callable[[Request], Awaitable[Response | dict[str, Any]]],
 ]:
     """Decorator for serving Genkit actions (flows, agents, tools, etc.) via FastAPI.
@@ -271,7 +271,7 @@ def genkit_fastapi_handler(
     """
 
     def decorator(
-        fn: Callable[[], Action[InputT, OutputT, ChunkT, InitT]] | Action[InputT, OutputT, ChunkT, InitT],
+        fn: Callable[[], Awaitable[Action[InputT, OutputT, ChunkT, InitT]]] | Action[InputT, OutputT, ChunkT, InitT],
     ) -> Callable[[Request], Awaitable[Response | dict[str, Any]]]:
         async def handler(request: Request) -> Response | dict[str, Any]:
             if isinstance(fn, Action):

--- a/py/packages/genkit/src/genkit/_ai/_generate.py
+++ b/py/packages/genkit/src/genkit/_ai/_generate.py
@@ -699,7 +699,7 @@ async def _generate_action_turn(
     chunks = ChunkAccumulator(
         message_index,
         formatter,
-        schema_type=raw_request.output.schema_type if raw_request.output else None,
+        schema_type=getattr(raw_request.output, 'schema_type', None) if raw_request.output else None,
     )
 
     async def dispatch_generate(

--- a/py/packages/genkit/src/genkit/_ai/_generate.py
+++ b/py/packages/genkit/src/genkit/_ai/_generate.py
@@ -572,9 +572,15 @@ class ChunkAccumulator:
     saved history numbered consistently.
     """
 
-    def __init__(self, message_index: int, formatter: Formatter[Any, Any] | None) -> None:
+    def __init__(
+        self,
+        message_index: int,
+        formatter: Formatter[Any, Any] | None,
+        schema_type: type[BaseModel] | None = None,
+    ) -> None:
         self.message_index = message_index
         self.formatter = formatter
+        self.schema_type = schema_type
         self.chunk_role: Role = Role.MODEL
         self.prev_chunks: list[ModelResponseChunk[Any]] = []
         self._chunk_parser: Callable[[ModelResponseChunk[Any]], Any | None] | None = (
@@ -596,6 +602,7 @@ class ChunkAccumulator:
             index=self.message_index,
             previous_chunks=prev_to_send,
             chunk_parser=self._chunk_parser,
+            schema_type=self.schema_type,
         )
 
     def stream_chunk(
@@ -689,7 +696,11 @@ async def _generate_action_turn(
         )
     raw_request = revised_request
 
-    chunks = ChunkAccumulator(message_index, formatter)
+    chunks = ChunkAccumulator(
+        message_index,
+        formatter,
+        schema_type=raw_request.output.schema_type if raw_request.output else None,
+    )
 
     async def dispatch_generate(
         params: GenerateHookParams,

--- a/py/packages/genkit/src/genkit/_ai/_prompt.py
+++ b/py/packages/genkit/src/genkit/_ai/_prompt.py
@@ -152,15 +152,15 @@ class ModelStreamResponse(Generic[OutputT]):
 
     def __init__(
         self,
-        channel: Channel[ModelResponseChunk, ModelResponse[OutputT]],
+        channel: Channel[ModelResponseChunk[OutputT], ModelResponse[OutputT]],
         response_future: asyncio.Future[ModelResponse[OutputT]],
     ) -> None:
         """Initialize with streaming channel and response future."""
-        self._channel: Channel[ModelResponseChunk, ModelResponse[OutputT]] = channel
+        self._channel: Channel[ModelResponseChunk[OutputT], ModelResponse[OutputT]] = channel
         self._response_future: asyncio.Future[ModelResponse[OutputT]] = response_future
 
     @property
-    def stream(self) -> AsyncIterable[ModelResponseChunk]:
+    def stream(self) -> AsyncIterable[ModelResponseChunk[OutputT]]:
         """Async iterable of response chunks.
 
         Returns:
@@ -191,7 +191,7 @@ class ModelStreamResponse(Generic[OutputT]):
     # Delegating to the underlying channel lets that work without forcing the
     # caller to remember the extra `.stream` hop, while `.stream` and `.response`
     # remain available for cases where you want both halves explicitly.
-    def __aiter__(self) -> AsyncIterator[ModelResponseChunk]:
+    def __aiter__(self) -> AsyncIterator[ModelResponseChunk[OutputT]]:
         return self._channel.__aiter__()
 
 
@@ -425,10 +425,10 @@ class ExecutablePrompt(Generic[InputT, OutputT]):
         **opts: Unpack[PromptGenerateOptions],
     ) -> ModelStreamResponse[OutputT]:
         """Stream the prompt execution, returning (stream, response_future)."""
-        channel: Channel[ModelResponseChunk, ModelResponse[OutputT]] = Channel(timeout=timeout)
+        channel: Channel[ModelResponseChunk[OutputT], ModelResponse[OutputT]] = Channel(timeout=timeout)
         stream_opts: PromptGenerateOptions = {
             **opts,  # ty doesn't infer Unpack[TD] as TD in function body (PEP 692 gap)
-            'on_chunk': lambda c: channel.send(cast(ModelResponseChunk, c)),
+            'on_chunk': lambda c: channel.send(cast('ModelResponseChunk[OutputT]', c)),
         }
         resp = self._call_impl(input, stream_opts)
         response_future: asyncio.Future[ModelResponse[OutputT]] = asyncio.create_task(resp)

--- a/py/packages/genkit/src/genkit/_core/_action.py
+++ b/py/packages/genkit/src/genkit/_core/_action.py
@@ -336,7 +336,7 @@ _action_context: ContextVar[dict[str, Any] | None] = ContextVar('context')
 _ = _action_context.set(None)
 
 
-class ActionRunContext:
+class ActionRunContext(Generic[ChunkT]):
     """Execution context for an action.
 
     Provides read-only access to action context (auth, metadata), streaming
@@ -395,7 +395,7 @@ class ActionRunContext:
         """
         return self._streaming_callback
 
-    def send_chunk(self, chunk: object) -> None:
+    def send_chunk(self, chunk: ChunkT) -> None:
         """Send a streaming chunk to the client.
 
         Args:

--- a/py/packages/genkit/src/genkit/_core/_model.py
+++ b/py/packages/genkit/src/genkit/_core/_model.py
@@ -24,10 +24,10 @@ from __future__ import annotations
 
 from collections.abc import Callable, Sequence
 from copy import deepcopy
-from functools import cached_property
+from functools import cached_property, lru_cache
 from typing import Any, ClassVar, Generic, cast
 
-from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, field_validator, model_serializer
+from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, TypeAdapter, ValidationError, field_validator, model_serializer
 from pydantic.alias_generators import to_camel
 from typing_extensions import TypeVar
 
@@ -399,12 +399,19 @@ class ModelResponse(GenkitModel, Generic[OutputT]):
         return self.message.interrupts
 
 
+@lru_cache(maxsize=128)
+def _schema_adapter(schema_type: type[BaseModel]) -> TypeAdapter[BaseModel]:
+    """Cache one TypeAdapter per output schema class for partial chunk validation."""
+    return TypeAdapter(schema_type)
+
+
 class ModelResponseChunk(ModelResponseChunkSchema, Generic[OutputT]):
     """Streaming chunk with text, accumulated text, and output parsing."""
 
     # Field(exclude=True) means these fields are not included in serialization
     previous_chunks: list[ModelResponseChunk[Any]] = Field(default_factory=list, exclude=True)
     chunk_parser: Callable[[ModelResponseChunk[Any]], object] | None = Field(None, exclude=True)
+    schema_type: type[BaseModel] | None = Field(None, exclude=True)
 
     def __init__(
         self,
@@ -412,6 +419,7 @@ class ModelResponseChunk(ModelResponseChunkSchema, Generic[OutputT]):
         previous_chunks: list[ModelResponseChunk[Any]] | None = None,
         index: int | float | None = None,
         chunk_parser: Callable[[ModelResponseChunk[Any]], object] | None = None,
+        schema_type: type[BaseModel] | None = None,
         **kwargs: Any,  # noqa: ANN401
     ) -> None:
         """Initialize from a chunk or keyword arguments."""
@@ -429,6 +437,7 @@ class ModelResponseChunk(ModelResponseChunkSchema, Generic[OutputT]):
             super().__init__(**kwargs)
         self.previous_chunks = previous_chunks or []
         self.chunk_parser = chunk_parser
+        self.schema_type = schema_type
 
     def __eq__(self, other: object) -> bool:
         """Check equality."""
@@ -471,11 +480,26 @@ class ModelResponseChunk(ModelResponseChunkSchema, Generic[OutputT]):
         return ''.join(parts) + self.text
 
     @cached_property
-    def output(self) -> OutputT:
-        """Parsed JSON output from accumulated text."""
-        if self.chunk_parser:
-            return cast(OutputT, self.chunk_parser(self))
-        return cast(OutputT, extract_json(self.accumulated_text))
+    def output(self) -> OutputT | None:
+        """Parsed output from accumulated text (None until parseable).
+
+        When an output schema type is known, the accumulated partial JSON is
+        validated into that Pydantic type using partial validation, so callers
+        get a real (possibly trailing-truncated) model instance. Until every
+        required field has started streaming, this returns None. Without a
+        schema type, returns the raw extracted JSON value.
+        """
+        parsed = self.chunk_parser(self) if self.chunk_parser else extract_json(self.accumulated_text)
+        if self.schema_type is not None and isinstance(parsed, dict):
+            try:
+                return cast(
+                    'OutputT | None',
+                    _schema_adapter(self.schema_type).validate_python(parsed, experimental_allow_partial=True),
+                )
+            except ValidationError:
+                # Not enough of the payload has streamed to satisfy the schema yet.
+                return None
+        return cast('OutputT | None', parsed)
 
 
 def text_from_message(msg: Message) -> str:

--- a/py/packages/genkit/src/genkit/_core/_model.py
+++ b/py/packages/genkit/src/genkit/_core/_model.py
@@ -24,15 +24,16 @@ from __future__ import annotations
 
 from collections.abc import Callable, Sequence
 from copy import deepcopy
-from functools import cached_property, lru_cache
+from functools import cached_property
 from typing import Any, ClassVar, Generic, cast
 
-from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, TypeAdapter, ValidationError, field_validator, model_serializer
+from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, field_validator, model_serializer
 from pydantic.alias_generators import to_camel
 from typing_extensions import TypeVar
 
 from genkit._core._base import GenkitModel
 from genkit._core._extract_json import extract_json
+from genkit._core._partial import partial_model
 from genkit._core._typing import (
     Candidate,
     DocumentData,
@@ -399,12 +400,6 @@ class ModelResponse(GenkitModel, Generic[OutputT]):
         return self.message.interrupts
 
 
-@lru_cache(maxsize=128)
-def _schema_adapter(schema_type: type[BaseModel]) -> TypeAdapter[BaseModel]:
-    """Cache one TypeAdapter per output schema class for partial chunk validation."""
-    return TypeAdapter(schema_type)
-
-
 class ModelResponseChunk(ModelResponseChunkSchema, Generic[OutputT]):
     """Streaming chunk with text, accumulated text, and output parsing."""
 
@@ -481,24 +476,25 @@ class ModelResponseChunk(ModelResponseChunkSchema, Generic[OutputT]):
 
     @cached_property
     def output(self) -> OutputT | None:
-        """Parsed output from accumulated text (None until parseable).
+        """Parsed output from accumulated text.
 
-        When an output schema type is known, the accumulated partial JSON is
-        validated into that Pydantic type using partial validation, so callers
-        get a real (possibly trailing-truncated) model instance. Until every
-        required field has started streaming, this returns None. Without a
-        schema type, returns the raw extracted JSON value.
+        With no ``output_schema`` class, this is the extracted JSON value
+        (a dict, list, scalar, or ``None`` if an object has not started).
+
+        When ``output_schema`` is a Pydantic model, the extracted dict is
+        validated into a synthesized all-optional sibling (``RecipePartial``),
+        so fields that have not arrived yet are ``None``. This is **not** the
+        original model: ``isinstance(chunk.output, Recipe)`` is false, and a
+        type checker still sees ``Recipe | None``. The final
+        ``ModelResponse.output`` validates into the real type.
         """
-        parsed = self.chunk_parser(self) if self.chunk_parser else extract_json(self.accumulated_text)
+        parsed = (
+            self.chunk_parser(self)
+            if self.chunk_parser
+            else extract_json(self.accumulated_text, throw_on_bad_json=False)
+        )
         if self.schema_type is not None and isinstance(parsed, dict):
-            try:
-                return cast(
-                    'OutputT | None',
-                    _schema_adapter(self.schema_type).validate_python(parsed, experimental_allow_partial=True),
-                )
-            except ValidationError:
-                # Not enough of the payload has streamed to satisfy the schema yet.
-                return None
+            return cast('OutputT | None', partial_model(self.schema_type).model_validate(parsed))
         return cast('OutputT | None', parsed)
 
 

--- a/py/packages/genkit/src/genkit/_core/_partial.py
+++ b/py/packages/genkit/src/genkit/_core/_partial.py
@@ -1,0 +1,81 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Synthesize an all-optional Pydantic model for streaming chunks.
+
+``output_schema=Recipe`` cannot construct a real ``Recipe`` until every
+required field has arrived. Streaming chunks get a sibling class
+(``RecipePartial``) where every field is ``T | None = None``. The final
+``ModelResponse.output`` still validates into the original type.
+"""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from types import UnionType
+from typing import Annotated, Union, get_args, get_origin
+
+from pydantic import BaseModel, ConfigDict, create_model
+
+
+def _is_base_model(annotation: object) -> bool:
+    return isinstance(annotation, type) and issubclass(annotation, BaseModel) and annotation is not BaseModel
+
+
+def _rewrite_annotation(annotation: object) -> object:
+    """Rewrite nested model types into their synthesized partials."""
+    origin = get_origin(annotation)
+    if origin is Annotated:
+        args = get_args(annotation)
+        return _rewrite_annotation(args[0]) if args else annotation
+    if origin in (Union, UnionType):
+        rewritten = [_rewrite_annotation(arg) if arg is not type(None) else arg for arg in get_args(annotation)]
+        non_none = [arg for arg in rewritten if arg is not type(None)]
+        if len(non_none) == 1:
+            return non_none[0] | None
+        return annotation
+    if origin in (list, set, frozenset):
+        args = get_args(annotation)
+        if not args:
+            return annotation
+        inner = _rewrite_annotation(args[0])
+        if origin is list:
+            return list[inner]  # type: ignore[valid-type]
+        if origin is set:
+            return set[inner]  # type: ignore[valid-type]
+        return frozenset[inner]  # type: ignore[valid-type]
+    if _is_base_model(annotation):
+        return partial_model(annotation)
+    return annotation
+
+
+@lru_cache(maxsize=128)
+def partial_model(schema_type: type[BaseModel]) -> type[BaseModel]:
+    """Return a cached sibling model with every field optional.
+
+    The result is not a subclass of ``schema_type``. ``isinstance(chunk.output,
+    Recipe)`` is false; ``type(chunk.output).__name__`` is ``RecipePartial``.
+    """
+    fields: dict[str, tuple[object, None]] = {}
+    for name, info in schema_type.model_fields.items():
+        annotation = _rewrite_annotation(info.annotation) if info.annotation is not None else object
+        fields[name] = (annotation | None, None)
+    return create_model(
+        f'{schema_type.__name__}Partial',
+        __module__=schema_type.__module__,
+        __config__=ConfigDict(extra='ignore', populate_by_name=True),
+        **fields,  # type: ignore[arg-type]
+    )

--- a/py/packages/genkit/src/genkit/_core/_partial.py
+++ b/py/packages/genkit/src/genkit/_core/_partial.py
@@ -20,22 +20,26 @@
 required field has arrived. Streaming chunks get a sibling class
 (``RecipePartial``) where every field is ``T | None = None``. The final
 ``ModelResponse.output`` still validates into the original type.
+
+The values below are runtime type objects being assembled dynamically, so
+they are deliberately typed ``Any``: the type expressions this module
+builds (``X | None``, ``list[X]``) only exist at runtime.
 """
 
 from __future__ import annotations
 
 from functools import lru_cache
 from types import UnionType
-from typing import Annotated, Union, get_args, get_origin
+from typing import Annotated, Any, Union, get_args, get_origin
 
 from pydantic import BaseModel, ConfigDict, create_model
 
 
-def _is_base_model(annotation: object) -> bool:
+def _is_base_model(annotation: Any) -> bool:  # noqa: ANN401
     return isinstance(annotation, type) and issubclass(annotation, BaseModel) and annotation is not BaseModel
 
 
-def _rewrite_annotation(annotation: object) -> object:
+def _rewrite_annotation(annotation: Any) -> Any:  # noqa: ANN401
     """Rewrite nested model types into their synthesized partials."""
     origin = get_origin(annotation)
     if origin is Annotated:
@@ -53,10 +57,10 @@ def _rewrite_annotation(annotation: object) -> object:
             return annotation
         inner = _rewrite_annotation(args[0])
         if origin is list:
-            return list[inner]  # type: ignore[valid-type]
+            return list[inner]
         if origin is set:
-            return set[inner]  # type: ignore[valid-type]
-        return frozenset[inner]  # type: ignore[valid-type]
+            return set[inner]
+        return frozenset[inner]
     if _is_base_model(annotation):
         return partial_model(annotation)
     return annotation
@@ -69,13 +73,13 @@ def partial_model(schema_type: type[BaseModel]) -> type[BaseModel]:
     The result is not a subclass of ``schema_type``. ``isinstance(chunk.output,
     Recipe)`` is false; ``type(chunk.output).__name__`` is ``RecipePartial``.
     """
-    fields: dict[str, tuple[object, None]] = {}
+    fields: dict[str, Any] = {}
     for name, info in schema_type.model_fields.items():
-        annotation = _rewrite_annotation(info.annotation) if info.annotation is not None else object
+        annotation: Any = _rewrite_annotation(info.annotation) if info.annotation is not None else object
         fields[name] = (annotation | None, None)
     return create_model(
         f'{schema_type.__name__}Partial',
         __module__=schema_type.__module__,
         __config__=ConfigDict(extra='ignore', populate_by_name=True),
-        **fields,  # type: ignore[arg-type]
+        **fields,
     )

--- a/py/packages/genkit/tests/genkit/ai/streaming_typed_output_test.py
+++ b/py/packages/genkit/tests/genkit/ai/streaming_typed_output_test.py
@@ -6,10 +6,13 @@
 """Tests for typed streaming output (issue #6007).
 
 Covers:
-- ModelResponseChunk.output partial validation into the output schema type
+- ModelResponseChunk.output wrapping extracted JSON in a synthesized
+  all-optional partial of the output schema type
 - ActionRunContext genericity over the chunk type
-- End-to-end generate_stream with output_schema producing typed chunks
+- End-to-end generate_stream with output_schema producing partial chunks
 """
+
+from typing import Any
 
 import pytest
 from pydantic import BaseModel
@@ -36,25 +39,43 @@ def _chunk(text: str, schema_type: type[BaseModel] | None = None) -> ModelRespon
     )
 
 
-class TestChunkPartialValidation:
-    """chunk.output with a schema type validates partials into that type."""
+class TestChunkPartialOutput:
+    """chunk.output with a schema type wraps extracted JSON in a partial."""
 
-    def test_unparseable_prefix_returns_none(self) -> None:
-        assert _chunk('{"ti', schema_type=Recipe).output is None
+    def test_preamble_returns_none(self) -> None:
+        # No JSON object has started yet.
+        assert _chunk('Here is the JSON:', schema_type=Recipe).output is None
+        assert _chunk('Here is the JSON:').output is None
 
-    def test_missing_required_field_returns_none(self) -> None:
-        # title present but steps has not started streaming yet
-        assert _chunk('{"title": "Chocolate C', schema_type=Recipe).output is None
+    def test_prefix_with_no_fields_is_empty_partial(self) -> None:
+        # The object has started but no key has finished; all fields None.
+        out = _chunk('{"ti', schema_type=Recipe).output
+        assert out is not None
+        assert not isinstance(out, Recipe)
+        assert out.title is None
+        assert out.steps is None
 
-    def test_partial_trailing_value_returns_model_instance(self) -> None:
+    def test_first_field_is_available_immediately(self) -> None:
+        # title present but steps has not started streaming yet:
+        # the partial carries title, steps stays None. Not None overall.
+        out = _chunk('{"title": "Chocolate C', schema_type=Recipe).output
+        assert out is not None
+        assert not isinstance(out, Recipe)
+        assert out.title == 'Chocolate C'
+        assert out.steps is None
+
+    def test_partial_trailing_value(self) -> None:
         out = _chunk('{"title": "Chocolate Cake", "steps": ["mi', schema_type=Recipe).output
-        assert isinstance(out, Recipe)
+        assert out is not None
         assert out.title == 'Chocolate Cake'
         assert out.steps == ['mi']
 
-    def test_complete_json_returns_model_instance(self) -> None:
+    def test_complete_json_is_still_the_partial_type(self) -> None:
+        # Chunks never hand back the real model; only ModelResponse.output does.
         out = _chunk('{"title": "Cake", "steps": ["mix", "bake"]}', schema_type=Recipe).output
-        assert isinstance(out, Recipe)
+        assert out is not None
+        assert not isinstance(out, Recipe)
+        assert type(out).__name__ == 'RecipePartial'
         assert out.steps == ['mix', 'bake']
 
     def test_no_schema_type_preserves_raw_json_behavior(self) -> None:
@@ -63,8 +84,8 @@ class TestChunkPartialValidation:
         assert out == {'title': 'Cake', 'steps': ['mix']}
         assert not isinstance(out, Recipe)
 
-    def test_schema_validation_applies_to_chunk_parser_result(self) -> None:
-        # chunk_parser output (used by format definitions) is also validated
+    def test_partial_wraps_chunk_parser_result(self) -> None:
+        # chunk_parser output (used by format definitions) is also wrapped
         wrapper = ModelResponseChunk(
             role='model',
             content=[Part(root=TextPart(text='ignored'))],
@@ -72,7 +93,8 @@ class TestChunkPartialValidation:
             schema_type=Recipe,
         )
         out = wrapper.output
-        assert isinstance(out, Recipe)
+        assert out is not None
+        assert not isinstance(out, Recipe)
         assert out.title == 'Parsed'
 
     def test_non_dict_parse_result_passes_through(self) -> None:
@@ -102,8 +124,8 @@ class TestActionRunContextGenerics:
 
 
 @pytest.mark.asyncio
-async def test_generate_stream_with_output_schema_yields_typed_chunks() -> None:
-    """End to end: generate_stream(output_schema=...) chunks validate into the schema."""
+async def test_generate_stream_with_output_schema_yields_partial_chunks() -> None:
+    """End to end: generate_stream(output_schema=...) chunks are partials of the schema."""
     ai = Genkit(model='programmableModel')
     pm, _ = define_programmable_model(ai)
 
@@ -123,18 +145,20 @@ async def test_generate_stream_with_output_schema_yields_typed_chunks() -> None:
 
     stream_result = ai.generate_stream(prompt='hi', output_schema=Recipe)
 
-    outputs: list[object] = []
+    outputs: list[Any] = []
     async for chunk in stream_result.stream:
         outputs.append(chunk.output)
 
-    # First chunk: required field `steps` hasn't started -> None.
-    assert outputs[0] is None
-    # Later chunks: real, partially-populated Recipe instances.
-    assert isinstance(outputs[1], Recipe)
+    # First chunk: title is already usable; steps has not started -> None.
+    assert outputs[0] is not None
+    assert not isinstance(outputs[0], Recipe)
+    assert outputs[0].title == 'Chocolate C'
+    assert outputs[0].steps is None
+    # Later chunks fill in as keys arrive; still partials, never the real model.
     assert outputs[1].title == 'Chocolate Cake'
     assert outputs[1].steps == ['mi']
-    assert isinstance(outputs[2], Recipe)
     assert outputs[2].steps == ['mix', 'bake']
+    assert not isinstance(outputs[2], Recipe)
 
     # Final response is fully validated, as before.
     response = await stream_result.response

--- a/py/packages/genkit/tests/genkit/ai/streaming_typed_output_test.py
+++ b/py/packages/genkit/tests/genkit/ai/streaming_typed_output_test.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+#
+# Copyright 2026 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for typed streaming output (issue #6007).
+
+Covers:
+- ModelResponseChunk.output partial validation into the output schema type
+- ActionRunContext genericity over the chunk type
+- End-to-end generate_stream with output_schema producing typed chunks
+"""
+
+import pytest
+from pydantic import BaseModel
+
+from genkit import Genkit, Message, ModelResponse, ModelResponseChunk
+from genkit._ai._testing import define_programmable_model
+from genkit._core._action import ActionRunContext
+from genkit._core._typing import Part, Role, TextPart
+
+
+class Recipe(BaseModel):
+    """Test output schema."""
+
+    title: str
+    steps: list[str]
+
+
+def _chunk(text: str, schema_type: type[BaseModel] | None = None) -> ModelResponseChunk:
+    """Build a chunk whose accumulated text is exactly ``text``."""
+    return ModelResponseChunk(
+        role='model',
+        content=[Part(root=TextPart(text=text))],
+        schema_type=schema_type,
+    )
+
+
+class TestChunkPartialValidation:
+    """chunk.output with a schema type validates partials into that type."""
+
+    def test_unparseable_prefix_returns_none(self) -> None:
+        assert _chunk('{"ti', schema_type=Recipe).output is None
+
+    def test_missing_required_field_returns_none(self) -> None:
+        # title present but steps has not started streaming yet
+        assert _chunk('{"title": "Chocolate C', schema_type=Recipe).output is None
+
+    def test_partial_trailing_value_returns_model_instance(self) -> None:
+        out = _chunk('{"title": "Chocolate Cake", "steps": ["mi', schema_type=Recipe).output
+        assert isinstance(out, Recipe)
+        assert out.title == 'Chocolate Cake'
+        assert out.steps == ['mi']
+
+    def test_complete_json_returns_model_instance(self) -> None:
+        out = _chunk('{"title": "Cake", "steps": ["mix", "bake"]}', schema_type=Recipe).output
+        assert isinstance(out, Recipe)
+        assert out.steps == ['mix', 'bake']
+
+    def test_no_schema_type_preserves_raw_json_behavior(self) -> None:
+        # Backward compat: without a schema type, output is the raw extracted JSON
+        out = _chunk('{"title": "Cake", "steps": ["mix"]}').output
+        assert out == {'title': 'Cake', 'steps': ['mix']}
+        assert not isinstance(out, Recipe)
+
+    def test_schema_validation_applies_to_chunk_parser_result(self) -> None:
+        # chunk_parser output (used by format definitions) is also validated
+        wrapper = ModelResponseChunk(
+            role='model',
+            content=[Part(root=TextPart(text='ignored'))],
+            chunk_parser=lambda _c: {'title': 'Parsed', 'steps': ['a']},
+            schema_type=Recipe,
+        )
+        out = wrapper.output
+        assert isinstance(out, Recipe)
+        assert out.title == 'Parsed'
+
+    def test_non_dict_parse_result_passes_through(self) -> None:
+        # A scalar/array payload can't be validated into an object schema;
+        # it is returned as-is rather than silently dropped.
+        assert _chunk('[1, 2, 3]', schema_type=Recipe).output == [1, 2, 3]
+
+
+class TestActionRunContextGenerics:
+    """ActionRunContext is generic over the chunk type, with a default."""
+
+    def test_unparameterized_usage_still_works(self) -> None:
+        received: list[object] = []
+        ctx = ActionRunContext(streaming_callback=received.append)
+        ctx.send_chunk({'anything': 1})
+        assert received == [{'anything': 1}]
+
+    def test_parameterized_usage_works_at_runtime(self) -> None:
+        received: list[Recipe] = []
+        ctx: ActionRunContext[Recipe] = ActionRunContext(streaming_callback=received.append)
+        ctx.send_chunk(Recipe(title='t', steps=[]))
+        assert received[0].title == 't'
+
+    def test_class_is_subscriptable(self) -> None:
+        # Generic alias construction must not raise
+        assert ActionRunContext[Recipe] is not None
+
+
+@pytest.mark.asyncio
+async def test_generate_stream_with_output_schema_yields_typed_chunks() -> None:
+    """End to end: generate_stream(output_schema=...) chunks validate into the schema."""
+    ai = Genkit(model='programmableModel')
+    pm, _ = define_programmable_model(ai)
+
+    final_text = '{"title": "Chocolate Cake", "steps": ["mix", "bake"]}'
+    pm.chunks = [
+        [
+            ModelResponseChunk(role=Role.MODEL, content=[Part(root=TextPart(text='{"title": "Chocolate C'))]),
+            ModelResponseChunk(role=Role.MODEL, content=[Part(root=TextPart(text='ake", "steps": ["mi'))]),
+            ModelResponseChunk(role=Role.MODEL, content=[Part(root=TextPart(text='x", "bake"]}'))]),
+        ]
+    ]
+    pm.responses = [
+        ModelResponse(
+            message=Message(role=Role.MODEL, content=[Part(root=TextPart(text=final_text))]),
+        )
+    ]
+
+    stream_result = ai.generate_stream(prompt='hi', output_schema=Recipe)
+
+    outputs: list[object] = []
+    async for chunk in stream_result.stream:
+        outputs.append(chunk.output)
+
+    # First chunk: required field `steps` hasn't started -> None.
+    assert outputs[0] is None
+    # Later chunks: real, partially-populated Recipe instances.
+    assert isinstance(outputs[1], Recipe)
+    assert outputs[1].title == 'Chocolate Cake'
+    assert outputs[1].steps == ['mi']
+    assert isinstance(outputs[2], Recipe)
+    assert outputs[2].steps == ['mix', 'bake']
+
+    # Final response is fully validated, as before.
+    response = await stream_result.response
+    assert isinstance(response.output, Recipe)
+    assert response.output.title == 'Chocolate Cake'
+    assert response.output.steps == ['mix', 'bake']
+
+
+@pytest.mark.asyncio
+async def test_generate_stream_without_schema_chunks_unchanged() -> None:
+    """Backward compat: no output_schema keeps raw JSON chunk output."""
+    ai = Genkit(model='programmableModel')
+    pm, _ = define_programmable_model(ai)
+
+    pm.chunks = [[ModelResponseChunk(role=Role.MODEL, content=[Part(root=TextPart(text='{"a": 1}'))])]]
+    pm.responses = [
+        ModelResponse(message=Message(role=Role.MODEL, content=[Part(root=TextPart(text='{"a": 1}'))])),
+    ]
+
+    stream_result = ai.generate_stream(prompt='hi')
+    async for chunk in stream_result.stream:
+        assert chunk.output == {'a': 1}
+    await stream_result.response


### PR DESCRIPTION
## Summary

Streams typed partial objects on `generate_stream` chunks when using a Pydantic model as `output_schema`.

- **Dynamic Partial Models**: When `output_schema` is a Pydantic model (e.g. `Recipe`), `chunk.output` is instantiated as a **synthesized all-optional sibling** model (e.g. `RecipePartial`), generated via `create_model` and cached per class.
- **Incremental Streaming**: Fields become available incrementally as their keys arrive in the stream; unpopulated fields default to `None`.
- **Authoritative Final Output**: The final `(await sr.response).output` remains the real, fully validated Pydantic model.
- **Backward Compatibility**: Dict schemas and schema-less streams remain unchanged (`chunk.output` stays the extracted JSON value).

---

## Usage Example

```python
sr = ai.generate_stream(prompt="...", output_schema=Recipe)

async for chunk in sr:
    if chunk.output is None:          # No JSON object started yet
        continue
    chunk.output.title                # Usable as soon as "title" arrives
    chunk.output.steps                # None until "steps" starts streaming

recipe = (await sr.response).output   # Real Recipe instance (full validation)
```

---

## ⚠️ Type Annotation vs. Runtime Behavior

`generate_stream(..., output_schema=Recipe)` returns `ModelStreamResponse[Recipe]`, annotating `chunk.output` as `Recipe | None`. 

After a `None` check, static type checkers (pyright, mypy, etc.) treat `chunk.output` as a **finished, fully populated** `Recipe`. However, at runtime:

- **Dynamic Class**: The object is an instance of `RecipePartial` dynamically created at runtime (not visible to static type checkers).
- **Instance Checks**: `isinstance(chunk.output, Recipe)` evaluates to `False`.
- **Field Optionality**: All fields are effectively `T | None`. For example, `chunk.output.title.upper()` passes static type checks but can raise `AttributeError` mid-stream if `title` is `None`.

### Recommended Pattern
Always guard on individual fields rather than assuming the full model is populated:

```python
if chunk.output and chunk.output.title:
    update_label(chunk.output.title)
```

---

## Design Rationale

- **Provisional Chunks vs. Final Response**: Chunks are provisional; `(await sr.response).output` is the authoritative, fully validated value (matching the contract documented in Go's `GenerateDataStream`).
- **Why accept the annotation gap?**:
  - Returning `None` until all required fields arrive would defeat the purpose of streaming and hide data already received.
  - Python's static type system cannot express a generic `Partial[T]` mapping arbitrary user Pydantic models to all-optional variants without runtime metaprogramming.
