### PR TITLE
fix(go/tracing): mark only originating span as failure source

### DIFF
--- a/go/core/tracing/tracing.go
+++ b/go/core/tracing/tracing.go
@@ -68,6 +68,15 @@ func isErrorAlreadyMarked(err error) bool {
 	return false
 }
 
+// unwrapMarkedError removes the internal marker when it is the outermost
+// wrapper, preserving the application error's type and identity.
+func unwrapMarkedError(err error) error {
+	if me, ok := err.(*markedError); ok {
+		return me.error
+	}
+	return err
+}
+
 // captureStackTrace captures the current Go stack trace for error reporting
 func captureStackTrace() string {
 	buf := make([]byte, 4096)
@@ -300,14 +309,19 @@ func RunInNewSpan[I, O any](
 	if err != nil {
 		sm.State = spanStateError
 		sm.Error = err.Error()
-		sm.IsFailureSource = true
 		if !isErrorAlreadyMarked(err) {
-			span.RecordError(err)
-			span.SetStatus(codes.Error, err.Error())
+			sm.IsFailureSource = true
+			err = markErrorAsHandled(err)
 		}
+		telemetryErr := unwrapMarkedError(err)
+		span.RecordError(telemetryErr)
+		span.SetStatus(codes.Error, telemetryErr.Error())
 	} else {
 		sm.State = spanStateSuccess
 		sm.Output = output
+	}
+	if parentSM == nil {
+		err = unwrapMarkedError(err)
 	}
 	return output, err
 }

--- a/go/core/tracing/tracing.go
+++ b/go/core/tracing/tracing.go
@@ -71,7 +71,7 @@ func isErrorAlreadyMarked(err error) bool {
 // unwrapMarkedError removes the internal marker when it is the outermost
 // wrapper, preserving the application error's type and identity.
 func unwrapMarkedError(err error) error {
-	if me, ok := err.(*markedError); ok {
+	if me, ok := err.(*markedError); ok && me != nil {
 		return me.error
 	}
 	return err
@@ -320,7 +320,7 @@ func RunInNewSpan[I, O any](
 		sm.State = spanStateSuccess
 		sm.Output = output
 	}
-	if parentSM == nil {
+	if parentSM == nil && err != nil {
 		err = unwrapMarkedError(err)
 	}
 	return output, err

--- a/go/core/tracing/tracing_test.go
+++ b/go/core/tracing/tracing_test.go
@@ -18,6 +18,7 @@ package tracing
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"slices"
 	"strconv"
@@ -498,24 +499,67 @@ func TestNestedSpanPaths(t *testing.T) {
 	}
 }
 
-// TestIsFailureSourceOnError verifies that genkit:isFailureSource is set correctly
+// TestIsFailureSourceOnError verifies that only the span where an error
+// originates is marked as the failure source.
 func TestIsFailureSourceOnError(t *testing.T) {
-	ctx := context.Background()
+	testErr := errors.New("test error")
+	var parent, child *spanMetadata
 
-	testErr := fmt.Errorf("test error")
-
-	// Call RunInNewSpan with a function that returns an error
-	_, err := RunInNewSpan(ctx, &SpanMetadata{
-		Name: "failing-action",
+	_, err := RunInNewSpan(context.Background(), &SpanMetadata{
+		Name: "parent-action",
 		Type: "action",
 	}, "input", func(ctx context.Context, input string) (string, error) {
-		return "", testErr
+		parent = spanMetaKey.FromContext(ctx)
+		return RunInNewSpan(ctx, &SpanMetadata{
+			Name: "child-action",
+			Type: "action",
+		}, input, func(ctx context.Context, input string) (string, error) {
+			child = spanMetaKey.FromContext(ctx)
+			return "", testErr
+		})
 	})
 
-	// The test confirms the function works - isFailureSource should be set
-	// on the span via span.SetAttributes() during error handling
-	if err == nil {
-		t.Fatal("Expected error to be returned")
+	if !errors.Is(err, testErr) {
+		t.Fatalf("errors.Is(err, testErr) = false, err = %v", err)
+	}
+	if err != testErr {
+		t.Errorf("outermost span returned %T %v, want original error identity", err, err)
+	}
+	if parent == nil || child == nil {
+		t.Fatalf("span metadata was not captured: parent = %v, child = %v", parent, child)
+	}
+	if !child.IsFailureSource {
+		t.Error("child span is not marked as the failure source")
+	}
+	if parent.IsFailureSource {
+		t.Error("parent span is incorrectly marked as the failure source")
+	}
+	hasFailureSource := func(sm *spanMetadata) bool {
+		return slices.ContainsFunc(sm.attributes(), func(attr attribute.KeyValue) bool {
+			return attr.Key == "genkit:isFailureSource" && attr.Value.AsBool()
+		})
+	}
+	if !hasFailureSource(child) {
+		t.Error("child span is missing the genkit:isFailureSource attribute")
+	}
+	if hasFailureSource(parent) {
+		t.Error("parent span incorrectly has the genkit:isFailureSource attribute")
+	}
+	if child.State != spanStateError || parent.State != spanStateError {
+		t.Errorf("span states = child %q, parent %q; want both %q", child.State, parent.State, spanStateError)
+	}
+}
+
+func TestUnwrapMarkedError(t *testing.T) {
+	testErr := errors.New("test error")
+	marked := markErrorAsHandled(testErr)
+
+	if got := unwrapMarkedError(marked); got != testErr {
+		t.Errorf("unwrapMarkedError(marked error) = %T %v, want original error", got, got)
+	}
+	wrapped := fmt.Errorf("parent context: %w", marked)
+	if got := unwrapMarkedError(wrapped); got != wrapped {
+		t.Errorf("unwrapMarkedError(contextual wrapper) = %T %v, want wrapper preserved", got, got)
 	}
 }
 

--- a/go/core/tracing/tracing_test.go
+++ b/go/core/tracing/tracing_test.go
@@ -561,6 +561,10 @@ func TestUnwrapMarkedError(t *testing.T) {
 	if got := unwrapMarkedError(wrapped); got != wrapped {
 		t.Errorf("unwrapMarkedError(contextual wrapper) = %T %v, want wrapper preserved", got, got)
 	}
+	var typedNil *markedError
+	if got := unwrapMarkedError(typedNil); got != typedNil {
+		t.Errorf("unwrapMarkedError(typed nil) = %T %v, want typed nil preserved", got, got)
+	}
 }
 
 // TestRootSpanAutoDetection tests that spans are automatically marked as root when no parent exists


### PR DESCRIPTION
## Summary

- mark only the span where an error originates with `genkit:isFailureSource`
- propagate an internal handled marker through nested Genkit spans while keeping parent spans in the error state
- preserve the application error type in OpenTelemetry events and restore the original error identity at the outermost Genkit span

## Problem

`RunInNewSpan` currently sets `IsFailureSource` on every span that observes a returned error. As the same error propagates through nested actions and flows, each parent span therefore exports `genkit:isFailureSource=true`, which obscures the actual source and can overcount failures in monitoring.

The tracing package already contains `markedError`, `markErrorAsHandled`, and `isErrorAlreadyMarked`, but the marker was never applied in `RunInNewSpan`.

## Implementation

The originating span now marks and wraps an unhandled error before returning it. Parent spans recognize the marker and omit `genkit:isFailureSource`, while still recording their normal OpenTelemetry error event and error status.

The internal wrapper is removed when recording the application error in OpenTelemetry and when the error exits the outermost Genkit span. This keeps `exception.type`, direct sentinel comparisons, and `errors.Is`/`errors.As` behavior compatible with the original error.

## Testing

Added regression coverage that verifies:

- the child/originating span exports `genkit:isFailureSource=true`
- the parent span does not export the failure-source attribute
- both child and parent spans remain in the error state
- the original error identity and `errors.Is` behavior are preserved
- the internal marker is removed without stripping application-added wrappers

Commands run:

```text
go vet ./core/tracing
go test -race ./core/tracing
go test ./...
```

All passed.

Fixes #5153

## Checklist

- [x] PR title follows Conventional Commits
- [x] Tested with unit, race, vet, and full Go test suite
- [x] Docs not applicable: no public API or user-facing behavior changed
