### PR TITLE
feat(py): stream debug logs to the Dev UI

### DIFF
--- a/genkit-tools/telemetry-server/src/index.ts
+++ b/genkit-tools/telemetry-server/src/index.ts
@@ -278,9 +278,12 @@ export async function startTelemetryServer(params: {
       '/api/otlp/v1/traces',
       '/api/otlp/v1/logs',
       '/api/otlp/v1/metrics',
+      '/api/otlp/:parentTraceId/:parentSpanId',
     ],
     async (request, response) => {
       try {
+        const { parentTraceId, parentSpanId } = request.params;
+
         if (
           !request.body.resourceSpans?.length &&
           !request.body.resourceLogs?.length
@@ -291,6 +294,16 @@ export async function startTelemetryServer(params: {
         }
         const traces = traceDataFromOtlp(request.body);
         for (const trace of traces) {
+          if (parentTraceId) {
+            trace.traceId = parentTraceId;
+            for (const span of Object.values(trace.spans)) {
+              span.attributes['genkit:otlp-traceId'] = span.traceId;
+              span.traceId = parentTraceId;
+              if (!span.parentSpanId && parentSpanId) {
+                span.parentSpanId = parentSpanId;
+              }
+            }
+          }
           const traceData = TraceDataSchema.parse(trace);
           await params.traceStore.save(traceData.traceId, traceData);
 

--- a/genkit-tools/telemetry-server/src/utils/otlp.ts
+++ b/genkit-tools/telemetry-server/src/utils/otlp.ts
@@ -24,6 +24,7 @@ interface OtlpValue {
   stringValue?: string;
   intValue?: number;
   boolValue?: boolean;
+  doubleValue?: number;
   arrayValue?: {
     values: OtlpValue[];
   };
@@ -105,6 +106,7 @@ export function fromOtlpValue(value: OtlpValue): any {
   if (value.stringValue !== undefined) return value.stringValue;
   if (value.intValue !== undefined) return value.intValue;
   if (value.boolValue !== undefined) return value.boolValue;
+  if (value.doubleValue !== undefined) return value.doubleValue;
   if (value.arrayValue !== undefined)
     return value.arrayValue.values.map(fromOtlpValue);
   return undefined;

--- a/genkit-tools/telemetry-server/tests/otlp_test.ts
+++ b/genkit-tools/telemetry-server/tests/otlp_test.ts
@@ -240,6 +240,10 @@ describe('otlp-logs', () => {
                       key: 'genkit:name',
                       value: { stringValue: 'generateContentStream' },
                     },
+                    {
+                      key: 'confidence',
+                      value: { doubleValue: 0.87 },
+                    },
                   ],
                 },
                 {
@@ -267,6 +271,7 @@ describe('otlp-logs', () => {
         body: 'This is a test log message',
         attributes: {
           'genkit:name': 'generateContentStream',
+          confidence: 0.87,
         },
         instrumentationLibrary: {
           name: 'genkit-tracer',

--- a/py/packages/genkit/src/genkit/_ai/_generate.py
+++ b/py/packages/genkit/src/genkit/_ai/_generate.py
@@ -91,6 +91,46 @@ logger = get_logger(__name__)
 HookParamsT = TypeVar('HookParamsT')
 HookResultT = TypeVar('HookResultT')
 
+# A termination known to be abnormal carries no conforming output, so a schema
+# error here would mask the finish reason the caller needs to handle it.
+ABNORMAL_FINISH_REASONS = frozenset({
+    FinishReason.BLOCKED,
+    FinishReason.ABORTED,
+    FinishReason.INTERRUPTED,
+    FinishReason.OTHER,
+})
+
+
+def log_output_parse(
+    *,
+    model: str | None,
+    finish_reason: FinishReason | None,
+    finish_message: str | None,
+    formatter: Formatter[Any, Any] | None,
+    message: Message | None,
+) -> None:
+    """Warn on an abnormal finish; debug when the formatter cannot parse."""
+    if formatter is None:
+        return
+    if finish_reason in ABNORMAL_FINISH_REASONS:
+        logger.warning(
+            'model finished abnormally, skipping output parsing',
+            model=model,
+            finishReason=finish_reason,
+            finishMessage=finish_message,
+        )
+        return
+    if message is None or not is_debug_enabled(logger):
+        return
+    try:
+        formatter.parse_message(message)
+    except Exception as e:
+        logger.debug(
+            'model output does not match the expected schema',
+            model=model,
+            error=e,
+        )
+
 
 def middleware_name(mw: MiddlewareDef) -> str:
     """Class name is what shows up on hook log records."""
@@ -107,10 +147,11 @@ def hook_finished(
     extra: dict[str, object],
 ) -> dict[str, object]:
     """Attributes for the ``middleware hook finished`` record."""
+    ms = max(0, round((time.monotonic() - start) * 1000))
     out: dict[str, object] = {
         'middleware': name,
         'hook': hook,
-        'duration_ms': int((time.monotonic() - start) * 1000),
+        'duration': f'{ms}ms',
         **extra,
     }
     if not next_called:
@@ -600,9 +641,8 @@ async def generate_with_request(
             'max_turns': raw_request.max_turns,
             'streaming': on_chunk is not None,
         }
-        if raw_request.output is not None:
-            resolved['format'] = raw_request.output.format
-            resolved['constrained'] = raw_request.output.constrained
+        resolved['format'] = raw_request.output.format if raw_request.output else None
+        resolved['constrained'] = raw_request.output.constrained if raw_request.output else None
         if middleware:
             resolved['middleware'] = [middleware_name(m) for m in middleware]
         logger.debug('generate request resolved', **resolved)
@@ -660,7 +700,10 @@ class ChunkAccumulator:
         """Send one framework-wrapped chunk through the current stream chain."""
         if ctx.on_chunk is None:
             return
-        ctx.on_chunk(self.make(role=role, chunk=chunk))
+        try:
+            ctx.on_chunk(self.make(role=role, chunk=chunk))
+        except Exception as e:
+            logger.debug('tool stream callback failed, dropping chunk', error=e)
 
     @contextlib.contextmanager
     def intercept_model_stream(
@@ -955,6 +998,14 @@ async def _generate_action_turn(
                 responded['input_tokens'] = response.usage.input_tokens
                 responded['output_tokens'] = response.usage.output_tokens
             logger.debug('model responded', **responded)
+
+        log_output_parse(
+            model=turn_options.model,
+            finish_reason=response.finish_reason,
+            finish_message=response.finish_message,
+            formatter=formatter,
+            message=generated_msg,
+        )
 
         response.assert_valid()
 
@@ -1428,6 +1479,7 @@ async def resolve_tool_requests(
             intr = _interrupt_from_tool_exc(e)
             if intr is None:
                 raise
+            logger.debug('tool triggered an interrupt', tool=trp.tool_request.name)
             return (None, _interrupt_request_part(trp, intr))
 
     outs = await asyncio.gather(*[_resolve_one_tool(tool, trp) for _, tool, trp in work])
@@ -1760,6 +1812,13 @@ async def _run_restart_through_middleware(
     except Exception as e:
         intr = _interrupt_from_tool_exc(e)
         if intr is not None:
+            # run_tool_after_restart already logged when the tool body interrupted.
+            # wrap_tool can raise Interrupt itself; that's the only leftover case.
+            if not isinstance(e, GenkitError):
+                logger.debug(
+                    'restarted tool triggered an interrupt',
+                    tool=restart_trp.tool_request.name,
+                )
             # Re-interrupting during restart is a hard error — same as the legacy
             # run_tool_after_restart path, which raises FAILED_PRECONDITION when
             # the inner tool throws an Interrupt during restart. Surface the

--- a/py/packages/genkit/src/genkit/_ai/_generate.py
+++ b/py/packages/genkit/src/genkit/_ai/_generate.py
@@ -19,11 +19,11 @@
 import asyncio
 import contextlib
 import copy
-import re
 import secrets
+import time
 from collections.abc import Awaitable, Callable, Generator, Sequence
 from dataclasses import dataclass
-from typing import Any, cast
+from typing import Any, TypeVar, cast
 
 from pydantic import BaseModel
 from typing_extensions import Never
@@ -83,6 +83,88 @@ from genkit._core._typing import (
 DEFAULT_MAX_TURNS = 5
 
 logger = get_logger(__name__)
+
+HookParamsT = TypeVar('HookParamsT')
+HookResultT = TypeVar('HookResultT')
+
+
+def middleware_name(mw: MiddlewareDef) -> str:
+    """Class name is what shows up on hook log records."""
+    return type(mw).__name__
+
+
+def hook_finished(
+    *,
+    name: str,
+    hook: str,
+    start: float,
+    next_called: bool,
+    error: str | None,
+    extra: dict[str, object],
+) -> dict[str, object]:
+    """Attributes for the ``middleware hook finished`` record."""
+    out: dict[str, object] = {
+        'middleware': name,
+        'hook': hook,
+        'duration_ms': int((time.monotonic() - start) * 1000),
+        **extra,
+    }
+    if not next_called:
+        out['short_circuited'] = True
+    if error is not None:
+        out['error'] = error
+    return out
+
+
+async def run_logged_hook(
+    *,
+    mw: MiddlewareDef,
+    hook: str,
+    params: HookParamsT,
+    ctx: GenerateMiddlewareContext,
+    wrap: Callable[
+        [
+            HookParamsT,
+            GenerateMiddlewareContext,
+            Callable[[HookParamsT, GenerateMiddlewareContext], Awaitable[HookResultT]],
+        ],
+        Awaitable[HookResultT],
+    ],
+    inner: Callable[[HookParamsT, GenerateMiddlewareContext], Awaitable[HookResultT]],
+    extra: dict[str, object] | None = None,
+) -> HookResultT:
+    """Run one middleware hook, with started/finished records when debug is on."""
+    if not is_debug_enabled(logger):
+        return await wrap(params, ctx, inner)
+    attrs = extra or {}
+    name = middleware_name(mw)
+    logger.debug('middleware hook started', middleware=name, hook=hook, **attrs)
+    start = time.monotonic()
+    next_called = False
+
+    async def tracked(tp: HookParamsT, tc: GenerateMiddlewareContext) -> HookResultT:
+        nonlocal next_called
+        next_called = True
+        return await inner(tp, tc)
+
+    err: str | None = None
+    try:
+        return await wrap(params, ctx, tracked)
+    except Exception as e:
+        err = str(e)
+        raise
+    finally:
+        logger.debug(
+            'middleware hook finished',
+            **hook_finished(
+                name=name,
+                hook=hook,
+                start=start,
+                next_called=next_called,
+                error=err,
+                extra=attrs,
+            ),
+        )
 
 
 class ScopedGenkitView:
@@ -220,7 +302,15 @@ async def dispatch_tool(
             _m: MiddlewareDef = _mw,
             _i: Callable[[ToolHookParams, GenerateMiddlewareContext], Awaitable[MultipartToolResponse]] = _inner,
         ) -> MultipartToolResponse:
-            return await _m.wrap_tool(p, c, _i)
+            return await run_logged_hook(
+                mw=_m,
+                hook='tool',
+                params=p,
+                ctx=c,
+                wrap=_m.wrap_tool,
+                inner=_i,
+                extra={'tool': p.tool.name},
+            )
 
         runner = run_next
     return await runner(params, ctx)
@@ -387,63 +477,6 @@ def _augment_with_context(
     return new_req
 
 
-# Matches data URIs: everything up to the first comma is the media-type +
-# parameters (e.g. "data:audio/L16;codec=pcm;rate=24000;base64,").
-_DATA_URI_RE = re.compile(r'data:[^,]{0,200},(?=.{100})', re.ASCII)
-
-# Longest string kept intact when serializing a response for debug logs.
-_MAX_LOGGED_STR_LEN = 8192
-
-# Tighter limit inside subtrees carrying the provider's own payload.
-_PROVIDER_STR_LEN = 1024
-_PROVIDER_FIELDS = frozenset({'custom', 'raw'})
-
-# Most list items kept when serializing a response for debug logs.
-_MAX_LOGGED_LIST_LEN = 100
-
-
-def _redact_large_values(obj: Any, limit: int = _MAX_LOGGED_STR_LEN) -> Any:  # noqa: ANN401
-    """Recursively shrink oversized values in a serialized dict/list.
-
-    Data URIs keep their media type and drop the payload
-    (``data:image/png;base64,...<12345 chars>``); other over-long strings keep
-    their leading characters; binary values collapse to their size; over-long
-    lists keep their leading items. ``custom`` and ``raw`` subtrees use
-    ``_PROVIDER_STR_LEN`` so a provider blob costs less than model output.
-
-    Args:
-        obj: Value from a ``model_dump()``, walked recursively.
-        limit: Longest string kept intact within this subtree.
-
-    Returns:
-        The value with oversized leaves replaced by a truncated form that
-        reports how much was dropped.
-    """
-    if isinstance(obj, str):
-        m = _DATA_URI_RE.match(obj)
-        if m:
-            return f'{m.group()}...<{len(obj) - m.end()} chars>'
-        if len(obj) > limit:
-            return f'{obj[:limit]}...<{len(obj) - limit} chars>'
-        return obj
-    if isinstance(obj, (bytes, bytearray, memoryview)):
-        return f'<{len(obj)} bytes>'
-    if isinstance(obj, dict):
-        return {
-            k: _redact_large_values(v, _PROVIDER_STR_LEN if k in _PROVIDER_FIELDS else limit) for k, v in obj.items()
-        }
-    if isinstance(obj, list):
-        head = [_redact_large_values(v, limit) for v in obj[:_MAX_LOGGED_LIST_LEN]]
-        dropped = len(obj) - len(head)
-        return [*head, f'...<{dropped} more items>'] if dropped else head
-    return obj
-
-
-def _loggable_response(response: ModelResponse) -> dict[str, Any]:
-    """Serialize a response for debug logging with oversized values shrunk."""
-    return _redact_large_values(response.model_dump())
-
-
 def raise_if_aborted(abort_signal: asyncio.Event) -> None:
     if abort_signal.is_set():
         raise GenkitError(status='ABORTED', message='Generation aborted.')
@@ -554,6 +587,21 @@ async def generate_with_request(
             raw_request.tools = existing
     else:
         mw_pipeline = _GenerateMiddlewarePipeline(middleware=[], ctx=run_ctx)
+
+    if is_debug_enabled(logger):
+        resolved: dict[str, object] = {
+            'model': raw_request.model,
+            'messages': len(raw_request.messages),
+            'tools': len(raw_request.tools or []),
+            'max_turns': raw_request.max_turns,
+            'streaming': on_chunk is not None,
+        }
+        if raw_request.output is not None:
+            resolved['format'] = raw_request.output.format
+            resolved['constrained'] = raw_request.output.constrained
+        if middleware:
+            resolved['middleware'] = [middleware_name(m) for m in middleware]
+        logger.debug('generate request resolved', **resolved)
 
     return await _generate_action_turn(
         registry=registry,
@@ -708,7 +756,15 @@ async def _generate_action_turn(
                 _m: MiddlewareDef = _mw,
                 _i: Callable[[GenerateHookParams, GenerateMiddlewareContext], Awaitable[ModelResponse]] = _inner,
             ) -> ModelResponse:
-                return await _m.wrap_generate(p, c, _i)
+                return await run_logged_hook(
+                    mw=_m,
+                    hook='generate',
+                    params=p,
+                    ctx=c,
+                    wrap=_m.wrap_generate,
+                    inner=_i,
+                    extra={'iteration': p.iteration},
+                )
 
             runner = run_next
         return await runner(params, ctx)
@@ -730,7 +786,14 @@ async def _generate_action_turn(
                 _mw: MiddlewareDef = _mw,
                 _inner: Callable[[ModelHookParams, GenerateMiddlewareContext], Awaitable[ModelResponse]] = _inner,
             ) -> ModelResponse:
-                return await _mw.wrap_model(params, c, _inner)
+                return await run_logged_hook(
+                    mw=_mw,
+                    hook='model',
+                    params=params,
+                    ctx=c,
+                    wrap=_mw.wrap_model,
+                    inner=_inner,
+                )
 
             runner = cast(Callable[[ModelHookParams, GenerateMiddlewareContext], Awaitable[ModelResponse]], run_next)
         return await runner(params, ctx)
@@ -764,6 +827,13 @@ async def _generate_action_turn(
             request = _augment_with_context(request)
 
         async def next_fn(params: ModelHookParams, c: GenerateMiddlewareContext) -> ModelResponse:
+            if is_debug_enabled(logger):
+                logger.debug(
+                    'calling model',
+                    model=turn_options.model,
+                    turn=current_turn,
+                    messages=len(params.request.messages),
+                )
             return (
                 await model.run(
                     input=params.request,
@@ -797,11 +867,22 @@ async def _generate_action_turn(
         if schema_type:
             response._schema_type = schema_type
 
+        generated_msg = response.message
+        tool_requests = [x for x in generated_msg.content if x.root.tool_request] if generated_msg is not None else []
+
         if is_debug_enabled(logger):
-            logger.debug('generate response', response=_loggable_response(response))
+            responded: dict[str, object] = {
+                'model': turn_options.model,
+                'turn': current_turn,
+                'finish_reason': response.finish_reason,
+                'tool_requests': len(tool_requests),
+            }
+            if response.usage is not None:
+                responded['input_tokens'] = response.usage.input_tokens
+                responded['output_tokens'] = response.usage.output_tokens
+            logger.debug('model responded', **responded)
 
         response.assert_valid()
-        generated_msg = response.message
 
         if generated_msg is None:
             return _persist_threaded_conversation(response, turn_options.messages)
@@ -821,8 +902,6 @@ async def _generate_action_turn(
             generate_meta['output'] = generate_output
             existing_meta['generate'] = generate_meta
             generated_msg.metadata = existing_meta
-
-        tool_requests = [x for x in generated_msg.content if x.root.tool_request]
 
         if turn_options.return_tool_requests or len(tool_requests) == 0:
             if len(tool_requests) == 0:
@@ -852,6 +931,11 @@ async def _generate_action_turn(
         # if an interrupt message is returned, stop the tool loop and return a
         # response.
         if revised_model_msg:
+            logger.debug(
+                'generation paused by tool interrupts',
+                model=turn_options.model,
+                turn=current_turn,
+            )
             interrupted_resp = response.model_copy(deep=False)
             interrupted_resp.finish_reason = FinishReason.INTERRUPTED
             interrupted_resp.finish_message = 'One or more tool calls resulted in interrupts.'
@@ -1210,6 +1294,12 @@ async def resolve_tool_requests(
 
     if not work:
         return (None, Message(role=Role.TOOL, content=[]))
+
+    if is_debug_enabled(logger):
+        logger.debug(
+            'executing tool requests',
+            tools=[trp.tool_request.name for _, _, trp in work],
+        )
 
     async def _resolve_one_tool(
         tool: Action, trp: ToolRequestPart

--- a/py/packages/genkit/src/genkit/_ai/_generate.py
+++ b/py/packages/genkit/src/genkit/_ai/_generate.py
@@ -19,11 +19,11 @@
 import asyncio
 import contextlib
 import copy
-import re
 import secrets
+import time
 from collections.abc import Awaitable, Callable, Generator, Sequence
 from dataclasses import dataclass
-from typing import Any, cast
+from typing import Any, TypeVar, cast
 
 from pydantic import BaseModel, ValidationError
 from typing_extensions import Never
@@ -87,6 +87,88 @@ from genkit._core._typing import (
 DEFAULT_MAX_TURNS = 5
 
 logger = get_logger(__name__)
+
+HookParamsT = TypeVar('HookParamsT')
+HookResultT = TypeVar('HookResultT')
+
+
+def middleware_name(mw: MiddlewareDef) -> str:
+    """Class name is what shows up on hook log records."""
+    return type(mw).__name__
+
+
+def hook_finished(
+    *,
+    name: str,
+    hook: str,
+    start: float,
+    next_called: bool,
+    error: str | None,
+    extra: dict[str, object],
+) -> dict[str, object]:
+    """Attributes for the ``middleware hook finished`` record."""
+    out: dict[str, object] = {
+        'middleware': name,
+        'hook': hook,
+        'duration_ms': int((time.monotonic() - start) * 1000),
+        **extra,
+    }
+    if not next_called:
+        out['short_circuited'] = True
+    if error is not None:
+        out['error'] = error
+    return out
+
+
+async def run_logged_hook(
+    *,
+    mw: MiddlewareDef,
+    hook: str,
+    params: HookParamsT,
+    ctx: GenerateMiddlewareContext,
+    wrap: Callable[
+        [
+            HookParamsT,
+            GenerateMiddlewareContext,
+            Callable[[HookParamsT, GenerateMiddlewareContext], Awaitable[HookResultT]],
+        ],
+        Awaitable[HookResultT],
+    ],
+    inner: Callable[[HookParamsT, GenerateMiddlewareContext], Awaitable[HookResultT]],
+    extra: dict[str, object] | None = None,
+) -> HookResultT:
+    """Run one middleware hook, with started/finished records when debug is on."""
+    if not is_debug_enabled(logger):
+        return await wrap(params, ctx, inner)
+    attrs = extra or {}
+    name = middleware_name(mw)
+    logger.debug('middleware hook started', middleware=name, hook=hook, **attrs)
+    start = time.monotonic()
+    next_called = False
+
+    async def tracked(tp: HookParamsT, tc: GenerateMiddlewareContext) -> HookResultT:
+        nonlocal next_called
+        next_called = True
+        return await inner(tp, tc)
+
+    err: str | None = None
+    try:
+        return await wrap(params, ctx, tracked)
+    except BaseException as e:
+        err = str(e) or type(e).__name__
+        raise
+    finally:
+        logger.debug(
+            'middleware hook finished',
+            **hook_finished(
+                name=name,
+                hook=hook,
+                start=start,
+                next_called=next_called,
+                error=err,
+                extra=attrs,
+            ),
+        )
 
 
 class ScopedGenkitView:
@@ -224,7 +306,15 @@ async def dispatch_tool(
             _m: MiddlewareDef = _mw,
             _i: Callable[[ToolHookParams, GenerateMiddlewareContext], Awaitable[MultipartToolResponse]] = _inner,
         ) -> MultipartToolResponse:
-            return await _m.wrap_tool(p, c, _i)
+            return await run_logged_hook(
+                mw=_m,
+                hook='tool',
+                params=p,
+                ctx=c,
+                wrap=_m.wrap_tool,
+                inner=_i,
+                extra={'tool': p.tool.name},
+            )
 
         runner = run_next
     return await runner(params, ctx)
@@ -391,63 +481,6 @@ def _augment_with_context(
     return new_req
 
 
-# Matches data URIs: everything up to the first comma is the media-type +
-# parameters (e.g. "data:audio/L16;codec=pcm;rate=24000;base64,").
-_DATA_URI_RE = re.compile(r'data:[^,]{0,200},(?=.{100})', re.ASCII)
-
-# Longest string kept intact when serializing a response for debug logs.
-_MAX_LOGGED_STR_LEN = 8192
-
-# Tighter limit inside subtrees carrying the provider's own payload.
-_PROVIDER_STR_LEN = 1024
-_PROVIDER_FIELDS = frozenset({'custom', 'raw'})
-
-# Most list items kept when serializing a response for debug logs.
-_MAX_LOGGED_LIST_LEN = 100
-
-
-def _redact_large_values(obj: Any, limit: int = _MAX_LOGGED_STR_LEN) -> Any:  # noqa: ANN401
-    """Recursively shrink oversized values in a serialized dict/list.
-
-    Data URIs keep their media type and drop the payload
-    (``data:image/png;base64,...<12345 chars>``); other over-long strings keep
-    their leading characters; binary values collapse to their size; over-long
-    lists keep their leading items. ``custom`` and ``raw`` subtrees use
-    ``_PROVIDER_STR_LEN`` so a provider blob costs less than model output.
-
-    Args:
-        obj: Value from a ``model_dump()``, walked recursively.
-        limit: Longest string kept intact within this subtree.
-
-    Returns:
-        The value with oversized leaves replaced by a truncated form that
-        reports how much was dropped.
-    """
-    if isinstance(obj, str):
-        m = _DATA_URI_RE.match(obj)
-        if m:
-            return f'{m.group()}...<{len(obj) - m.end()} chars>'
-        if len(obj) > limit:
-            return f'{obj[:limit]}...<{len(obj) - limit} chars>'
-        return obj
-    if isinstance(obj, (bytes, bytearray, memoryview)):
-        return f'<{len(obj)} bytes>'
-    if isinstance(obj, dict):
-        return {
-            k: _redact_large_values(v, _PROVIDER_STR_LEN if k in _PROVIDER_FIELDS else limit) for k, v in obj.items()
-        }
-    if isinstance(obj, list):
-        head = [_redact_large_values(v, limit) for v in obj[:_MAX_LOGGED_LIST_LEN]]
-        dropped = len(obj) - len(head)
-        return [*head, f'...<{dropped} more items>'] if dropped else head
-    return obj
-
-
-def _loggable_response(response: ModelResponse) -> dict[str, Any]:
-    """Serialize a response for debug logging with oversized values shrunk."""
-    return _redact_large_values(response.model_dump())
-
-
 def raise_if_aborted(abort_signal: asyncio.Event) -> None:
     if abort_signal.is_set():
         raise GenkitError(status='ABORTED', message='Generation aborted.')
@@ -558,6 +591,21 @@ async def generate_with_request(
             raw_request.tools = existing
     else:
         mw_pipeline = _GenerateMiddlewarePipeline(middleware=[], ctx=run_ctx)
+
+    if is_debug_enabled(logger):
+        resolved: dict[str, object] = {
+            'model': raw_request.model,
+            'messages': len(raw_request.messages),
+            'tools': len(raw_request.tools or []),
+            'max_turns': raw_request.max_turns,
+            'streaming': on_chunk is not None,
+        }
+        if raw_request.output is not None:
+            resolved['format'] = raw_request.output.format
+            resolved['constrained'] = raw_request.output.constrained
+        if middleware:
+            resolved['middleware'] = [middleware_name(m) for m in middleware]
+        logger.debug('generate request resolved', **resolved)
 
     return await _generate_action_turn(
         registry=registry,
@@ -769,7 +817,15 @@ async def _generate_action_turn(
                 _m: MiddlewareDef = _mw,
                 _i: Callable[[GenerateHookParams, GenerateMiddlewareContext], Awaitable[ModelResponse]] = _inner,
             ) -> ModelResponse:
-                return await _m.wrap_generate(p, c, _i)
+                return await run_logged_hook(
+                    mw=_m,
+                    hook='generate',
+                    params=p,
+                    ctx=c,
+                    wrap=_m.wrap_generate,
+                    inner=_i,
+                    extra={'iteration': p.iteration},
+                )
 
             runner = run_next
         return await runner(params, ctx)
@@ -791,7 +847,14 @@ async def _generate_action_turn(
                 _mw: MiddlewareDef = _mw,
                 _inner: Callable[[ModelHookParams, GenerateMiddlewareContext], Awaitable[ModelResponse]] = _inner,
             ) -> ModelResponse:
-                return await _mw.wrap_model(params, c, _inner)
+                return await run_logged_hook(
+                    mw=_mw,
+                    hook='model',
+                    params=params,
+                    ctx=c,
+                    wrap=_mw.wrap_model,
+                    inner=_inner,
+                )
 
             runner = cast(Callable[[ModelHookParams, GenerateMiddlewareContext], Awaitable[ModelResponse]], run_next)
         return await runner(params, ctx)
@@ -825,6 +888,13 @@ async def _generate_action_turn(
             request = _augment_with_context(request)
 
         async def next_fn(params: ModelHookParams, c: GenerateMiddlewareContext) -> ModelResponse:
+            if is_debug_enabled(logger):
+                logger.debug(
+                    'calling model',
+                    model=turn_options.model,
+                    turn=current_turn,
+                    messages=len(params.request.messages),
+                )
             result = await model.run(
                 input=params.request,
                 context=c.custom_context,
@@ -871,11 +941,22 @@ async def _generate_action_turn(
         if schema_type:
             response._schema_type = schema_type
 
+        generated_msg = response.message
+        tool_requests = [x for x in generated_msg.content if x.root.tool_request] if generated_msg is not None else []
+
         if is_debug_enabled(logger):
-            logger.debug('generate response', response=_loggable_response(response))
+            responded: dict[str, object] = {
+                'model': turn_options.model,
+                'turn': current_turn,
+                'finish_reason': response.finish_reason,
+                'tool_requests': len(tool_requests),
+            }
+            if response.usage is not None:
+                responded['input_tokens'] = response.usage.input_tokens
+                responded['output_tokens'] = response.usage.output_tokens
+            logger.debug('model responded', **responded)
 
         response.assert_valid()
-        generated_msg = response.message
 
         # A ticket means generate is done. Don't run tools against a start handle.
         if generated_msg is None or response.operation is not None:
@@ -896,8 +977,6 @@ async def _generate_action_turn(
             generate_meta['output'] = generate_output
             existing_meta['generate'] = generate_meta
             generated_msg.metadata = existing_meta
-
-        tool_requests = [x for x in generated_msg.content if x.root.tool_request]
 
         if turn_options.return_tool_requests or len(tool_requests) == 0:
             if len(tool_requests) == 0:
@@ -927,6 +1006,11 @@ async def _generate_action_turn(
         # if an interrupt message is returned, stop the tool loop and return a
         # response.
         if revised_model_msg:
+            logger.debug(
+                'generation paused by tool interrupts',
+                model=turn_options.model,
+                turn=current_turn,
+            )
             interrupted_resp = response.model_copy(deep=False)
             interrupted_resp.finish_reason = FinishReason.INTERRUPTED
             interrupted_resp.finish_message = 'One or more tool calls resulted in interrupts.'
@@ -1301,6 +1385,12 @@ async def resolve_tool_requests(
 
     if not work:
         return (None, Message(role=Role.TOOL, content=[]))
+
+    if is_debug_enabled(logger):
+        logger.debug(
+            'executing tool requests',
+            tools=[trp.tool_request.name for _, _, trp in work],
+        )
 
     async def _resolve_one_tool(
         tool: Action, trp: ToolRequestPart

--- a/py/packages/genkit/src/genkit/_ai/_generate.py
+++ b/py/packages/genkit/src/genkit/_ai/_generate.py
@@ -93,11 +93,12 @@ HookResultT = TypeVar('HookResultT')
 
 # A termination known to be abnormal carries no conforming output, so a schema
 # error here would mask the finish reason the caller needs to handle it.
+# OTHER is the providers' catch-all for unmapped stop reasons (a normal
+# pause or compaction), not a signal that parsing should be skipped.
 ABNORMAL_FINISH_REASONS = frozenset({
     FinishReason.BLOCKED,
     FinishReason.ABORTED,
     FinishReason.INTERRUPTED,
-    FinishReason.OTHER,
 })
 
 
@@ -598,6 +599,11 @@ async def generate_with_request(
     # Shallow-copy the wire-shape struct so per-field updates below (and any
     # future mutations) don't leak back to the caller's ``raw_request``.
     raw_request = raw_request.model_copy()
+    if not raw_request.messages:
+        raise GenkitError(
+            status='INVALID_ARGUMENT',
+            message='at least one message is required in generate request',
+        )
     registry = registry if registry.is_child else registry.new_child()
 
     if raw_request.tools:
@@ -700,10 +706,7 @@ class ChunkAccumulator:
         """Send one framework-wrapped chunk through the current stream chain."""
         if ctx.on_chunk is None:
             return
-        try:
-            ctx.on_chunk(self.make(role=role, chunk=chunk))
-        except Exception as e:
-            logger.debug('tool stream callback failed, dropping chunk', error=e)
+        ctx.on_chunk(self.make(role=role, chunk=chunk))
 
     @contextlib.contextmanager
     def intercept_model_stream(
@@ -1030,7 +1033,7 @@ async def _generate_action_turn(
             generated_msg.metadata = existing_meta
 
         if turn_options.return_tool_requests or len(tool_requests) == 0:
-            if len(tool_requests) == 0:
+            if len(tool_requests) == 0 and response.finish_reason not in ABNORMAL_FINISH_REASONS:
                 response.assert_valid_schema()
             return _persist_threaded_conversation(response, turn_options.messages)
 
@@ -1340,7 +1343,10 @@ async def resolve_parameters(
     if request.output and request.output.format:
         looked_up_format = registry.lookup_value('format', request.output.format)
         if looked_up_format is None:
-            raise ValueError(f'Unable to resolve format {request.output.format}')
+            raise GenkitError(
+                status='INVALID_ARGUMENT',
+                message=f'Unable to resolve format {request.output.format}',
+            )
         format_def = cast(FormatDef, looked_up_format)
 
     return (model_action, tools, format_def)

--- a/py/packages/genkit/src/genkit/_ai/_model.py
+++ b/py/packages/genkit/src/genkit/_ai/_model.py
@@ -32,6 +32,7 @@ from genkit._core._action import (
     get_func_description,
 )
 from genkit._core._error import GenkitError
+from genkit._core._logger import get_logger
 from genkit._core._model import (
     Message,
     ModelConfig as ModelConfig,
@@ -52,6 +53,8 @@ from genkit._core._typing import ActionMetadata, ModelInfo
 # Type alias for model functions (must be async)
 # Use ctx.send_chunk() for streaming
 ModelFn = Callable[[ModelRequest, ActionRunContext], Awaitable[ModelResponse[Any]]]
+
+logger = get_logger(__name__)
 
 # Veneer-facing argument shapes. Internals resolve these into ResolvedModel.
 ModelArg: TypeAlias = str | ModelRef[BaseModel]
@@ -143,8 +146,10 @@ def resolve_model_arg(
         )
     resolved = registry.lookup_value('defaultModel', 'defaultModel')
     if isinstance(resolved, ModelRef):
+        logger.debug('no model specified, using default model', model=resolved.name)
         return cast(ModelArg, resolved)
     if isinstance(resolved, str) and resolved:
+        logger.debug('no model specified, using default model', model=resolved)
         return resolved
     if resolved is not None and resolved != '':
         raise GenkitError(

--- a/py/packages/genkit/src/genkit/_ai/_tools.py
+++ b/py/packages/genkit/src/genkit/_ai/_tools.py
@@ -27,9 +27,12 @@ from pydantic import BaseModel
 
 from genkit._core._action import Action, ActionKind, ActionRunContext
 from genkit._core._error import GenkitError, GenkitInterrupt
+from genkit._core._logger import get_logger
 from genkit._core._middleware import GenerateMiddlewareContext
 from genkit._core._registry import Registry
 from genkit._core._typing import ToolDefinition, ToolRequest, ToolRequestPart, ToolResponse, ToolResponsePart
+
+logger = get_logger(__name__)
 
 
 class Tool:
@@ -313,6 +316,10 @@ async def run_tool_after_restart(
             else (e if isinstance(e, Interrupt) else None)
         )
         if intr is not None:
+            logger.debug(
+                'restarted tool triggered an interrupt',
+                tool=restart_trp.tool_request.name,
+            )
             raise restart_interrupt_error(intr) from e
         raise
 

--- a/py/packages/genkit/src/genkit/_core/_constants.py
+++ b/py/packages/genkit/src/genkit/_core/_constants.py
@@ -16,8 +16,18 @@
 
 """Module containing various core constants."""
 
-# The version of Genkit sent over HTTP in the headers.
-# TODO(#4349): make this dynamic
-GENKIT_VERSION = '0.3.2'
+import importlib.metadata
+
+
+def package_version() -> str:
+    """Installed ``genkit`` package version, or ``0.0.0`` if it is not installed."""
+    try:
+        return importlib.metadata.version('genkit')
+    except importlib.metadata.PackageNotFoundError:
+        return '0.0.0'
+
+
+# Sent over HTTP in the client header and on the OTLP log scope.
+GENKIT_VERSION = package_version()
 
 GENKIT_CLIENT_HEADER = f'genkit-python/{GENKIT_VERSION}'

--- a/py/packages/genkit/src/genkit/_core/_logger.py
+++ b/py/packages/genkit/src/genkit/_core/_logger.py
@@ -7,11 +7,13 @@ from __future__ import annotations
 
 import logging
 import os
+from typing import cast
 
 import structlog
-from structlog.typing import FilteringBoundLogger
+from structlog.typing import BindableLogger, FilteringBoundLogger
 
 from genkit._core._environment import is_dev_environment
+from genkit._core._trace._log_exporter import enable_log_export
 
 # Environment variable name
 GENKIT_LOG = 'GENKIT_LOG'
@@ -90,10 +92,12 @@ def configure_structlog_level() -> bool:
 def configure_logging(*, shared_tty: bool | None = None) -> None:
     """Configure genkit console logging and mute reflection access logs on a shared TTY.
 
-    Safe to call more than once. Default level is ``info``; override with
-    ``GENKIT_LOG=debug|info|warn|error``.
+    Safe to call more than once. Default console level is ``info``; override
+    with ``GENKIT_LOG=debug|info|warn|error``. In ``GENKIT_ENV=dev``, debug
+    records also stream to the Dev UI when a telemetry URL is set.
     """
     configure_structlog_level()
+    _maybe_enable_log_export()
 
     if shared_tty is None:
         shared_tty = is_dev_environment()
@@ -110,9 +114,92 @@ def configure_logging(*, shared_tty: bool | None = None) -> None:
             logger.setLevel(quiet_level)
 
 
+def _maybe_enable_log_export() -> None:
+    """Turn on Dev UI log streaming when a telemetry URL is already known."""
+    if not is_dev_environment():
+        return
+    url = os.environ.get('GENKIT_TELEMETRY_SERVER', '').strip()
+    if not url:
+        return
+    enable_log_export(url=url)
+
+
+_EMIT_LEVELS: dict[str, int] = {
+    'debug': logging.DEBUG,
+    'info': logging.INFO,
+    'warning': logging.WARNING,
+    'warn': logging.WARNING,
+    'error': logging.ERROR,
+    'critical': logging.CRITICAL,
+    'exception': logging.ERROR,
+    'msg': logging.INFO,
+}
+
+
+class ExportTee:
+    """Forwards every record to the Dev UI sink, then to the console logger.
+
+    The console still honours ``GENKIT_LOG``. The export sink is debug and
+    above, so a quiet terminal can still fill the trace viewer's log panel.
+    """
+
+    def __init__(self, bound: BindableLogger, attrs: dict[str, object] | None = None) -> None:
+        self._bound = bound
+        self._attrs = attrs or {}
+
+    def bind(self, **new_values: object) -> ExportTee:
+        return ExportTee(self._bound.bind(**new_values), attrs={**self._attrs, **new_values})
+
+    def unbind(self, *keys: str) -> ExportTee:
+        kept = {k: v for k, v in self._attrs.items() if k not in keys}
+        return ExportTee(self._bound.unbind(*keys), attrs=kept)
+
+    def new(self, **new_values: object) -> ExportTee:
+        return ExportTee(self._bound.new(**new_values), attrs=dict(new_values))
+
+    def is_enabled_for(self, level: int) -> bool:
+        from genkit._core._trace._log_exporter import log_export_is_enabled
+
+        if level >= logging.DEBUG and log_export_is_enabled():
+            return True
+        for attr in ('is_enabled_for', 'isEnabledFor'):
+            check = getattr(self._bound, attr, None)
+            if not callable(check):
+                continue
+            try:
+                return bool(check(level))
+            except Exception:
+                return True
+        return True
+
+    def _emit(self, level: int, event: str, kw: dict[str, object]) -> None:
+        from genkit._core._trace._log_exporter import emit_log
+
+        emit_log(level=level, event=event, attrs={**self._attrs, **kw})
+
+    def __getattr__(self, name: str) -> object:
+        target = getattr(self._bound, name)
+        if name == 'log' and callable(target):
+
+            def emit_log(level: int, event: str, *args: object, **kw: object) -> object:
+                self._emit(level, event, kw)
+                return target(level, event, *args, **kw)
+
+            return emit_log
+        if name not in _EMIT_LEVELS or not callable(target):
+            return target
+        emit_level = _EMIT_LEVELS[name]
+
+        def emit_then(event: str, *args: object, **kw: object) -> object:
+            self._emit(emit_level, event, kw)
+            return target(event, *args, **kw)
+
+        return emit_then
+
+
 def get_logger(name: str | None = None) -> FilteringBoundLogger:
-    """Return a structlog bound logger with a concrete return type for checkers."""
-    return structlog.get_logger(name)
+    """Return a structlog bound logger that also feeds the Dev UI log sink."""
+    return cast(FilteringBoundLogger, ExportTee(structlog.get_logger(name)))
 
 
 def is_debug_enabled(logger: FilteringBoundLogger) -> bool:
@@ -122,9 +209,14 @@ def is_debug_enabled(logger: FilteringBoundLogger) -> bool:
         logger: Logger to inspect.
 
     Returns:
-        ``True`` when DEBUG events are emitted, including when ``logger``
+        ``True`` when DEBUG events are emitted, including when the Dev UI
+        log sink is on (console may still be quieter) or when ``logger``
         exposes no usable level check.
     """
+    from genkit._core._trace._log_exporter import log_export_is_enabled
+
+    if log_export_is_enabled():
+        return True
     for attr in ('is_enabled_for', 'isEnabledFor'):
         check = getattr(logger, attr, None)
         if not callable(check):

--- a/py/packages/genkit/src/genkit/_core/_logger.py
+++ b/py/packages/genkit/src/genkit/_core/_logger.py
@@ -7,11 +7,13 @@ from __future__ import annotations
 
 import logging
 import os
+from typing import cast
 
 import structlog
-from structlog.typing import FilteringBoundLogger
+from structlog.typing import BindableLogger, FilteringBoundLogger
 
 from genkit._core._environment import is_dev_environment
+from genkit._core._trace._log_exporter import enable_log_export
 
 # Environment variable name
 GENKIT_LOG = 'GENKIT_LOG'
@@ -94,10 +96,12 @@ def configure_structlog_level() -> bool:
 def configure_logging(*, shared_tty: bool | None = None) -> None:
     """Configure genkit console logging and mute reflection access logs on a shared TTY.
 
-    Safe to call more than once. Default level is ``info``; override with
-    ``GENKIT_LOG=debug|info|warn|error``.
+    Safe to call more than once. Default console level is ``info``; override
+    with ``GENKIT_LOG=debug|info|warn|error``. In ``GENKIT_ENV=dev``, debug
+    records also stream to the Dev UI when a telemetry URL is set.
     """
     configure_structlog_level()
+    _maybe_enable_log_export()
 
     if shared_tty is None:
         shared_tty = is_dev_environment()
@@ -114,9 +118,92 @@ def configure_logging(*, shared_tty: bool | None = None) -> None:
             logger.setLevel(quiet_level)
 
 
+def _maybe_enable_log_export() -> None:
+    """Turn on Dev UI log streaming when a telemetry URL is already known."""
+    if not is_dev_environment():
+        return
+    url = os.environ.get('GENKIT_TELEMETRY_SERVER', '').strip()
+    if not url:
+        return
+    enable_log_export(url=url)
+
+
+_EMIT_LEVELS: dict[str, int] = {
+    'debug': logging.DEBUG,
+    'info': logging.INFO,
+    'warning': logging.WARNING,
+    'warn': logging.WARNING,
+    'error': logging.ERROR,
+    'critical': logging.CRITICAL,
+    'exception': logging.ERROR,
+    'msg': logging.INFO,
+}
+
+
+class ExportTee:
+    """Forwards every record to the Dev UI sink, then to the console logger.
+
+    The console still honours ``GENKIT_LOG``. The export sink is debug and
+    above, so a quiet terminal can still fill the trace viewer's log panel.
+    """
+
+    def __init__(self, bound: BindableLogger, attrs: dict[str, object] | None = None) -> None:
+        self._bound = bound
+        self._attrs = attrs or {}
+
+    def bind(self, **new_values: object) -> ExportTee:
+        return ExportTee(self._bound.bind(**new_values), attrs={**self._attrs, **new_values})
+
+    def unbind(self, *keys: str) -> ExportTee:
+        kept = {k: v for k, v in self._attrs.items() if k not in keys}
+        return ExportTee(self._bound.unbind(*keys), attrs=kept)
+
+    def new(self, **new_values: object) -> ExportTee:
+        return ExportTee(self._bound.new(**new_values), attrs=dict(new_values))
+
+    def is_enabled_for(self, level: int) -> bool:
+        from genkit._core._trace._log_exporter import log_export_is_enabled
+
+        if level >= logging.DEBUG and log_export_is_enabled():
+            return True
+        for attr in ('is_enabled_for', 'isEnabledFor'):
+            check = getattr(self._bound, attr, None)
+            if not callable(check):
+                continue
+            try:
+                return bool(check(level))
+            except Exception:
+                return True
+        return True
+
+    def _emit(self, level: int, event: str, kw: dict[str, object]) -> None:
+        from genkit._core._trace._log_exporter import emit_log
+
+        emit_log(level=level, event=event, attrs={**self._attrs, **kw})
+
+    def __getattr__(self, name: str) -> object:
+        target = getattr(self._bound, name)
+        if name == 'log' and callable(target):
+
+            def emit_log(level: int, event: str, *args: object, **kw: object) -> object:
+                self._emit(level, event, kw)
+                return target(level, event, *args, **kw)
+
+            return emit_log
+        if name not in _EMIT_LEVELS or not callable(target):
+            return target
+        emit_level = _EMIT_LEVELS[name]
+
+        def emit_then(event: str, *args: object, **kw: object) -> object:
+            self._emit(emit_level, event, kw)
+            return target(event, *args, **kw)
+
+        return emit_then
+
+
 def get_logger(name: str | None = None) -> FilteringBoundLogger:
-    """Return a structlog bound logger with a concrete return type for checkers."""
-    return structlog.get_logger(name)
+    """Return a structlog bound logger that also feeds the Dev UI log sink."""
+    return cast(FilteringBoundLogger, ExportTee(structlog.get_logger(name)))
 
 
 def is_debug_enabled(logger: FilteringBoundLogger) -> bool:
@@ -126,9 +213,14 @@ def is_debug_enabled(logger: FilteringBoundLogger) -> bool:
         logger: Logger to inspect.
 
     Returns:
-        ``True`` when DEBUG events are emitted, including when ``logger``
+        ``True`` when DEBUG events are emitted, including when the Dev UI
+        log sink is on (console may still be quieter) or when ``logger``
         exposes no usable level check.
     """
+    from genkit._core._trace._log_exporter import log_export_is_enabled
+
+    if log_export_is_enabled():
+        return True
     for attr in ('is_enabled_for', 'isEnabledFor'):
         check = getattr(logger, attr, None)
         if not callable(check):

--- a/py/packages/genkit/src/genkit/_core/_logger.py
+++ b/py/packages/genkit/src/genkit/_core/_logger.py
@@ -176,17 +176,17 @@ class ExportTee:
                 return True
         return True
 
-    def _emit(self, level: int, event: str, kw: dict[str, object]) -> None:
+    def _emit(self, level: int, event: str, args: tuple[object, ...], kw: dict[str, object]) -> None:
         from genkit._core._trace._log_exporter import emit_log
 
-        emit_log(level=level, event=event, attrs={**self._attrs, **kw})
+        emit_log(level=level, event=_interpolate_event(event, args), attrs={**self._attrs, **kw})
 
     def __getattr__(self, name: str) -> object:
         target = getattr(self._bound, name)
         if name == 'log' and callable(target):
 
             def emit_log(level: int, event: str, *args: object, **kw: object) -> object:
-                self._emit(level, event, kw)
+                self._emit(level, event, args, kw)
                 return target(level, event, *args, **kw)
 
             return emit_log
@@ -195,10 +195,20 @@ class ExportTee:
         emit_level = _EMIT_LEVELS[name]
 
         def emit_then(event: str, *args: object, **kw: object) -> object:
-            self._emit(emit_level, event, kw)
+            self._emit(emit_level, event, args, kw)
             return target(event, *args, **kw)
 
         return emit_then
+
+
+def _interpolate_event(event: str, args: tuple[object, ...]) -> str:
+    """Fill printf-style ``%s`` so the Dev UI panel matches the console line."""
+    if not args:
+        return event
+    try:
+        return event % args
+    except (TypeError, ValueError):
+        return event
 
 
 def get_logger(name: str | None = None) -> FilteringBoundLogger:

--- a/py/packages/genkit/src/genkit/_core/_reflection_v2.py
+++ b/py/packages/genkit/src/genkit/_core/_reflection_v2.py
@@ -54,6 +54,7 @@ from genkit._core._model import ModelRef
 from genkit._core._reflection import as_agent_input_dict, resolve_agent_init
 from genkit._core._registry import Registry
 from genkit._core._trace._default_exporter import TraceServerExporter
+from genkit._core._trace._log_exporter import enable_log_export
 from genkit._core._tracing import add_custom_exporter
 from genkit._core._typing import (
     AgentInput,
@@ -161,6 +162,7 @@ class ReflectionServerV2:
         self.reflection_handshake_telemetry_applied = True
         # Register HTTP export to this URL on the global OTel provider.
         add_custom_exporter(TraceServerExporter(telemetry_server_url=url), 'reflection_v2_telemetry')
+        enable_log_export(url=url)
         logger.debug('reflection V2: connected to telemetry server', url=url)
 
     async def run_forever(self) -> None:

--- a/py/packages/genkit/src/genkit/_core/_reflection_v2.py
+++ b/py/packages/genkit/src/genkit/_core/_reflection_v2.py
@@ -53,6 +53,7 @@ from genkit._core._middleware import GenerateMiddleware
 from genkit._core._reflection import as_agent_input_dict, resolve_agent_init
 from genkit._core._registry import Registry
 from genkit._core._trace._default_exporter import TraceServerExporter
+from genkit._core._trace._log_exporter import enable_log_export
 from genkit._core._tracing import add_custom_exporter
 from genkit._core._typing import (
     AgentInput,
@@ -160,6 +161,7 @@ class ReflectionServerV2:
         self.reflection_handshake_telemetry_applied = True
         # Register HTTP export to this URL on the global OTel provider.
         add_custom_exporter(TraceServerExporter(telemetry_server_url=url), 'reflection_v2_telemetry')
+        enable_log_export(url=url)
         logger.debug('reflection V2: connected to telemetry server', url=url)
 
     async def run_forever(self) -> None:

--- a/py/packages/genkit/src/genkit/_core/_trace/_log_exporter.py
+++ b/py/packages/genkit/src/genkit/_core/_trace/_log_exporter.py
@@ -1,0 +1,353 @@
+# Copyright 2026 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Dev UI log export — OTLP-JSON POSTs to the telemetry server.
+
+Console level stays on ``GENKIT_LOG``. This sink is debug and above, and it
+never waits on the collector: ``generate()`` has already returned.
+"""
+
+from __future__ import annotations
+
+import atexit
+import json
+import logging
+import os
+import threading
+import time
+from queue import Empty, Full, Queue
+from urllib.parse import urljoin
+
+import httpx
+from opentelemetry import trace as trace_api
+
+from genkit._core._constants import GENKIT_VERSION
+from genkit._core._environment import is_dev_environment
+
+GENKIT_OTEL_ENABLE_LOGS = 'GENKIT_OTEL_ENABLE_LOGS'
+GENKIT_TELEMETRY_SERVER = 'GENKIT_TELEMETRY_SERVER'
+
+LOG_ENDPOINT = '/api/otlp'
+LOG_HEADERS = {'Content-Type': 'application/json', 'Accept': 'application/json'}
+SCOPE_NAME = 'genkit-py'
+
+QUEUE_SIZE = 1024
+BATCH_SIZE = 64
+BATCH_DELAY_S = 0.1
+# Long enough for a slow local Dev UI to accept the batch; short enough that
+# a hung collector does not pin this worker for the rest of the process.
+EXPORT_TIMEOUT_S = 300.0
+# The export worker is a daemon: once the interpreter starts tearing down it
+# is killed, so we give the last batch a couple of seconds to land. Ctrl-C of
+# a wedged collector still shouldn't sit for minutes.
+SHUTDOWN_FLUSH_TIMEOUT_S = 2.0
+
+# Keep the Dev UI log panel readable — a generate() that binds 200 keys or a
+# megabyte prompt shouldn't serialize that onto the generate thread.
+MAX_ATTRIBUTES = 32
+MAX_ATTR_CHARS = 2048
+REDACT_KEYS = frozenset({
+    'api_key',
+    'authorization',
+    'password',
+    'secret',
+    'token',
+    'access_token',
+})
+
+SEVERITY: dict[int, tuple[int, str]] = {
+    logging.DEBUG: (5, 'DEBUG'),
+    logging.INFO: (9, 'INFO'),
+    logging.WARNING: (13, 'WARN'),
+    logging.ERROR: (17, 'ERROR'),
+    logging.CRITICAL: (21, 'FATAL'),
+}
+
+_exporter: LogServerExporter | None = None
+_exporter_lock = threading.Lock()
+_skip_export = threading.local()
+_atexit_registered = False
+
+
+def logs_opted_out() -> bool:
+    """True only when ``GENKIT_OTEL_ENABLE_LOGS`` is a ParseBool false."""
+    raw = os.environ.get(GENKIT_OTEL_ENABLE_LOGS, '').strip().lower()
+    return raw in {'false', '0', 'f'}
+
+
+def log_export_is_enabled() -> bool:
+    """True when a destination is configured and accepting records."""
+    current = _exporter
+    return current is not None and not current.stopped
+
+
+def enable_log_export(*, url: str) -> None:
+    """Start (or retarget) log export. No-op when opted out, empty, or not dev."""
+    global _exporter
+    if not url or logs_opted_out() or not is_dev_environment():
+        return
+    # Late import: _default_exporter pulls get_logger, and get_logger tees here.
+    from genkit._core._trace._default_exporter import resolve_telemetry_server_url
+
+    try:
+        resolved = resolve_telemetry_server_url(
+            telemetry_server_url=url,
+            telemetry_server_endpoint=LOG_ENDPOINT,
+        )
+    except ValueError as error:
+        _diag(level=logging.ERROR, event=f'GENKIT_TELEMETRY_SERVER is not a valid URL: {error}')
+        return
+    with _exporter_lock:
+        if _exporter is not None:
+            _exporter.set_url(url=resolved)
+            return
+        _exporter = LogServerExporter(telemetry_server_url=resolved)
+        _register_atexit()
+
+
+def reset_log_export() -> None:
+    """Tear down the process-wide exporter. Tests only."""
+    global _exporter
+    with _exporter_lock:
+        current = _exporter
+        _exporter = None
+    if current is not None:
+        current.shutdown()
+
+
+def emit_log(*, level: int, event: str, attrs: dict[str, object] | None = None) -> None:
+    """Queue one record. Never blocks. Encode bugs raise on this thread."""
+    if getattr(_skip_export, 'on', False):
+        return
+    current = _exporter
+    if current is None or current.stopped or level < logging.DEBUG:
+        return
+    current.enqueue(record=build_log_record(level=level, event=event, attrs=attrs or {}))
+
+
+def build_log_record(*, level: int, event: str, attrs: dict[str, object]) -> dict[str, object]:
+    """One OTLP-JSON ``logRecords`` item."""
+    number, text = _severity(level=level)
+    encoded, dropped = _otlp_attributes(attrs=attrs)
+    record: dict[str, object] = {
+        'timeUnixNano': str(time.time_ns()),
+        'severityNumber': number,
+        'severityText': text,
+        'body': {'stringValue': event},
+        'attributes': encoded,
+    }
+    if dropped:
+        record['droppedAttributesCount'] = dropped
+    span = trace_api.get_current_span()
+    ctx = span.get_span_context()
+    if ctx is not None and ctx.is_valid:
+        record['traceId'] = format(ctx.trace_id, '032x')
+        record['spanId'] = format(ctx.span_id, '016x')
+    return record
+
+
+def build_payload(*, records: list[dict[str, object]]) -> dict[str, object]:
+    """One ``resourceLogs`` document for a batch."""
+    return {
+        'resourceLogs': [
+            {
+                'resource': {'attributes': [], 'droppedAttributesCount': 0},
+                'scopeLogs': [
+                    {
+                        'scope': {'name': SCOPE_NAME, 'version': GENKIT_VERSION},
+                        'logRecords': records,
+                    }
+                ],
+            }
+        ]
+    }
+
+
+def _severity(*, level: int) -> tuple[int, str]:
+    for threshold in (logging.CRITICAL, logging.ERROR, logging.WARNING, logging.INFO, logging.DEBUG):
+        if level >= threshold:
+            return SEVERITY[threshold]
+    return SEVERITY[logging.DEBUG]
+
+
+def _should_redact(*, key: str) -> bool:
+    lowered = key.lower()
+    return lowered in REDACT_KEYS or lowered.endswith('_key') or lowered.endswith('_token')
+
+
+def _otlp_attributes(*, attrs: dict[str, object]) -> tuple[list[dict[str, object]], int]:
+    encoded: list[dict[str, object]] = []
+    dropped = 0
+    for key, value in attrs.items():
+        name = str(key)
+        if name.startswith('_') or value is None:
+            continue
+        if len(encoded) >= MAX_ATTRIBUTES:
+            dropped += 1
+            continue
+        if _should_redact(key=name):
+            encoded.append({'key': name, 'value': {'stringValue': '[redacted]'}})
+            continue
+        encoded.append({'key': name, 'value': _otlp_value(value=value)})
+    return encoded, dropped
+
+
+def _otlp_value(*, value: object) -> dict[str, object]:
+    if isinstance(value, bool):
+        return {'boolValue': value}
+    if isinstance(value, int):
+        return {'intValue': value}
+    if isinstance(value, float):
+        return {'doubleValue': value}
+    if isinstance(value, (bytes, bytearray, memoryview)):
+        return {'stringValue': f'<{len(value)} bytes>'}
+    if isinstance(value, str):
+        return {'stringValue': _clip_attr(value)}
+    try:
+        return {'stringValue': _clip_attr(json.dumps(value))}
+    except (TypeError, ValueError):
+        return {'stringValue': _clip_attr(str(value))}
+
+
+def _clip_attr(value: str) -> str:
+    if len(value) <= MAX_ATTR_CHARS:
+        return value
+    return f'{value[:MAX_ATTR_CHARS]}...<{len(value) - MAX_ATTR_CHARS} chars>'
+
+
+def _diag(*, level: int, event: str) -> None:
+    """Console-only line — must not re-enter export."""
+    _skip_export.on = True
+    try:
+        # Late import: _logger.get_logger tees back into emit_log.
+        from genkit._core._logger import get_logger
+
+        logger = get_logger(__name__)
+        if level >= logging.ERROR:
+            logger.error(event)
+        else:
+            logger.warning(event)
+    finally:
+        _skip_export.on = False
+
+
+def _register_atexit() -> None:
+    global _atexit_registered
+    if _atexit_registered:
+        return
+    atexit.register(reset_log_export)
+    _atexit_registered = True
+
+
+def put_poison_pill(*, queue: Queue[dict[str, object] | None]) -> None:
+    """Make sure the worker sees the stop token even when the queue is full."""
+    try:
+        queue.put_nowait(None)
+        return
+    except Full:
+        pass
+    try:
+        queue.get_nowait()
+        queue.task_done()
+    except Empty:
+        pass
+    try:
+        queue.put_nowait(None)
+    except Full:
+        pass
+
+
+class LogServerExporter:
+    """Background OTLP log sink. Same worker shape as the quiet-TTY span exporter."""
+
+    def __init__(self, *, telemetry_server_url: str) -> None:
+        self.telemetry_server_url = telemetry_server_url
+        self.stopped = False
+        self.dropped = 0
+        self.warned_overflow = False
+        self.warned_unreachable = False
+        self.last_result_ok = True
+        self.queue: Queue[dict[str, object] | None] = Queue(maxsize=QUEUE_SIZE)
+        self.worker = threading.Thread(target=self.run_worker, name='genkit-log-export', daemon=True)
+        self.worker.start()
+
+    def set_url(self, *, url: str) -> None:
+        self.telemetry_server_url = url
+
+    def enqueue(self, *, record: dict[str, object]) -> None:
+        if self.stopped:
+            return
+        try:
+            self.queue.put_nowait(record)
+        except Full:
+            self.dropped += 1
+            if not self.warned_overflow:
+                self.warned_overflow = True
+                _diag(
+                    level=logging.WARNING,
+                    event='log export queue is full; dropping records from the Dev UI log view',
+                )
+
+    def run_worker(self) -> None:
+        with httpx.Client(timeout=EXPORT_TIMEOUT_S) as client:
+            while True:
+                item = self.queue.get()
+                try:
+                    if item is None:
+                        return
+                    batch = [item]
+                    deadline = time.monotonic() + BATCH_DELAY_S
+                    while len(batch) < BATCH_SIZE:
+                        remaining = deadline - time.monotonic()
+                        if remaining <= 0:
+                            break
+                        try:
+                            nxt = self.queue.get(timeout=remaining)
+                        except Empty:
+                            break
+                        if nxt is None:
+                            self.queue.task_done()
+                            self.post_batch(client=client, records=batch)
+                            return
+                        batch.append(nxt)
+                        self.queue.task_done()
+                    self.post_batch(client=client, records=batch)
+                finally:
+                    self.queue.task_done()
+
+    def post_batch(self, *, client: httpx.Client, records: list[dict[str, object]]) -> None:
+        url = urljoin(self.telemetry_server_url, LOG_ENDPOINT)
+        try:
+            body = json.dumps(build_payload(records=records))
+            # The caller already returned; this wait lives on the worker.
+            response = client.post(url, content=body, headers=LOG_HEADERS)
+            if response.status_code != 200:
+                self.note_transport_failure(error=RuntimeError(f'HTTP {response.status_code}'))
+                return
+            self.last_result_ok = True
+            self.warned_unreachable = False
+        except Exception as error:
+            self.note_transport_failure(error=error)
+
+    def note_transport_failure(self, *, error: BaseException) -> None:
+        self.last_result_ok = False
+        if self.warned_unreachable:
+            return
+        self.warned_unreachable = True
+        _diag(level=logging.ERROR, event=f'Failed to export logs: {error}')
+
+    def force_flush(self, *, timeout_s: float = 30.0) -> bool:
+        finished = threading.Event()
+
+        def wait() -> None:
+            self.queue.join()
+            finished.set()
+
+        waiter = threading.Thread(target=wait, name='genkit-log-flush', daemon=True)
+        waiter.start()
+        return finished.wait(timeout_s)
+
+    def shutdown(self) -> None:
+        self.stopped = True
+        self.force_flush(timeout_s=SHUTDOWN_FLUSH_TIMEOUT_S)
+        put_poison_pill(queue=self.queue)

--- a/py/packages/genkit/src/genkit/_core/_trace/_log_exporter.py
+++ b/py/packages/genkit/src/genkit/_core/_trace/_log_exporter.py
@@ -1,0 +1,353 @@
+# Copyright 2026 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Dev UI log export — OTLP-JSON POSTs to the telemetry server.
+
+Console level stays on ``GENKIT_LOG``. This sink is debug and above, and it
+never waits on the collector: ``generate()`` has already returned.
+"""
+
+from __future__ import annotations
+
+import atexit
+import json
+import logging
+import os
+import threading
+import time
+from queue import Empty, Full, Queue
+from urllib.parse import urljoin
+
+import httpx
+from opentelemetry import trace as trace_api
+
+from genkit._core._constants import GENKIT_VERSION
+from genkit._core._environment import is_dev_environment
+
+GENKIT_OTEL_ENABLE_LOGS = 'GENKIT_OTEL_ENABLE_LOGS'
+GENKIT_TELEMETRY_SERVER = 'GENKIT_TELEMETRY_SERVER'
+
+LOG_ENDPOINT = '/api/otlp'
+LOG_HEADERS = {'Content-Type': 'application/json', 'Accept': 'application/json'}
+SCOPE_NAME = 'genkit-py'
+
+QUEUE_SIZE = 1024
+BATCH_SIZE = 64
+BATCH_DELAY_S = 0.1
+# Long enough for a slow local Dev UI to accept the batch; short enough that
+# a hung collector does not pin this worker for the rest of the process.
+EXPORT_TIMEOUT_S = 300.0
+# The export worker is a daemon: once the interpreter starts tearing down it
+# is killed, so we give the last batch a couple of seconds to land. Ctrl-C of
+# a wedged collector still shouldn't sit for minutes.
+SHUTDOWN_FLUSH_TIMEOUT_S = 2.0
+
+# Keep the Dev UI log panel readable — a generate() that binds 200 keys or a
+# megabyte prompt shouldn't serialize that onto the generate thread.
+MAX_ATTRIBUTES = 32
+MAX_ATTR_CHARS = 2048
+REDACT_KEYS = frozenset({
+    'api_key',
+    'authorization',
+    'password',
+    'secret',
+    'token',
+    'access_token',
+})
+
+SEVERITY: dict[int, tuple[int, str]] = {
+    logging.DEBUG: (5, 'DEBUG'),
+    logging.INFO: (9, 'INFO'),
+    logging.WARNING: (13, 'WARN'),
+    logging.ERROR: (17, 'ERROR'),
+    logging.CRITICAL: (17, 'ERROR'),
+}
+
+_exporter: LogServerExporter | None = None
+_exporter_lock = threading.Lock()
+_skip_export = threading.local()
+_atexit_registered = False
+
+
+def logs_opted_out() -> bool:
+    """True only when ``GENKIT_OTEL_ENABLE_LOGS`` is a ParseBool false."""
+    raw = os.environ.get(GENKIT_OTEL_ENABLE_LOGS, '').strip().lower()
+    return raw in {'false', '0', 'f'}
+
+
+def log_export_is_enabled() -> bool:
+    """True when a destination is configured and accepting records."""
+    current = _exporter
+    return current is not None and not current.stopped
+
+
+def enable_log_export(*, url: str) -> None:
+    """Start (or retarget) log export. No-op when opted out, empty, or not dev."""
+    global _exporter
+    if not url or logs_opted_out() or not is_dev_environment():
+        return
+    # Late import: _default_exporter pulls get_logger, and get_logger tees here.
+    from genkit._core._trace._default_exporter import resolve_telemetry_server_url
+
+    try:
+        resolved = resolve_telemetry_server_url(
+            telemetry_server_url=url,
+            telemetry_server_endpoint=LOG_ENDPOINT,
+        )
+    except ValueError as error:
+        _diag(level=logging.ERROR, event=f'GENKIT_TELEMETRY_SERVER is not a valid URL: {error}')
+        return
+    with _exporter_lock:
+        if _exporter is not None:
+            _exporter.set_url(url=resolved)
+            return
+        _exporter = LogServerExporter(telemetry_server_url=resolved)
+        _register_atexit()
+
+
+def reset_log_export() -> None:
+    """Tear down the process-wide exporter. Tests only."""
+    global _exporter
+    with _exporter_lock:
+        current = _exporter
+        _exporter = None
+    if current is not None:
+        current.shutdown()
+
+
+def emit_log(*, level: int, event: str, attrs: dict[str, object] | None = None) -> None:
+    """Queue one record. Never blocks. Encode bugs raise on this thread."""
+    if getattr(_skip_export, 'on', False):
+        return
+    current = _exporter
+    if current is None or current.stopped or level < logging.DEBUG:
+        return
+    current.enqueue(record=build_log_record(level=level, event=event, attrs=attrs or {}))
+
+
+def build_log_record(*, level: int, event: str, attrs: dict[str, object]) -> dict[str, object]:
+    """One OTLP-JSON ``logRecords`` item. Raises if an attribute cannot encode."""
+    number, text = _severity(level=level)
+    encoded, dropped = _otlp_attributes(attrs=attrs)
+    record: dict[str, object] = {
+        'timeUnixNano': str(time.time_ns()),
+        'severityNumber': number,
+        'severityText': text,
+        'body': {'stringValue': event},
+        'attributes': encoded,
+    }
+    if dropped:
+        record['droppedAttributesCount'] = dropped
+    span = trace_api.get_current_span()
+    ctx = span.get_span_context()
+    if ctx is not None and ctx.is_valid:
+        record['traceId'] = format(ctx.trace_id, '032x')
+        record['spanId'] = format(ctx.span_id, '016x')
+    # Fail on this thread if the record cannot be JSON — a broken payload
+    # must not look like a quiet collector miss after generate() returns.
+    json.dumps(record)
+    return record
+
+
+def build_payload(*, records: list[dict[str, object]]) -> dict[str, object]:
+    """One ``resourceLogs`` document for a batch."""
+    return {
+        'resourceLogs': [
+            {
+                'resource': {'attributes': [], 'droppedAttributesCount': 0},
+                'scopeLogs': [
+                    {
+                        'scope': {'name': SCOPE_NAME, 'version': GENKIT_VERSION},
+                        'logRecords': records,
+                    }
+                ],
+            }
+        ]
+    }
+
+
+def _severity(*, level: int) -> tuple[int, str]:
+    for threshold in (logging.CRITICAL, logging.ERROR, logging.WARNING, logging.INFO, logging.DEBUG):
+        if level >= threshold:
+            return SEVERITY[threshold]
+    return SEVERITY[logging.DEBUG]
+
+
+def _should_redact(*, key: str) -> bool:
+    lowered = key.lower()
+    return lowered in REDACT_KEYS or lowered.endswith('_key') or lowered.endswith('_token')
+
+
+def _otlp_attributes(*, attrs: dict[str, object]) -> tuple[list[dict[str, object]], int]:
+    encoded: list[dict[str, object]] = []
+    dropped = 0
+    for key, value in attrs.items():
+        name = str(key)
+        if name.startswith('_') or value is None:
+            continue
+        if len(encoded) >= MAX_ATTRIBUTES:
+            dropped += 1
+            continue
+        if _should_redact(key=name):
+            encoded.append({'key': name, 'value': {'stringValue': '[redacted]'}})
+            continue
+        encoded.append({'key': name, 'value': _otlp_value(value=value)})
+    return encoded, dropped
+
+
+def _otlp_value(*, value: object) -> dict[str, object]:
+    if isinstance(value, bool):
+        return {'boolValue': value}
+    if isinstance(value, int):
+        return {'intValue': value}
+    if isinstance(value, str):
+        return {'stringValue': _clip_attr(value)}
+    if isinstance(value, float):
+        return {'stringValue': _clip_attr(format(value, 'g'))}
+    try:
+        return {'stringValue': _clip_attr(json.dumps(value))}
+    except (TypeError, ValueError):
+        return {'stringValue': _clip_attr(str(value))}
+
+
+def _clip_attr(value: str) -> str:
+    if len(value) <= MAX_ATTR_CHARS:
+        return value
+    return f'{value[:MAX_ATTR_CHARS]}...<{len(value) - MAX_ATTR_CHARS} chars>'
+
+
+def _diag(*, level: int, event: str) -> None:
+    """Console-only line — must not re-enter export."""
+    _skip_export.on = True
+    try:
+        # Late import: _logger.get_logger tees back into emit_log.
+        from genkit._core._logger import get_logger
+
+        logger = get_logger(__name__)
+        if level >= logging.ERROR:
+            logger.error(event)
+        else:
+            logger.warning(event)
+    finally:
+        _skip_export.on = False
+
+
+def _register_atexit() -> None:
+    global _atexit_registered
+    if _atexit_registered:
+        return
+    atexit.register(reset_log_export)
+    _atexit_registered = True
+
+
+def put_poison_pill(*, queue: Queue[dict[str, object] | None]) -> None:
+    """Make sure the worker sees the stop token even when the queue is full."""
+    try:
+        queue.put_nowait(None)
+        return
+    except Full:
+        pass
+    try:
+        queue.get_nowait()
+    except Empty:
+        pass
+    try:
+        queue.put_nowait(None)
+    except Full:
+        pass
+
+
+class LogServerExporter:
+    """Background OTLP log sink. Same worker shape as the quiet-TTY span exporter."""
+
+    def __init__(self, *, telemetry_server_url: str) -> None:
+        self.telemetry_server_url = telemetry_server_url
+        self.stopped = False
+        self.dropped = 0
+        self.warned_overflow = False
+        self.warned_unreachable = False
+        self.last_result_ok = True
+        self.queue: Queue[dict[str, object] | None] = Queue(maxsize=QUEUE_SIZE)
+        self.worker = threading.Thread(target=self.run_worker, name='genkit-log-export', daemon=True)
+        self.worker.start()
+
+    def set_url(self, *, url: str) -> None:
+        self.telemetry_server_url = url
+
+    def enqueue(self, *, record: dict[str, object]) -> None:
+        if self.stopped:
+            return
+        try:
+            self.queue.put_nowait(record)
+        except Full:
+            self.dropped += 1
+            if not self.warned_overflow:
+                self.warned_overflow = True
+                _diag(
+                    level=logging.WARNING,
+                    event='log export queue is full; dropping records from the Dev UI log view',
+                )
+
+    def run_worker(self) -> None:
+        while True:
+            item = self.queue.get()
+            try:
+                if item is None:
+                    return
+                batch = [item]
+                deadline = time.monotonic() + BATCH_DELAY_S
+                while len(batch) < BATCH_SIZE:
+                    remaining = deadline - time.monotonic()
+                    if remaining <= 0:
+                        break
+                    try:
+                        nxt = self.queue.get(timeout=remaining)
+                    except Empty:
+                        break
+                    if nxt is None:
+                        self.queue.task_done()
+                        self.post_batch(records=batch)
+                        return
+                    batch.append(nxt)
+                    self.queue.task_done()
+                self.post_batch(records=batch)
+            finally:
+                self.queue.task_done()
+
+    def post_batch(self, *, records: list[dict[str, object]]) -> None:
+        url = urljoin(self.telemetry_server_url, LOG_ENDPOINT)
+        body = json.dumps(build_payload(records=records))
+        try:
+            # The caller already returned; this wait lives on the worker.
+            with httpx.Client(timeout=EXPORT_TIMEOUT_S) as client:
+                response = client.post(url, content=body, headers=LOG_HEADERS)
+            if response.status_code != 200:
+                self.note_transport_failure(error=RuntimeError(f'HTTP {response.status_code}'))
+                return
+            self.last_result_ok = True
+            self.warned_unreachable = False
+        except (httpx.RequestError, OSError) as error:
+            self.note_transport_failure(error=error)
+
+    def note_transport_failure(self, *, error: BaseException) -> None:
+        self.last_result_ok = False
+        if self.warned_unreachable:
+            return
+        self.warned_unreachable = True
+        _diag(level=logging.ERROR, event=f'Failed to export logs: {error}')
+
+    def force_flush(self, *, timeout_s: float = 30.0) -> bool:
+        finished = threading.Event()
+
+        def wait() -> None:
+            self.queue.join()
+            finished.set()
+
+        waiter = threading.Thread(target=wait, name='genkit-log-flush', daemon=True)
+        waiter.start()
+        return finished.wait(timeout_s)
+
+    def shutdown(self) -> None:
+        self.stopped = True
+        self.force_flush(timeout_s=SHUTDOWN_FLUSH_TIMEOUT_S)
+        put_poison_pill(queue=self.queue)

--- a/py/packages/genkit/src/genkit/_core/_trace/_log_exporter.py
+++ b/py/packages/genkit/src/genkit/_core/_trace/_log_exporter.py
@@ -47,13 +47,15 @@ SHUTDOWN_FLUSH_TIMEOUT_S = 2.0
 MAX_ATTRIBUTES = 32
 MAX_ATTR_CHARS = 2048
 REDACT_KEYS = frozenset({
-    'api_key',
+    'apikey',
+    'authtoken',
+    'accesstoken',
     'authorization',
     'password',
     'secret',
     'token',
-    'access_token',
 })
+REDACT_SUFFIXES = ('key', 'token', 'secret', 'password')
 
 SEVERITY: dict[int, tuple[int, str]] = {
     logging.DEBUG: (5, 'DEBUG'),
@@ -171,8 +173,13 @@ def _severity(*, level: int) -> tuple[int, str]:
 
 
 def _should_redact(*, key: str) -> bool:
-    lowered = key.lower()
-    return lowered in REDACT_KEYS or lowered.endswith('_key') or lowered.endswith('_token')
+    # apiKey / authToken / apikey all collapse to the same compact form so
+    # a plugin that logs the key under any of those names does not POST it
+    # to the telemetry server.
+    compact = key.lower().replace('_', '')
+    if compact in REDACT_KEYS:
+        return True
+    return any(compact.endswith(suffix) for suffix in REDACT_SUFFIXES)
 
 
 def _otlp_attributes(*, attrs: dict[str, object]) -> tuple[list[dict[str, object]], int]:
@@ -289,31 +296,38 @@ class LogServerExporter:
                 )
 
     def run_worker(self) -> None:
-        with httpx.Client(timeout=EXPORT_TIMEOUT_S) as client:
-            while True:
-                item = self.queue.get()
-                try:
-                    if item is None:
-                        return
-                    batch = [item]
-                    deadline = time.monotonic() + BATCH_DELAY_S
-                    while len(batch) < BATCH_SIZE:
-                        remaining = deadline - time.monotonic()
-                        if remaining <= 0:
-                            break
-                        try:
-                            nxt = self.queue.get(timeout=remaining)
-                        except Empty:
-                            break
-                        if nxt is None:
-                            self.queue.task_done()
-                            self.post_batch(client=client, records=batch)
+        try:
+            with httpx.Client(timeout=EXPORT_TIMEOUT_S) as client:
+                while True:
+                    item = self.queue.get()
+                    try:
+                        if item is None:
                             return
-                        batch.append(nxt)
+                        batch = [item]
+                        deadline = time.monotonic() + BATCH_DELAY_S
+                        while len(batch) < BATCH_SIZE:
+                            remaining = deadline - time.monotonic()
+                            if remaining <= 0:
+                                break
+                            try:
+                                nxt = self.queue.get(timeout=remaining)
+                            except Empty:
+                                break
+                            if nxt is None:
+                                self.queue.task_done()
+                                self.post_batch(client=client, records=batch)
+                                return
+                            batch.append(nxt)
+                            self.queue.task_done()
+                        self.post_batch(client=client, records=batch)
+                    finally:
                         self.queue.task_done()
-                    self.post_batch(client=client, records=batch)
-                finally:
-                    self.queue.task_done()
+        except Exception as error:
+            # Client() or context-exit can raise before post_batch's guard.
+            # Stop accepting records so debug branches stop building payloads
+            # that will never export.
+            self.stopped = True
+            _diag(level=logging.ERROR, event=f'log export worker stopped: {error}')
 
     def post_batch(self, *, client: httpx.Client, records: list[dict[str, object]]) -> None:
         url = urljoin(self.telemetry_server_url, LOG_ENDPOINT)

--- a/py/packages/genkit/tests/genkit/ai/generate_logging_test.py
+++ b/py/packages/genkit/tests/genkit/ai/generate_logging_test.py
@@ -1,7 +1,7 @@
 # Copyright 2025 Google LLC
 # SPDX-License-Identifier: Apache-2.0
 
-"""Unit tests for the debug-log payload built by genkit._ai._generate."""
+"""Unit tests for the debug-log records emitted by genkit._ai._generate."""
 
 from collections.abc import Iterator
 
@@ -10,17 +10,10 @@ import structlog
 from structlog.testing import capture_logs
 
 from genkit import Genkit, Message, ModelResponse
-from genkit._ai._generate import (
-    _MAX_LOGGED_LIST_LEN,
-    _MAX_LOGGED_STR_LEN,
-    _PROVIDER_STR_LEN,
-    _loggable_response,
-    _redact_large_values,
-)
 from genkit._ai._testing import define_programmable_model
 from genkit._core._environment import GENKIT_ENV
 from genkit._core._logger import GENKIT_LOG, get_logger
-from genkit._core._typing import CustomPart, GenerationUsage, Media, MediaPart, Role, TextPart
+from genkit._core._typing import Role, TextPart
 
 BLOB = 'A' * 1_000_000
 
@@ -43,112 +36,6 @@ def _clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv(GENKIT_ENV, raising=False)
 
 
-def test_short_values_pass_through() -> None:
-    """Values under the limits are untouched."""
-    payload = {'text': 'hello', 'items': [1, None, True, 'short'], 'nested': {'k': 'v'}}
-
-    assert _redact_large_values(payload) == payload
-
-
-def test_data_uris_keep_their_media_type() -> None:
-    """Data URIs report the dropped payload size and keep the media type."""
-    uri = 'data:audio/L16;codec=pcm;rate=24000;base64,' + 'B' * 500
-
-    assert _redact_large_values(uri) == 'data:audio/L16;codec=pcm;rate=24000;base64,...<500 chars>'
-
-
-def test_bare_long_strings_are_truncated() -> None:
-    """A long string with no data URI prefix keeps its leading characters."""
-    blob = 'C' * (_MAX_LOGGED_STR_LEN + 4096)
-
-    redacted = _redact_large_values(blob)
-
-    assert redacted.startswith('C' * _MAX_LOGGED_STR_LEN)
-    assert redacted.endswith('...<4096 chars>')
-
-
-def test_binary_values_collapse_to_their_size() -> None:
-    """bytes survive model_dump in python mode, so they are reported by length."""
-    assert _redact_large_values(b'\x00' * 200_000) == '<200000 bytes>'
-    assert _redact_large_values(bytearray(b'ab')) == '<2 bytes>'
-    assert _redact_large_values(memoryview(b'abc')) == '<3 bytes>'
-
-
-def test_long_lists_are_truncated() -> None:
-    """An over-long list keeps its leading items and reports the remainder."""
-    redacted = _redact_large_values(list(range(_MAX_LOGGED_LIST_LEN + 250)))
-
-    assert len(redacted) == _MAX_LOGGED_LIST_LEN + 1
-    assert redacted[:3] == [0, 1, 2]
-    assert redacted[-1] == '...<250 more items>'
-
-
-def test_redaction_recurses_into_containers() -> None:
-    """Oversized values nested in dicts and lists are shrunk too."""
-    blob = 'D' * (_MAX_LOGGED_STR_LEN + 1)
-
-    redacted = _redact_large_values({'a': [{'b': blob, 'c': b'xy'}]})
-
-    assert redacted == {'a': [{'b': 'D' * _MAX_LOGGED_STR_LEN + '...<1 chars>', 'c': '<2 bytes>'}]}
-
-
-def test_loggable_response_keeps_provider_payloads_bounded() -> None:
-    """raw and custom stay in the log for provider debugging, but bounded in size."""
-    response = ModelResponse(
-        message=Message(role=Role.MODEL, content=[TextPart(text='hi')]),
-        custom={'audio': BLOB},
-        raw={'audio': BLOB},
-        usage=GenerationUsage(input_tokens=1, output_tokens=2),
-    )
-
-    logged = _loggable_response(response)
-
-    assert logged['message']['content'][0]['text'] == 'hi'
-    assert logged['usage']['inputTokens'] == 1
-    assert logged['raw']['audio'].endswith(f'...<{1_000_000 - _PROVIDER_STR_LEN} chars>')
-    assert logged['custom']['audio'] == logged['raw']['audio']
-    assert len(str(logged)) < len(str(response.model_dump())) / 100
-
-
-def test_loggable_response_truncates_nested_part_payloads() -> None:
-    """Oversized values on a part, not just on the response, are shrunk."""
-    response = ModelResponse(
-        message=Message(role=Role.MODEL, content=[CustomPart(custom={'blob': BLOB})]),
-    )
-
-    logged = _loggable_response(response)
-
-    assert logged['message']['content'][0]['custom']['blob'].endswith(f'...<{1_000_000 - _PROVIDER_STR_LEN} chars>')
-
-
-def test_model_output_gets_a_longer_limit_than_provider_payloads() -> None:
-    """Model text survives to _MAX_LOGGED_STR_LEN while raw is held to _PROVIDER_STR_LEN."""
-    prose = 'W' * (_MAX_LOGGED_STR_LEN * 2)
-    response = ModelResponse(
-        message=Message(role=Role.MODEL, content=[TextPart(text=prose)]),
-        raw={'echo': prose},
-    )
-
-    logged = _loggable_response(response)
-
-    assert logged['message']['content'][0]['text'].endswith(f'...<{_MAX_LOGGED_STR_LEN} chars>')
-    assert logged['raw']['echo'].endswith(f'...<{_MAX_LOGGED_STR_LEN * 2 - _PROVIDER_STR_LEN} chars>')
-
-
-def test_loggable_response_truncates_media_in_message() -> None:
-    """Inline media that survives into the message is truncated rather than dumped."""
-    response = ModelResponse(
-        message=Message(
-            role=Role.MODEL,
-            content=[MediaPart(media=Media(content_type='image/png', url='data:image/png;base64,' + 'E' * 900))],
-        ),
-    )
-
-    logged = _loggable_response(response)
-
-    assert logged['message']['content'][0]['media']['url'] == 'data:image/png;base64,...<900 chars>'
-
-
 async def _generate_once() -> None:
     """Run one generate call against a model returning a blob in raw and custom."""
     ai = Genkit(model='programmableModel')
@@ -165,7 +52,7 @@ async def _generate_once() -> None:
 
 @pytest.mark.asyncio
 async def test_generate_logs_nothing_at_default_level() -> None:
-    """A generate call under the default configuration emits no response dump."""
+    """A generate call under the default configuration emits no named records."""
     structlog.reset_defaults()
 
     with capture_logs() as entries:
@@ -178,17 +65,21 @@ async def test_generate_logs_nothing_at_default_level() -> None:
 
 
 @pytest.mark.asyncio
-async def test_generate_logs_bounded_response_when_debug_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
-    """With debug on, the response is logged but the blob is truncated."""
+async def test_generate_logs_named_records_when_debug_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    """With debug on, generate emits the named request/turn records."""
     structlog.reset_defaults()
     monkeypatch.setenv(GENKIT_LOG, 'debug')
 
     with capture_logs() as entries:
         await _generate_once()
 
-    logged = [entry for entry in entries if entry['event'] == 'generate response']
-    assert len(logged) == 1
-    assert len(str(logged[0]['response'])) < 3 * _MAX_LOGGED_STR_LEN
+    events = [entry['event'] for entry in entries]
+    assert 'generate request resolved' in events
+    assert 'calling model' in events
+    responded = [entry for entry in entries if entry['event'] == 'model responded']
+    assert len(responded) == 1
+    assert responded[0]['tool_requests'] == 0
+    assert 'response' not in responded[0]
 
 
 @pytest.mark.asyncio

--- a/py/packages/genkit/tests/genkit/ai/generate_logging_test.py
+++ b/py/packages/genkit/tests/genkit/ai/generate_logging_test.py
@@ -1,7 +1,7 @@
 # Copyright 2025 Google LLC
 # SPDX-License-Identifier: Apache-2.0
 
-"""Unit tests for the debug-log payload built by genkit._ai._generate."""
+"""Unit tests for the debug-log records emitted by genkit._ai._generate."""
 
 from collections.abc import Iterator
 
@@ -10,17 +10,10 @@ import structlog
 from structlog.testing import capture_logs
 
 from genkit import Genkit, Message, ModelResponse
-from genkit._ai._generate import (
-    _MAX_LOGGED_LIST_LEN,
-    _MAX_LOGGED_STR_LEN,
-    _PROVIDER_STR_LEN,
-    _loggable_response,
-    _redact_large_values,
-)
 from genkit._ai._testing import define_programmable_model
 from genkit._core._environment import GENKIT_ENV
 from genkit._core._logger import GENKIT_LOG
-from genkit._core._typing import CustomPart, GenerationUsage, Media, MediaPart, Role, TextPart
+from genkit._core._typing import Role, TextPart
 
 BLOB = 'A' * 1_000_000
 
@@ -43,112 +36,6 @@ def _clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv(GENKIT_ENV, raising=False)
 
 
-def test_short_values_pass_through() -> None:
-    """Values under the limits are untouched."""
-    payload = {'text': 'hello', 'items': [1, None, True, 'short'], 'nested': {'k': 'v'}}
-
-    assert _redact_large_values(payload) == payload
-
-
-def test_data_uris_keep_their_media_type() -> None:
-    """Data URIs report the dropped payload size and keep the media type."""
-    uri = 'data:audio/L16;codec=pcm;rate=24000;base64,' + 'B' * 500
-
-    assert _redact_large_values(uri) == 'data:audio/L16;codec=pcm;rate=24000;base64,...<500 chars>'
-
-
-def test_bare_long_strings_are_truncated() -> None:
-    """A long string with no data URI prefix keeps its leading characters."""
-    blob = 'C' * (_MAX_LOGGED_STR_LEN + 4096)
-
-    redacted = _redact_large_values(blob)
-
-    assert redacted.startswith('C' * _MAX_LOGGED_STR_LEN)
-    assert redacted.endswith('...<4096 chars>')
-
-
-def test_binary_values_collapse_to_their_size() -> None:
-    """bytes survive model_dump in python mode, so they are reported by length."""
-    assert _redact_large_values(b'\x00' * 200_000) == '<200000 bytes>'
-    assert _redact_large_values(bytearray(b'ab')) == '<2 bytes>'
-    assert _redact_large_values(memoryview(b'abc')) == '<3 bytes>'
-
-
-def test_long_lists_are_truncated() -> None:
-    """An over-long list keeps its leading items and reports the remainder."""
-    redacted = _redact_large_values(list(range(_MAX_LOGGED_LIST_LEN + 250)))
-
-    assert len(redacted) == _MAX_LOGGED_LIST_LEN + 1
-    assert redacted[:3] == [0, 1, 2]
-    assert redacted[-1] == '...<250 more items>'
-
-
-def test_redaction_recurses_into_containers() -> None:
-    """Oversized values nested in dicts and lists are shrunk too."""
-    blob = 'D' * (_MAX_LOGGED_STR_LEN + 1)
-
-    redacted = _redact_large_values({'a': [{'b': blob, 'c': b'xy'}]})
-
-    assert redacted == {'a': [{'b': 'D' * _MAX_LOGGED_STR_LEN + '...<1 chars>', 'c': '<2 bytes>'}]}
-
-
-def test_loggable_response_keeps_provider_payloads_bounded() -> None:
-    """raw and custom stay in the log for provider debugging, but bounded in size."""
-    response = ModelResponse(
-        message=Message(role=Role.MODEL, content=[TextPart(text='hi')]),
-        custom={'audio': BLOB},
-        raw={'audio': BLOB},
-        usage=GenerationUsage(input_tokens=1, output_tokens=2),
-    )
-
-    logged = _loggable_response(response)
-
-    assert logged['message']['content'][0]['text'] == 'hi'
-    assert logged['usage']['inputTokens'] == 1
-    assert logged['raw']['audio'].endswith(f'...<{1_000_000 - _PROVIDER_STR_LEN} chars>')
-    assert logged['custom']['audio'] == logged['raw']['audio']
-    assert len(str(logged)) < len(str(response.model_dump())) / 100
-
-
-def test_loggable_response_truncates_nested_part_payloads() -> None:
-    """Oversized values on a part, not just on the response, are shrunk."""
-    response = ModelResponse(
-        message=Message(role=Role.MODEL, content=[CustomPart(custom={'blob': BLOB})]),
-    )
-
-    logged = _loggable_response(response)
-
-    assert logged['message']['content'][0]['custom']['blob'].endswith(f'...<{1_000_000 - _PROVIDER_STR_LEN} chars>')
-
-
-def test_model_output_gets_a_longer_limit_than_provider_payloads() -> None:
-    """Model text survives to _MAX_LOGGED_STR_LEN while raw is held to _PROVIDER_STR_LEN."""
-    prose = 'W' * (_MAX_LOGGED_STR_LEN * 2)
-    response = ModelResponse(
-        message=Message(role=Role.MODEL, content=[TextPart(text=prose)]),
-        raw={'echo': prose},
-    )
-
-    logged = _loggable_response(response)
-
-    assert logged['message']['content'][0]['text'].endswith(f'...<{_MAX_LOGGED_STR_LEN} chars>')
-    assert logged['raw']['echo'].endswith(f'...<{_MAX_LOGGED_STR_LEN * 2 - _PROVIDER_STR_LEN} chars>')
-
-
-def test_loggable_response_truncates_media_in_message() -> None:
-    """Inline media that survives into the message is truncated rather than dumped."""
-    response = ModelResponse(
-        message=Message(
-            role=Role.MODEL,
-            content=[MediaPart(media=Media(content_type='image/png', url='data:image/png;base64,' + 'E' * 900))],
-        ),
-    )
-
-    logged = _loggable_response(response)
-
-    assert logged['message']['content'][0]['media']['url'] == 'data:image/png;base64,...<900 chars>'
-
-
 async def _generate_once() -> None:
     """Run one generate call against a model returning a blob in raw and custom."""
     ai = Genkit(model='programmableModel')
@@ -165,7 +52,7 @@ async def _generate_once() -> None:
 
 @pytest.mark.asyncio
 async def test_generate_logs_nothing_at_default_level() -> None:
-    """A generate call under the default configuration emits no response dump."""
+    """A generate call under the default configuration emits no named records."""
     structlog.reset_defaults()
 
     with capture_logs() as entries:
@@ -176,17 +63,21 @@ async def test_generate_logs_nothing_at_default_level() -> None:
 
 
 @pytest.mark.asyncio
-async def test_generate_logs_bounded_response_when_debug_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
-    """With debug on, the response is logged but the blob is truncated."""
+async def test_generate_logs_named_records_when_debug_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    """With debug on, generate emits the named request/turn records."""
     structlog.reset_defaults()
     monkeypatch.setenv(GENKIT_LOG, 'debug')
 
     with capture_logs() as entries:
         await _generate_once()
 
-    logged = [entry for entry in entries if entry['event'] == 'generate response']
-    assert len(logged) == 1
-    assert len(str(logged[0]['response'])) < 3 * _MAX_LOGGED_STR_LEN
+    events = [entry['event'] for entry in entries]
+    assert 'generate request resolved' in events
+    assert 'calling model' in events
+    responded = [entry for entry in entries if entry['event'] == 'model responded']
+    assert len(responded) == 1
+    assert responded[0]['tool_requests'] == 0
+    assert 'response' not in responded[0]
 
 
 @pytest.mark.asyncio

--- a/py/packages/genkit/tests/genkit/ai/generate_logging_test.py
+++ b/py/packages/genkit/tests/genkit/ai/generate_logging_test.py
@@ -163,6 +163,34 @@ async def test_abnormal_finish_skips_output_parsing(monkeypatch: pytest.MonkeyPa
 
 
 @pytest.mark.asyncio
+async def test_other_finish_does_not_warn_as_abnormal(monkeypatch: pytest.MonkeyPatch) -> None:
+    """OTHER is an unmapped stop reason, not a refusal — do not warn at info."""
+    structlog.reset_defaults()
+    monkeypatch.setenv(GENKIT_LOG, 'info')
+    ai = Genkit()
+    pm, _ = define_programmable_model(ai)
+    pm.responses = [
+        ModelResponse(
+            message=Message(role=Role.MODEL, content=[TextPart(text='{"ok": true}')]),
+            finish_reason=FinishReason.OTHER,
+        )
+    ]
+
+    with capture_logs() as entries:
+        await generate_action(
+            ai.registry,
+            GenerateActionOptions(
+                model='programmableModel',
+                messages=[Message(role=Role.USER, content=[TextPart(text='hi')])],
+                output=GenerateActionOutputConfig(format='json'),
+            ),
+        )
+
+    warned = [e for e in entries if e['event'] == 'model finished abnormally, skipping output parsing']
+    assert warned == []
+
+
+@pytest.mark.asyncio
 async def test_schema_mismatch_logs_when_debug_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
     """Unparseable JSON is a debug breadcrumb; generate still returns."""
     structlog.reset_defaults()
@@ -277,8 +305,8 @@ async def test_restarted_tool_interrupt_logs(monkeypatch: pytest.MonkeyPatch) ->
 
 
 @pytest.mark.asyncio
-async def test_tool_stream_callback_failure_is_dropped(monkeypatch: pytest.MonkeyPatch) -> None:
-    """A sinking tool-stream callback is logged and does not fail the tool."""
+async def test_tool_stream_callback_failure_fails_generate(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A sinking callback fails generate the same way a model-chunk sink does."""
     structlog.reset_defaults()
     monkeypatch.setenv(GENKIT_LOG, 'debug')
     ai = Genkit()
@@ -306,8 +334,8 @@ async def test_tool_stream_callback_failure_is_dropped(monkeypatch: pytest.Monke
         if getattr(chunk, 'role', None) == Role.TOOL:
             raise RuntimeError('sink closed')
 
-    with capture_logs() as entries:
-        response = await generate_action(
+    with pytest.raises(RuntimeError, match='sink closed'):
+        await generate_action(
             ai.registry,
             GenerateActionOptions(
                 model='programmableModel',
@@ -316,7 +344,3 @@ async def test_tool_stream_callback_failure_is_dropped(monkeypatch: pytest.Monke
             ),
             on_chunk=on_chunk,
         )
-
-    assert response.message is not None
-    dropped = [e for e in entries if e['event'] == 'tool stream callback failed, dropping chunk']
-    assert len(dropped) == 1

--- a/py/packages/genkit/tests/genkit/ai/generate_logging_test.py
+++ b/py/packages/genkit/tests/genkit/ai/generate_logging_test.py
@@ -10,10 +10,25 @@ import structlog
 from structlog.testing import capture_logs
 
 from genkit import Genkit, Message, ModelResponse
+from genkit._ai._generate import generate_action
+from genkit._ai._model import resolve_model_arg
 from genkit._ai._testing import define_programmable_model
+from genkit._ai._tools import Interrupt, restart_tool
 from genkit._core._environment import GENKIT_ENV
+from genkit._core._error import GenkitError
 from genkit._core._logger import GENKIT_LOG, get_logger
-from genkit._core._typing import Role, TextPart
+from genkit._core._model import GenerateActionOptions
+from genkit._core._registry import Registry
+from genkit._core._typing import (
+    FinishReason,
+    GenerateActionOutputConfig,
+    Part,
+    Resume,
+    Role,
+    TextPart,
+    ToolRequest,
+    ToolRequestPart,
+)
 
 BLOB = 'A' * 1_000_000
 
@@ -98,3 +113,210 @@ async def test_response_is_not_serialized_when_debug_is_off(monkeypatch: pytest.
     await _generate_once()
 
     assert calls == []
+
+
+def test_default_model_fallback_logs(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Omitting model= leaves a breadcrumb with the constructor default name."""
+    structlog.reset_defaults()
+    monkeypatch.setenv(GENKIT_LOG, 'debug')
+    registry = Registry()
+    registry.register_value('defaultModel', 'defaultModel', 'echo-model')
+
+    with capture_logs() as entries:
+        resolve_model_arg(model=None, registry=registry)
+
+    events = [entry for entry in entries if entry['event'] == 'no model specified, using default model']
+    assert len(events) == 1
+    assert events[0]['model'] == 'echo-model'
+
+
+@pytest.mark.asyncio
+async def test_abnormal_finish_skips_output_parsing(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A blocked model with a formatter warns instead of parsing."""
+    structlog.reset_defaults()
+    monkeypatch.setenv(GENKIT_LOG, 'debug')
+    ai = Genkit()
+    pm, _ = define_programmable_model(ai)
+    pm.responses = [
+        ModelResponse(
+            message=Message(role=Role.MODEL, content=[TextPart(text='nope')]),
+            finish_reason=FinishReason.BLOCKED,
+            finish_message='safety',
+        )
+    ]
+
+    with capture_logs() as entries:
+        await generate_action(
+            ai.registry,
+            GenerateActionOptions(
+                model='programmableModel',
+                messages=[Message(role=Role.USER, content=[TextPart(text='hi')])],
+                output=GenerateActionOutputConfig(format='json'),
+            ),
+        )
+
+    warned = [e for e in entries if e['event'] == 'model finished abnormally, skipping output parsing']
+    assert len(warned) == 1
+    assert warned[0]['finishReason'] == FinishReason.BLOCKED
+    assert warned[0]['finishMessage'] == 'safety'
+    assert 'model output does not match the expected schema' not in [e['event'] for e in entries]
+
+
+@pytest.mark.asyncio
+async def test_schema_mismatch_logs_when_debug_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Unparseable JSON is a debug breadcrumb; generate still returns."""
+    structlog.reset_defaults()
+    monkeypatch.setenv(GENKIT_LOG, 'debug')
+    ai = Genkit()
+    pm, _ = define_programmable_model(ai)
+    pm.responses = [
+        ModelResponse(
+            message=Message(role=Role.MODEL, content=[TextPart(text='not json')]),
+            finish_reason=FinishReason.STOP,
+        )
+    ]
+
+    with capture_logs() as entries:
+        response = await generate_action(
+            ai.registry,
+            GenerateActionOptions(
+                model='programmableModel',
+                messages=[Message(role=Role.USER, content=[TextPart(text='hi')])],
+                output=GenerateActionOutputConfig(format='json'),
+            ),
+        )
+
+    assert response.message is not None
+    mismatched = [e for e in entries if e['event'] == 'model output does not match the expected schema']
+    assert len(mismatched) == 1
+    assert mismatched[0]['model'] == 'programmableModel'
+
+
+@pytest.mark.asyncio
+async def test_tool_interrupt_logs(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An interrupting tool is named on the debug record."""
+    structlog.reset_defaults()
+    monkeypatch.setenv(GENKIT_LOG, 'debug')
+    ai = Genkit()
+    pm, _ = define_programmable_model(ai)
+
+    @ai.tool(name='hold')
+    async def hold(_: dict) -> str:  # noqa: ARG001
+        raise Interrupt({'hold': True})
+
+    pm.responses = [
+        ModelResponse(
+            message=Message(
+                role=Role.MODEL,
+                content=[Part(root=ToolRequestPart(tool_request=ToolRequest(name='hold', input={}, ref='1')))],
+            ),
+            finish_reason=FinishReason.STOP,
+        )
+    ]
+
+    with capture_logs() as entries:
+        await generate_action(
+            ai.registry,
+            GenerateActionOptions(
+                model='programmableModel',
+                messages=[Message(role=Role.USER, content=[TextPart(text='hi')])],
+                tools=['hold'],
+            ),
+        )
+
+    interrupted = [e for e in entries if e['event'] == 'tool triggered an interrupt']
+    assert len(interrupted) == 1
+    assert interrupted[0]['tool'] == 'hold'
+    assert 'generation paused by tool interrupts' in [e['event'] for e in entries]
+
+
+@pytest.mark.asyncio
+async def test_restarted_tool_interrupt_logs(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A tool that interrupts again on restart leaves the same breadcrumb Go does."""
+    structlog.reset_defaults()
+    monkeypatch.setenv(GENKIT_LOG, 'debug')
+    ai = Genkit()
+    pm, _ = define_programmable_model(ai)
+
+    @ai.tool(name='hold')
+    async def hold(_: dict) -> str:  # noqa: ARG001
+        raise Interrupt({'hold': True})
+
+    pm.responses = [
+        ModelResponse(
+            message=Message(
+                role=Role.MODEL,
+                content=[Part(root=ToolRequestPart(tool_request=ToolRequest(name='hold', input={}, ref='1')))],
+            ),
+            finish_reason=FinishReason.STOP,
+        )
+    ]
+    first = await generate_action(
+        ai.registry,
+        GenerateActionOptions(
+            model='programmableModel',
+            messages=[Message(role=Role.USER, content=[TextPart(text='hi')])],
+            tools=['hold'],
+        ),
+    )
+
+    with capture_logs() as entries, pytest.raises(GenkitError, match='interrupted again'):
+        await generate_action(
+            ai.registry,
+            GenerateActionOptions(
+                model='programmableModel',
+                messages=list(first.messages),
+                tools=['hold'],
+                resume=Resume(restart=[restart_tool(interrupt=first.interrupts[0])]),
+            ),
+        )
+
+    restarted = [e for e in entries if e['event'] == 'restarted tool triggered an interrupt']
+    assert len(restarted) == 1
+    assert restarted[0]['tool'] == 'hold'
+
+
+@pytest.mark.asyncio
+async def test_tool_stream_callback_failure_is_dropped(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A sinking tool-stream callback is logged and does not fail the tool."""
+    structlog.reset_defaults()
+    monkeypatch.setenv(GENKIT_LOG, 'debug')
+    ai = Genkit()
+    pm, _ = define_programmable_model(ai)
+
+    @ai.tool(name='echo')
+    async def echo(_: dict) -> str:  # noqa: ARG001
+        return 'ok'
+
+    pm.responses = [
+        ModelResponse(
+            message=Message(
+                role=Role.MODEL,
+                content=[Part(root=ToolRequestPart(tool_request=ToolRequest(name='echo', input={}, ref='1')))],
+            ),
+            finish_reason=FinishReason.STOP,
+        ),
+        ModelResponse(
+            message=Message(role=Role.MODEL, content=[TextPart(text='done')]),
+            finish_reason=FinishReason.STOP,
+        ),
+    ]
+
+    def on_chunk(chunk: object) -> None:
+        if getattr(chunk, 'role', None) == Role.TOOL:
+            raise RuntimeError('sink closed')
+
+    with capture_logs() as entries:
+        response = await generate_action(
+            ai.registry,
+            GenerateActionOptions(
+                model='programmableModel',
+                messages=[Message(role=Role.USER, content=[TextPart(text='hi')])],
+                tools=['echo'],
+            ),
+            on_chunk=on_chunk,
+        )
+
+    assert response.message is not None
+    dropped = [e for e in entries if e['event'] == 'tool stream callback failed, dropping chunk']
+    assert len(dropped) == 1

--- a/py/packages/genkit/tests/genkit/core/constants_test.py
+++ b/py/packages/genkit/tests/genkit/core/constants_test.py
@@ -1,0 +1,13 @@
+# Copyright 2025 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for package version constants."""
+
+import importlib.metadata
+
+from genkit._core._constants import GENKIT_CLIENT_HEADER, GENKIT_VERSION
+
+
+def test_genkit_version_comes_from_the_installed_package() -> None:
+    assert GENKIT_VERSION == importlib.metadata.version('genkit')
+    assert GENKIT_CLIENT_HEADER == f'genkit-python/{GENKIT_VERSION}'

--- a/py/packages/genkit/tests/genkit/core/trace/log_exporter_test.py
+++ b/py/packages/genkit/tests/genkit/core/trace/log_exporter_test.py
@@ -1,0 +1,374 @@
+# Copyright 2026 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for Dev UI OTLP log export."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import threading
+import time
+from collections.abc import Iterator
+from queue import Full
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+from structlog.testing import capture_logs
+
+from genkit._core._constants import GENKIT_VERSION
+from genkit._core._environment import GENKIT_ENV
+from genkit._core._logger import get_logger, is_debug_enabled
+from genkit._core._trace._log_exporter import (
+    BATCH_DELAY_S,
+    GENKIT_OTEL_ENABLE_LOGS,
+    LOG_ENDPOINT,
+    MAX_ATTR_CHARS,
+    MAX_ATTRIBUTES,
+    SCOPE_NAME,
+    SHUTDOWN_FLUSH_TIMEOUT_S,
+    build_log_record,
+    build_payload,
+    emit_log,
+    enable_log_export,
+    log_export_is_enabled,
+    logs_opted_out,
+    put_poison_pill,
+    reset_log_export,
+)
+from genkit._core._tracing import SpanMetadata, run_in_new_span
+
+
+@pytest.fixture
+def _reset_export() -> Iterator[None]:
+    reset_log_export()
+    yield
+    reset_log_export()
+
+
+@pytest.fixture
+def _dev_env() -> Iterator[None]:
+    with patch.dict(os.environ, {GENKIT_ENV: 'dev', GENKIT_OTEL_ENABLE_LOGS: ''}, clear=False):
+        os.environ.pop(GENKIT_OTEL_ENABLE_LOGS, None)
+        yield
+
+
+def test_logs_opted_out_matches_parse_bool() -> None:
+    """Only ParseBool false values opt out — ``off`` keeps export on."""
+    for value in ['false', 'False', '0', 'f', 'F']:
+        with patch.dict(os.environ, {GENKIT_OTEL_ENABLE_LOGS: value}):
+            assert logs_opted_out() is True
+    for value in ['', 'true', '1', 'off', 'yes']:
+        with patch.dict(os.environ, {GENKIT_OTEL_ENABLE_LOGS: value} if value else {}, clear=False):
+            if not value:
+                os.environ.pop(GENKIT_OTEL_ENABLE_LOGS, None)
+            assert logs_opted_out() is False
+
+
+def test_build_log_record_wire_shape() -> None:
+    """OTLP-JSON: string nanoseconds, severity 5/9/13/17, typed attrs only."""
+    record = build_log_record(
+        level=logging.DEBUG,
+        event='looking up weather',
+        attrs={'city': 'Paris', 'count': 2, 'ok': True, 'temp': 3.5, '_skip': 1, 'empty': None},
+    )
+    assert record['severityNumber'] == 5
+    assert record['severityText'] == 'DEBUG'
+    assert record['body'] == {'stringValue': 'looking up weather'}
+    nano = record['timeUnixNano']
+    assert isinstance(nano, str) and nano.isdigit()
+    raw_attrs = record['attributes']
+    assert isinstance(raw_attrs, list)
+    keys: dict[object, object] = {}
+    for item in raw_attrs:
+        assert isinstance(item, dict)
+        keys[item['key']] = item['value']
+    assert keys['city'] == {'stringValue': 'Paris'}
+    assert keys['count'] == {'intValue': 2}
+    assert keys['ok'] == {'boolValue': True}
+    assert keys['temp'] == {'stringValue': '3.5'}
+    assert '_skip' not in keys
+    assert 'empty' not in keys
+    assert 'traceId' not in record
+    assert 'spanId' not in record
+
+
+def test_build_log_record_stamps_active_span() -> None:
+    """A record under a span carries lowercase hex ids."""
+    captured: dict[str, str] = {}
+
+    def go() -> None:
+        record = build_log_record(level=logging.INFO, event='inside', attrs={})
+        trace_id = record['traceId']
+        span_id = record['spanId']
+        assert isinstance(trace_id, str)
+        assert isinstance(span_id, str)
+        captured['traceId'] = trace_id
+        captured['spanId'] = span_id
+
+    from genkit._core._tracing import init_provider
+
+    init_provider()
+    with run_in_new_span(metadata=SpanMetadata(name='demo')):
+        go()
+
+    assert len(captured['traceId']) == 32
+    assert len(captured['spanId']) == 16
+    assert captured['traceId'] == captured['traceId'].lower()
+
+
+def test_build_payload_scope() -> None:
+    """One resourceLogs / scopeLogs batch named genkit-py."""
+    record = build_log_record(level=logging.INFO, event='hi', attrs={})
+    payload = build_payload(records=[record])
+    resource_logs = payload['resourceLogs']
+    assert isinstance(resource_logs, list)
+    first = resource_logs[0]
+    assert isinstance(first, dict)
+    scope_logs = first['scopeLogs']
+    assert isinstance(scope_logs, list)
+    first_scope = scope_logs[0]
+    assert isinstance(first_scope, dict)
+    assert first_scope['scope'] == {'name': SCOPE_NAME, 'version': GENKIT_VERSION}
+    assert first_scope['logRecords'] == [record]
+
+
+@pytest.mark.usefixtures('_reset_export', '_dev_env')
+def test_enable_ignored_when_opted_out() -> None:
+    with patch.dict(os.environ, {GENKIT_OTEL_ENABLE_LOGS: 'false'}):
+        enable_log_export(url='http://127.0.0.1:9')
+        assert log_export_is_enabled() is False
+
+
+@pytest.mark.usefixtures('_reset_export')
+def test_enable_ignored_outside_dev() -> None:
+    with patch.dict(os.environ, {GENKIT_ENV: 'prod'}):
+        enable_log_export(url='http://127.0.0.1:9')
+        assert log_export_is_enabled() is False
+
+
+@pytest.mark.usefixtures('_reset_export', '_dev_env')
+def test_export_does_not_stall_on_hung_collector() -> None:
+    """emit_log returns while a collector that never reads is still hanging."""
+    started = threading.Event()
+    release = threading.Event()
+
+    def blocking_post(*_args: object, **_kwargs: object) -> MagicMock:
+        started.set()
+        release.wait(timeout=5)
+        raise httpx.ConnectError('hung')
+
+    with patch('genkit._core._trace._log_exporter.httpx.Client') as mock_client_class:
+        mock_client = MagicMock()
+        mock_client.post.side_effect = blocking_post
+        mock_client_class.return_value.__enter__ = MagicMock(return_value=mock_client)
+        mock_client_class.return_value.__exit__ = MagicMock(return_value=None)
+
+        enable_log_export(url='http://127.0.0.1:9')
+        t0 = time.perf_counter()
+        emit_log(level=logging.DEBUG, event='hello', attrs={'city': 'Paris'})
+        elapsed = time.perf_counter() - t0
+
+        assert elapsed < 0.5
+        assert started.wait(timeout=1)
+        release.set()
+        from genkit._core._trace._log_exporter import _exporter
+
+        assert _exporter is not None
+        assert _exporter.force_flush(timeout_s=2) is True
+        assert _exporter.last_result_ok is False
+
+
+@pytest.mark.usefixtures('_reset_export', '_dev_env')
+def test_transport_failure_logs_one_error() -> None:
+    """A dead collector is one error line — not a traceback."""
+    enable_log_export(url='http://127.0.0.1:1')
+    with capture_logs() as entries:
+        emit_log(level=logging.INFO, event='hello', attrs={})
+        from genkit._core._trace._log_exporter import _exporter
+
+        assert _exporter is not None
+        assert _exporter.force_flush(timeout_s=2) is True
+        emit_log(level=logging.INFO, event='again', attrs={})
+        assert _exporter.force_flush(timeout_s=2) is True
+
+    errors = [e for e in entries if 'Failed to export logs' in str(e.get('event', ''))]
+    assert len(errors) == 1
+    assert 'exception' not in errors[0]
+
+
+@pytest.mark.usefixtures('_reset_export', '_dev_env')
+def test_overflow_drops_and_warns_once() -> None:
+    """A full queue drops the record and warns once — emit never blocks."""
+    enable_log_export(url='http://127.0.0.1:1')
+    from genkit._core._trace._log_exporter import _exporter
+
+    assert _exporter is not None
+    record = build_log_record(level=logging.DEBUG, event='overflow', attrs={})
+    with patch.object(_exporter.queue, 'put_nowait', side_effect=Full):
+        with capture_logs() as entries:
+            t0 = time.perf_counter()
+            _exporter.enqueue(record=record)
+            _exporter.enqueue(record=record)
+            assert time.perf_counter() - t0 < 0.2
+        warnings = [e for e in entries if 'queue is full' in str(e.get('event', ''))]
+        assert len(warnings) == 1
+        assert _exporter.dropped == 2
+
+
+@pytest.mark.usefixtures('_reset_export', '_dev_env')
+def test_posts_otlp_path_and_batches() -> None:
+    """Worker POSTs ``/api/otlp`` with a resourceLogs envelope."""
+    seen: list[dict[str, object]] = []
+    posted = threading.Event()
+
+    def capture_post(*_args: object, **kwargs: object) -> MagicMock:
+        body = kwargs.get('content') or (_args[1] if len(_args) > 1 else None)
+        if isinstance(body, (bytes, str)):
+            seen.append(json.loads(body))
+        posted.set()
+        response = MagicMock()
+        response.status_code = 200
+        return response
+
+    with patch('genkit._core._trace._log_exporter.httpx.Client') as mock_client_class:
+        mock_client = MagicMock()
+        mock_client.post.side_effect = capture_post
+        mock_client_class.return_value.__enter__ = MagicMock(return_value=mock_client)
+        mock_client_class.return_value.__exit__ = MagicMock(return_value=None)
+
+        enable_log_export(url='http://localhost:4033')
+        emit_log(level=logging.DEBUG, event='a', attrs={'n': 1})
+        emit_log(level=logging.INFO, event='b', attrs={})
+        from genkit._core._trace._log_exporter import _exporter
+
+        assert _exporter is not None
+        assert _exporter.force_flush(timeout_s=2) is True
+        assert posted.wait(timeout=2)
+
+    mock_client.post.assert_called()
+    called = mock_client.post.call_args
+    url = called.args[0] if called.args else called.kwargs.get('url')
+    assert url is not None and url.endswith(LOG_ENDPOINT)
+    records = seen[0]['resourceLogs'][0]['scopeLogs'][0]['logRecords']  # type: ignore[index]
+    events = [r['body']['stringValue'] for r in records]  # type: ignore[index]
+    assert 'a' in events
+    assert 'b' in events
+    assert BATCH_DELAY_S == 0.1
+
+
+@pytest.mark.usefixtures('_reset_export', '_dev_env')
+def test_get_logger_tees_debug_when_console_is_info() -> None:
+    """GENKIT_LOG=info keeps the TTY quiet; the Dev UI still gets debug."""
+    enable_log_export(url='http://127.0.0.1:9')
+    from genkit._core._logger import configure_structlog_level
+    from genkit._core._trace._log_exporter import _exporter
+
+    with patch.dict(os.environ, {'GENKIT_LOG': 'info'}):
+        structlog_ok = configure_structlog_level()
+        logger = get_logger('tee-test')
+        assert is_debug_enabled(logger) is True
+        queued: list[dict[str, object]] = []
+        assert _exporter is not None
+        original = _exporter.enqueue
+
+        def capture(*, record: dict[str, object]) -> None:
+            queued.append(record)
+
+        _exporter.enqueue = capture  # type: ignore[method-assign]
+        try:
+            logger.debug('looking up weather', city='Paris')
+            logger.info('kept on console')
+        finally:
+            _exporter.enqueue = original  # type: ignore[method-assign]
+
+    events = [r['body']['stringValue'] for r in queued]  # type: ignore[index]
+    assert 'looking up weather' in events
+    assert 'kept on console' in events
+    assert structlog_ok in {True, False}
+
+
+@pytest.mark.usefixtures('_reset_export', '_dev_env')
+def test_handshake_enables_log_export_when_env_url_missing() -> None:
+    """Reflection register/configure URL turns on log export, same as traces."""
+    os.environ.pop('GENKIT_TELEMETRY_SERVER', None)
+    from genkit._core._reflection_v2 import ReflectionServerV2
+    from genkit._core._registry import Registry
+
+    with patch('genkit._core._reflection_v2.add_custom_exporter'):
+        server = ReflectionServerV2(registry=Registry(), ws_url='ws://localhost:1')
+        server.apply_handshake_telemetry('http://localhost:4033')
+        assert log_export_is_enabled() is True
+        server.apply_handshake_telemetry('http://localhost:4033')
+
+
+def test_build_log_record_bounds_and_redacts_attrs() -> None:
+    """A generate() that binds 200 keys or an API key shouldn't dump them."""
+    attrs: dict[str, object] = {
+        'api_key': 'sk-secret',
+        'prompt': 'P' * (MAX_ATTR_CHARS + 50),
+    }
+    extra = MAX_ATTRIBUTES + 10
+    attrs.update({f'k{i}': i for i in range(extra)})
+    record = build_log_record(level=logging.DEBUG, event='bounded', attrs=attrs)
+    raw_attrs = record['attributes']
+    assert isinstance(raw_attrs, list)
+    assert len(raw_attrs) == MAX_ATTRIBUTES
+    assert record['droppedAttributesCount'] == extra - (MAX_ATTRIBUTES - 2)
+    keys = {item['key']: item['value'] for item in raw_attrs if isinstance(item, dict)}
+    assert keys['api_key'] == {'stringValue': '[redacted]'}
+    prompt_value = keys['prompt']
+    assert isinstance(prompt_value, dict)
+    prompt = prompt_value['stringValue']
+    assert isinstance(prompt, str)
+    assert prompt.startswith('P' * MAX_ATTR_CHARS)
+    assert prompt.endswith(f'...<{50} chars>')
+
+
+def test_put_poison_pill_lands_when_queue_is_full() -> None:
+    """Shutdown must stop the worker even if the last slot is a leftover record."""
+    from queue import Queue
+
+    queue: Queue[dict[str, object] | None] = Queue(maxsize=1)
+    queue.put_nowait({'leftover': True})
+    put_poison_pill(queue=queue)
+    assert queue.get_nowait() is None
+    assert queue.empty()
+
+
+@pytest.mark.usefixtures('_reset_export', '_dev_env')
+def test_shutdown_does_not_wait_for_export_timeout() -> None:
+    """atexit / Ctrl-C flush the last batch for ~2s, not the 5-minute POST."""
+    started = threading.Event()
+    release = threading.Event()
+
+    def blocking_post(*_args: object, **_kwargs: object) -> MagicMock:
+        started.set()
+        release.wait(timeout=10)
+        raise httpx.ConnectError('hung')
+
+    with patch('genkit._core._trace._log_exporter.httpx.Client') as mock_client_class:
+        mock_client = MagicMock()
+        mock_client.post.side_effect = blocking_post
+        mock_client_class.return_value.__enter__ = MagicMock(return_value=mock_client)
+        mock_client_class.return_value.__exit__ = MagicMock(return_value=None)
+
+        enable_log_export(url='http://127.0.0.1:9')
+        emit_log(level=logging.DEBUG, event='hello', attrs={})
+        assert started.wait(timeout=1)
+        t0 = time.perf_counter()
+        reset_log_export()
+        elapsed = time.perf_counter() - t0
+        release.set()
+
+    assert elapsed < SHUTDOWN_FLUSH_TIMEOUT_S + 1.5
+    assert SHUTDOWN_FLUSH_TIMEOUT_S == 2.0
+
+
+@pytest.mark.usefixtures('_reset_export', '_dev_env')
+def test_enable_rejects_invalid_url_on_caller_thread() -> None:
+    """A typo'd collector URL fails when export starts, not as missing Dev UI logs."""
+    enable_log_export(url='not-a-url')
+    assert log_export_is_enabled() is False

--- a/py/packages/genkit/tests/genkit/core/trace/log_exporter_test.py
+++ b/py/packages/genkit/tests/genkit/core/trace/log_exporter_test.py
@@ -1,0 +1,393 @@
+# Copyright 2026 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for Dev UI OTLP log export."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import threading
+import time
+from collections.abc import Iterator
+from queue import Full
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+from structlog.testing import capture_logs
+
+from genkit._core._constants import GENKIT_VERSION
+from genkit._core._environment import GENKIT_ENV
+from genkit._core._logger import get_logger, is_debug_enabled
+from genkit._core._trace._log_exporter import (
+    BATCH_DELAY_S,
+    GENKIT_OTEL_ENABLE_LOGS,
+    LOG_ENDPOINT,
+    MAX_ATTR_CHARS,
+    MAX_ATTRIBUTES,
+    SCOPE_NAME,
+    SHUTDOWN_FLUSH_TIMEOUT_S,
+    build_log_record,
+    build_payload,
+    emit_log,
+    enable_log_export,
+    log_export_is_enabled,
+    logs_opted_out,
+    put_poison_pill,
+    reset_log_export,
+)
+from genkit._core._tracing import SpanMetadata, run_in_new_span
+
+
+@pytest.fixture
+def _reset_export() -> Iterator[None]:
+    reset_log_export()
+    yield
+    reset_log_export()
+
+
+@pytest.fixture
+def _dev_env() -> Iterator[None]:
+    with patch.dict(os.environ, {GENKIT_ENV: 'dev', GENKIT_OTEL_ENABLE_LOGS: ''}, clear=False):
+        os.environ.pop(GENKIT_OTEL_ENABLE_LOGS, None)
+        yield
+
+
+def test_logs_opted_out_matches_parse_bool() -> None:
+    """Only ParseBool false values opt out — ``off`` keeps export on."""
+    for value in ['false', 'False', '0', 'f', 'F']:
+        with patch.dict(os.environ, {GENKIT_OTEL_ENABLE_LOGS: value}):
+            assert logs_opted_out() is True
+    for value in ['', 'true', '1', 'off', 'yes']:
+        with patch.dict(os.environ, {GENKIT_OTEL_ENABLE_LOGS: value} if value else {}, clear=False):
+            if not value:
+                os.environ.pop(GENKIT_OTEL_ENABLE_LOGS, None)
+            assert logs_opted_out() is False
+
+
+def test_build_log_record_wire_shape() -> None:
+    """OTLP-JSON: string nanoseconds, severity 5/9/13/21, typed attrs only."""
+    record = build_log_record(
+        level=logging.DEBUG,
+        event='looking up weather',
+        attrs={
+            'city': 'Paris',
+            'count': 2,
+            'ok': True,
+            'temp': 3.5,
+            'blob': b'12345',
+            'buf': bytearray(b'123'),
+            'mem': memoryview(b'abc'),
+            '_skip': 1,
+            'empty': None,
+        },
+    )
+    assert record['severityNumber'] == 5
+    assert record['severityText'] == 'DEBUG'
+    assert record['body'] == {'stringValue': 'looking up weather'}
+    nano = record['timeUnixNano']
+    assert isinstance(nano, str) and nano.isdigit()
+    raw_attrs = record['attributes']
+    assert isinstance(raw_attrs, list)
+    keys: dict[object, object] = {}
+    for item in raw_attrs:
+        assert isinstance(item, dict)
+        keys[item['key']] = item['value']
+    assert keys['city'] == {'stringValue': 'Paris'}
+    assert keys['count'] == {'intValue': 2}
+    assert keys['ok'] == {'boolValue': True}
+    assert keys['temp'] == {'doubleValue': 3.5}
+    assert keys['blob'] == {'stringValue': '<5 bytes>'}
+    assert keys['buf'] == {'stringValue': '<3 bytes>'}
+    assert keys['mem'] == {'stringValue': '<3 bytes>'}
+    assert '_skip' not in keys
+    assert 'empty' not in keys
+    assert 'traceId' not in record
+    assert 'spanId' not in record
+
+    crit_record = build_log_record(level=logging.CRITICAL, event='panic', attrs={})
+    assert crit_record['severityNumber'] == 21
+    assert crit_record['severityText'] == 'FATAL'
+
+
+def test_build_log_record_stamps_active_span() -> None:
+    """A record under a span carries lowercase hex ids."""
+    captured: dict[str, str] = {}
+
+    def go() -> None:
+        record = build_log_record(level=logging.INFO, event='inside', attrs={})
+        trace_id = record['traceId']
+        span_id = record['spanId']
+        assert isinstance(trace_id, str)
+        assert isinstance(span_id, str)
+        captured['traceId'] = trace_id
+        captured['spanId'] = span_id
+
+    from genkit._core._tracing import init_provider
+
+    init_provider()
+    with run_in_new_span(metadata=SpanMetadata(name='demo')):
+        go()
+
+    assert len(captured['traceId']) == 32
+    assert len(captured['spanId']) == 16
+    assert captured['traceId'] == captured['traceId'].lower()
+
+
+def test_build_payload_scope() -> None:
+    """One resourceLogs / scopeLogs batch named genkit-py."""
+    record = build_log_record(level=logging.INFO, event='hi', attrs={})
+    payload = build_payload(records=[record])
+    resource_logs = payload['resourceLogs']
+    assert isinstance(resource_logs, list)
+    first = resource_logs[0]
+    assert isinstance(first, dict)
+    scope_logs = first['scopeLogs']
+    assert isinstance(scope_logs, list)
+    first_scope = scope_logs[0]
+    assert isinstance(first_scope, dict)
+    assert first_scope['scope'] == {'name': SCOPE_NAME, 'version': GENKIT_VERSION}
+    assert first_scope['logRecords'] == [record]
+
+
+@pytest.mark.usefixtures('_reset_export', '_dev_env')
+def test_enable_ignored_when_opted_out() -> None:
+    with patch.dict(os.environ, {GENKIT_OTEL_ENABLE_LOGS: 'false'}):
+        enable_log_export(url='http://127.0.0.1:9')
+        assert log_export_is_enabled() is False
+
+
+@pytest.mark.usefixtures('_reset_export')
+def test_enable_ignored_outside_dev() -> None:
+    with patch.dict(os.environ, {GENKIT_ENV: 'prod'}):
+        enable_log_export(url='http://127.0.0.1:9')
+        assert log_export_is_enabled() is False
+
+
+@pytest.mark.usefixtures('_reset_export', '_dev_env')
+def test_export_does_not_stall_on_hung_collector() -> None:
+    """emit_log returns while a collector that never reads is still hanging."""
+    started = threading.Event()
+    release = threading.Event()
+
+    def blocking_post(*_args: object, **_kwargs: object) -> MagicMock:
+        started.set()
+        release.wait(timeout=5)
+        raise httpx.ConnectError('hung')
+
+    with patch('genkit._core._trace._log_exporter.httpx.Client') as mock_client_class:
+        mock_client = MagicMock()
+        mock_client.post.side_effect = blocking_post
+        mock_client_class.return_value.__enter__ = MagicMock(return_value=mock_client)
+        mock_client_class.return_value.__exit__ = MagicMock(return_value=None)
+
+        enable_log_export(url='http://127.0.0.1:9')
+        t0 = time.perf_counter()
+        emit_log(level=logging.DEBUG, event='hello', attrs={'city': 'Paris'})
+        elapsed = time.perf_counter() - t0
+
+        assert elapsed < 0.5
+        assert started.wait(timeout=1)
+        release.set()
+        from genkit._core._trace._log_exporter import _exporter
+
+        assert _exporter is not None
+        assert _exporter.force_flush(timeout_s=2) is True
+        assert _exporter.last_result_ok is False
+
+
+@pytest.mark.usefixtures('_reset_export', '_dev_env')
+def test_transport_failure_logs_one_error() -> None:
+    """A dead collector is one error line — not a traceback."""
+    enable_log_export(url='http://127.0.0.1:1')
+    with capture_logs() as entries:
+        emit_log(level=logging.INFO, event='hello', attrs={})
+        from genkit._core._trace._log_exporter import _exporter
+
+        assert _exporter is not None
+        assert _exporter.force_flush(timeout_s=2) is True
+        emit_log(level=logging.INFO, event='again', attrs={})
+        assert _exporter.force_flush(timeout_s=2) is True
+
+    errors = [e for e in entries if 'Failed to export logs' in str(e.get('event', ''))]
+    assert len(errors) == 1
+    assert 'exception' not in errors[0]
+
+
+@pytest.mark.usefixtures('_reset_export', '_dev_env')
+def test_overflow_drops_and_warns_once() -> None:
+    """A full queue drops the record and warns once — emit never blocks."""
+    enable_log_export(url='http://127.0.0.1:1')
+    from genkit._core._trace._log_exporter import _exporter
+
+    assert _exporter is not None
+    record = build_log_record(level=logging.DEBUG, event='overflow', attrs={})
+    with patch.object(_exporter.queue, 'put_nowait', side_effect=Full):
+        with capture_logs() as entries:
+            t0 = time.perf_counter()
+            _exporter.enqueue(record=record)
+            _exporter.enqueue(record=record)
+            assert time.perf_counter() - t0 < 0.2
+        warnings = [e for e in entries if 'queue is full' in str(e.get('event', ''))]
+        assert len(warnings) == 1
+        assert _exporter.dropped == 2
+
+
+@pytest.mark.usefixtures('_reset_export', '_dev_env')
+def test_posts_otlp_path_and_batches() -> None:
+    """Worker POSTs ``/api/otlp`` with a resourceLogs envelope."""
+    seen: list[dict[str, object]] = []
+    posted = threading.Event()
+
+    def capture_post(*_args: object, **kwargs: object) -> MagicMock:
+        body = kwargs.get('content') or (_args[1] if len(_args) > 1 else None)
+        if isinstance(body, (bytes, str)):
+            seen.append(json.loads(body))
+        posted.set()
+        response = MagicMock()
+        response.status_code = 200
+        return response
+
+    with patch('genkit._core._trace._log_exporter.httpx.Client') as mock_client_class:
+        mock_client = MagicMock()
+        mock_client.post.side_effect = capture_post
+        mock_client_class.return_value.__enter__ = MagicMock(return_value=mock_client)
+        mock_client_class.return_value.__exit__ = MagicMock(return_value=None)
+
+        enable_log_export(url='http://localhost:4033')
+        emit_log(level=logging.DEBUG, event='a', attrs={'n': 1})
+        emit_log(level=logging.INFO, event='b', attrs={})
+        from genkit._core._trace._log_exporter import _exporter
+
+        assert _exporter is not None
+        assert _exporter.force_flush(timeout_s=2) is True
+        assert posted.wait(timeout=2)
+
+    mock_client.post.assert_called()
+    called = mock_client.post.call_args
+    url = called.args[0] if called.args else called.kwargs.get('url')
+    assert url is not None and url.endswith(LOG_ENDPOINT)
+    records = seen[0]['resourceLogs'][0]['scopeLogs'][0]['logRecords']  # type: ignore[index]
+    events = [r['body']['stringValue'] for r in records]  # type: ignore[index]
+    assert 'a' in events
+    assert 'b' in events
+    assert BATCH_DELAY_S == 0.1
+
+
+@pytest.mark.usefixtures('_reset_export', '_dev_env')
+def test_get_logger_tees_debug_when_console_is_info() -> None:
+    """GENKIT_LOG=info keeps the TTY quiet; the Dev UI still gets debug."""
+    enable_log_export(url='http://127.0.0.1:9')
+    from genkit._core._logger import configure_structlog_level
+    from genkit._core._trace._log_exporter import _exporter
+
+    with patch.dict(os.environ, {'GENKIT_LOG': 'info'}):
+        structlog_ok = configure_structlog_level()
+        logger = get_logger('tee-test')
+        assert is_debug_enabled(logger) is True
+        queued: list[dict[str, object]] = []
+        assert _exporter is not None
+        original = _exporter.enqueue
+
+        def capture(*, record: dict[str, object]) -> None:
+            queued.append(record)
+
+        _exporter.enqueue = capture  # type: ignore[method-assign]
+        try:
+            logger.debug('looking up weather', city='Paris')
+            logger.info('kept on console')
+        finally:
+            _exporter.enqueue = original  # type: ignore[method-assign]
+
+    events = [r['body']['stringValue'] for r in queued]  # type: ignore[index]
+    assert 'looking up weather' in events
+    assert 'kept on console' in events
+    assert structlog_ok in {True, False}
+
+
+@pytest.mark.usefixtures('_reset_export', '_dev_env')
+def test_handshake_enables_log_export_when_env_url_missing() -> None:
+    """Reflection register/configure URL turns on log export, same as traces."""
+    os.environ.pop('GENKIT_TELEMETRY_SERVER', None)
+    from genkit._core._reflection_v2 import ReflectionServerV2
+    from genkit._core._registry import Registry
+
+    with patch('genkit._core._reflection_v2.add_custom_exporter'):
+        server = ReflectionServerV2(registry=Registry(), ws_url='ws://localhost:1')
+        server.apply_handshake_telemetry('http://localhost:4033')
+        assert log_export_is_enabled() is True
+        server.apply_handshake_telemetry('http://localhost:4033')
+
+
+def test_build_log_record_bounds_and_redacts_attrs() -> None:
+    """A generate() that binds 200 keys or an API key shouldn't dump them."""
+    attrs: dict[str, object] = {
+        'api_key': 'sk-secret',
+        'prompt': 'P' * (MAX_ATTR_CHARS + 50),
+    }
+    extra = MAX_ATTRIBUTES + 10
+    attrs.update({f'k{i}': i for i in range(extra)})
+    record = build_log_record(level=logging.DEBUG, event='bounded', attrs=attrs)
+    raw_attrs = record['attributes']
+    assert isinstance(raw_attrs, list)
+    assert len(raw_attrs) == MAX_ATTRIBUTES
+    assert record['droppedAttributesCount'] == extra - (MAX_ATTRIBUTES - 2)
+    keys = {item['key']: item['value'] for item in raw_attrs if isinstance(item, dict)}
+    assert keys['api_key'] == {'stringValue': '[redacted]'}
+    prompt_value = keys['prompt']
+    assert isinstance(prompt_value, dict)
+    prompt = prompt_value['stringValue']
+    assert isinstance(prompt, str)
+    assert prompt.startswith('P' * MAX_ATTR_CHARS)
+    assert prompt.endswith(f'...<{50} chars>')
+
+
+def test_put_poison_pill_lands_when_queue_is_full() -> None:
+    """Shutdown must stop the worker even if the last slot is a leftover record."""
+    from queue import Queue
+
+    queue: Queue[dict[str, object] | None] = Queue(maxsize=1)
+    queue.put_nowait({'leftover': True})
+    put_poison_pill(queue=queue)
+    assert queue.get_nowait() is None
+    queue.task_done()
+    queue.join()
+    assert queue.empty()
+
+
+@pytest.mark.usefixtures('_reset_export', '_dev_env')
+def test_shutdown_does_not_wait_for_export_timeout() -> None:
+    """atexit / Ctrl-C flush the last batch for ~2s, not the 5-minute POST."""
+    started = threading.Event()
+    release = threading.Event()
+
+    def blocking_post(*_args: object, **_kwargs: object) -> MagicMock:
+        started.set()
+        release.wait(timeout=10)
+        raise httpx.ConnectError('hung')
+
+    with patch('genkit._core._trace._log_exporter.httpx.Client') as mock_client_class:
+        mock_client = MagicMock()
+        mock_client.post.side_effect = blocking_post
+        mock_client_class.return_value.__enter__ = MagicMock(return_value=mock_client)
+        mock_client_class.return_value.__exit__ = MagicMock(return_value=None)
+
+        enable_log_export(url='http://127.0.0.1:9')
+        emit_log(level=logging.DEBUG, event='hello', attrs={})
+        assert started.wait(timeout=1)
+        t0 = time.perf_counter()
+        reset_log_export()
+        elapsed = time.perf_counter() - t0
+        release.set()
+
+    assert elapsed < SHUTDOWN_FLUSH_TIMEOUT_S + 1.5
+    assert SHUTDOWN_FLUSH_TIMEOUT_S == 2.0
+
+
+@pytest.mark.usefixtures('_reset_export', '_dev_env')
+def test_enable_rejects_invalid_url_on_caller_thread() -> None:
+    """A typo'd collector URL fails when export starts, not as missing Dev UI logs."""
+    enable_log_export(url='not-a-url')
+    assert log_export_is_enabled() is False

--- a/py/packages/genkit/tests/genkit/core/trace/log_exporter_test.py
+++ b/py/packages/genkit/tests/genkit/core/trace/log_exporter_test.py
@@ -297,14 +297,27 @@ def test_get_logger_tees_debug_when_console_is_info() -> None:
         _exporter.enqueue = capture  # type: ignore[method-assign]
         try:
             logger.debug('looking up weather', city='Paris')
+            logger.error('Startup failed: %s: %s', 'ValueError', 'boom')
             logger.info('kept on console')
         finally:
             _exporter.enqueue = original  # type: ignore[method-assign]
 
     events = [r['body']['stringValue'] for r in queued]  # type: ignore[index]
     assert 'looking up weather' in events
+    assert 'Startup failed: ValueError: boom' in events
     assert 'kept on console' in events
     assert structlog_ok in {True, False}
+
+
+@pytest.mark.usefixtures('_reset_export', '_dev_env')
+def test_worker_stops_when_client_construction_fails() -> None:
+    """Client() raising must flip stopped so debug branches stop building records."""
+    with patch('genkit._core._trace._log_exporter.httpx.Client', side_effect=RuntimeError('no client')):
+        enable_log_export(url='http://127.0.0.1:9')
+        deadline = time.monotonic() + 2.0
+        while log_export_is_enabled() and time.monotonic() < deadline:
+            time.sleep(0.01)
+        assert log_export_is_enabled() is False
 
 
 @pytest.mark.usefixtures('_reset_export', '_dev_env')
@@ -342,6 +355,22 @@ def test_build_log_record_bounds_and_redacts_attrs() -> None:
     assert isinstance(prompt, str)
     assert prompt.startswith('P' * MAX_ATTR_CHARS)
     assert prompt.endswith(f'...<{50} chars>')
+
+
+def test_build_log_record_redacts_camel_case_secrets() -> None:
+    """apiKey / authToken / apikey must not POST in cleartext to /api/otlp."""
+    record = build_log_record(
+        level=logging.DEBUG,
+        event='calling provider',
+        attrs={'apiKey': 'sk-secret', 'authToken': 'tok', 'apikey': 'sk-2', 'city': 'Paris'},
+    )
+    raw_attrs = record['attributes']
+    assert isinstance(raw_attrs, list)
+    keys = {item['key']: item['value'] for item in raw_attrs if isinstance(item, dict)}
+    assert keys['apiKey'] == {'stringValue': '[redacted]'}
+    assert keys['authToken'] == {'stringValue': '[redacted]'}
+    assert keys['apikey'] == {'stringValue': '[redacted]'}
+    assert keys['city'] == {'stringValue': 'Paris'}
 
 
 def test_put_poison_pill_lands_when_queue_is_full() -> None:


### PR DESCRIPTION
Under `genkit start`, `ai.generate()` should leave a breadcrumb next to the span in the Dev UI log panel — without dumping the response blob onto the shared TTY.

```python
ai.generate(model='googleai/gemini-2.5-flash', prompt='hi')
```

Debug used to serialize a (redacted) `ModelResponse`. That was either too big for the log panel or missing entirely when `GENKIT_LOG=info`. After this, generate emits named records — `generate request resolved`, `calling model`, `model responded`, `middleware hook started` / `finished`, `executing tool requests` — and a background OTLP sink POSTs them to `/api/otlp`.

`ExportTee` splits the two sinks. The console still honours `GENKIT_LOG`. The Dev UI sink is debug and above, so a quiet terminal can still fill the trace viewer's log panel when `GENKIT_TELEMETRY_SERVER` is set (`GENKIT_ENV=dev`).

Collector I/O stays off the generate thread (300s batch POST; 2s shutdown flush) so a wedged Dev UI does not stall Ctrl-C.