### PR TITLE
feat(go/ai/exp): add `AgentHandle`, the untyped caller-side agent surface

### DIFF
--- a/go/README.md
+++ b/go/README.md
@@ -421,13 +421,15 @@ conn.Detach() // server takes ownership of the remaining work
 out, _ := conn.Output() // returns immediately; FinishReason is "detached"
 snapshotID := out.SnapshotID
 
-// Later: poll the snapshot, then resume once it has finalized.
-snap, _ := chatAgent.GetSnapshot(ctx, snapshotID)
+// Later: read where it stands, or block until it settles.
+snap, _ := chatAgent.GetSnapshot(ctx, snapshotID)     // one read, no waiting
+snap, _ = chatAgent.WaitForSnapshot(ctx, snapshotID)  // blocks until terminal
 switch snap.Status {
-case aix.SnapshotStatusPending:   // still working
+case aix.SnapshotStatusPending:   // still working (GetSnapshot only)
 case aix.SnapshotStatusCompleted: // snap.State holds the final state; resume it
 case aix.SnapshotStatusFailed:    // snap.Error holds the failure; still resumable
 case aix.SnapshotStatusAborted:   // stopped early; resumable from the last finished turn
+case aix.SnapshotStatusExpired:   // the worker stopped heartbeating
 }
 
 // Or stop it early; the runtime observes the abort and cancels the work.

--- a/go/README.md
+++ b/go/README.md
@@ -461,9 +461,10 @@ mux := http.NewServeMux()
 for _, r := range genkitx.AllAgentRoutes(g) {
     mux.HandleFunc(r.Pattern(), r.Handler())
 }
-// POST /agents/chat                one turn per request (?stream=true for SSE)
-// POST /agents/chat/getSnapshot    read a snapshot by ID
-// POST /agents/chat/abort          abort background work
+// POST /agents/chat                     one turn per request (?stream=true for SSE)
+// POST /agents/chat/getSnapshot         read a snapshot by ID
+// POST /agents/chat/waitForSnapshot     block until a snapshot settles
+// POST /agents/chat/abort               abort background work
 log.Fatal(server.Start(ctx, "127.0.0.1:8080", mux))
 ```
 

--- a/go/README.md
+++ b/go/README.md
@@ -501,9 +501,10 @@ mux := http.NewServeMux()
 for _, r := range genkitx.AllAgentRoutes(g) {
     mux.HandleFunc(r.Pattern(), r.Handler())
 }
-// POST /agents/chat                one turn per request (?stream=true for SSE)
-// POST /agents/chat/getSnapshot    read a snapshot by ID
-// POST /agents/chat/abort          abort background work
+// POST /agents/chat                     one turn per request (?stream=true for SSE)
+// POST /agents/chat/getSnapshot         read a snapshot by ID
+// POST /agents/chat/waitForSnapshot     block until a snapshot settles
+// POST /agents/chat/abort               abort background work
 log.Fatal(server.Start(ctx, "127.0.0.1:8080", mux))
 ```
 

--- a/go/ai/exp/agent.go
+++ b/go/ai/exp/agent.go
@@ -513,14 +513,16 @@ type AgentFunc[State any] = func(ctx context.Context, resp Responder, sess *Sess
 //
 // Server-managed agents (those with a [SessionStore] configured) also
 // register companion actions for the snapshot lifecycle, available via
-// [Agent.GetSnapshotAction] and [Agent.AbortAction] for serving
-// alongside the agent, and expose the store itself via [Agent.Store].
+// [Agent.GetSnapshotAction], [Agent.WaitForSnapshotAction], and
+// [Agent.AbortAction] for serving alongside the agent, and expose the store
+// itself via [Agent.Store].
 type Agent[State any] struct {
 	action *core.BidiAction[*AgentInput, *AgentOutput[State], *AgentStreamChunk, *AgentInit[State]]
 	// Companion actions, retained so transports can serve them without a
 	// registry lookup. Nil when the corresponding capability is absent;
 	// see newSnapshotActions.
 	getSnapshot api.Action
+	wait        api.Action
 	abort       api.Action
 	// store is the configured session store, or nil for a client-managed
 	// agent. Retained so callers can reach it via Store without threading
@@ -535,7 +537,7 @@ type Agent[State any] struct {
 
 // Name returns the agent's registered name. This is also the name under
 // which any inline-defined prompt and companion actions (getSnapshot,
-// abort) are registered.
+// waitForSnapshot, abort) are registered.
 func (a *Agent[State]) Name() string {
 	return a.action.Name()
 }
@@ -551,6 +553,19 @@ func (a *Agent[State]) Name() string {
 // [Agent.GetSnapshot], which applies the configured state transform.
 func (a *Agent[State]) GetSnapshotAction() api.Action {
 	return a.getSnapshot
+}
+
+// WaitForSnapshotAction returns the agent's waitForSnapshot companion action,
+// which resolves a snapshot the same way getSnapshot does and returns once it
+// settles (input [GetSnapshotRequest], output [SessionSnapshot]). It returns
+// nil when the agent is client-managed (no [SessionStore] configured).
+//
+// Use it to expose following a detached invocation over a transport (e.g.
+// mount it with genkit.Handler next to the agent itself), so a remote caller
+// waits in one request instead of a read per tick; local Go code should use
+// [Agent.WaitForSnapshot], which applies the configured state transform.
+func (a *Agent[State]) WaitForSnapshotAction() api.Action {
+	return a.wait
 }
 
 // AbortAction returns the agent's abort companion action,
@@ -598,7 +613,30 @@ func (a *Agent[State]) GetSnapshot(ctx context.Context, snapshotID string) (*Ses
 	if snapshotID == "" {
 		return nil, status.Errorf(status.ErrInvalidArgument, "agent %q: GetSnapshot: snapshotID is required", a.Name())
 	}
-	return readSnapshot(ctx, a.store, a.transform, snapshotID, "")
+	return readSnapshot(ctx, a.store, a.transform, "getSnapshot", snapshotID, "")
+}
+
+// WaitForSnapshot fetches a session snapshot by ID and blocks until it settles,
+// returning the terminal snapshot with the same transform and shaping as
+// [Agent.GetSnapshot]. An already-terminal snapshot returns at once. It is how
+// an owner follows a detached invocation to its end; a caller holding only the
+// agent's name waits through [AgentHandle.WaitForSnapshot] instead.
+//
+// A snapshot that failed, aborted, or expired is returned like any other, so a
+// non-nil error means the wait itself could not proceed: a read failed, or ctx
+// ended and its error is returned. Bound the wait with [context.WithTimeout]
+// and read the snapshot afterwards to learn where it stands.
+//
+// It returns FAILED_PRECONDITION on a client-managed agent (no store) and
+// INVALID_ARGUMENT when snapshotID is empty; a missing snapshot is NOT_FOUND.
+func (a *Agent[State]) WaitForSnapshot(ctx context.Context, snapshotID string) (*SessionSnapshot[State], error) {
+	if a.store == nil {
+		return nil, status.Errorf(ErrSessionStoreNotConfigured, "agent %q: WaitForSnapshot requires a session store", a.Name())
+	}
+	if snapshotID == "" {
+		return nil, status.Errorf(status.ErrInvalidArgument, "agent %q: WaitForSnapshot: snapshotID is required", a.Name())
+	}
+	return waitSnapshot(ctx, a.store, a.transform, "waitForSnapshot", snapshotID, "")
 }
 
 // GetLatestSnapshot fetches a session's most recently created snapshot (whatever
@@ -615,7 +653,7 @@ func (a *Agent[State]) GetLatestSnapshot(ctx context.Context, sessionID string) 
 	if sessionID == "" {
 		return nil, status.Errorf(status.ErrInvalidArgument, "agent %q: GetLatestSnapshot: sessionID is required", a.Name())
 	}
-	return readSnapshot(ctx, a.store, a.transform, "", sessionID)
+	return readSnapshot(ctx, a.store, a.transform, "getSnapshot", "", sessionID)
 }
 
 // Abort aborts the detached invocation behind a pending snapshot by
@@ -648,7 +686,7 @@ func (a *Agent[State]) Abort(ctx context.Context, snapshotID string) (SnapshotSt
 var _ api.BidiAction = (*Agent[any])(nil)
 
 // Register registers the agent's run action and any companion actions
-// (getSnapshot, abort) with the registry. Agents defined via
+// (getSnapshot, waitForSnapshot, abort) with the registry. Agents defined via
 // [DefineAgent] or [DefineCustomAgent] are already registered; this
 // exists so an agent can travel to another registry as a unit. An
 // inline-defined prompt does not travel: the agent holds it directly, so
@@ -666,6 +704,9 @@ func (a *Agent[State]) Register(r api.Registry) {
 	a.action.Register(r)
 	if a.getSnapshot != nil {
 		a.getSnapshot.Register(r)
+	}
+	if a.wait != nil {
+		a.wait.Register(r)
 	}
 	if a.abort != nil {
 		a.abort.Register(r)
@@ -892,11 +933,12 @@ func newCustomAgent[State any](
 			return rt.run(ctx, fn)
 		})
 
-	getSnapshot, abort := newSnapshotActions(name, cfg.store, cfg.transform)
+	getSnapshot, wait, abort := newSnapshotActions(name, cfg.store, cfg.transform)
 
 	return &Agent[State]{
 		action:      action,
 		getSnapshot: getSnapshot,
+		wait:        wait,
 		abort:       abort,
 		store:       cfg.store,
 		transform:   cfg.transform,

--- a/go/ai/exp/agent.go
+++ b/go/ai/exp/agent.go
@@ -3137,32 +3137,11 @@ func (a *Agent[State]) RunText(
 	}, opts...)
 }
 
-// resolveOptions applies invocation options and returns the init struct.
-// Mutual exclusivity is checked here, once, after all options are merged:
-// WithState excludes both WithSessionID and WithSnapshotID (a
-// client-managed conversation's identity rides inside the state itself),
-// while WithSessionID and WithSnapshotID compose as an assertion.
-// Per-option duplicate checks live in applyInvocation.
+// resolveOptions applies invocation options and returns the init struct; the
+// merge rules live in resolveInvocationInit (option.go), shared with the
+// untyped [AgentHandle] surface.
 func (a *Agent[State]) resolveOptions(opts []InvocationOption[State]) (*AgentInit[State], error) {
-	invOpts := &invocationOptions[State]{}
-	for _, opt := range opts {
-		if err := opt.applyInvocation(invOpts); err != nil {
-			return nil, fmt.Errorf("Agent %q: %w", a.action.Name(), err)
-		}
-	}
-
-	if invOpts.state != nil && invOpts.snapshotID != "" {
-		return nil, fmt.Errorf("Agent %q: WithState and WithSnapshotID are mutually exclusive", a.action.Name())
-	}
-	if invOpts.state != nil && invOpts.sessionIDSet {
-		return nil, fmt.Errorf("Agent %q: WithState and WithSessionID are mutually exclusive; the conversation's identity rides inside the state (SessionState.SessionID)", a.action.Name())
-	}
-
-	return &AgentInit[State]{
-		SessionID:  invOpts.sessionID,
-		SnapshotID: invOpts.snapshotID,
-		State:      invOpts.state,
-	}, nil
+	return resolveInvocationInit(a.action.Name(), opts)
 }
 
 // --- AgentConnection ---

--- a/go/ai/exp/agent.go
+++ b/go/ai/exp/agent.go
@@ -623,9 +623,10 @@ func (a *Agent[State]) GetSnapshot(ctx context.Context, snapshotID string) (*Ses
 // agent's name waits through [AgentHandle.WaitForSnapshot] instead.
 //
 // A snapshot that failed, aborted, or expired is returned like any other, so a
-// non-nil error means the wait itself could not proceed: a read failed, or ctx
-// ended and its error is returned. Bound the wait with [context.WithTimeout]
-// and read the snapshot afterwards to learn where it stands.
+// non-nil error means the wait itself could not proceed: reads failed past the
+// wait's transient-retry budget, or ctx ended and its error is returned. Bound
+// the wait with [context.WithTimeout] and read the snapshot afterwards to
+// learn where it stands.
 //
 // It returns FAILED_PRECONDITION on a client-managed agent (no store) and
 // INVALID_ARGUMENT when snapshotID is empty; a missing snapshot is NOT_FOUND.
@@ -702,14 +703,10 @@ func (a *Agent[State]) Register(r api.Registry) {
 	// registry consumers recover them by key (genkit.LookupAction) rather
 	// than by reaching through the agent action; see newSnapshotActions.
 	a.action.Register(r)
-	if a.getSnapshot != nil {
-		a.getSnapshot.Register(r)
-	}
-	if a.wait != nil {
-		a.wait.Register(r)
-	}
-	if a.abort != nil {
-		a.abort.Register(r)
+	for _, companion := range []api.Action{a.getSnapshot, a.wait, a.abort} {
+		if companion != nil {
+			companion.Register(r)
+		}
 	}
 }
 
@@ -2866,7 +2863,9 @@ func (a *Agent[State]) Connect(
 	ctx context.Context,
 	opts ...InvocationOption[State],
 ) (*AgentConnection[State], error) {
-	init, err := a.resolveOptions(opts)
+	// The merge rules live in resolveInvocationInit (option.go), shared with
+	// the untyped [AgentHandle] surface.
+	init, err := resolveInvocationInit(a.action.Name(), opts)
 	if err != nil {
 		return nil, err
 	}
@@ -2913,13 +2912,6 @@ func (a *Agent[State]) RunText(
 	return a.Run(ctx, &AgentInput{
 		Message: ai.NewUserTextMessage(text),
 	}, opts...)
-}
-
-// resolveOptions applies invocation options and returns the init struct; the
-// merge rules live in resolveInvocationInit (option.go), shared with the
-// untyped [AgentHandle] surface.
-func (a *Agent[State]) resolveOptions(opts []InvocationOption[State]) (*AgentInit[State], error) {
-	return resolveInvocationInit(a.action.Name(), opts)
 }
 
 // --- AgentConnection ---

--- a/go/ai/exp/agent.go
+++ b/go/ai/exp/agent.go
@@ -3128,7 +3128,8 @@ func agentLoop[State any](r api.Registry, prompt ai.Prompt, defaultInput any) Ag
 
 // Connect starts a new agent invocation with bidirectional streaming.
 // Use this for multi-turn interactions where you need to send multiple inputs
-// and receive streaming chunks. For single-turn usage, see Run and RunText.
+// and receive streaming chunks. For single-turn usage, see Run and RunText;
+// for a single turn that keeps working after the call returns, RunDetached.
 func (a *Agent[State]) Connect(
 	ctx context.Context,
 	opts ...InvocationOption[State],
@@ -3182,6 +3183,51 @@ func (a *Agent[State]) RunText(
 	return a.Run(ctx, &AgentInput{
 		Message: ai.NewUserTextMessage(text),
 	}, opts...)
+}
+
+// RunDetached launches input as a detached (background) invocation and returns
+// the task tracking it. It is the one-shot counterpart of
+// [AgentConnection.Detach]: the input is delivered with [AgentInput.Detach]
+// set, whatever the caller set it to; the runtime persists a pending snapshot
+// and keeps working on a context decoupled from ctx; and the returned
+// [DetachedTask] polls, waits on, or aborts that snapshot, with custom state
+// typed as State. The pending snapshot is the durable record: record
+// [DetachedTask.SnapshotID] and rehydrate with [Agent.Task] to pick the
+// work up later, including from another process.
+//
+// The launch is rejected with FAILED_PRECONDITION when the agent cannot
+// support detach: it has no session store, or the store does not implement
+// [SnapshotSubscriber]. The rejection is the invocation's failed output
+// ([AgentOutput.Error]) surfaced as the returned error; match it by status.
+//
+// An agent may also settle the invocation synchronously, before the runtime
+// observes the detach directive (e.g. a custom agent whose fn returns without
+// consuming the input). When a turn committed, RunDetached returns a task over
+// its snapshot, which is already terminal, so Poll and Wait resolve
+// immediately; when nothing was recorded, it fails with FAILED_PRECONDITION
+// naming the finish reason, since there is no durable record to track.
+func (a *Agent[State]) RunDetached(
+	ctx context.Context,
+	input *AgentInput,
+	opts ...InvocationOption[State],
+) (*DetachedTask[State], error) {
+	if input == nil {
+		return nil, status.Errorf(status.ErrInvalidArgument, "agent %q: input must not be nil", a.Name())
+	}
+	out, err := a.Run(ctx, detachedInput(input), opts...)
+	if err != nil {
+		return nil, err
+	}
+	return detachedTaskFrom(a.Name(), a, out)
+}
+
+// Task returns the task tracking a snapshot ID recorded earlier (e.g.
+// by a prior process that called [Agent.RunDetached]), with custom state typed
+// as State. It performs no I/O and does not verify the snapshot exists; the
+// first [DetachedTask.Poll] or [DetachedTask.Wait] surfaces NOT_FOUND for an
+// unknown ID.
+func (a *Agent[State]) Task(snapshotID string) *DetachedTask[State] {
+	return &DetachedTask[State]{ops: a, snapshotID: snapshotID}
 }
 
 // --- AgentConnection ---

--- a/go/ai/exp/agent.go
+++ b/go/ai/exp/agent.go
@@ -781,9 +781,10 @@ func (a *Agent[State]) GetSnapshot(ctx context.Context, snapshotID string) (*Ses
 // agent's name waits through [AgentHandle.WaitForSnapshot] instead.
 //
 // A snapshot that failed, aborted, or expired is returned like any other, so a
-// non-nil error means the wait itself could not proceed: a read failed, or ctx
-// ended and its error is returned. Bound the wait with [context.WithTimeout]
-// and read the snapshot afterwards to learn where it stands.
+// non-nil error means the wait itself could not proceed: reads failed past the
+// wait's transient-retry budget, or ctx ended and its error is returned. Bound
+// the wait with [context.WithTimeout] and read the snapshot afterwards to
+// learn where it stands.
 //
 // It returns FAILED_PRECONDITION on a client-managed agent (no store) and
 // INVALID_ARGUMENT when snapshotID is empty; a missing snapshot is NOT_FOUND.
@@ -860,14 +861,10 @@ func (a *Agent[State]) Register(r api.Registry) {
 	// registry consumers recover them by key (genkit.LookupAction) rather
 	// than by reaching through the agent action; see newSnapshotActions.
 	a.action.Register(r)
-	if a.getSnapshot != nil {
-		a.getSnapshot.Register(r)
-	}
-	if a.wait != nil {
-		a.wait.Register(r)
-	}
-	if a.abort != nil {
-		a.abort.Register(r)
+	for _, companion := range []api.Action{a.getSnapshot, a.wait, a.abort} {
+		if companion != nil {
+			companion.Register(r)
+		}
 	}
 }
 
@@ -3136,7 +3133,9 @@ func (a *Agent[State]) Connect(
 	ctx context.Context,
 	opts ...InvocationOption[State],
 ) (*AgentConnection[State], error) {
-	init, err := a.resolveOptions(opts)
+	// The merge rules live in resolveInvocationInit (option.go), shared with
+	// the untyped [AgentHandle] surface.
+	init, err := resolveInvocationInit(a.action.Name(), opts)
 	if err != nil {
 		return nil, err
 	}
@@ -3183,13 +3182,6 @@ func (a *Agent[State]) RunText(
 	return a.Run(ctx, &AgentInput{
 		Message: ai.NewUserTextMessage(text),
 	}, opts...)
-}
-
-// resolveOptions applies invocation options and returns the init struct; the
-// merge rules live in resolveInvocationInit (option.go), shared with the
-// untyped [AgentHandle] surface.
-func (a *Agent[State]) resolveOptions(opts []InvocationOption[State]) (*AgentInit[State], error) {
-	return resolveInvocationInit(a.action.Name(), opts)
 }
 
 // --- AgentConnection ---

--- a/go/ai/exp/agent.go
+++ b/go/ai/exp/agent.go
@@ -1545,8 +1545,14 @@ func (rt *agentRuntime[State]) handleDetach(
 	// an interval below). Timestamps are caller-managed; a reader treats a
 	// pending snapshot whose heartbeat has gone stale as expired (its background
 	// worker is presumed dead).
+	//
+	// The runtime mints the pending row's ID, as reserveTurnSnapshotID does for
+	// turn snapshots, rather than letting the store mint at write time: task
+	// handles built on this ID rely on the runtime's UUID format (in
+	// particular, it contains no ':'), which a store-minted ID would not
+	// guarantee.
 	now := time.Now()
-	pending, err := rt.cfg.store.SaveSnapshot(context.WithoutCancel(clientCtx), "",
+	pending, err := rt.cfg.store.SaveSnapshot(context.WithoutCancel(clientCtx), uuid.New().String(),
 		func(_ *SessionSnapshot[State]) (*SessionSnapshot[State], error) {
 			return &SessionSnapshot[State]{
 				SessionID:   sessionID,

--- a/go/ai/exp/agent.go
+++ b/go/ai/exp/agent.go
@@ -1754,8 +1754,14 @@ func (rt *agentRuntime[State]) handleDetach(
 	// an interval below). Timestamps are caller-managed; a reader treats a
 	// pending snapshot whose heartbeat has gone stale as expired (its background
 	// worker is presumed dead).
+	//
+	// The runtime mints the pending row's ID, as reserveTurnSnapshotID does for
+	// turn snapshots, rather than letting the store mint at write time: task
+	// handles built on this ID rely on the runtime's UUID format (in
+	// particular, it contains no ':'), which a store-minted ID would not
+	// guarantee.
 	now := time.Now()
-	pending, err := rt.cfg.store.SaveSnapshot(context.WithoutCancel(clientCtx), "",
+	pending, err := rt.cfg.store.SaveSnapshot(context.WithoutCancel(clientCtx), uuid.New().String(),
 		func(_ *SessionSnapshot[State]) (*SessionSnapshot[State], error) {
 			return &SessionSnapshot[State]{
 				SessionID:   sessionID,

--- a/go/ai/exp/agent.go
+++ b/go/ai/exp/agent.go
@@ -2867,32 +2867,11 @@ func (a *Agent[State]) RunText(
 	}, opts...)
 }
 
-// resolveOptions applies invocation options and returns the init struct.
-// Mutual exclusivity is checked here, once, after all options are merged:
-// WithState excludes both WithSessionID and WithSnapshotID (a
-// client-managed conversation's identity rides inside the state itself),
-// while WithSessionID and WithSnapshotID compose as an assertion.
-// Per-option duplicate checks live in applyInvocation.
+// resolveOptions applies invocation options and returns the init struct; the
+// merge rules live in resolveInvocationInit (option.go), shared with the
+// untyped [AgentHandle] surface.
 func (a *Agent[State]) resolveOptions(opts []InvocationOption[State]) (*AgentInit[State], error) {
-	invOpts := &invocationOptions[State]{}
-	for _, opt := range opts {
-		if err := opt.applyInvocation(invOpts); err != nil {
-			return nil, fmt.Errorf("Agent %q: %w", a.action.Name(), err)
-		}
-	}
-
-	if invOpts.state != nil && invOpts.snapshotID != "" {
-		return nil, fmt.Errorf("Agent %q: WithState and WithSnapshotID are mutually exclusive", a.action.Name())
-	}
-	if invOpts.state != nil && invOpts.sessionIDSet {
-		return nil, fmt.Errorf("Agent %q: WithState and WithSessionID are mutually exclusive; the conversation's identity rides inside the state (SessionState.SessionID)", a.action.Name())
-	}
-
-	return &AgentInit[State]{
-		SessionID:  invOpts.sessionID,
-		SnapshotID: invOpts.snapshotID,
-		State:      invOpts.state,
-	}, nil
+	return resolveInvocationInit(a.action.Name(), opts)
 }
 
 // --- AgentConnection ---

--- a/go/ai/exp/agent.go
+++ b/go/ai/exp/agent.go
@@ -671,14 +671,16 @@ type AgentFunc[State any] = func(ctx context.Context, resp Responder, sess *Sess
 //
 // Server-managed agents (those with a [SessionStore] configured) also
 // register companion actions for the snapshot lifecycle, available via
-// [Agent.GetSnapshotAction] and [Agent.AbortAction] for serving
-// alongside the agent, and expose the store itself via [Agent.Store].
+// [Agent.GetSnapshotAction], [Agent.WaitForSnapshotAction], and
+// [Agent.AbortAction] for serving alongside the agent, and expose the store
+// itself via [Agent.Store].
 type Agent[State any] struct {
 	action *core.BidiAction[*AgentInput, *AgentOutput[State], *AgentStreamChunk, *AgentInit[State]]
 	// Companion actions, retained so transports can serve them without a
 	// registry lookup. Nil when the corresponding capability is absent;
 	// see newSnapshotActions.
 	getSnapshot api.Action
+	wait        api.Action
 	abort       api.Action
 	// store is the configured session store, or nil for a client-managed
 	// agent. Retained so callers can reach it via Store without threading
@@ -693,7 +695,7 @@ type Agent[State any] struct {
 
 // Name returns the agent's registered name. This is also the name under
 // which any inline-defined prompt and companion actions (getSnapshot,
-// abort) are registered.
+// waitForSnapshot, abort) are registered.
 func (a *Agent[State]) Name() string {
 	return a.action.Name()
 }
@@ -709,6 +711,19 @@ func (a *Agent[State]) Name() string {
 // [Agent.GetSnapshot], which applies the configured state transform.
 func (a *Agent[State]) GetSnapshotAction() api.Action {
 	return a.getSnapshot
+}
+
+// WaitForSnapshotAction returns the agent's waitForSnapshot companion action,
+// which resolves a snapshot the same way getSnapshot does and returns once it
+// settles (input [GetSnapshotRequest], output [SessionSnapshot]). It returns
+// nil when the agent is client-managed (no [SessionStore] configured).
+//
+// Use it to expose following a detached invocation over a transport (e.g.
+// mount it with genkit.Handler next to the agent itself), so a remote caller
+// waits in one request instead of a read per tick; local Go code should use
+// [Agent.WaitForSnapshot], which applies the configured state transform.
+func (a *Agent[State]) WaitForSnapshotAction() api.Action {
+	return a.wait
 }
 
 // AbortAction returns the agent's abort companion action,
@@ -756,7 +771,30 @@ func (a *Agent[State]) GetSnapshot(ctx context.Context, snapshotID string) (*Ses
 	if snapshotID == "" {
 		return nil, status.Errorf(status.ErrInvalidArgument, "agent %q: GetSnapshot: snapshotID is required", a.Name())
 	}
-	return readSnapshot(ctx, a.store, a.transform, snapshotID, "")
+	return readSnapshot(ctx, a.store, a.transform, "getSnapshot", snapshotID, "")
+}
+
+// WaitForSnapshot fetches a session snapshot by ID and blocks until it settles,
+// returning the terminal snapshot with the same transform and shaping as
+// [Agent.GetSnapshot]. An already-terminal snapshot returns at once. It is how
+// an owner follows a detached invocation to its end; a caller holding only the
+// agent's name waits through [AgentHandle.WaitForSnapshot] instead.
+//
+// A snapshot that failed, aborted, or expired is returned like any other, so a
+// non-nil error means the wait itself could not proceed: a read failed, or ctx
+// ended and its error is returned. Bound the wait with [context.WithTimeout]
+// and read the snapshot afterwards to learn where it stands.
+//
+// It returns FAILED_PRECONDITION on a client-managed agent (no store) and
+// INVALID_ARGUMENT when snapshotID is empty; a missing snapshot is NOT_FOUND.
+func (a *Agent[State]) WaitForSnapshot(ctx context.Context, snapshotID string) (*SessionSnapshot[State], error) {
+	if a.store == nil {
+		return nil, status.Errorf(ErrSessionStoreNotConfigured, "agent %q: WaitForSnapshot requires a session store", a.Name())
+	}
+	if snapshotID == "" {
+		return nil, status.Errorf(status.ErrInvalidArgument, "agent %q: WaitForSnapshot: snapshotID is required", a.Name())
+	}
+	return waitSnapshot(ctx, a.store, a.transform, "waitForSnapshot", snapshotID, "")
 }
 
 // GetLatestSnapshot fetches a session's most recently created snapshot (whatever
@@ -773,7 +811,7 @@ func (a *Agent[State]) GetLatestSnapshot(ctx context.Context, sessionID string) 
 	if sessionID == "" {
 		return nil, status.Errorf(status.ErrInvalidArgument, "agent %q: GetLatestSnapshot: sessionID is required", a.Name())
 	}
-	return readSnapshot(ctx, a.store, a.transform, "", sessionID)
+	return readSnapshot(ctx, a.store, a.transform, "getSnapshot", "", sessionID)
 }
 
 // Abort aborts the detached invocation behind a pending snapshot by
@@ -806,7 +844,7 @@ func (a *Agent[State]) Abort(ctx context.Context, snapshotID string) (SnapshotSt
 var _ api.BidiAction = (*Agent[any])(nil)
 
 // Register registers the agent's run action and any companion actions
-// (getSnapshot, abort) with the registry. Agents defined via
+// (getSnapshot, waitForSnapshot, abort) with the registry. Agents defined via
 // [DefineAgent] or [DefineCustomAgent] are already registered; this
 // exists so an agent can travel to another registry as a unit. An
 // inline-defined prompt does not travel: the agent holds it directly, so
@@ -824,6 +862,9 @@ func (a *Agent[State]) Register(r api.Registry) {
 	a.action.Register(r)
 	if a.getSnapshot != nil {
 		a.getSnapshot.Register(r)
+	}
+	if a.wait != nil {
+		a.wait.Register(r)
 	}
 	if a.abort != nil {
 		a.abort.Register(r)
@@ -1050,11 +1091,12 @@ func newCustomAgent[State any](
 			return rt.run(ctx, fn)
 		})
 
-	getSnapshot, abort := newSnapshotActions(name, cfg.store, cfg.transform)
+	getSnapshot, wait, abort := newSnapshotActions(name, cfg.store, cfg.transform)
 
 	return &Agent[State]{
 		action:      action,
 		getSnapshot: getSnapshot,
+		wait:        wait,
 		abort:       abort,
 		store:       cfg.store,
 		transform:   cfg.transform,

--- a/go/ai/exp/agent_test.go
+++ b/go/ai/exp/agent_test.go
@@ -5031,6 +5031,11 @@ func TestAgent_GetSnapshotAction_NoStore(t *testing.T) {
 	if getAction != nil {
 		t.Error("getSnapshot action should NOT be registered without a store")
 	}
+	waitAction := core.ResolveActionFor[*GetSnapshotRequest, *SessionSnapshot[testState], struct{}](
+		reg, api.ActionTypeAgentWait, "noStoreFlow")
+	if waitAction != nil {
+		t.Error("waitForSnapshot action should NOT be registered without a store")
+	}
 	abortAction := core.ResolveActionFor[*AgentAbortRequest, *AgentAbortResponse, struct{}](
 		reg, api.ActionTypeAgentAbort, "noStoreFlow")
 	if abortAction != nil {
@@ -5395,6 +5400,12 @@ func TestAgent_AbortAction_GatedOnCapabilities(t *testing.T) {
 		if getAction == nil {
 			t.Error("getSnapshot action should be registered even when store lacks SnapshotSubscriber")
 		}
+		// Waiting needs no subscription: without one it re-reads the row.
+		waitAction := core.ResolveActionFor[*GetSnapshotRequest, *SessionSnapshot[testState], struct{}](
+			reg, api.ActionTypeAgentWait, "minCaps")
+		if waitAction == nil {
+			t.Error("waitForSnapshot action should be registered even when store lacks SnapshotSubscriber")
+		}
 		abortAction := core.ResolveActionFor[*AgentAbortRequest, *AgentAbortResponse, struct{}](
 			reg, api.ActionTypeAgentAbort, "minCaps")
 		if abortAction != nil {
@@ -5419,29 +5430,38 @@ func TestAgent_CompanionActionAccessors(t *testing.T) {
 		if got := af.GetSnapshotAction(); got != nil {
 			t.Errorf("GetSnapshotAction() = %v, want nil", got)
 		}
+		if got := af.WaitForSnapshotAction(); got != nil {
+			t.Errorf("WaitForSnapshotAction() = %v, want nil", got)
+		}
 		if got := af.AbortAction(); got != nil {
 			t.Errorf("AbortAction() = %v, want nil", got)
 		}
 	})
 
-	t.Run("store without aborter → getSnapshot only", func(t *testing.T) {
+	t.Run("store without aborter → reads and waits, no abort", func(t *testing.T) {
 		reg := newTestRegistry(t)
 		af := DefineCustomAgent(reg, "getOnly", noopFn,
 			WithSessionStore[testState](minimalStore[testState]{}))
 		if af.GetSnapshotAction() == nil {
 			t.Error("GetSnapshotAction() = nil, want action")
 		}
+		if af.WaitForSnapshotAction() == nil {
+			t.Error("WaitForSnapshotAction() = nil, want action")
+		}
 		if got := af.AbortAction(); got != nil {
 			t.Errorf("AbortAction() = %v, want nil", got)
 		}
 	})
 
-	t.Run("aborter store → both, identical to the registered actions", func(t *testing.T) {
+	t.Run("aborter store → all, identical to the registered actions", func(t *testing.T) {
 		reg := newTestRegistry(t)
 		af := DefineCustomAgent(reg, "bothCompanions", noopFn,
 			WithSessionStore(newTestInMemStore[testState]()))
 		if got, want := af.GetSnapshotAction(), reg.LookupAction("/agent-snapshot/bothCompanions"); got == nil || got != want {
 			t.Errorf("GetSnapshotAction() = %v, want registered action %v", got, want)
+		}
+		if got, want := af.WaitForSnapshotAction(), reg.LookupAction("/agent-wait/bothCompanions"); got == nil || got != want {
+			t.Errorf("WaitForSnapshotAction() = %v, want registered action %v", got, want)
 		}
 		if got, want := af.AbortAction(), reg.LookupAction("/agent-abort/bothCompanions"); got == nil || got != want {
 			t.Errorf("AbortAction() = %v, want registered action %v", got, want)

--- a/go/ai/exp/agent_test.go
+++ b/go/ai/exp/agent_test.go
@@ -2416,6 +2416,74 @@ func TestAgent_RunText_WithSnapshot(t *testing.T) {
 	}
 }
 
+func TestAgent_RunDetached(t *testing.T) {
+	// The typed launch: the task polls, rehydrates, and waits with custom
+	// state typed as the agent's own, so the owner never unmarshals raw JSON.
+	reg := newTestRegistry(t)
+	store := newTestInMemStore[testState]()
+	agent, entered, release := defineGatedAgent(t, reg, "typedWorker", store)
+
+	task, err := agent.RunDetached(context.Background(), &AgentInput{Message: ai.NewUserTextMessage("go")})
+	if err != nil {
+		t.Fatalf("RunDetached: %v", err)
+	}
+	if task.SnapshotID() == "" {
+		t.Fatal("RunDetached returned a task with no snapshot ID")
+	}
+	select {
+	case <-entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("background work did not start")
+	}
+
+	snap, err := task.Poll(context.Background())
+	if err != nil {
+		t.Fatalf("Poll: %v", err)
+	}
+	if snap.Status != SnapshotStatusPending {
+		t.Fatalf("Poll status = %q, want %q", snap.Status, SnapshotStatusPending)
+	}
+
+	close(release)
+	final, err := agent.Task(task.SnapshotID()).Wait(context.Background())
+	if err != nil {
+		t.Fatalf("Wait: %v", err)
+	}
+	if final.Status != SnapshotStatusCompleted {
+		t.Fatalf("Wait status = %q, want %q", final.Status, SnapshotStatusCompleted)
+	}
+	if final.State == nil || final.State.Custom.Counter != 42 {
+		t.Fatalf("final state = %+v, want typed custom state with Counter 42", final.State)
+	}
+
+	// Aborting a settled task reports its terminal status, as Agent.Abort does.
+	if got, err := task.Abort(context.Background()); err != nil || got != SnapshotStatusCompleted {
+		t.Fatalf("Abort after settle = (%q, %v), want (%q, nil)", got, err, SnapshotStatusCompleted)
+	}
+}
+
+func TestAgent_RunDetached_Rejected(t *testing.T) {
+	t.Run("nil input", func(t *testing.T) {
+		reg := newTestRegistry(t)
+		agent, _, _ := defineGatedAgent(t, reg, "nilInput", newTestInMemStore[testState]())
+		if _, err := agent.RunDetached(context.Background(), nil); !errors.Is(err, status.ErrInvalidArgument) {
+			t.Fatalf("RunDetached(nil) error = %v, want INVALID_ARGUMENT", err)
+		}
+	})
+
+	t.Run("client-managed agent cannot detach", func(t *testing.T) {
+		reg := newTestRegistry(t)
+		agent := defineEchoAgent(t, reg, "storeless")
+		_, err := agent.RunDetached(context.Background(), &AgentInput{Message: ai.NewUserTextMessage("go")})
+		if err == nil {
+			t.Fatal("RunDetached succeeded on a storeless agent, want rejection")
+		}
+		if got := status.Of(err); got != status.FailedPrecondition {
+			t.Fatalf("status.Of(err) = %v, want FAILED_PRECONDITION (err: %v)", got, err)
+		}
+	})
+}
+
 func TestPromptAgent_RunText(t *testing.T) {
 	ctx := context.Background()
 	reg := setupPromptTestRegistry(t)

--- a/go/ai/exp/agent_test.go
+++ b/go/ai/exp/agent_test.go
@@ -4403,6 +4403,11 @@ func TestAgent_GetSnapshotAction_NoStore(t *testing.T) {
 	if getAction != nil {
 		t.Error("getSnapshot action should NOT be registered without a store")
 	}
+	waitAction := core.ResolveActionFor[*GetSnapshotRequest, *SessionSnapshot[testState], struct{}](
+		reg, api.ActionTypeAgentWait, "noStoreFlow")
+	if waitAction != nil {
+		t.Error("waitForSnapshot action should NOT be registered without a store")
+	}
 	abortAction := core.ResolveActionFor[*AgentAbortRequest, *AgentAbortResponse, struct{}](
 		reg, api.ActionTypeAgentAbort, "noStoreFlow")
 	if abortAction != nil {
@@ -4767,6 +4772,12 @@ func TestAgent_AbortAction_GatedOnCapabilities(t *testing.T) {
 		if getAction == nil {
 			t.Error("getSnapshot action should be registered even when store lacks SnapshotSubscriber")
 		}
+		// Waiting needs no subscription: without one it re-reads the row.
+		waitAction := core.ResolveActionFor[*GetSnapshotRequest, *SessionSnapshot[testState], struct{}](
+			reg, api.ActionTypeAgentWait, "minCaps")
+		if waitAction == nil {
+			t.Error("waitForSnapshot action should be registered even when store lacks SnapshotSubscriber")
+		}
 		abortAction := core.ResolveActionFor[*AgentAbortRequest, *AgentAbortResponse, struct{}](
 			reg, api.ActionTypeAgentAbort, "minCaps")
 		if abortAction != nil {
@@ -4791,29 +4802,38 @@ func TestAgent_CompanionActionAccessors(t *testing.T) {
 		if got := af.GetSnapshotAction(); got != nil {
 			t.Errorf("GetSnapshotAction() = %v, want nil", got)
 		}
+		if got := af.WaitForSnapshotAction(); got != nil {
+			t.Errorf("WaitForSnapshotAction() = %v, want nil", got)
+		}
 		if got := af.AbortAction(); got != nil {
 			t.Errorf("AbortAction() = %v, want nil", got)
 		}
 	})
 
-	t.Run("store without aborter → getSnapshot only", func(t *testing.T) {
+	t.Run("store without aborter → reads and waits, no abort", func(t *testing.T) {
 		reg := newTestRegistry(t)
 		af := DefineCustomAgent(reg, "getOnly", noopFn,
 			WithSessionStore[testState](minimalStore[testState]{}))
 		if af.GetSnapshotAction() == nil {
 			t.Error("GetSnapshotAction() = nil, want action")
 		}
+		if af.WaitForSnapshotAction() == nil {
+			t.Error("WaitForSnapshotAction() = nil, want action")
+		}
 		if got := af.AbortAction(); got != nil {
 			t.Errorf("AbortAction() = %v, want nil", got)
 		}
 	})
 
-	t.Run("aborter store → both, identical to the registered actions", func(t *testing.T) {
+	t.Run("aborter store → all, identical to the registered actions", func(t *testing.T) {
 		reg := newTestRegistry(t)
 		af := DefineCustomAgent(reg, "bothCompanions", noopFn,
 			WithSessionStore(newTestInMemStore[testState]()))
 		if got, want := af.GetSnapshotAction(), reg.LookupAction("/agent-snapshot/bothCompanions"); got == nil || got != want {
 			t.Errorf("GetSnapshotAction() = %v, want registered action %v", got, want)
+		}
+		if got, want := af.WaitForSnapshotAction(), reg.LookupAction("/agent-wait/bothCompanions"); got == nil || got != want {
+			t.Errorf("WaitForSnapshotAction() = %v, want registered action %v", got, want)
 		}
 		if got, want := af.AbortAction(), reg.LookupAction("/agent-abort/bothCompanions"); got == nil || got != want {
 			t.Errorf("AbortAction() = %v, want registered action %v", got, want)

--- a/go/ai/exp/handle.go
+++ b/go/ai/exp/handle.go
@@ -250,79 +250,46 @@ func (h *AgentHandle) RunText(ctx context.Context, text string, opts ...Invocati
 	return h.Run(ctx, &AgentInput{Message: ai.NewUserTextMessage(text)}, opts...)
 }
 
+// RunDetached launches input as a detached (background) invocation and returns
+// the task tracking it. It is [Agent.RunDetached] for callers holding only the
+// handle, with the task's snapshots read as raw JSON: the input is delivered
+// with [AgentInput.Detach] set whatever the caller set it to, a launch the
+// agent cannot support (no session store, or one without [SnapshotSubscriber];
+// check [AgentMetadata.Abortable] to pre-flight) fails with
+// FAILED_PRECONDITION, and an invocation the agent settled before observing
+// the detach yields a task over its committed snapshot.
+//
+// The rejection is decoded from the invocation's failed output, which keeps
+// only the status name, so match it with [status.Of] rather than errors.Is.
+func (h *AgentHandle) RunDetached(ctx context.Context, input *AgentInput, opts ...InvocationOption[json.RawMessage]) (*DetachedTask[json.RawMessage], error) {
+	if h == nil {
+		return nil, nilHandleError("RunDetached")
+	}
+	if input == nil {
+		return nil, status.Errorf(status.ErrInvalidArgument, "agent %q: input must not be nil", h.name)
+	}
+	out, err := h.Run(ctx, detachedInput(input), opts...)
+	if err != nil {
+		return nil, err
+	}
+	return detachedTaskFrom(h.name, h, out)
+}
+
+// Task returns the task tracking a snapshot ID recorded earlier (e.g.
+// by a prior process that called [AgentHandle.RunDetached]), with custom state
+// as raw JSON. It performs no I/O and does not verify the snapshot exists; the
+// first [DetachedTask.Poll] or [DetachedTask.Wait] surfaces NOT_FOUND for an
+// unknown ID.
+func (h *AgentHandle) Task(snapshotID string) *DetachedTask[json.RawMessage] {
+	return &DetachedTask[json.RawMessage]{ops: h, snapshotID: snapshotID}
+}
+
 // nilHandleError is what a method reports on a nil receiver, so a caller that
 // skipped the nil check after [LookupAgent] reads the cause rather than a
 // panic. method names the caller.
 func nilHandleError(method string) error {
 	return status.Errorf(status.ErrInvalidArgument,
 		"AgentHandle.%s: called on a nil handle; check that LookupAgent found the agent", method)
-}
-
-// Start launches input as a detached (background) invocation and returns the
-// task tracking it. It is the one-shot counterpart of
-// [AgentConnection.Detach]: the input is delivered with [AgentInput.Detach]
-// set, the agent's runtime persists a pending snapshot and keeps working on a
-// context decoupled from ctx, and the returned [DetachedTask] polls, waits on,
-// or aborts that snapshot. The pending snapshot is the durable record: record
-// [DetachedTask.SnapshotID] and rehydrate with [AgentHandle.Task] to pick the
-// work up later, including from another process.
-//
-// The launch is rejected with FAILED_PRECONDITION when the agent cannot
-// support detach: it has no session store, or the store does not implement
-// [SnapshotSubscriber]. Check [AgentMetadata.Abortable] to pre-flight. The
-// rejection is decoded from the invocation's failed output, which keeps only
-// the status name, so match it with [status.Of] rather than errors.Is.
-//
-// An agent may also settle the invocation synchronously, before the runtime
-// observes the detach directive (e.g. a custom agent whose fn returns without
-// consuming the input). When a turn committed, Start returns a task over its
-// snapshot, which is already terminal, so Poll and Wait resolve immediately;
-// when nothing was recorded, Start fails with FAILED_PRECONDITION naming the
-// finish reason, since there is no durable record to track.
-func (h *AgentHandle) Start(ctx context.Context, input *AgentInput, opts ...InvocationOption[json.RawMessage]) (*DetachedTask, error) {
-	if h == nil {
-		return nil, status.Errorf(status.ErrInvalidArgument,
-			"AgentHandle.Start: called on a nil handle; check that LookupAgent found the agent")
-	}
-	if input == nil {
-		return nil, status.Errorf(status.ErrInvalidArgument, "agent %q: input must not be nil", h.name)
-	}
-	detachInput := *input
-	detachInput.Detach = true
-	out, err := h.Run(ctx, &detachInput, opts...)
-	if err != nil {
-		return nil, err
-	}
-	switch out.FinishReason {
-	case AgentFinishReasonDetached:
-		return &DetachedTask{handle: h, snapshotID: out.SnapshotID}, nil
-	case AgentFinishReasonFailed:
-		var cause error = out.Error
-		if out.Error == nil {
-			cause = status.Errorf(status.ErrInternal, "launch failed without error detail")
-		}
-		return nil, fmt.Errorf("agent %q: background launch failed: %w", h.name, cause)
-	default:
-		// The invocation settled before the runtime observed the detach
-		// directive (nothing orders the intake reader ahead of an agent fn
-		// that never consumes its input). A committed turn's snapshot is the
-		// settled work's durable record, so hand back a task over it; Poll
-		// and Wait resolve immediately with the terminal snapshot.
-		if out.SnapshotID != "" {
-			return &DetachedTask{handle: h, snapshotID: out.SnapshotID}, nil
-		}
-		return nil, status.Errorf(status.ErrFailedPrecondition,
-			"agent %q: the invocation settled synchronously (finish reason %q, session %q) without recording a snapshot, so there is no background task to track",
-			h.name, out.FinishReason, out.SessionID)
-	}
-}
-
-// Task returns a [DetachedTask] for a snapshot ID recorded earlier (e.g. by a
-// prior process that called [AgentHandle.Start]). It performs no I/O and does
-// not verify the snapshot exists; the first [DetachedTask.Poll] or
-// [DetachedTask.Wait] surfaces NOT_FOUND for an unknown ID.
-func (h *AgentHandle) Task(snapshotID string) *DetachedTask {
-	return &DetachedTask{handle: h, snapshotID: snapshotID}
 }
 
 // GetSnapshot fetches a session snapshot by ID through the agent's getSnapshot
@@ -508,51 +475,4 @@ func callJSON[Resp any](ctx context.Context, agentName string, act api.Action, w
 		return nil, fmt.Errorf("agent %q: unmarshal %s response: %w", agentName, what, err)
 	}
 	return &resp, nil
-}
-
-// --- DetachedTask ---
-
-// DetachedTask tracks a detached (background) agent invocation through its
-// pending snapshot. Obtain one from [AgentHandle.Start] when launching, or
-// rehydrate one from a recorded snapshot ID with [AgentHandle.Task]; the two
-// are equivalent, because the snapshot is the only state a task has.
-type DetachedTask struct {
-	handle     *AgentHandle
-	snapshotID string
-}
-
-// SnapshotID returns the ID of the snapshot tracking the task: pending while
-// the background work runs, finalized in place when it settles. It is the
-// task's durable identity; record it to pick the task up later with
-// [AgentHandle.Task].
-func (t *DetachedTask) SnapshotID() string { return t.snapshotID }
-
-// Poll fetches the task's snapshot once, without waiting. The snapshot's
-// Status says where the task stands: [SnapshotStatusPending] while the work
-// runs, a terminal status once it settles (see [SnapshotStatus.Terminal]),
-// including [SnapshotStatusExpired] when the worker stopped heartbeating and
-// is presumed dead. A terminal snapshot carries the cumulative session state.
-func (t *DetachedTask) Poll(ctx context.Context) (*SessionSnapshot[json.RawMessage], error) {
-	return t.handle.GetSnapshot(ctx, t.snapshotID)
-}
-
-// Wait blocks until the task settles and returns its terminal snapshot, in one
-// dispatch of the agent's waitForSnapshot companion action: the waiting happens
-// server-side, next to the store that knows when the work finished, so the
-// caller neither picks a cadence nor pays a dispatch per tick. A task that
-// failed, aborted, or expired still returns its snapshot rather than an error
-// (inspect [SessionSnapshot.Status] and [SessionSnapshot.Error]), so a non-nil
-// error means the wait itself could not proceed: reads failed past the wait's
-// transient-retry budget, or ctx ended and its error is returned.
-//
-// Use [context.WithTimeout] to bound the wait; on the deadline the wait returns
-// ctx's error, and [DetachedTask.Poll] then reports where the task stands.
-func (t *DetachedTask) Wait(ctx context.Context) (*SessionSnapshot[json.RawMessage], error) {
-	return t.handle.WaitForSnapshot(ctx, t.snapshotID)
-}
-
-// Abort asks the task's background work to stop and returns the snapshot's
-// status after the attempt; see [AgentHandle.Abort].
-func (t *DetachedTask) Abort(ctx context.Context) (SnapshotStatus, error) {
-	return t.handle.Abort(ctx, t.snapshotID)
 }

--- a/go/ai/exp/handle.go
+++ b/go/ai/exp/handle.go
@@ -451,19 +451,7 @@ func (t *actionTransport) snapshotVia(ctx context.Context, act api.Action, verb 
 			"agent %q publishes no action to %s a snapshot; an agent publishes one only when it has a session store",
 			t.name, verb)
 	}
-	reqJSON, err := json.Marshal(req)
-	if err != nil {
-		return nil, fmt.Errorf("agent %q: marshal snapshot request: %w", t.name, err)
-	}
-	raw, err := act.RunJSON(ctx, reqJSON, nil)
-	if err != nil {
-		return nil, err
-	}
-	var snap SessionSnapshot[json.RawMessage]
-	if err := json.Unmarshal(raw, &snap); err != nil {
-		return nil, fmt.Errorf("agent %q: unmarshal snapshot: %w", t.name, err)
-	}
-	return &snap, nil
+	return callJSON[SessionSnapshot[json.RawMessage]](ctx, t.name, act, "snapshot", req)
 }
 
 func (t *actionTransport) Abort(ctx context.Context, snapshotID string) (SnapshotStatus, error) {
@@ -479,19 +467,31 @@ func (t *actionTransport) Abort(ctx context.Context, snapshotID string) (Snapsho
 		return "", status.Errorf(status.ErrFailedPrecondition,
 			"agent %q: the session store does not support abort (it does not implement SnapshotSubscriber)", t.name)
 	}
-	reqJSON, err := json.Marshal(&AgentAbortRequest{SnapshotID: snapshotID})
-	if err != nil {
-		return "", fmt.Errorf("agent %q: marshal abort request: %w", t.name, err)
-	}
-	raw, err := t.abort.RunJSON(ctx, reqJSON, nil)
+	resp, err := callJSON[AgentAbortResponse](ctx, t.name, t.abort, "abort", &AgentAbortRequest{SnapshotID: snapshotID})
 	if err != nil {
 		return "", err
 	}
-	var resp AgentAbortResponse
-	if err := json.Unmarshal(raw, &resp); err != nil {
-		return "", fmt.Errorf("agent %q: unmarshal abort response: %w", t.name, err)
-	}
 	return resp.Status, nil
+}
+
+// callJSON dispatches req to act, one of the agent's companion actions, and
+// decodes the result into Resp. what names the exchange in the marshal and
+// unmarshal errors; a dispatch error is returned as is, so its status stays
+// matchable.
+func callJSON[Resp any](ctx context.Context, agentName string, act api.Action, what string, req any) (*Resp, error) {
+	reqJSON, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("agent %q: marshal %s request: %w", agentName, what, err)
+	}
+	raw, err := act.RunJSON(ctx, reqJSON, nil)
+	if err != nil {
+		return nil, err
+	}
+	var resp Resp
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		return nil, fmt.Errorf("agent %q: unmarshal %s response: %w", agentName, what, err)
+	}
+	return &resp, nil
 }
 
 // --- DetachedTask ---

--- a/go/ai/exp/handle.go
+++ b/go/ai/exp/handle.go
@@ -1,0 +1,388 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package exp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/firebase/genkit/go/core/api"
+	"github.com/firebase/genkit/go/core/status"
+)
+
+// defaultTaskPollInterval is how often [DetachedTask.Wait] re-reads a pending
+// task's snapshot when [WithPollInterval] is not given.
+const defaultTaskPollInterval = 2 * time.Second
+
+// AgentHandle is the untyped caller-side view of an agent: its run action and
+// snapshot-lifecycle companion actions (getSnapshot, abort), addressed with
+// the custom-state type fixed to [json.RawMessage]. It is how code that does
+// not hold the defining [Agent] value calls an agent it knows only by name:
+// orchestrators, middleware, and tools resolve one with [LookupAgent] (or the
+// genkit/exp package's LookupAgent), and a typed owner hands one out with
+// [Agent.Handle].
+//
+// A handle adds no capability over the actions it wraps; it only removes the
+// wire plumbing (JSON marshaling, companion-action lookup and dispatch) that
+// name-resolved callers would otherwise repeat. Custom state on every surface
+// is [json.RawMessage]: unmarshal [SessionState.Custom] into the agent's own
+// state type when the caller knows it.
+type AgentHandle struct {
+	name string
+	run  api.BidiAction
+	// Companion actions; nil when the agent lacks the capability (see
+	// [Agent.GetSnapshotAction] and [Agent.AbortAction]).
+	getSnapshot api.Action
+	abort       api.Action
+	meta        *AgentMetadata
+}
+
+// LookupAgent resolves the agent registered under name and returns its
+// [AgentHandle]. It is the caller-side counterpart of [DefineAgent] and
+// friends: definition hands back the typed [Agent], and a later caller that
+// holds only the name recovers this untyped view, companion actions included.
+// Callers holding a genkit instance should use the genkit/exp package's
+// LookupAgent instead.
+//
+// It returns NOT_FOUND when nothing is registered under the agent key, and
+// INVALID_ARGUMENT when the registered action is not an agent.
+func LookupAgent(r api.Registry, name string) (*AgentHandle, error) {
+	action := r.LookupAction(api.KeyFromName(api.ActionTypeAgent, name))
+	if action == nil {
+		return nil, status.Errorf(status.ErrNotFound, "agent %q not found in registry", name)
+	}
+	run, ok := action.(api.BidiAction)
+	if !ok {
+		return nil, status.Errorf(status.ErrInvalidArgument, "%q is registered but is not an agent", name)
+	}
+	return &AgentHandle{
+		name:        name,
+		run:         run,
+		getSnapshot: r.LookupAction(api.KeyFromName(api.ActionTypeAgentSnapshot, name)),
+		abort:       r.LookupAction(api.KeyFromName(api.ActionTypeAgentAbort, name)),
+		meta:        AgentMetadataOf(run),
+	}, nil
+}
+
+// Handle returns the agent's untyped caller-side view: the same surface
+// [LookupAgent] builds for callers that hold only the agent's name. Use it to
+// hand the agent to code written against [AgentHandle] (orchestration helpers,
+// middleware) without exposing the typed [Agent]. It performs no registry
+// lookup, so it also works for an unregistered agent (see [NewCustomAgent]).
+func (a *Agent[State]) Handle() *AgentHandle {
+	return &AgentHandle{
+		name:        a.Name(),
+		run:         a,
+		getSnapshot: a.getSnapshot,
+		abort:       a.abort,
+		meta:        AgentMetadataOf(a),
+	}
+}
+
+// AgentMetadataOf extracts the [AgentMetadata] an agent's action descriptor
+// carries under its "agent" metadata key, or nil when a is not an agent action
+// or carries none. It handles both in-process descriptors (typed metadata) and
+// descriptors decoded from JSON (map form), so callers can inspect an agent's
+// capabilities ([AgentMetadata.StateManagement], [AgentMetadata.Abortable])
+// without knowing where the action came from. The returned value is a copy;
+// mutating it does not affect the descriptor.
+func AgentMetadataOf(a api.Action) *AgentMetadata {
+	if a == nil {
+		return nil
+	}
+	switch m := a.Desc().Metadata["agent"].(type) {
+	case AgentMetadata:
+		return &m
+	case *AgentMetadata:
+		if m == nil {
+			return nil
+		}
+		copied := *m
+		return &copied
+	case map[string]any:
+		b, err := json.Marshal(m)
+		if err != nil {
+			return nil
+		}
+		meta := &AgentMetadata{}
+		if err := json.Unmarshal(b, meta); err != nil {
+			return nil
+		}
+		return meta
+	}
+	return nil
+}
+
+// Name returns the agent's registered name.
+func (h *AgentHandle) Name() string { return h.name }
+
+// Metadata returns the agent's capability metadata (who manages state, whether
+// background work can be aborted), or nil when the agent's descriptor carries
+// none. Treat the returned value as read-only; it is shared across calls.
+func (h *AgentHandle) Metadata() *AgentMetadata { return h.meta }
+
+// Run starts a single-turn invocation with the given input and returns the
+// final output, with custom state as raw JSON. It is [Agent.Run] for callers
+// holding only the handle; the [InvocationOption] values instantiate at
+// [json.RawMessage] (e.g. WithSessionID[json.RawMessage](id)).
+//
+// In-band failures (e.g. a failed turn) resolve as a failed [AgentOutput]
+// rather than an error, exactly like [Agent.Run]; a non-nil error means the
+// invocation never started (a rejected init payload) or could not run to a
+// result.
+func (h *AgentHandle) Run(ctx context.Context, input *AgentInput, opts ...InvocationOption[json.RawMessage]) (*AgentOutput[json.RawMessage], error) {
+	if input == nil {
+		return nil, status.Errorf(status.ErrInvalidArgument, "agent %q: input must not be nil", h.name)
+	}
+	init, err := resolveInvocationInit(h.name, opts)
+	if err != nil {
+		return nil, err
+	}
+	inputJSON, err := json.Marshal(input)
+	if err != nil {
+		return nil, fmt.Errorf("agent %q: marshal input: %w", h.name, err)
+	}
+	var initJSON json.RawMessage
+	if init.SessionID != "" || init.SnapshotID != "" || init.State != nil {
+		initJSON, err = json.Marshal(init)
+		if err != nil {
+			return nil, fmt.Errorf("agent %q: marshal init: %w", h.name, err)
+		}
+	}
+	res, err := h.run.RunBidiJSON(ctx, inputJSON, nil, &api.BidiJSONOptions{Init: initJSON})
+	if err != nil {
+		return nil, err
+	}
+	var out AgentOutput[json.RawMessage]
+	if err := json.Unmarshal(res.Result, &out); err != nil {
+		return nil, fmt.Errorf("agent %q: unmarshal output: %w", h.name, err)
+	}
+	return &out, nil
+}
+
+// Start launches input as a detached (background) invocation and returns the
+// task tracking it. It is the one-shot counterpart of
+// [AgentConnection.Detach]: the input is delivered with [AgentInput.Detach]
+// set, the agent's runtime persists a pending snapshot and keeps working on a
+// context decoupled from ctx, and the returned [DetachedTask] polls, waits on,
+// or aborts that snapshot. The pending snapshot is the durable record: record
+// [DetachedTask.SnapshotID] and rehydrate with [AgentHandle.Task] to pick the
+// work up later, including from another process.
+//
+// The launch is rejected with FAILED_PRECONDITION when the agent cannot
+// support detach: it has no session store, or the store does not implement
+// [SnapshotSubscriber]. Check [AgentMetadata.Abortable] to pre-flight. The
+// rejection is decoded from the invocation's failed output, which keeps only
+// the status name, so match it with [status.Of] rather than errors.Is.
+func (h *AgentHandle) Start(ctx context.Context, input *AgentInput, opts ...InvocationOption[json.RawMessage]) (*DetachedTask, error) {
+	if input == nil {
+		return nil, status.Errorf(status.ErrInvalidArgument, "agent %q: input must not be nil", h.name)
+	}
+	detachInput := *input
+	detachInput.Detach = true
+	out, err := h.Run(ctx, &detachInput, opts...)
+	if err != nil {
+		return nil, err
+	}
+	switch out.FinishReason {
+	case AgentFinishReasonDetached:
+		return &DetachedTask{handle: h, snapshotID: out.SnapshotID}, nil
+	case AgentFinishReasonFailed:
+		var cause error = out.Error
+		if out.Error == nil {
+			cause = status.Errorf(status.ErrInternal, "launch failed without error detail")
+		}
+		return nil, fmt.Errorf("agent %q: background launch failed: %w", h.name, cause)
+	default:
+		// With detach riding the first input, the runtime resolves the
+		// invocation as detached or failed before any turn output can settle
+		// it; any other reason means the agent did not honor the detach
+		// contract.
+		return nil, status.Errorf(status.ErrInternal,
+			"agent %q: expected the invocation to detach, got finish reason %q", h.name, out.FinishReason)
+	}
+}
+
+// Task returns a [DetachedTask] for a snapshot ID recorded earlier (e.g. by a
+// prior process that called [AgentHandle.Start]). It performs no I/O and does
+// not verify the snapshot exists; the first [DetachedTask.Poll] or
+// [DetachedTask.Wait] surfaces NOT_FOUND for an unknown ID.
+func (h *AgentHandle) Task(snapshotID string) *DetachedTask {
+	return &DetachedTask{handle: h, snapshotID: snapshotID}
+}
+
+// GetSnapshot fetches a session snapshot by ID through the agent's getSnapshot
+// companion action, so the read is shaped exactly as remote callers see it:
+// the configured [WithStateTransform] applies and a stale-heartbeat pending
+// row surfaces as [SnapshotStatusExpired]. It is [Agent.GetSnapshot] with
+// custom state as raw JSON.
+//
+// It returns FAILED_PRECONDITION ([ErrSessionStoreNotConfigured]) when the
+// agent has no session store and INVALID_ARGUMENT when snapshotID is empty; a
+// missing snapshot is NOT_FOUND.
+func (h *AgentHandle) GetSnapshot(ctx context.Context, snapshotID string) (*SessionSnapshot[json.RawMessage], error) {
+	if snapshotID == "" {
+		return nil, status.Errorf(status.ErrInvalidArgument, "agent %q: GetSnapshot: snapshotID is required", h.name)
+	}
+	return h.readSnapshot(ctx, &GetSnapshotRequest{SnapshotID: snapshotID})
+}
+
+// GetLatestSnapshot fetches a session's most recently created snapshot
+// (whatever its status) through the agent's getSnapshot companion action, with
+// the same shaping as [AgentHandle.GetSnapshot]. It is
+// [Agent.GetLatestSnapshot] with custom state as raw JSON.
+//
+// It returns FAILED_PRECONDITION ([ErrSessionStoreNotConfigured]) when the
+// agent has no session store and INVALID_ARGUMENT when sessionID is empty; an
+// unknown session is NOT_FOUND.
+func (h *AgentHandle) GetLatestSnapshot(ctx context.Context, sessionID string) (*SessionSnapshot[json.RawMessage], error) {
+	if sessionID == "" {
+		return nil, status.Errorf(status.ErrInvalidArgument, "agent %q: GetLatestSnapshot: sessionID is required", h.name)
+	}
+	return h.readSnapshot(ctx, &GetSnapshotRequest{SessionID: sessionID})
+}
+
+// readSnapshot dispatches req to the getSnapshot companion action and decodes
+// the snapshot. The action runs in-process here, so its error chain stays
+// live: sentinel matching with errors.Is works, subtypes included (e.g.
+// [ErrSnapshotNotFound] is a [status.ErrNotFound]).
+func (h *AgentHandle) readSnapshot(ctx context.Context, req *GetSnapshotRequest) (*SessionSnapshot[json.RawMessage], error) {
+	if h.getSnapshot == nil {
+		return nil, status.Errorf(ErrSessionStoreNotConfigured,
+			"agent %q has no session store, so it keeps no snapshots to read", h.name)
+	}
+	reqJSON, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("agent %q: marshal snapshot request: %w", h.name, err)
+	}
+	raw, err := h.getSnapshot.RunJSON(ctx, reqJSON, nil)
+	if err != nil {
+		return nil, err
+	}
+	var snap SessionSnapshot[json.RawMessage]
+	if err := json.Unmarshal(raw, &snap); err != nil {
+		return nil, fmt.Errorf("agent %q: unmarshal snapshot: %w", h.name, err)
+	}
+	return &snap, nil
+}
+
+// Abort asks the background work behind a pending snapshot to stop, through
+// the agent's abort companion action, and returns the snapshot's status after
+// the attempt: [SnapshotStatusAborted] when the row was pending, or the
+// existing terminal status (the abort was a no-op) when it had already
+// settled. A missing snapshot is NOT_FOUND, matching the companion action
+// remote callers use (unlike [Agent.Abort], which reports it as "").
+//
+// It returns FAILED_PRECONDITION when the agent has no session store
+// ([ErrSessionStoreNotConfigured]) or the store cannot observe aborts (no
+// [SnapshotSubscriber]; see [AgentMetadata.Abortable]), and INVALID_ARGUMENT
+// when snapshotID is empty.
+func (h *AgentHandle) Abort(ctx context.Context, snapshotID string) (SnapshotStatus, error) {
+	if snapshotID == "" {
+		return "", status.Errorf(status.ErrInvalidArgument, "agent %q: Abort: snapshotID is required", h.name)
+	}
+	if h.abort == nil {
+		if h.getSnapshot == nil {
+			return "", status.Errorf(ErrSessionStoreNotConfigured, "agent %q: Abort requires a session store", h.name)
+		}
+		return "", status.Errorf(status.ErrFailedPrecondition,
+			"agent %q: the session store does not support abort (it does not implement SnapshotSubscriber)", h.name)
+	}
+	reqJSON, err := json.Marshal(&AgentAbortRequest{SnapshotID: snapshotID})
+	if err != nil {
+		return "", fmt.Errorf("agent %q: marshal abort request: %w", h.name, err)
+	}
+	raw, err := h.abort.RunJSON(ctx, reqJSON, nil)
+	if err != nil {
+		return "", err
+	}
+	var resp AgentAbortResponse
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		return "", fmt.Errorf("agent %q: unmarshal abort response: %w", h.name, err)
+	}
+	return resp.Status, nil
+}
+
+// --- DetachedTask ---
+
+// DetachedTask tracks a detached (background) agent invocation through its
+// pending snapshot. Obtain one from [AgentHandle.Start] when launching, or
+// rehydrate one from a recorded snapshot ID with [AgentHandle.Task]; the two
+// are equivalent, because the snapshot is the only state a task has.
+type DetachedTask struct {
+	handle     *AgentHandle
+	snapshotID string
+}
+
+// SnapshotID returns the ID of the snapshot tracking the task: pending while
+// the background work runs, finalized in place when it settles. It is the
+// task's durable identity; record it to pick the task up later with
+// [AgentHandle.Task].
+func (t *DetachedTask) SnapshotID() string { return t.snapshotID }
+
+// Poll fetches the task's snapshot once, without waiting. The snapshot's
+// Status says where the task stands: [SnapshotStatusPending] while the work
+// runs, a terminal status once it settles (see [SnapshotStatus.Terminal]),
+// including [SnapshotStatusExpired] when the worker stopped heartbeating and
+// is presumed dead. A terminal snapshot carries the cumulative session state.
+func (t *DetachedTask) Poll(ctx context.Context) (*SessionSnapshot[json.RawMessage], error) {
+	return t.handle.GetSnapshot(ctx, t.snapshotID)
+}
+
+// Wait blocks until the task settles and returns its terminal snapshot,
+// re-reading the snapshot on an interval ([WithPollInterval] to change it). A
+// task that failed, aborted, or expired still returns its snapshot rather than
+// an error (inspect [SessionSnapshot.Status] and [SessionSnapshot.Error]), so
+// a non-nil error means the wait itself could not proceed: a read failed, or
+// ctx ended and its error is returned. Use [context.WithTimeout] to bound the
+// wait.
+func (t *DetachedTask) Wait(ctx context.Context, opts ...WaitOption) (*SessionSnapshot[json.RawMessage], error) {
+	waitOpts := &waitOptions{}
+	for _, opt := range opts {
+		if err := opt.applyWait(waitOpts); err != nil {
+			return nil, fmt.Errorf("agent %q: Wait: %w", t.handle.name, err)
+		}
+	}
+	interval := waitOpts.pollInterval
+	if interval == 0 {
+		interval = defaultTaskPollInterval
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		snap, err := t.Poll(ctx)
+		if err != nil {
+			return nil, err
+		}
+		if snap.Status.Terminal() {
+			return snap, nil
+		}
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}
+
+// Abort asks the task's background work to stop and returns the snapshot's
+// status after the attempt; see [AgentHandle.Abort].
+func (t *DetachedTask) Abort(ctx context.Context) (SnapshotStatus, error) {
+	return t.handle.Abort(ctx, t.snapshotID)
+}

--- a/go/ai/exp/handle.go
+++ b/go/ai/exp/handle.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/firebase/genkit/go/core/api"
 	"github.com/firebase/genkit/go/core/status"
+	"github.com/firebase/genkit/go/internal/base"
 )
 
 // AgentHandle is the untyped caller-side view of an agent: its run action and
@@ -116,17 +117,12 @@ func AgentMetadataOf(a api.Action) *AgentMetadata {
 		copied := *m
 		return &copied
 	case map[string]any:
-		b, err := json.Marshal(m)
-		if err != nil {
-			return nil
-		}
-		meta := &AgentMetadata{}
 		// Best-effort decode: encoding/json fills every well-typed field
 		// before reporting the first type error, so one mistyped field in a
 		// wire descriptor leaves that field zero instead of erasing the
 		// capabilities that did decode.
-		_ = json.Unmarshal(b, meta)
-		return meta
+		meta, _ := base.MapToStruct[AgentMetadata](m)
+		return &meta
 	}
 	return nil
 }
@@ -266,9 +262,10 @@ func (h *AgentHandle) GetSnapshot(ctx context.Context, snapshotID string) (*Sess
 // read per tick.
 //
 // A snapshot that failed, aborted, or expired is returned like any other, so a
-// non-nil error means the wait itself could not proceed: a read failed, or ctx
-// ended and its error is returned. Bound the wait with [context.WithTimeout],
-// then call [AgentHandle.GetSnapshot] to learn where the task stands.
+// non-nil error means the wait itself could not proceed: reads failed past the
+// wait's transient-retry budget, or ctx ended and its error is returned. Bound
+// the wait with [context.WithTimeout], then call [AgentHandle.GetSnapshot] to
+// learn where the task stands.
 //
 // It returns FAILED_PRECONDITION ([ErrSessionStoreNotConfigured]) when the
 // agent has no session store and INVALID_ARGUMENT when snapshotID is empty; a
@@ -390,8 +387,8 @@ func (t *DetachedTask) Poll(ctx context.Context) (*SessionSnapshot[json.RawMessa
 // caller neither picks a cadence nor pays a dispatch per tick. A task that
 // failed, aborted, or expired still returns its snapshot rather than an error
 // (inspect [SessionSnapshot.Status] and [SessionSnapshot.Error]), so a non-nil
-// error means the wait itself could not proceed: a read failed, or ctx ended
-// and its error is returned.
+// error means the wait itself could not proceed: reads failed past the wait's
+// transient-retry budget, or ctx ended and its error is returned.
 //
 // Use [context.WithTimeout] to bound the wait; on the deadline the wait returns
 // ctx's error, and [DetachedTask.Poll] then reports where the task stands.

--- a/go/ai/exp/handle.go
+++ b/go/ai/exp/handle.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/firebase/genkit/go/ai"
 	"github.com/firebase/genkit/go/core/api"
 	"github.com/firebase/genkit/go/core/status"
 	"github.com/firebase/genkit/go/internal/base"
@@ -225,8 +226,7 @@ func (h *AgentHandle) Metadata() *AgentMetadata {
 // result.
 func (h *AgentHandle) Run(ctx context.Context, input *AgentInput, opts ...InvocationOption[json.RawMessage]) (*AgentOutput[json.RawMessage], error) {
 	if h == nil {
-		return nil, status.Errorf(status.ErrInvalidArgument,
-			"AgentHandle.Run: called on a nil handle; check that LookupAgent found the agent")
+		return nil, nilHandleError("Run")
 	}
 	if input == nil {
 		return nil, status.Errorf(status.ErrInvalidArgument, "agent %q: input must not be nil", h.name)
@@ -239,6 +239,23 @@ func (h *AgentHandle) Run(ctx context.Context, input *AgentInput, opts ...Invoca
 	// transport takes one because a turn is streamed at that level whatever
 	// carries it, so a streaming surface on the handle needs no new seam.
 	return h.transport.Run(ctx, input, init, nil)
+}
+
+// RunText is [AgentHandle.Run] with a user text message as the input, the way
+// [Agent.RunText] is for [Agent.Run].
+func (h *AgentHandle) RunText(ctx context.Context, text string, opts ...InvocationOption[json.RawMessage]) (*AgentOutput[json.RawMessage], error) {
+	if h == nil {
+		return nil, nilHandleError("RunText")
+	}
+	return h.Run(ctx, &AgentInput{Message: ai.NewUserTextMessage(text)}, opts...)
+}
+
+// nilHandleError is what a method reports on a nil receiver, so a caller that
+// skipped the nil check after [LookupAgent] reads the cause rather than a
+// panic. method names the caller.
+func nilHandleError(method string) error {
+	return status.Errorf(status.ErrInvalidArgument,
+		"AgentHandle.%s: called on a nil handle; check that LookupAgent found the agent", method)
 }
 
 // Start launches input as a detached (background) invocation and returns the

--- a/go/ai/exp/handle.go
+++ b/go/ai/exp/handle.go
@@ -20,20 +20,16 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"time"
 
 	"github.com/firebase/genkit/go/core/api"
 	"github.com/firebase/genkit/go/core/status"
 )
 
-// defaultTaskPollInterval is how often [DetachedTask.Wait] re-reads a pending
-// task's snapshot when [WithPollInterval] is not given.
-const defaultTaskPollInterval = 2 * time.Second
-
 // AgentHandle is the untyped caller-side view of an agent: its run action and
-// snapshot-lifecycle companion actions (getSnapshot, abort), addressed with
-// the custom-state type fixed to [json.RawMessage]. It is how code that does
-// not hold the defining [Agent] value calls an agent it knows only by name:
+// snapshot-lifecycle companion actions (getSnapshot, waitForSnapshot, abort),
+// addressed with the custom-state type fixed to [json.RawMessage]. It is how
+// code that does not hold the defining [Agent] value calls an agent it knows
+// only by name:
 // orchestrators, middleware, and tools resolve one with [LookupAgent] (or the
 // genkit/exp package's LookupAgent), and a typed owner hands one out with
 // [Agent.Handle].
@@ -47,8 +43,10 @@ type AgentHandle struct {
 	name string
 	run  api.BidiAction
 	// Companion actions; nil when the agent lacks the capability (see
-	// [Agent.GetSnapshotAction] and [Agent.AbortAction]).
+	// [Agent.GetSnapshotAction], [Agent.WaitForSnapshotAction], and
+	// [Agent.AbortAction]).
 	getSnapshot api.Action
+	wait        api.Action
 	abort       api.Action
 	meta        *AgentMetadata
 }
@@ -75,6 +73,7 @@ func LookupAgent(r api.Registry, name string) (*AgentHandle, error) {
 		name:        name,
 		run:         run,
 		getSnapshot: r.LookupAction(api.KeyFromName(api.ActionTypeAgentSnapshot, name)),
+		wait:        r.LookupAction(api.KeyFromName(api.ActionTypeAgentWait, name)),
 		abort:       r.LookupAction(api.KeyFromName(api.ActionTypeAgentAbort, name)),
 		meta:        AgentMetadataOf(run),
 	}, nil
@@ -90,6 +89,7 @@ func (a *Agent[State]) Handle() *AgentHandle {
 		name:        a.Name(),
 		run:         a,
 		getSnapshot: a.getSnapshot,
+		wait:        a.wait,
 		abort:       a.abort,
 		meta:        AgentMetadataOf(a),
 	}
@@ -254,7 +254,30 @@ func (h *AgentHandle) GetSnapshot(ctx context.Context, snapshotID string) (*Sess
 	if snapshotID == "" {
 		return nil, status.Errorf(status.ErrInvalidArgument, "agent %q: GetSnapshot: snapshotID is required", h.name)
 	}
-	return h.readSnapshot(ctx, &GetSnapshotRequest{SnapshotID: snapshotID})
+	return h.snapshotVia(ctx, h.getSnapshot, "read", &GetSnapshotRequest{SnapshotID: snapshotID})
+}
+
+// WaitForSnapshot fetches a session snapshot by ID and blocks until it settles,
+// through the agent's waitForSnapshot companion action, returning the terminal
+// snapshot shaped exactly as [AgentHandle.GetSnapshot] shapes a read. An
+// already-terminal snapshot returns at once. It is [Agent.WaitForSnapshot] with
+// custom state as raw JSON, and it is how a caller that holds only actions
+// follows a detached invocation: one dispatch for the whole wait, rather than a
+// read per tick.
+//
+// A snapshot that failed, aborted, or expired is returned like any other, so a
+// non-nil error means the wait itself could not proceed: a read failed, or ctx
+// ended and its error is returned. Bound the wait with [context.WithTimeout],
+// then call [AgentHandle.GetSnapshot] to learn where the task stands.
+//
+// It returns FAILED_PRECONDITION ([ErrSessionStoreNotConfigured]) when the
+// agent has no session store and INVALID_ARGUMENT when snapshotID is empty; a
+// missing snapshot is NOT_FOUND.
+func (h *AgentHandle) WaitForSnapshot(ctx context.Context, snapshotID string) (*SessionSnapshot[json.RawMessage], error) {
+	if snapshotID == "" {
+		return nil, status.Errorf(status.ErrInvalidArgument, "agent %q: WaitForSnapshot: snapshotID is required", h.name)
+	}
+	return h.snapshotVia(ctx, h.wait, "follow", &GetSnapshotRequest{SnapshotID: snapshotID})
 }
 
 // GetLatestSnapshot fetches a session's most recently created snapshot
@@ -269,23 +292,25 @@ func (h *AgentHandle) GetLatestSnapshot(ctx context.Context, sessionID string) (
 	if sessionID == "" {
 		return nil, status.Errorf(status.ErrInvalidArgument, "agent %q: GetLatestSnapshot: sessionID is required", h.name)
 	}
-	return h.readSnapshot(ctx, &GetSnapshotRequest{SessionID: sessionID})
+	return h.snapshotVia(ctx, h.getSnapshot, "read", &GetSnapshotRequest{SessionID: sessionID})
 }
 
-// readSnapshot dispatches req to the getSnapshot companion action and decodes
-// the snapshot. The action runs in-process here, so its error chain stays
-// live: sentinel matching with errors.Is works, subtypes included (e.g.
-// [ErrSnapshotNotFound] is a [status.ErrNotFound]).
-func (h *AgentHandle) readSnapshot(ctx context.Context, req *GetSnapshotRequest) (*SessionSnapshot[json.RawMessage], error) {
-	if h.getSnapshot == nil {
+// snapshotVia dispatches req to act, one of the two companion actions that
+// answer a [GetSnapshotRequest] with a [SessionSnapshot], and decodes the
+// result. verb names what the caller wanted to do with the snapshot, for the
+// message reporting an agent that keeps none. The action runs in-process here,
+// so its error chain stays live: sentinel matching with errors.Is works,
+// subtypes included (e.g. [ErrSnapshotNotFound] is a [status.ErrNotFound]).
+func (h *AgentHandle) snapshotVia(ctx context.Context, act api.Action, verb string, req *GetSnapshotRequest) (*SessionSnapshot[json.RawMessage], error) {
+	if act == nil {
 		return nil, status.Errorf(ErrSessionStoreNotConfigured,
-			"agent %q has no session store, so it keeps no snapshots to read", h.name)
+			"agent %q has no session store, so it keeps no snapshots to %s", h.name, verb)
 	}
 	reqJSON, err := json.Marshal(req)
 	if err != nil {
 		return nil, fmt.Errorf("agent %q: marshal snapshot request: %w", h.name, err)
 	}
-	raw, err := h.getSnapshot.RunJSON(ctx, reqJSON, nil)
+	raw, err := act.RunJSON(ctx, reqJSON, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -359,40 +384,19 @@ func (t *DetachedTask) Poll(ctx context.Context) (*SessionSnapshot[json.RawMessa
 	return t.handle.GetSnapshot(ctx, t.snapshotID)
 }
 
-// Wait blocks until the task settles and returns its terminal snapshot,
-// re-reading the snapshot on an interval ([WithPollInterval] to change it). A
-// task that failed, aborted, or expired still returns its snapshot rather than
-// an error (inspect [SessionSnapshot.Status] and [SessionSnapshot.Error]), so
-// a non-nil error means the wait itself could not proceed: a read failed, or
-// ctx ended and its error is returned. Use [context.WithTimeout] to bound the
-// wait.
-func (t *DetachedTask) Wait(ctx context.Context, opts ...WaitOption) (*SessionSnapshot[json.RawMessage], error) {
-	waitOpts := &waitOptions{}
-	for _, opt := range opts {
-		if err := opt.applyWait(waitOpts); err != nil {
-			return nil, fmt.Errorf("agent %q: Wait: %w", t.handle.name, err)
-		}
-	}
-	interval := waitOpts.pollInterval
-	if interval == 0 {
-		interval = defaultTaskPollInterval
-	}
-	ticker := time.NewTicker(interval)
-	defer ticker.Stop()
-	for {
-		snap, err := t.Poll(ctx)
-		if err != nil {
-			return nil, err
-		}
-		if snap.Status.Terminal() {
-			return snap, nil
-		}
-		select {
-		case <-ctx.Done():
-			return nil, ctx.Err()
-		case <-ticker.C:
-		}
-	}
+// Wait blocks until the task settles and returns its terminal snapshot, in one
+// dispatch of the agent's waitForSnapshot companion action: the waiting happens
+// server-side, next to the store that knows when the work finished, so the
+// caller neither picks a cadence nor pays a dispatch per tick. A task that
+// failed, aborted, or expired still returns its snapshot rather than an error
+// (inspect [SessionSnapshot.Status] and [SessionSnapshot.Error]), so a non-nil
+// error means the wait itself could not proceed: a read failed, or ctx ended
+// and its error is returned.
+//
+// Use [context.WithTimeout] to bound the wait; on the deadline the wait returns
+// ctx's error, and [DetachedTask.Poll] then reports where the task stands.
+func (t *DetachedTask) Wait(ctx context.Context) (*SessionSnapshot[json.RawMessage], error) {
+	return t.handle.WaitForSnapshot(ctx, t.snapshotID)
 }
 
 // Abort asks the task's background work to stop and returns the snapshot's

--- a/go/ai/exp/handle.go
+++ b/go/ai/exp/handle.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"maps"
+	"sync"
 
 	"github.com/firebase/genkit/go/core/api"
 	"github.com/firebase/genkit/go/core/status"
@@ -49,8 +49,13 @@ type AgentHandle struct {
 	name string
 	// meta is the agent's capability metadata, or nil when it is unknown. It
 	// is static, so the handle holds it rather than asking the transport for
-	// it on every call.
+	// it on every call, and it is resolved on first use rather than at
+	// construction: deriving it deep-copies the agent's state schema, which
+	// costs more than a lookup itself, and most callers only run the agent.
+	// metaSrc is the descriptor it comes from, released once resolved.
+	metaOnce  sync.Once
 	meta      *AgentMetadata
+	metaSrc   api.Action
 	transport agentTransport
 }
 
@@ -97,26 +102,25 @@ type agentTransport interface {
 }
 
 // LookupAgent resolves the agent registered under name and returns its
-// [AgentHandle]. It is the caller-side counterpart of [DefineAgent] and
-// friends: definition hands back the typed [Agent], and a later caller that
-// holds only the name recovers this untyped view, companion actions included.
-// Callers holding a genkit instance should use the genkit/exp package's
-// LookupAgent instead.
+// [AgentHandle], or nil when name resolves to no agent. It is the caller-side
+// counterpart of [DefineAgent] and friends: definition hands back the typed
+// [Agent], and a later caller that holds only the name recovers this untyped
+// view, companion actions included. Callers holding a genkit instance should
+// use the genkit/exp package's LookupAgent instead.
 //
-// It returns NOT_FOUND when nothing is registered under the agent key, and
-// INVALID_ARGUMENT when the registered action is not an agent.
-func LookupAgent(r api.Registry, name string) (*AgentHandle, error) {
-	action := r.LookupAction(api.KeyFromName(api.ActionTypeAgent, name))
-	if action == nil {
-		return nil, status.Errorf(status.ErrNotFound, "agent %q not found in registry", name)
-	}
-	run, ok := action.(api.BidiAction)
+// Nil covers both misses, matching every other Lookup in the framework: no
+// action under the agent key, and an action registered there that is not an
+// agent. Neither is worth distinguishing to a caller, because the answer to
+// both is the same and the caller knows the name it asked for. Guard the
+// result, or call [AgentHandle.Run] and let its nil check report it.
+func LookupAgent(r api.Registry, name string) *AgentHandle {
+	run, ok := r.LookupAction(api.KeyFromName(api.ActionTypeAgent, name)).(api.BidiAction)
 	if !ok {
-		return nil, status.Errorf(status.ErrInvalidArgument, "%q is registered but is not an agent", name)
+		return nil
 	}
 	return &AgentHandle{
-		name: name,
-		meta: AgentMetadataOf(run),
+		name:    name,
+		metaSrc: run,
 		transport: &actionTransport{
 			name:        name,
 			run:         run,
@@ -124,7 +128,7 @@ func LookupAgent(r api.Registry, name string) (*AgentHandle, error) {
 			wait:        r.LookupAction(api.KeyFromName(api.ActionTypeAgentWait, name)),
 			abort:       r.LookupAction(api.KeyFromName(api.ActionTypeAgentAbort, name)),
 		},
-	}, nil
+	}
 }
 
 // Handle returns the agent's untyped caller-side view: the same surface
@@ -134,8 +138,8 @@ func LookupAgent(r api.Registry, name string) (*AgentHandle, error) {
 // lookup, so it also works for an unregistered agent (see [NewCustomAgent]).
 func (a *Agent[State]) Handle() *AgentHandle {
 	return &AgentHandle{
-		name: a.Name(),
-		meta: AgentMetadataOf(a),
+		name:    a.Name(),
+		metaSrc: a,
 		transport: &actionTransport{
 			name:        a.Name(),
 			run:         a,
@@ -154,8 +158,7 @@ func (a *Agent[State]) Handle() *AgentHandle {
 // without knowing where the action came from.
 //
 // The returned value is a copy: mutating its fields, [AgentMetadata.StateSchema]
-// included, does not affect the descriptor. Values nested inside the schema are
-// shared, so treat what it points at as read-only.
+// and anything nested inside it included, does not affect the descriptor.
 //
 // A wire descriptor that does not decode reports as nil rather than partially.
 // Every field here is a capability a caller gates on, and a zero value reads as
@@ -169,14 +172,14 @@ func AgentMetadataOf(a api.Action) *AgentMetadata {
 	}
 	switch m := a.Desc().Metadata["agent"].(type) {
 	case AgentMetadata:
-		m.StateSchema = maps.Clone(m.StateSchema)
+		m.StateSchema = base.CloneSchema(m.StateSchema)
 		return &m
 	case *AgentMetadata:
 		if m == nil {
 			return nil
 		}
 		copied := *m
-		copied.StateSchema = maps.Clone(copied.StateSchema)
+		copied.StateSchema = base.CloneSchema(copied.StateSchema)
 		return &copied
 	case map[string]any:
 		meta, err := base.MapToStruct[AgentMetadata](m)
@@ -195,7 +198,15 @@ func (h *AgentHandle) Name() string { return h.name }
 // background work can be aborted), or nil when the agent's descriptor carries
 // none or did not decode. The handle holds one copy, detached from the
 // descriptor but shared across calls, so treat it as read-only.
-func (h *AgentHandle) Metadata() *AgentMetadata { return h.meta }
+func (h *AgentHandle) Metadata() *AgentMetadata {
+	if h == nil {
+		return nil
+	}
+	h.metaOnce.Do(func() {
+		h.meta, h.metaSrc = AgentMetadataOf(h.metaSrc), nil
+	})
+	return h.meta
+}
 
 // Run starts a single-turn invocation with the given input and returns the
 // final output, with custom state as raw JSON. It is [Agent.Run] for callers
@@ -207,6 +218,10 @@ func (h *AgentHandle) Metadata() *AgentMetadata { return h.meta }
 // invocation never started (a rejected init payload) or could not run to a
 // result.
 func (h *AgentHandle) Run(ctx context.Context, input *AgentInput, opts ...InvocationOption[json.RawMessage]) (*AgentOutput[json.RawMessage], error) {
+	if h == nil {
+		return nil, status.Errorf(status.ErrInvalidArgument,
+			"AgentHandle.Run: called on a nil handle; check that LookupAgent found the agent")
+	}
 	if input == nil {
 		return nil, status.Errorf(status.ErrInvalidArgument, "agent %q: input must not be nil", h.name)
 	}
@@ -242,6 +257,10 @@ func (h *AgentHandle) Run(ctx context.Context, input *AgentInput, opts ...Invoca
 // when nothing was recorded, Start fails with FAILED_PRECONDITION naming the
 // finish reason, since there is no durable record to track.
 func (h *AgentHandle) Start(ctx context.Context, input *AgentInput, opts ...InvocationOption[json.RawMessage]) (*DetachedTask, error) {
+	if h == nil {
+		return nil, status.Errorf(status.ErrInvalidArgument,
+			"AgentHandle.Start: called on a nil handle; check that LookupAgent found the agent")
+	}
 	if input == nil {
 		return nil, status.Errorf(status.ErrInvalidArgument, "agent %q: input must not be nil", h.name)
 	}

--- a/go/ai/exp/handle.go
+++ b/go/ai/exp/handle.go
@@ -203,7 +203,14 @@ func (h *AgentHandle) Metadata() *AgentMetadata {
 		return nil
 	}
 	h.metaOnce.Do(func() {
-		h.meta, h.metaSrc = AgentMetadataOf(h.metaSrc), nil
+		// Derive only when there is a descriptor to derive from. A handle
+		// constructed with eager metadata and no metaSrc (the shape a remote
+		// transport takes, having no api.Action to inspect, like JS
+		// remoteAgent filling stateManagement) keeps what it was built with;
+		// running the derivation over a nil source would clobber it to nil.
+		if h.metaSrc != nil {
+			h.meta, h.metaSrc = AgentMetadataOf(h.metaSrc), nil
+		}
 	})
 	return h.meta
 }

--- a/go/ai/exp/handle.go
+++ b/go/ai/exp/handle.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
 
 	"github.com/firebase/genkit/go/core/api"
 	"github.com/firebase/genkit/go/core/status"
@@ -101,27 +102,38 @@ func (a *Agent[State]) Handle() *AgentHandle {
 // or carries none. It handles both in-process descriptors (typed metadata) and
 // descriptors decoded from JSON (map form), so callers can inspect an agent's
 // capabilities ([AgentMetadata.StateManagement], [AgentMetadata.Abortable])
-// without knowing where the action came from. The returned value is a copy;
-// mutating it does not affect the descriptor.
+// without knowing where the action came from.
+//
+// The returned value is a copy: mutating its fields, [AgentMetadata.StateSchema]
+// included, does not affect the descriptor. Values nested inside the schema are
+// shared, so treat what it points at as read-only.
+//
+// A wire descriptor that does not decode reports as nil rather than partially.
+// Every field here is a capability a caller gates on, and a zero value reads as
+// a definite "no": an agent whose abortable field arrived mistyped would be
+// refused background work it can do, and told why in terms that are not true.
+// Absent metadata is the honest answer, and callers already treat it as
+// "unknown" and fall back to asking the runtime.
 func AgentMetadataOf(a api.Action) *AgentMetadata {
 	if a == nil {
 		return nil
 	}
 	switch m := a.Desc().Metadata["agent"].(type) {
 	case AgentMetadata:
+		m.StateSchema = maps.Clone(m.StateSchema)
 		return &m
 	case *AgentMetadata:
 		if m == nil {
 			return nil
 		}
 		copied := *m
+		copied.StateSchema = maps.Clone(copied.StateSchema)
 		return &copied
 	case map[string]any:
-		// Best-effort decode: encoding/json fills every well-typed field
-		// before reporting the first type error, so one mistyped field in a
-		// wire descriptor leaves that field zero instead of erasing the
-		// capabilities that did decode.
-		meta, _ := base.MapToStruct[AgentMetadata](m)
+		meta, err := base.MapToStruct[AgentMetadata](m)
+		if err != nil {
+			return nil
+		}
 		return &meta
 	}
 	return nil
@@ -132,7 +144,8 @@ func (h *AgentHandle) Name() string { return h.name }
 
 // Metadata returns the agent's capability metadata (who manages state, whether
 // background work can be aborted), or nil when the agent's descriptor carries
-// none. Treat the returned value as read-only; it is shared across calls.
+// none or did not decode. The handle holds one copy, detached from the
+// descriptor but shared across calls, so treat it as read-only.
 func (h *AgentHandle) Metadata() *AgentMetadata { return h.meta }
 
 // Run starts a single-turn invocation with the given input and returns the
@@ -300,8 +313,13 @@ func (h *AgentHandle) GetLatestSnapshot(ctx context.Context, sessionID string) (
 // subtypes included (e.g. [ErrSnapshotNotFound] is a [status.ErrNotFound]).
 func (h *AgentHandle) snapshotVia(ctx context.Context, act api.Action, verb string, req *GetSnapshotRequest) (*SessionSnapshot[json.RawMessage], error) {
 	if act == nil {
+		// State what is known. A handle built by name binds each companion by
+		// its own registry lookup, so a missing one means only that the agent
+		// does not publish it; no session store is the usual cause, not a fact
+		// the handle can check. The middleware relays this text to a model.
 		return nil, status.Errorf(ErrSessionStoreNotConfigured,
-			"agent %q has no session store, so it keeps no snapshots to %s", h.name, verb)
+			"agent %q publishes no action to %s a snapshot; an agent publishes one only when it has a session store",
+			h.name, verb)
 	}
 	reqJSON, err := json.Marshal(req)
 	if err != nil {
@@ -335,7 +353,9 @@ func (h *AgentHandle) Abort(ctx context.Context, snapshotID string) (SnapshotSta
 	}
 	if h.abort == nil {
 		if h.getSnapshot == nil {
-			return "", status.Errorf(ErrSessionStoreNotConfigured, "agent %q: Abort requires a session store", h.name)
+			return "", status.Errorf(ErrSessionStoreNotConfigured,
+				"agent %q publishes no action to abort background work; an agent publishes one only when it has a session store that can observe aborts",
+				h.name)
 		}
 		return "", status.Errorf(status.ErrFailedPrecondition,
 			"agent %q: the session store does not support abort (it does not implement SnapshotSubscriber)", h.name)

--- a/go/ai/exp/handle.go
+++ b/go/ai/exp/handle.go
@@ -121,9 +121,11 @@ func AgentMetadataOf(a api.Action) *AgentMetadata {
 			return nil
 		}
 		meta := &AgentMetadata{}
-		if err := json.Unmarshal(b, meta); err != nil {
-			return nil
-		}
+		// Best-effort decode: encoding/json fills every well-typed field
+		// before reporting the first type error, so one mistyped field in a
+		// wire descriptor leaves that field zero instead of erasing the
+		// capabilities that did decode.
+		_ = json.Unmarshal(b, meta)
 		return meta
 	}
 	return nil
@@ -159,7 +161,7 @@ func (h *AgentHandle) Run(ctx context.Context, input *AgentInput, opts ...Invoca
 		return nil, fmt.Errorf("agent %q: marshal input: %w", h.name, err)
 	}
 	var initJSON json.RawMessage
-	if init.SessionID != "" || init.SnapshotID != "" || init.State != nil {
+	if init != nil {
 		initJSON, err = json.Marshal(init)
 		if err != nil {
 			return nil, fmt.Errorf("agent %q: marshal init: %w", h.name, err)
@@ -190,6 +192,13 @@ func (h *AgentHandle) Run(ctx context.Context, input *AgentInput, opts ...Invoca
 // [SnapshotSubscriber]. Check [AgentMetadata.Abortable] to pre-flight. The
 // rejection is decoded from the invocation's failed output, which keeps only
 // the status name, so match it with [status.Of] rather than errors.Is.
+//
+// An agent may also settle the invocation synchronously, before the runtime
+// observes the detach directive (e.g. a custom agent whose fn returns without
+// consuming the input). When a turn committed, Start returns a task over its
+// snapshot, which is already terminal, so Poll and Wait resolve immediately;
+// when nothing was recorded, Start fails with FAILED_PRECONDITION naming the
+// finish reason, since there is no durable record to track.
 func (h *AgentHandle) Start(ctx context.Context, input *AgentInput, opts ...InvocationOption[json.RawMessage]) (*DetachedTask, error) {
 	if input == nil {
 		return nil, status.Errorf(status.ErrInvalidArgument, "agent %q: input must not be nil", h.name)
@@ -210,12 +219,17 @@ func (h *AgentHandle) Start(ctx context.Context, input *AgentInput, opts ...Invo
 		}
 		return nil, fmt.Errorf("agent %q: background launch failed: %w", h.name, cause)
 	default:
-		// With detach riding the first input, the runtime resolves the
-		// invocation as detached or failed before any turn output can settle
-		// it; any other reason means the agent did not honor the detach
-		// contract.
-		return nil, status.Errorf(status.ErrInternal,
-			"agent %q: expected the invocation to detach, got finish reason %q", h.name, out.FinishReason)
+		// The invocation settled before the runtime observed the detach
+		// directive (nothing orders the intake reader ahead of an agent fn
+		// that never consumes its input). A committed turn's snapshot is the
+		// settled work's durable record, so hand back a task over it; Poll
+		// and Wait resolve immediately with the terminal snapshot.
+		if out.SnapshotID != "" {
+			return &DetachedTask{handle: h, snapshotID: out.SnapshotID}, nil
+		}
+		return nil, status.Errorf(status.ErrFailedPrecondition,
+			"agent %q: the invocation settled synchronously (finish reason %q, session %q) without recording a snapshot, so there is no background task to track",
+			h.name, out.FinishReason, out.SessionID)
 	}
 }
 

--- a/go/ai/exp/handle.go
+++ b/go/ai/exp/handle.go
@@ -150,12 +150,11 @@ func (a *Agent[State]) Handle() *AgentHandle {
 	}
 }
 
-// AgentMetadataOf extracts the [AgentMetadata] an agent's action descriptor
+// agentMetadataOf extracts the [AgentMetadata] an agent's action descriptor
 // carries under its "agent" metadata key, or nil when a is not an agent action
 // or carries none. It handles both in-process descriptors (typed metadata) and
-// descriptors decoded from JSON (map form), so callers can inspect an agent's
-// capabilities ([AgentMetadata.StateManagement], [AgentMetadata.Abortable])
-// without knowing where the action came from.
+// descriptors decoded from JSON (map form), so [AgentHandle.Metadata] reads an
+// agent's capabilities without knowing where the action came from.
 //
 // The returned value is a copy: mutating its fields, [AgentMetadata.StateSchema]
 // and anything nested inside it included, does not affect the descriptor.
@@ -166,7 +165,7 @@ func (a *Agent[State]) Handle() *AgentHandle {
 // refused background work it can do, and told why in terms that are not true.
 // Absent metadata is the honest answer, and callers already treat it as
 // "unknown" and fall back to asking the runtime.
-func AgentMetadataOf(a api.Action) *AgentMetadata {
+func agentMetadataOf(a api.Action) *AgentMetadata {
 	if a == nil {
 		return nil
 	}
@@ -209,7 +208,7 @@ func (h *AgentHandle) Metadata() *AgentMetadata {
 		// remoteAgent filling stateManagement) keeps what it was built with;
 		// running the derivation over a nil source would clobber it to nil.
 		if h.metaSrc != nil {
-			h.meta, h.metaSrc = AgentMetadataOf(h.metaSrc), nil
+			h.meta, h.metaSrc = agentMetadataOf(h.metaSrc), nil
 		}
 	})
 	return h.meta

--- a/go/ai/exp/handle.go
+++ b/go/ai/exp/handle.go
@@ -27,30 +27,73 @@ import (
 	"github.com/firebase/genkit/go/internal/base"
 )
 
-// AgentHandle is the untyped caller-side view of an agent: its run action and
-// snapshot-lifecycle companion actions (getSnapshot, waitForSnapshot, abort),
-// addressed with the custom-state type fixed to [json.RawMessage]. It is how
-// code that does not hold the defining [Agent] value calls an agent it knows
-// only by name:
-// orchestrators, middleware, and tools resolve one with [LookupAgent] (or the
-// genkit/exp package's LookupAgent), and a typed owner hands one out with
-// [Agent.Handle].
+// AgentHandle is the untyped caller-side view of an agent: one turn, plus the
+// snapshot lifecycle behind a detached one (read, follow, abort), addressed
+// with the custom-state type fixed to [json.RawMessage]. It is how code that
+// does not hold the defining [Agent] value calls an agent it knows only by
+// name: orchestrators, middleware, and tools resolve one with [LookupAgent]
+// (or the genkit/exp package's LookupAgent), and a typed owner hands one out
+// with [Agent.Handle].
 //
-// A handle adds no capability over the actions it wraps; it only removes the
+// A handle adds no capability over the agent it names; it only removes the
 // wire plumbing (JSON marshaling, companion-action lookup and dispatch) that
 // name-resolved callers would otherwise repeat. Custom state on every surface
 // is [json.RawMessage]: unmarshal [SessionState.Custom] into the agent's own
 // state type when the caller knows it.
+//
+// Reaching the agent is an [agentTransport]'s job, so where the agent lives is
+// not part of this surface. Both constructors bind the in-process transport
+// today; the seam is what will let one bind an agent behind an HTTP endpoint
+// without moving a method.
 type AgentHandle struct {
 	name string
-	run  api.BidiAction
-	// Companion actions; nil when the agent lacks the capability (see
-	// [Agent.GetSnapshotAction], [Agent.WaitForSnapshotAction], and
-	// [Agent.AbortAction]).
-	getSnapshot api.Action
-	wait        api.Action
-	abort       api.Action
-	meta        *AgentMetadata
+	// meta is the agent's capability metadata, or nil when it is unknown. It
+	// is static, so the handle holds it rather than asking the transport for
+	// it on every call.
+	meta      *AgentMetadata
+	transport agentTransport
+}
+
+// agentTransport is how an [AgentHandle] reaches the agent it names. The
+// handle owns the ergonomic surface and the argument validation that holds
+// wherever the agent lives; a transport owns marshaling, dispatch, and the
+// refusal an agent that lacks a capability earns.
+//
+// It is unexported until a second implementation exists. The in-process
+// transport below is the only one today, and an HTTP one over the
+// /agents/{name}/... routes is what the seam is for; writing that is what will
+// settle the shape well enough to publish it.
+//
+// Two rules every implementation owes its callers:
+//
+// Errors are matched by status name ([status.Classified]), never by sentinel
+// identity. A transport that crosses a wire decodes a status name and nothing
+// else, so a sentinel subtype arrives as its parent status: the in-process
+// transport's live error chain is a convenience of where it runs, not a
+// promise of the seam. A message that would name which subtype it is has to
+// hedge instead.
+//
+// Capability metadata is not here. It is static, [AgentHandle] holds it
+// directly, and a transport that had to fetch it could report no failure
+// through a getter that returns one value. Whoever builds a transport supplies
+// what it knows about the agent, and nil means unknown.
+//
+// Connect-style sessions are deliberately out of scope. [AgentHandle] exposes
+// none, and a long-lived duplex stream is a different problem from four
+// request/response calls.
+type agentTransport interface {
+	// Run delivers one turn and returns its final output. init carries the
+	// session source and may be nil; cb receives streamed chunks as raw JSON
+	// and may be nil.
+	Run(ctx context.Context, input *AgentInput, init *AgentInit[json.RawMessage], cb func(context.Context, json.RawMessage) error) (*AgentOutput[json.RawMessage], error)
+	// GetSnapshot reads one snapshot, addressed either by its own ID or as a
+	// session's latest.
+	GetSnapshot(ctx context.Context, lookup *GetSnapshotRequest) (*SessionSnapshot[json.RawMessage], error)
+	// WaitForSnapshot blocks until the snapshot settles and returns it.
+	WaitForSnapshot(ctx context.Context, snapshotID string) (*SessionSnapshot[json.RawMessage], error)
+	// Abort stops the background work behind a pending snapshot and reports
+	// the snapshot's status after the attempt.
+	Abort(ctx context.Context, snapshotID string) (SnapshotStatus, error)
 }
 
 // LookupAgent resolves the agent registered under name and returns its
@@ -72,12 +115,15 @@ func LookupAgent(r api.Registry, name string) (*AgentHandle, error) {
 		return nil, status.Errorf(status.ErrInvalidArgument, "%q is registered but is not an agent", name)
 	}
 	return &AgentHandle{
-		name:        name,
-		run:         run,
-		getSnapshot: r.LookupAction(api.KeyFromName(api.ActionTypeAgentSnapshot, name)),
-		wait:        r.LookupAction(api.KeyFromName(api.ActionTypeAgentWait, name)),
-		abort:       r.LookupAction(api.KeyFromName(api.ActionTypeAgentAbort, name)),
-		meta:        AgentMetadataOf(run),
+		name: name,
+		meta: AgentMetadataOf(run),
+		transport: &actionTransport{
+			name:        name,
+			run:         run,
+			getSnapshot: r.LookupAction(api.KeyFromName(api.ActionTypeAgentSnapshot, name)),
+			wait:        r.LookupAction(api.KeyFromName(api.ActionTypeAgentWait, name)),
+			abort:       r.LookupAction(api.KeyFromName(api.ActionTypeAgentAbort, name)),
+		},
 	}, nil
 }
 
@@ -88,12 +134,15 @@ func LookupAgent(r api.Registry, name string) (*AgentHandle, error) {
 // lookup, so it also works for an unregistered agent (see [NewCustomAgent]).
 func (a *Agent[State]) Handle() *AgentHandle {
 	return &AgentHandle{
-		name:        a.Name(),
-		run:         a,
-		getSnapshot: a.getSnapshot,
-		wait:        a.wait,
-		abort:       a.abort,
-		meta:        AgentMetadataOf(a),
+		name: a.Name(),
+		meta: AgentMetadataOf(a),
+		transport: &actionTransport{
+			name:        a.Name(),
+			run:         a,
+			getSnapshot: a.getSnapshot,
+			wait:        a.wait,
+			abort:       a.abort,
+		},
 	}
 }
 
@@ -165,26 +214,10 @@ func (h *AgentHandle) Run(ctx context.Context, input *AgentInput, opts ...Invoca
 	if err != nil {
 		return nil, err
 	}
-	inputJSON, err := json.Marshal(input)
-	if err != nil {
-		return nil, fmt.Errorf("agent %q: marshal input: %w", h.name, err)
-	}
-	var initJSON json.RawMessage
-	if init != nil {
-		initJSON, err = json.Marshal(init)
-		if err != nil {
-			return nil, fmt.Errorf("agent %q: marshal init: %w", h.name, err)
-		}
-	}
-	res, err := h.run.RunBidiJSON(ctx, inputJSON, nil, &api.BidiJSONOptions{Init: initJSON})
-	if err != nil {
-		return nil, err
-	}
-	var out AgentOutput[json.RawMessage]
-	if err := json.Unmarshal(res.Result, &out); err != nil {
-		return nil, fmt.Errorf("agent %q: unmarshal output: %w", h.name, err)
-	}
-	return &out, nil
+	// No stream callback: a handle reports a turn by its final output. The
+	// transport takes one because a turn is streamed at that level whatever
+	// carries it, so a streaming surface on the handle needs no new seam.
+	return h.transport.Run(ctx, input, init, nil)
 }
 
 // Start launches input as a detached (background) invocation and returns the
@@ -263,7 +296,7 @@ func (h *AgentHandle) GetSnapshot(ctx context.Context, snapshotID string) (*Sess
 	if snapshotID == "" {
 		return nil, status.Errorf(status.ErrInvalidArgument, "agent %q: GetSnapshot: snapshotID is required", h.name)
 	}
-	return h.snapshotVia(ctx, h.getSnapshot, "read", &GetSnapshotRequest{SnapshotID: snapshotID})
+	return h.transport.GetSnapshot(ctx, &GetSnapshotRequest{SnapshotID: snapshotID})
 }
 
 // WaitForSnapshot fetches a session snapshot by ID and blocks until it settles,
@@ -287,7 +320,7 @@ func (h *AgentHandle) WaitForSnapshot(ctx context.Context, snapshotID string) (*
 	if snapshotID == "" {
 		return nil, status.Errorf(status.ErrInvalidArgument, "agent %q: WaitForSnapshot: snapshotID is required", h.name)
 	}
-	return h.snapshotVia(ctx, h.wait, "follow", &GetSnapshotRequest{SnapshotID: snapshotID})
+	return h.transport.WaitForSnapshot(ctx, snapshotID)
 }
 
 // GetLatestSnapshot fetches a session's most recently created snapshot
@@ -302,38 +335,7 @@ func (h *AgentHandle) GetLatestSnapshot(ctx context.Context, sessionID string) (
 	if sessionID == "" {
 		return nil, status.Errorf(status.ErrInvalidArgument, "agent %q: GetLatestSnapshot: sessionID is required", h.name)
 	}
-	return h.snapshotVia(ctx, h.getSnapshot, "read", &GetSnapshotRequest{SessionID: sessionID})
-}
-
-// snapshotVia dispatches req to act, one of the two companion actions that
-// answer a [GetSnapshotRequest] with a [SessionSnapshot], and decodes the
-// result. verb names what the caller wanted to do with the snapshot, for the
-// message reporting an agent that keeps none. The action runs in-process here,
-// so its error chain stays live: sentinel matching with errors.Is works,
-// subtypes included (e.g. [ErrSnapshotNotFound] is a [status.ErrNotFound]).
-func (h *AgentHandle) snapshotVia(ctx context.Context, act api.Action, verb string, req *GetSnapshotRequest) (*SessionSnapshot[json.RawMessage], error) {
-	if act == nil {
-		// State what is known. A handle built by name binds each companion by
-		// its own registry lookup, so a missing one means only that the agent
-		// does not publish it; no session store is the usual cause, not a fact
-		// the handle can check. The middleware relays this text to a model.
-		return nil, status.Errorf(ErrSessionStoreNotConfigured,
-			"agent %q publishes no action to %s a snapshot; an agent publishes one only when it has a session store",
-			h.name, verb)
-	}
-	reqJSON, err := json.Marshal(req)
-	if err != nil {
-		return nil, fmt.Errorf("agent %q: marshal snapshot request: %w", h.name, err)
-	}
-	raw, err := act.RunJSON(ctx, reqJSON, nil)
-	if err != nil {
-		return nil, err
-	}
-	var snap SessionSnapshot[json.RawMessage]
-	if err := json.Unmarshal(raw, &snap); err != nil {
-		return nil, fmt.Errorf("agent %q: unmarshal snapshot: %w", h.name, err)
-	}
-	return &snap, nil
+	return h.transport.GetSnapshot(ctx, &GetSnapshotRequest{SessionID: sessionID})
 }
 
 // Abort asks the background work behind a pending snapshot to stop, through
@@ -351,26 +353,117 @@ func (h *AgentHandle) Abort(ctx context.Context, snapshotID string) (SnapshotSta
 	if snapshotID == "" {
 		return "", status.Errorf(status.ErrInvalidArgument, "agent %q: Abort: snapshotID is required", h.name)
 	}
-	if h.abort == nil {
-		if h.getSnapshot == nil {
+	return h.transport.Abort(ctx, snapshotID)
+}
+
+// --- In-process transport ---
+
+// actionTransport reaches an agent through its registered actions, in this
+// process. It is what [LookupAgent] and [Agent.Handle] build, and the only
+// [agentTransport] today.
+//
+// A companion action is nil when the agent does not publish it, which an agent
+// does only when it has a session store supporting that capability. Turning
+// that into a refusal is the transport's job rather than the handle's: the
+// handle cannot see an action, and a transport reaching a remote agent learns
+// the same fact from a status the server sends back.
+//
+// Errors from here keep a live chain, so sentinel matching with errors.Is
+// works, subtypes included ([ErrSnapshotNotFound] is a [status.ErrNotFound]).
+// That is a property of running in-process, not of the seam. Callers written
+// against [AgentHandle] match on status name, per [agentTransport].
+type actionTransport struct {
+	name        string
+	run         api.BidiAction
+	getSnapshot api.Action
+	wait        api.Action
+	abort       api.Action
+}
+
+func (t *actionTransport) Run(ctx context.Context, input *AgentInput, init *AgentInit[json.RawMessage], cb func(context.Context, json.RawMessage) error) (*AgentOutput[json.RawMessage], error) {
+	inputJSON, err := json.Marshal(input)
+	if err != nil {
+		return nil, fmt.Errorf("agent %q: marshal input: %w", t.name, err)
+	}
+	var initJSON json.RawMessage
+	if init != nil {
+		initJSON, err = json.Marshal(init)
+		if err != nil {
+			return nil, fmt.Errorf("agent %q: marshal init: %w", t.name, err)
+		}
+	}
+	res, err := t.run.RunBidiJSON(ctx, inputJSON, cb, &api.BidiJSONOptions{Init: initJSON})
+	if err != nil {
+		return nil, err
+	}
+	var out AgentOutput[json.RawMessage]
+	if err := json.Unmarshal(res.Result, &out); err != nil {
+		return nil, fmt.Errorf("agent %q: unmarshal output: %w", t.name, err)
+	}
+	return &out, nil
+}
+
+func (t *actionTransport) GetSnapshot(ctx context.Context, lookup *GetSnapshotRequest) (*SessionSnapshot[json.RawMessage], error) {
+	return t.snapshotVia(ctx, t.getSnapshot, "read", lookup)
+}
+
+func (t *actionTransport) WaitForSnapshot(ctx context.Context, snapshotID string) (*SessionSnapshot[json.RawMessage], error) {
+	return t.snapshotVia(ctx, t.wait, "follow", &GetSnapshotRequest{SnapshotID: snapshotID})
+}
+
+// snapshotVia dispatches req to act, one of the two companion actions that
+// answer a [GetSnapshotRequest] with a [SessionSnapshot], and decodes the
+// result. verb names what the caller wanted to do with the snapshot, for the
+// message reporting an agent that keeps none.
+func (t *actionTransport) snapshotVia(ctx context.Context, act api.Action, verb string, req *GetSnapshotRequest) (*SessionSnapshot[json.RawMessage], error) {
+	if act == nil {
+		// State what is known. A transport built by name binds each companion
+		// by its own registry lookup, so a missing one means only that the
+		// agent does not publish it; no session store is the usual cause, not
+		// a fact this can check. The middleware relays this text to a model.
+		return nil, status.Errorf(ErrSessionStoreNotConfigured,
+			"agent %q publishes no action to %s a snapshot; an agent publishes one only when it has a session store",
+			t.name, verb)
+	}
+	reqJSON, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("agent %q: marshal snapshot request: %w", t.name, err)
+	}
+	raw, err := act.RunJSON(ctx, reqJSON, nil)
+	if err != nil {
+		return nil, err
+	}
+	var snap SessionSnapshot[json.RawMessage]
+	if err := json.Unmarshal(raw, &snap); err != nil {
+		return nil, fmt.Errorf("agent %q: unmarshal snapshot: %w", t.name, err)
+	}
+	return &snap, nil
+}
+
+func (t *actionTransport) Abort(ctx context.Context, snapshotID string) (SnapshotStatus, error) {
+	if t.abort == nil {
+		// Two refusals, because the caller can act on the difference: no
+		// snapshot action at all means no session store, while a store that
+		// reads but cannot abort is one without SnapshotSubscriber.
+		if t.getSnapshot == nil {
 			return "", status.Errorf(ErrSessionStoreNotConfigured,
 				"agent %q publishes no action to abort background work; an agent publishes one only when it has a session store that can observe aborts",
-				h.name)
+				t.name)
 		}
 		return "", status.Errorf(status.ErrFailedPrecondition,
-			"agent %q: the session store does not support abort (it does not implement SnapshotSubscriber)", h.name)
+			"agent %q: the session store does not support abort (it does not implement SnapshotSubscriber)", t.name)
 	}
 	reqJSON, err := json.Marshal(&AgentAbortRequest{SnapshotID: snapshotID})
 	if err != nil {
-		return "", fmt.Errorf("agent %q: marshal abort request: %w", h.name, err)
+		return "", fmt.Errorf("agent %q: marshal abort request: %w", t.name, err)
 	}
-	raw, err := h.abort.RunJSON(ctx, reqJSON, nil)
+	raw, err := t.abort.RunJSON(ctx, reqJSON, nil)
 	if err != nil {
 		return "", err
 	}
 	var resp AgentAbortResponse
 	if err := json.Unmarshal(raw, &resp); err != nil {
-		return "", fmt.Errorf("agent %q: unmarshal abort response: %w", h.name, err)
+		return "", fmt.Errorf("agent %q: unmarshal abort response: %w", t.name, err)
 	}
 	return resp.Status, nil
 }

--- a/go/ai/exp/handle_test.go
+++ b/go/ai/exp/handle_test.go
@@ -192,6 +192,25 @@ func TestAgentMetadataOf(t *testing.T) {
 		}
 	})
 
+	t.Run("map form keeps well-typed fields past a mistyped one", func(t *testing.T) {
+		// A wire descriptor with one bad field must not erase the
+		// capabilities that did decode: history forwarding and abort
+		// pre-flights key off these.
+		a := fakeDescAction{desc: api.ActionDesc{Metadata: map[string]any{
+			"agent": map[string]any{"stateManagement": "client", "abortable": "true"},
+		}}}
+		meta := AgentMetadataOf(a)
+		if meta == nil {
+			t.Fatal("AgentMetadataOf = nil, want best-effort metadata")
+		}
+		if meta.StateManagement != AgentStateManagementClient {
+			t.Errorf("StateManagement = %q, want %q despite the mistyped sibling", meta.StateManagement, AgentStateManagementClient)
+		}
+		if meta.Abortable {
+			t.Error("Abortable = true, want zero value for the mistyped field")
+		}
+	})
+
 	t.Run("action without agent metadata", func(t *testing.T) {
 		a := fakeDescAction{desc: api.ActionDesc{Metadata: map[string]any{"other": true}}}
 		if got := AgentMetadataOf(a); got != nil {
@@ -478,4 +497,57 @@ func TestAgentHandle_SnapshotReadErrors(t *testing.T) {
 			t.Fatalf("Poll(missing) error = %v, want NOT_FOUND", err)
 		}
 	})
+}
+
+func TestAgentHandle_StartSettledSynchronously(t *testing.T) {
+	// An agent whose fn returns without consuming its input can settle the
+	// invocation before the runtime observes the detach directive. Start must
+	// treat that as a first-class outcome: a task over the committed snapshot
+	// when one exists, or FAILED_PRECONDITION when nothing was recorded;
+	// never an INTERNAL contract-violation error. The race is scheduling-
+	// dependent, so accept either outcome on each iteration and pin only the
+	// contract.
+	reg := newTestRegistry(t)
+	store := newTestInMemStore[testState]()
+	agent := DefineCustomAgent(reg, "eager",
+		func(ctx context.Context, resp Responder, sess *SessionRunner[testState]) (*AgentResult, error) {
+			return nil, nil // settles immediately, no turn, no snapshot
+		},
+		WithSessionStore(store),
+	)
+	h := agent.Handle()
+	for i := 0; i < 20; i++ {
+		task, err := h.Start(context.Background(), &AgentInput{Message: ai.NewUserTextMessage("go")})
+		if err == nil {
+			// The detach won the race; the launch is a normal task.
+			if task == nil || task.SnapshotID() == "" {
+				t.Fatalf("iteration %d: nil or empty task without error", i)
+			}
+			continue
+		}
+		if !errors.Is(err, status.ErrFailedPrecondition) || !strings.Contains(err.Error(), "settled synchronously") {
+			t.Fatalf("iteration %d: err = %v, want FAILED_PRECONDITION about synchronous settlement", i, err)
+		}
+	}
+}
+
+func TestWaitOptionValidation(t *testing.T) {
+	reg := newTestRegistry(t)
+	store := newTestInMemStore[testState]()
+	defineGatedAgent(t, reg, "waiter", store)
+	h, err := LookupAgent(reg, "waiter")
+	if err != nil {
+		t.Fatalf("LookupAgent: %v", err)
+	}
+	task := h.Task("irrelevant")
+
+	if _, err := task.Wait(context.Background(), WithPollInterval(0)); err == nil || !strings.Contains(err.Error(), "must be positive") {
+		t.Fatalf("Wait(WithPollInterval(0)) error = %v, want positivity rejection", err)
+	}
+	if _, err := task.Wait(context.Background(), WithPollInterval(-time.Second)); err == nil || !strings.Contains(err.Error(), "must be positive") {
+		t.Fatalf("Wait(WithPollInterval(-1s)) error = %v, want positivity rejection", err)
+	}
+	if _, err := task.Wait(context.Background(), WithPollInterval(time.Second), WithPollInterval(2*time.Second)); err == nil || !strings.Contains(err.Error(), "more than once") {
+		t.Fatalf("duplicate WithPollInterval error = %v, want duplicate-option rejection", err)
+	}
 }

--- a/go/ai/exp/handle_test.go
+++ b/go/ai/exp/handle_test.go
@@ -135,8 +135,8 @@ func TestLookupAgent(t *testing.T) {
 		if _, err := h.RunText(context.Background(), "hi"); !errors.Is(err, status.ErrInvalidArgument) {
 			t.Errorf("RunText on a nil handle = %v, want INVALID_ARGUMENT", err)
 		}
-		if _, err := h.Start(context.Background(), &AgentInput{}); !errors.Is(err, status.ErrInvalidArgument) {
-			t.Errorf("Start on a nil handle = %v, want INVALID_ARGUMENT", err)
+		if _, err := h.RunDetached(context.Background(), &AgentInput{}); !errors.Is(err, status.ErrInvalidArgument) {
+			t.Errorf("RunDetached on a nil handle = %v, want INVALID_ARGUMENT", err)
 		}
 	})
 }
@@ -326,7 +326,7 @@ func TestAgentHandle_Run(t *testing.T) {
 	})
 }
 
-func TestAgentHandle_StartPollWaitTask(t *testing.T) {
+func TestAgentHandle_RunDetachedPollWaitRehydrate(t *testing.T) {
 	// Full background lifecycle through the handle: launch, observe pending,
 	// rehydrate the task from nothing but its snapshot ID, and wait for the
 	// finalized snapshot.
@@ -336,12 +336,12 @@ func TestAgentHandle_StartPollWaitTask(t *testing.T) {
 
 	h := LookupAgent(reg, "worker")
 
-	task, err := h.Start(context.Background(), &AgentInput{Message: ai.NewUserTextMessage("go")})
+	task, err := h.RunDetached(context.Background(), &AgentInput{Message: ai.NewUserTextMessage("go")})
 	if err != nil {
-		t.Fatalf("Start: %v", err)
+		t.Fatalf("RunDetached: %v", err)
 	}
 	if task.SnapshotID() == "" {
-		t.Fatal("Start returned a task with no snapshot ID")
+		t.Fatal("RunDetached returned a task with no snapshot ID")
 	}
 
 	select {
@@ -388,14 +388,14 @@ func TestAgentHandle_StartPollWaitTask(t *testing.T) {
 	}
 }
 
-func TestAgentHandle_StartRejected(t *testing.T) {
+func TestAgentHandle_RunDetachedRejected(t *testing.T) {
 	t.Run("client-managed agent cannot detach", func(t *testing.T) {
 		reg := newTestRegistry(t)
 		defineEchoAgent(t, reg, "storeless")
 		h := LookupAgent(reg, "storeless")
-		_, err := h.Start(context.Background(), &AgentInput{Message: ai.NewUserTextMessage("go")})
+		_, err := h.RunDetached(context.Background(), &AgentInput{Message: ai.NewUserTextMessage("go")})
 		if err == nil {
-			t.Fatal("Start succeeded on a storeless agent, want rejection")
+			t.Fatal("RunDetached succeeded on a storeless agent, want rejection")
 		}
 		// The rejection is decoded from the invocation's failed output, so only
 		// the status name survives; match by status, not sentinel.
@@ -434,9 +434,9 @@ func TestAgentHandle_AbortLifecycle(t *testing.T) {
 	agent, entered, _ := defineGatedAgent(t, reg, "abortable", store)
 
 	h := agent.Handle()
-	task, err := h.Start(context.Background(), &AgentInput{Message: ai.NewUserTextMessage("go")})
+	task, err := h.RunDetached(context.Background(), &AgentInput{Message: ai.NewUserTextMessage("go")})
 	if err != nil {
-		t.Fatalf("Start: %v", err)
+		t.Fatalf("RunDetached: %v", err)
 	}
 	select {
 	case <-entered:
@@ -522,14 +522,14 @@ func TestAgentHandle_SnapshotReadErrors(t *testing.T) {
 	})
 }
 
-func TestAgentHandle_StartSettledSynchronously(t *testing.T) {
+func TestAgentHandle_RunDetachedSettledSynchronously(t *testing.T) {
 	// An agent whose fn returns without consuming its input can settle the
-	// invocation before the runtime observes the detach directive. Start must
-	// treat that as a first-class outcome: a task over the committed snapshot
-	// when one exists, or FAILED_PRECONDITION when nothing was recorded;
-	// never an INTERNAL contract-violation error. The race is scheduling-
-	// dependent, so accept either outcome on each iteration and pin only the
-	// contract.
+	// invocation before the runtime observes the detach directive. RunDetached
+	// must treat that as a first-class outcome: a task over the committed
+	// snapshot when one exists, or FAILED_PRECONDITION when nothing was
+	// recorded; never an INTERNAL contract-violation error. The race is
+	// scheduling-dependent, so accept either outcome on each iteration and pin
+	// only the contract.
 	reg := newTestRegistry(t)
 	store := newTestInMemStore[testState]()
 	agent := DefineCustomAgent(reg, "eager",
@@ -540,7 +540,7 @@ func TestAgentHandle_StartSettledSynchronously(t *testing.T) {
 	)
 	h := agent.Handle()
 	for i := 0; i < 20; i++ {
-		task, err := h.Start(context.Background(), &AgentInput{Message: ai.NewUserTextMessage("go")})
+		task, err := h.RunDetached(context.Background(), &AgentInput{Message: ai.NewUserTextMessage("go")})
 		if err == nil {
 			// The detach won the race; the launch is a normal task.
 			if task == nil || task.SnapshotID() == "" {
@@ -659,6 +659,21 @@ func TestAgentHandle_DelegatesToTransport(t *testing.T) {
 		t.Error("Run passed a stream callback; the handle reports a turn by its final output")
 	}
 
+	// RunDetached sets the detach directive on a copy, whatever the caller
+	// set, and leaves the caller's input alone. The canned output settles
+	// without a snapshot, so the launch reports that; the directive is what
+	// this checks.
+	input := &AgentInput{Message: ai.NewUserTextMessage("go")}
+	if _, err := h.RunDetached(ctx, input); !errors.Is(err, status.ErrFailedPrecondition) {
+		t.Fatalf("RunDetached over a synchronously settled output: err = %v, want FAILED_PRECONDITION", err)
+	}
+	if tr.runInput == nil || !tr.runInput.Detach {
+		t.Errorf("RunDetached sent %+v, want the detach directive set", tr.runInput)
+	}
+	if input.Detach {
+		t.Error("RunDetached mutated the caller's input")
+	}
+
 	// Validation is the handle's too, so a bad argument costs no dispatch and
 	// fails identically wherever the agent lives.
 	before := tr.callCount
@@ -667,6 +682,7 @@ func TestAgentHandle_DelegatesToTransport(t *testing.T) {
 		call func() error
 	}{
 		{"nil input", func() error { _, err := h.Run(ctx, nil); return err }},
+		{"nil detached input", func() error { _, err := h.RunDetached(ctx, nil); return err }},
 		{"empty snapshot ID", func() error { _, err := h.GetSnapshot(ctx, ""); return err }},
 		{"empty wait ID", func() error { _, err := h.WaitForSnapshot(ctx, ""); return err }},
 		{"empty session ID", func() error { _, err := h.GetLatestSnapshot(ctx, ""); return err }},

--- a/go/ai/exp/handle_test.go
+++ b/go/ai/exp/handle_test.go
@@ -132,6 +132,9 @@ func TestLookupAgent(t *testing.T) {
 		if !errors.Is(err, status.ErrInvalidArgument) || !strings.Contains(err.Error(), "nil handle") {
 			t.Errorf("Run on a nil handle = %v, want INVALID_ARGUMENT naming the nil handle", err)
 		}
+		if _, err := h.RunText(context.Background(), "hi"); !errors.Is(err, status.ErrInvalidArgument) {
+			t.Errorf("RunText on a nil handle = %v, want INVALID_ARGUMENT", err)
+		}
 		if _, err := h.Start(context.Background(), &AgentInput{}); !errors.Is(err, status.ErrInvalidArgument) {
 			t.Errorf("Start on a nil handle = %v, want INVALID_ARGUMENT", err)
 		}
@@ -273,6 +276,27 @@ func TestAgentHandle_Run(t *testing.T) {
 			t.Fatalf("Run with WithState: %v", err)
 		}
 		// Two seeded messages plus this turn's user message.
+		if got, want := out.Message.Text(), "echo:again n:3"; got != want {
+			t.Errorf("Message.Text() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("RunText delivers a user text message", func(t *testing.T) {
+		out, err := h.RunText(context.Background(), "hi")
+		if err != nil {
+			t.Fatalf("RunText: %v", err)
+		}
+		if got, want := out.Message.Text(), "echo:hi n:1"; got != want {
+			t.Errorf("Message.Text() = %q, want %q", got, want)
+		}
+		out, err = h.RunText(context.Background(), "again",
+			WithState(&SessionState[json.RawMessage]{Messages: []*ai.Message{
+				ai.NewUserTextMessage("earlier question"),
+				ai.NewModelTextMessage("earlier answer"),
+			}}))
+		if err != nil {
+			t.Fatalf("RunText with WithState: %v", err)
+		}
 		if got, want := out.Message.Text(), "echo:again n:3"; got != want {
 			t.Errorf("Message.Text() = %q, want %q", got, want)
 		}

--- a/go/ai/exp/handle_test.go
+++ b/go/ai/exp/handle_test.go
@@ -192,22 +192,35 @@ func TestAgentMetadataOf(t *testing.T) {
 		}
 	})
 
-	t.Run("map form keeps well-typed fields past a mistyped one", func(t *testing.T) {
-		// A wire descriptor with one bad field must not erase the
-		// capabilities that did decode: history forwarding and abort
-		// pre-flights key off these.
+	t.Run("map form that does not decode reports nothing, not a partial", func(t *testing.T) {
+		// Every field here is a capability a caller gates on, so a partial
+		// decode is worse than none: the mistyped abortable below would read
+		// as a definite "cannot run in the background" and get the agent
+		// refused work it can do. Callers treat nil as "unknown" and ask the
+		// runtime instead.
 		a := fakeDescAction{desc: api.ActionDesc{Metadata: map[string]any{
 			"agent": map[string]any{"stateManagement": "client", "abortable": "true"},
 		}}}
-		meta := AgentMetadataOf(a)
+		if meta := AgentMetadataOf(a); meta != nil {
+			t.Fatalf("AgentMetadataOf = %+v, want nil for a descriptor that did not decode", meta)
+		}
+	})
+
+	t.Run("returned metadata does not alias the descriptor", func(t *testing.T) {
+		// The copy claim has to cover StateSchema too: it is a map, so a
+		// struct copy alone shares it with every other reader of a descriptor
+		// documented as immutable.
+		desc := api.ActionDesc{Metadata: map[string]any{
+			"agent": AgentMetadata{StateSchema: map[string]any{"type": "object"}},
+		}}
+		meta := AgentMetadataOf(fakeDescAction{desc: desc})
 		if meta == nil {
-			t.Fatal("AgentMetadataOf = nil, want best-effort metadata")
+			t.Fatal("AgentMetadataOf = nil, want typed metadata")
 		}
-		if meta.StateManagement != AgentStateManagementClient {
-			t.Errorf("StateManagement = %q, want %q despite the mistyped sibling", meta.StateManagement, AgentStateManagementClient)
-		}
-		if meta.Abortable {
-			t.Error("Abortable = true, want zero value for the mistyped field")
+		meta.StateSchema["type"] = "tampered"
+		original := desc.Metadata["agent"].(AgentMetadata)
+		if got := original.StateSchema["type"]; got != "object" {
+			t.Errorf("descriptor schema type = %v, want %q untouched", got, "object")
 		}
 	})
 

--- a/go/ai/exp/handle_test.go
+++ b/go/ai/exp/handle_test.go
@@ -345,8 +345,8 @@ func TestAgentHandle_StartPollWaitTask(t *testing.T) {
 	if custom.Counter != 42 {
 		t.Errorf("custom counter = %d, want 42", custom.Counter)
 	}
-	if got, want := final.State.LastModelMessage().Text(), "finished"; got != want {
-		t.Errorf("LastModelMessage().Text() = %q, want %q", got, want)
+	if got, want := tipText(t, final.State), "finished"; got != want {
+		t.Errorf("final message = %q, want %q", got, want)
 	}
 }
 

--- a/go/ai/exp/handle_test.go
+++ b/go/ai/exp/handle_test.go
@@ -1,0 +1,481 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package exp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/core"
+	"github.com/firebase/genkit/go/core/api"
+	"github.com/firebase/genkit/go/core/status"
+)
+
+// defineEchoAgent registers a client-managed custom agent that answers each
+// turn with "echo:<text> n:<history length>", so tests can observe both the
+// turn input and any history seeded through init state.
+func defineEchoAgent(t *testing.T, reg api.Registry, name string) *Agent[any] {
+	t.Helper()
+	return DefineCustomAgent(reg, name,
+		func(ctx context.Context, resp Responder, sess *SessionRunner[any]) (*AgentResult, error) {
+			if err := sess.Run(ctx, func(ctx context.Context, input *AgentInput) (*TurnResult, error) {
+				sess.AddMessages(ai.NewModelTextMessage(
+					fmt.Sprintf("echo:%s n:%d", input.Message.Text(), len(sess.Messages()))))
+				return nil, nil
+			}); err != nil {
+				return nil, err
+			}
+			return sess.Result(), nil
+		})
+}
+
+// defineGatedAgent registers a server-managed agent whose single turn parks
+// between two channels: it signals entered, waits for release, then commits a
+// model message and custom state. It is the background-work stand-in for the
+// detach lifecycle tests.
+func defineGatedAgent(t *testing.T, reg api.Registry, name string, store *testInMemStore[testState]) (agent *Agent[testState], entered, release chan struct{}) {
+	t.Helper()
+	entered = make(chan struct{})
+	release = make(chan struct{})
+	agent = DefineCustomAgent(reg, name,
+		func(ctx context.Context, resp Responder, sess *SessionRunner[testState]) (*AgentResult, error) {
+			return nil, sess.Run(ctx, func(ctx context.Context, input *AgentInput) (*TurnResult, error) {
+				select {
+				case entered <- struct{}{}:
+				case <-ctx.Done():
+					return nil, ctx.Err()
+				}
+				select {
+				case <-release:
+				case <-ctx.Done():
+					return nil, ctx.Err()
+				}
+				sess.AddMessages(ai.NewModelTextMessage("finished"))
+				sess.UpdateCustom(func(s testState) testState {
+					s.Counter = 42
+					return s
+				})
+				return nil, nil
+			})
+		},
+		WithSessionStore(store),
+	)
+	return agent, entered, release
+}
+
+func TestLookupAgent(t *testing.T) {
+	t.Run("resolves a registered agent with its companions", func(t *testing.T) {
+		reg := newTestRegistry(t)
+		store := newTestInMemStore[testState]()
+		defineGatedAgent(t, reg, "researcher", store)
+
+		h, err := LookupAgent(reg, "researcher")
+		if err != nil {
+			t.Fatalf("LookupAgent: %v", err)
+		}
+		if got := h.Name(); got != "researcher" {
+			t.Errorf("Name() = %q, want %q", got, "researcher")
+		}
+		meta := h.Metadata()
+		if meta == nil {
+			t.Fatal("Metadata() = nil, want agent metadata")
+		}
+		if meta.StateManagement != AgentStateManagementServer {
+			t.Errorf("StateManagement = %q, want %q", meta.StateManagement, AgentStateManagementServer)
+		}
+		if !meta.Abortable {
+			t.Error("Abortable = false, want true (store implements SnapshotSubscriber)")
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		reg := newTestRegistry(t)
+		_, err := LookupAgent(reg, "ghost")
+		if !errors.Is(err, status.ErrNotFound) {
+			t.Fatalf("LookupAgent error = %v, want NOT_FOUND", err)
+		}
+	})
+
+	t.Run("registered under the agent key but not an agent", func(t *testing.T) {
+		reg := newTestRegistry(t)
+		core.NewActionOf(api.ActionTypeAgent, "impostor", nil,
+			func(ctx context.Context, in string) (string, error) { return in, nil },
+		).Register(reg)
+		_, err := LookupAgent(reg, "impostor")
+		if !errors.Is(err, status.ErrInvalidArgument) {
+			t.Fatalf("LookupAgent error = %v, want INVALID_ARGUMENT", err)
+		}
+	})
+}
+
+// fakeDescAction is an api.Action stub carrying only a descriptor, for
+// AgentMetadataOf's decode paths. The embedded nil interface covers the
+// methods AgentMetadataOf never calls.
+type fakeDescAction struct {
+	api.Action
+	desc api.ActionDesc
+}
+
+func (f fakeDescAction) Desc() api.ActionDesc { return f.desc }
+
+func TestAgentMetadataOf(t *testing.T) {
+	t.Run("nil action", func(t *testing.T) {
+		if got := AgentMetadataOf(nil); got != nil {
+			t.Fatalf("AgentMetadataOf(nil) = %+v, want nil", got)
+		}
+	})
+
+	t.Run("typed value from a live agent", func(t *testing.T) {
+		reg := newTestRegistry(t)
+		agent := defineEchoAgent(t, reg, "typed")
+		meta := AgentMetadataOf(agent)
+		if meta == nil {
+			t.Fatal("AgentMetadataOf = nil, want metadata")
+		}
+		if meta.StateManagement != AgentStateManagementClient {
+			t.Errorf("StateManagement = %q, want %q", meta.StateManagement, AgentStateManagementClient)
+		}
+		if meta.Abortable {
+			t.Error("Abortable = true, want false (no store)")
+		}
+	})
+
+	t.Run("pointer form", func(t *testing.T) {
+		a := fakeDescAction{desc: api.ActionDesc{Metadata: map[string]any{
+			"agent": &AgentMetadata{StateManagement: AgentStateManagementServer, Abortable: true},
+		}}}
+		meta := AgentMetadataOf(a)
+		if meta == nil || meta.StateManagement != AgentStateManagementServer || !meta.Abortable {
+			t.Fatalf("AgentMetadataOf = %+v, want server-managed abortable", meta)
+		}
+	})
+
+	t.Run("map form as decoded from a JSON descriptor", func(t *testing.T) {
+		// Round-trip a real agent's metadata through JSON so the map shape is
+		// exactly what a serialized descriptor yields.
+		reg := newTestRegistry(t)
+		agent := defineEchoAgent(t, reg, "wire")
+		b, err := json.Marshal(agent.Desc().Metadata)
+		if err != nil {
+			t.Fatalf("marshal metadata: %v", err)
+		}
+		var decoded map[string]any
+		if err := json.Unmarshal(b, &decoded); err != nil {
+			t.Fatalf("unmarshal metadata: %v", err)
+		}
+		meta := AgentMetadataOf(fakeDescAction{desc: api.ActionDesc{Metadata: decoded}})
+		if meta == nil {
+			t.Fatal("AgentMetadataOf = nil, want metadata decoded from map")
+		}
+		if meta.StateManagement != AgentStateManagementClient {
+			t.Errorf("StateManagement = %q, want %q", meta.StateManagement, AgentStateManagementClient)
+		}
+	})
+
+	t.Run("action without agent metadata", func(t *testing.T) {
+		a := fakeDescAction{desc: api.ActionDesc{Metadata: map[string]any{"other": true}}}
+		if got := AgentMetadataOf(a); got != nil {
+			t.Fatalf("AgentMetadataOf = %+v, want nil", got)
+		}
+	})
+}
+
+func TestAgentHandle_Run(t *testing.T) {
+	reg := newTestRegistry(t)
+	defineEchoAgent(t, reg, "echo")
+	h, err := LookupAgent(reg, "echo")
+	if err != nil {
+		t.Fatalf("LookupAgent: %v", err)
+	}
+
+	t.Run("plain turn", func(t *testing.T) {
+		out, err := h.Run(context.Background(), &AgentInput{Message: ai.NewUserTextMessage("hi")})
+		if err != nil {
+			t.Fatalf("Run: %v", err)
+		}
+		// History at respond time is the user message plus nothing else.
+		if got, want := out.Message.Text(), "echo:hi n:1"; got != want {
+			t.Errorf("Message.Text() = %q, want %q", got, want)
+		}
+		if out.State == nil || out.State.SessionID == "" {
+			t.Errorf("client-managed output should carry state with a session ID, got %+v", out.State)
+		}
+	})
+
+	t.Run("options seed init state", func(t *testing.T) {
+		seeded := &SessionState[json.RawMessage]{Messages: []*ai.Message{
+			ai.NewUserTextMessage("earlier question"),
+			ai.NewModelTextMessage("earlier answer"),
+		}}
+		out, err := h.Run(context.Background(),
+			&AgentInput{Message: ai.NewUserTextMessage("again")},
+			WithState(seeded))
+		if err != nil {
+			t.Fatalf("Run with WithState: %v", err)
+		}
+		// Two seeded messages plus this turn's user message.
+		if got, want := out.Message.Text(), "echo:again n:3"; got != want {
+			t.Errorf("Message.Text() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("rejects nil input", func(t *testing.T) {
+		_, err := h.Run(context.Background(), nil)
+		if !errors.Is(err, status.ErrInvalidArgument) {
+			t.Fatalf("Run(nil) error = %v, want INVALID_ARGUMENT", err)
+		}
+	})
+
+	t.Run("rejects duplicate options", func(t *testing.T) {
+		_, err := h.Run(context.Background(), &AgentInput{Message: ai.NewUserTextMessage("x")},
+			WithSessionID[json.RawMessage]("a"), WithSessionID[json.RawMessage]("b"))
+		if err == nil || !strings.Contains(err.Error(), "more than once") {
+			t.Fatalf("duplicate WithSessionID error = %v, want duplicate-option rejection", err)
+		}
+	})
+
+	t.Run("rejects mutually exclusive options", func(t *testing.T) {
+		_, err := h.Run(context.Background(), &AgentInput{Message: ai.NewUserTextMessage("x")},
+			WithState(&SessionState[json.RawMessage]{}), WithSessionID[json.RawMessage]("a"))
+		if err == nil || !strings.Contains(err.Error(), "mutually exclusive") {
+			t.Fatalf("WithState+WithSessionID error = %v, want mutual-exclusion rejection", err)
+		}
+	})
+}
+
+func TestAgentHandle_StartPollWaitTask(t *testing.T) {
+	// Full background lifecycle through the handle: launch, observe pending,
+	// rehydrate the task from nothing but its snapshot ID, and wait for the
+	// finalized snapshot.
+	reg := newTestRegistry(t)
+	store := newTestInMemStore[testState]()
+	_, entered, release := defineGatedAgent(t, reg, "worker", store)
+
+	h, err := LookupAgent(reg, "worker")
+	if err != nil {
+		t.Fatalf("LookupAgent: %v", err)
+	}
+
+	task, err := h.Start(context.Background(), &AgentInput{Message: ai.NewUserTextMessage("go")})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if task.SnapshotID() == "" {
+		t.Fatal("Start returned a task with no snapshot ID")
+	}
+
+	select {
+	case <-entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("background work did not start")
+	}
+
+	snap, err := task.Poll(context.Background())
+	if err != nil {
+		t.Fatalf("Poll: %v", err)
+	}
+	if snap.Status != SnapshotStatusPending {
+		t.Fatalf("Poll status = %q, want %q", snap.Status, SnapshotStatusPending)
+	}
+	if snap.Status.Terminal() {
+		t.Error("pending status reported as terminal")
+	}
+
+	// Rehydrate from the recorded ID alone, as a later process would.
+	h2, err := LookupAgent(reg, "worker")
+	if err != nil {
+		t.Fatalf("LookupAgent (rehydrate): %v", err)
+	}
+	rehydrated := h2.Task(task.SnapshotID())
+
+	close(release)
+	final, err := rehydrated.Wait(context.Background(), WithPollInterval(10*time.Millisecond))
+	if err != nil {
+		t.Fatalf("Wait: %v", err)
+	}
+	if final.Status != SnapshotStatusCompleted {
+		t.Fatalf("Wait status = %q, want %q", final.Status, SnapshotStatusCompleted)
+	}
+	if final.State == nil {
+		t.Fatal("finalized snapshot carries no state")
+	}
+	var custom testState
+	if err := json.Unmarshal(final.State.Custom, &custom); err != nil {
+		t.Fatalf("unmarshal custom state: %v", err)
+	}
+	if custom.Counter != 42 {
+		t.Errorf("custom counter = %d, want 42", custom.Counter)
+	}
+	if got, want := final.State.LastModelMessage().Text(), "finished"; got != want {
+		t.Errorf("LastModelMessage().Text() = %q, want %q", got, want)
+	}
+}
+
+func TestAgentHandle_StartRejected(t *testing.T) {
+	t.Run("client-managed agent cannot detach", func(t *testing.T) {
+		reg := newTestRegistry(t)
+		defineEchoAgent(t, reg, "storeless")
+		h, err := LookupAgent(reg, "storeless")
+		if err != nil {
+			t.Fatalf("LookupAgent: %v", err)
+		}
+		_, err = h.Start(context.Background(), &AgentInput{Message: ai.NewUserTextMessage("go")})
+		if err == nil {
+			t.Fatal("Start succeeded on a storeless agent, want rejection")
+		}
+		// The rejection is decoded from the invocation's failed output, so only
+		// the status name survives; match by status, not sentinel.
+		if got := status.Of(err); got != status.FailedPrecondition {
+			t.Fatalf("status.Of(err) = %v, want FAILED_PRECONDITION (err: %v)", got, err)
+		}
+	})
+
+	t.Run("store without subscriber cannot abort", func(t *testing.T) {
+		reg := newTestRegistry(t)
+		DefineCustomAgent(reg, "unabortable",
+			func(ctx context.Context, resp Responder, sess *SessionRunner[testState]) (*AgentResult, error) {
+				return nil, sess.Run(ctx, func(ctx context.Context, input *AgentInput) (*TurnResult, error) {
+					return nil, nil
+				})
+			},
+			WithSessionStore[testState](minimalStore[testState]{}),
+		)
+		h, err := LookupAgent(reg, "unabortable")
+		if err != nil {
+			t.Fatalf("LookupAgent: %v", err)
+		}
+		if meta := h.Metadata(); meta == nil || meta.Abortable {
+			t.Errorf("Metadata() = %+v, want non-abortable", meta)
+		}
+		_, err = h.Abort(context.Background(), "some-id")
+		if !errors.Is(err, status.ErrFailedPrecondition) || !strings.Contains(err.Error(), "SnapshotSubscriber") {
+			t.Fatalf("Abort error = %v, want FAILED_PRECONDITION naming SnapshotSubscriber", err)
+		}
+	})
+}
+
+func TestAgentHandle_AbortLifecycle(t *testing.T) {
+	// Launch through the typed bridge (Agent.Handle), abort the task, and
+	// observe the aborted snapshot through Wait; a second abort is a no-op
+	// reporting the settled status.
+	reg := newTestRegistry(t)
+	store := newTestInMemStore[testState]()
+	agent, entered, _ := defineGatedAgent(t, reg, "abortable", store)
+
+	h := agent.Handle()
+	task, err := h.Start(context.Background(), &AgentInput{Message: ai.NewUserTextMessage("go")})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	select {
+	case <-entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("background work did not start")
+	}
+
+	got, err := task.Abort(context.Background())
+	if err != nil {
+		t.Fatalf("Abort: %v", err)
+	}
+	if got != SnapshotStatusAborted {
+		t.Fatalf("Abort status = %q, want %q", got, SnapshotStatusAborted)
+	}
+
+	final, err := task.Wait(context.Background(), WithPollInterval(10*time.Millisecond))
+	if err != nil {
+		t.Fatalf("Wait after abort: %v", err)
+	}
+	if final.Status != SnapshotStatusAborted {
+		t.Fatalf("Wait status = %q, want %q", final.Status, SnapshotStatusAborted)
+	}
+
+	// Aborting a settled task reports the existing terminal status.
+	again, err := task.Abort(context.Background())
+	if err != nil {
+		t.Fatalf("second Abort: %v", err)
+	}
+	if again != SnapshotStatusAborted {
+		t.Fatalf("second Abort status = %q, want %q", again, SnapshotStatusAborted)
+	}
+
+	// Aborting an unknown snapshot is NOT_FOUND, matching the companion
+	// action; the in-process chain keeps the sentinel matchable.
+	if _, err := h.Abort(context.Background(), "does-not-exist"); !errors.Is(err, ErrSnapshotNotFound) {
+		t.Fatalf("Abort(unknown) error = %v, want ErrSnapshotNotFound", err)
+	}
+}
+
+func TestAgentHandle_SnapshotReadErrors(t *testing.T) {
+	t.Run("no session store", func(t *testing.T) {
+		reg := newTestRegistry(t)
+		defineEchoAgent(t, reg, "bare")
+		h, err := LookupAgent(reg, "bare")
+		if err != nil {
+			t.Fatalf("LookupAgent: %v", err)
+		}
+		if _, err := h.GetSnapshot(context.Background(), "any"); !errors.Is(err, ErrSessionStoreNotConfigured) {
+			t.Fatalf("GetSnapshot error = %v, want ErrSessionStoreNotConfigured", err)
+		}
+		if _, err := h.GetLatestSnapshot(context.Background(), "sess"); !errors.Is(err, ErrSessionStoreNotConfigured) {
+			t.Fatalf("GetLatestSnapshot error = %v, want ErrSessionStoreNotConfigured", err)
+		}
+		if _, err := h.Abort(context.Background(), "any"); !errors.Is(err, ErrSessionStoreNotConfigured) {
+			t.Fatalf("Abort error = %v, want ErrSessionStoreNotConfigured", err)
+		}
+	})
+
+	t.Run("empty IDs are invalid", func(t *testing.T) {
+		reg := newTestRegistry(t)
+		store := newTestInMemStore[testState]()
+		defineGatedAgent(t, reg, "ids", store)
+		h, err := LookupAgent(reg, "ids")
+		if err != nil {
+			t.Fatalf("LookupAgent: %v", err)
+		}
+		if _, err := h.GetSnapshot(context.Background(), ""); !errors.Is(err, status.ErrInvalidArgument) {
+			t.Fatalf("GetSnapshot(\"\") error = %v, want INVALID_ARGUMENT", err)
+		}
+		if _, err := h.GetLatestSnapshot(context.Background(), ""); !errors.Is(err, status.ErrInvalidArgument) {
+			t.Fatalf("GetLatestSnapshot(\"\") error = %v, want INVALID_ARGUMENT", err)
+		}
+		if _, err := h.Abort(context.Background(), ""); !errors.Is(err, status.ErrInvalidArgument) {
+			t.Fatalf("Abort(\"\") error = %v, want INVALID_ARGUMENT", err)
+		}
+	})
+
+	t.Run("missing snapshot is NOT_FOUND with a live sentinel", func(t *testing.T) {
+		reg := newTestRegistry(t)
+		store := newTestInMemStore[testState]()
+		defineGatedAgent(t, reg, "misses", store)
+		h, err := LookupAgent(reg, "misses")
+		if err != nil {
+			t.Fatalf("LookupAgent: %v", err)
+		}
+		if _, err := h.GetSnapshot(context.Background(), "nope"); !errors.Is(err, ErrSnapshotNotFound) {
+			t.Fatalf("GetSnapshot(missing) error = %v, want ErrSnapshotNotFound", err)
+		}
+		if _, err := h.Task("nope").Poll(context.Background()); !errors.Is(err, status.ErrNotFound) {
+			t.Fatalf("Poll(missing) error = %v, want NOT_FOUND", err)
+		}
+	})
+}

--- a/go/ai/exp/handle_test.go
+++ b/go/ai/exp/handle_test.go
@@ -328,7 +328,7 @@ func TestAgentHandle_StartPollWaitTask(t *testing.T) {
 	rehydrated := h2.Task(task.SnapshotID())
 
 	close(release)
-	final, err := rehydrated.Wait(context.Background(), WithPollInterval(10*time.Millisecond))
+	final, err := rehydrated.Wait(context.Background())
 	if err != nil {
 		t.Fatalf("Wait: %v", err)
 	}
@@ -420,7 +420,7 @@ func TestAgentHandle_AbortLifecycle(t *testing.T) {
 		t.Fatalf("Abort status = %q, want %q", got, SnapshotStatusAborted)
 	}
 
-	final, err := task.Wait(context.Background(), WithPollInterval(10*time.Millisecond))
+	final, err := task.Wait(context.Background())
 	if err != nil {
 		t.Fatalf("Wait after abort: %v", err)
 	}
@@ -531,7 +531,7 @@ func TestAgentHandle_StartSettledSynchronously(t *testing.T) {
 	}
 }
 
-func TestWaitOptionValidation(t *testing.T) {
+func TestWaitValidation(t *testing.T) {
 	reg := newTestRegistry(t)
 	store := newTestInMemStore[testState]()
 	defineGatedAgent(t, reg, "waiter", store)
@@ -539,15 +539,13 @@ func TestWaitOptionValidation(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LookupAgent: %v", err)
 	}
-	task := h.Task("irrelevant")
 
-	if _, err := task.Wait(context.Background(), WithPollInterval(0)); err == nil || !strings.Contains(err.Error(), "must be positive") {
-		t.Fatalf("Wait(WithPollInterval(0)) error = %v, want positivity rejection", err)
+	// An unknown snapshot has nothing to wait on, so the wait fails the way
+	// the read does rather than blocking until ctx ends.
+	if _, err := h.Task("no-such-snapshot").Wait(context.Background()); !errors.Is(err, ErrSnapshotNotFound) {
+		t.Fatalf("Wait on unknown snapshot error = %v, want ErrSnapshotNotFound", err)
 	}
-	if _, err := task.Wait(context.Background(), WithPollInterval(-time.Second)); err == nil || !strings.Contains(err.Error(), "must be positive") {
-		t.Fatalf("Wait(WithPollInterval(-1s)) error = %v, want positivity rejection", err)
-	}
-	if _, err := task.Wait(context.Background(), WithPollInterval(time.Second), WithPollInterval(2*time.Second)); err == nil || !strings.Contains(err.Error(), "more than once") {
-		t.Fatalf("duplicate WithPollInterval error = %v, want duplicate-option rejection", err)
+	if _, err := h.WaitForSnapshot(context.Background(), ""); !errors.Is(err, status.ErrInvalidArgument) {
+		t.Fatalf("WaitForSnapshot(\"\") error = %v, want INVALID_ARGUMENT", err)
 	}
 }

--- a/go/ai/exp/handle_test.go
+++ b/go/ai/exp/handle_test.go
@@ -91,10 +91,7 @@ func TestLookupAgent(t *testing.T) {
 		store := newTestInMemStore[testState]()
 		defineGatedAgent(t, reg, "researcher", store)
 
-		h, err := LookupAgent(reg, "researcher")
-		if err != nil {
-			t.Fatalf("LookupAgent: %v", err)
-		}
+		h := LookupAgent(reg, "researcher")
 		if got := h.Name(); got != "researcher" {
 			t.Errorf("Name() = %q, want %q", got, "researcher")
 		}
@@ -110,22 +107,33 @@ func TestLookupAgent(t *testing.T) {
 		}
 	})
 
-	t.Run("not found", func(t *testing.T) {
+	// Both misses answer nil, as every other Lookup in the framework does. The
+	// caller knows the name it asked for, so telling the two apart would add a
+	// distinction with one remedy.
+	t.Run("misses report nil", func(t *testing.T) {
 		reg := newTestRegistry(t)
-		_, err := LookupAgent(reg, "ghost")
-		if !errors.Is(err, status.ErrNotFound) {
-			t.Fatalf("LookupAgent error = %v, want NOT_FOUND", err)
+		if h := LookupAgent(reg, "ghost"); h != nil {
+			t.Errorf("LookupAgent(unregistered) = %+v, want nil", h)
 		}
-	})
 
-	t.Run("registered under the agent key but not an agent", func(t *testing.T) {
-		reg := newTestRegistry(t)
 		core.NewActionOf(api.ActionTypeAgent, "impostor", nil,
 			func(ctx context.Context, in string) (string, error) { return in, nil },
 		).Register(reg)
-		_, err := LookupAgent(reg, "impostor")
-		if !errors.Is(err, status.ErrInvalidArgument) {
-			t.Fatalf("LookupAgent error = %v, want INVALID_ARGUMENT", err)
+		if h := LookupAgent(reg, "impostor"); h != nil {
+			t.Errorf("LookupAgent(non-agent action) = %+v, want nil", h)
+		}
+	})
+
+	// A nil handle names its own cause rather than panicking, which is what a
+	// caller that skipped the nil check actually needs to read.
+	t.Run("nil handle reports itself", func(t *testing.T) {
+		var h *AgentHandle
+		_, err := h.Run(context.Background(), &AgentInput{Message: ai.NewUserTextMessage("hi")})
+		if !errors.Is(err, status.ErrInvalidArgument) || !strings.Contains(err.Error(), "nil handle") {
+			t.Errorf("Run on a nil handle = %v, want INVALID_ARGUMENT naming the nil handle", err)
+		}
+		if _, err := h.Start(context.Background(), &AgentInput{}); !errors.Is(err, status.ErrInvalidArgument) {
+			t.Errorf("Start on a nil handle = %v, want INVALID_ARGUMENT", err)
 		}
 	})
 }
@@ -237,10 +245,7 @@ func TestAgentMetadataOf(t *testing.T) {
 func TestAgentHandle_Run(t *testing.T) {
 	reg := newTestRegistry(t)
 	defineEchoAgent(t, reg, "echo")
-	h, err := LookupAgent(reg, "echo")
-	if err != nil {
-		t.Fatalf("LookupAgent: %v", err)
-	}
+	h := LookupAgent(reg, "echo")
 
 	t.Run("plain turn", func(t *testing.T) {
 		out, err := h.Run(context.Background(), &AgentInput{Message: ai.NewUserTextMessage("hi")})
@@ -305,10 +310,7 @@ func TestAgentHandle_StartPollWaitTask(t *testing.T) {
 	store := newTestInMemStore[testState]()
 	_, entered, release := defineGatedAgent(t, reg, "worker", store)
 
-	h, err := LookupAgent(reg, "worker")
-	if err != nil {
-		t.Fatalf("LookupAgent: %v", err)
-	}
+	h := LookupAgent(reg, "worker")
 
 	task, err := h.Start(context.Background(), &AgentInput{Message: ai.NewUserTextMessage("go")})
 	if err != nil {
@@ -336,10 +338,7 @@ func TestAgentHandle_StartPollWaitTask(t *testing.T) {
 	}
 
 	// Rehydrate from the recorded ID alone, as a later process would.
-	h2, err := LookupAgent(reg, "worker")
-	if err != nil {
-		t.Fatalf("LookupAgent (rehydrate): %v", err)
-	}
+	h2 := LookupAgent(reg, "worker")
 	rehydrated := h2.Task(task.SnapshotID())
 
 	close(release)
@@ -369,11 +368,8 @@ func TestAgentHandle_StartRejected(t *testing.T) {
 	t.Run("client-managed agent cannot detach", func(t *testing.T) {
 		reg := newTestRegistry(t)
 		defineEchoAgent(t, reg, "storeless")
-		h, err := LookupAgent(reg, "storeless")
-		if err != nil {
-			t.Fatalf("LookupAgent: %v", err)
-		}
-		_, err = h.Start(context.Background(), &AgentInput{Message: ai.NewUserTextMessage("go")})
+		h := LookupAgent(reg, "storeless")
+		_, err := h.Start(context.Background(), &AgentInput{Message: ai.NewUserTextMessage("go")})
 		if err == nil {
 			t.Fatal("Start succeeded on a storeless agent, want rejection")
 		}
@@ -394,14 +390,11 @@ func TestAgentHandle_StartRejected(t *testing.T) {
 			},
 			WithSessionStore[testState](minimalStore[testState]{}),
 		)
-		h, err := LookupAgent(reg, "unabortable")
-		if err != nil {
-			t.Fatalf("LookupAgent: %v", err)
-		}
+		h := LookupAgent(reg, "unabortable")
 		if meta := h.Metadata(); meta == nil || meta.Abortable {
 			t.Errorf("Metadata() = %+v, want non-abortable", meta)
 		}
-		_, err = h.Abort(context.Background(), "some-id")
+		_, err := h.Abort(context.Background(), "some-id")
 		if !errors.Is(err, status.ErrFailedPrecondition) || !strings.Contains(err.Error(), "SnapshotSubscriber") {
 			t.Fatalf("Abort error = %v, want FAILED_PRECONDITION naming SnapshotSubscriber", err)
 		}
@@ -463,10 +456,7 @@ func TestAgentHandle_SnapshotReadErrors(t *testing.T) {
 	t.Run("no session store", func(t *testing.T) {
 		reg := newTestRegistry(t)
 		defineEchoAgent(t, reg, "bare")
-		h, err := LookupAgent(reg, "bare")
-		if err != nil {
-			t.Fatalf("LookupAgent: %v", err)
-		}
+		h := LookupAgent(reg, "bare")
 		if _, err := h.GetSnapshot(context.Background(), "any"); !errors.Is(err, ErrSessionStoreNotConfigured) {
 			t.Fatalf("GetSnapshot error = %v, want ErrSessionStoreNotConfigured", err)
 		}
@@ -482,10 +472,7 @@ func TestAgentHandle_SnapshotReadErrors(t *testing.T) {
 		reg := newTestRegistry(t)
 		store := newTestInMemStore[testState]()
 		defineGatedAgent(t, reg, "ids", store)
-		h, err := LookupAgent(reg, "ids")
-		if err != nil {
-			t.Fatalf("LookupAgent: %v", err)
-		}
+		h := LookupAgent(reg, "ids")
 		if _, err := h.GetSnapshot(context.Background(), ""); !errors.Is(err, status.ErrInvalidArgument) {
 			t.Fatalf("GetSnapshot(\"\") error = %v, want INVALID_ARGUMENT", err)
 		}
@@ -501,10 +488,7 @@ func TestAgentHandle_SnapshotReadErrors(t *testing.T) {
 		reg := newTestRegistry(t)
 		store := newTestInMemStore[testState]()
 		defineGatedAgent(t, reg, "misses", store)
-		h, err := LookupAgent(reg, "misses")
-		if err != nil {
-			t.Fatalf("LookupAgent: %v", err)
-		}
+		h := LookupAgent(reg, "misses")
 		if _, err := h.GetSnapshot(context.Background(), "nope"); !errors.Is(err, ErrSnapshotNotFound) {
 			t.Fatalf("GetSnapshot(missing) error = %v, want ErrSnapshotNotFound", err)
 		}
@@ -550,10 +534,7 @@ func TestWaitValidation(t *testing.T) {
 	reg := newTestRegistry(t)
 	store := newTestInMemStore[testState]()
 	defineGatedAgent(t, reg, "waiter", store)
-	h, err := LookupAgent(reg, "waiter")
-	if err != nil {
-		t.Fatalf("LookupAgent: %v", err)
-	}
+	h := LookupAgent(reg, "waiter")
 
 	// An unknown snapshot has nothing to wait on, so the wait fails the way
 	// the read does rather than blocking until ctx ends.

--- a/go/ai/exp/handle_test.go
+++ b/go/ai/exp/handle_test.go
@@ -21,7 +21,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -560,5 +562,167 @@ func TestWaitValidation(t *testing.T) {
 	}
 	if _, err := h.WaitForSnapshot(context.Background(), ""); !errors.Is(err, status.ErrInvalidArgument) {
 		t.Fatalf("WaitForSnapshot(\"\") error = %v, want INVALID_ARGUMENT", err)
+	}
+}
+
+// recordingTransport is an [agentTransport] that records what reached it and
+// answers from canned values. It is how the delegation tests see the seam: a
+// real transport would prove only that the call worked, not which arguments
+// the handle chose to send.
+type recordingTransport struct {
+	runInput  *AgentInput
+	runInit   *AgentInit[json.RawMessage]
+	runHasCB  bool
+	lookup    *GetSnapshotRequest
+	waitID    string
+	abortID   string
+	callCount int
+}
+
+func (t *recordingTransport) Run(ctx context.Context, input *AgentInput, init *AgentInit[json.RawMessage], cb func(context.Context, json.RawMessage) error) (*AgentOutput[json.RawMessage], error) {
+	t.callCount++
+	t.runInput, t.runInit, t.runHasCB = input, init, cb != nil
+	return &AgentOutput[json.RawMessage]{FinishReason: AgentFinishReasonStop}, nil
+}
+
+func (t *recordingTransport) GetSnapshot(ctx context.Context, lookup *GetSnapshotRequest) (*SessionSnapshot[json.RawMessage], error) {
+	t.callCount++
+	t.lookup = lookup
+	return &SessionSnapshot[json.RawMessage]{Status: SnapshotStatusCompleted}, nil
+}
+
+func (t *recordingTransport) WaitForSnapshot(ctx context.Context, snapshotID string) (*SessionSnapshot[json.RawMessage], error) {
+	t.callCount++
+	t.waitID = snapshotID
+	return &SessionSnapshot[json.RawMessage]{Status: SnapshotStatusCompleted}, nil
+}
+
+func (t *recordingTransport) Abort(ctx context.Context, snapshotID string) (SnapshotStatus, error) {
+	t.callCount++
+	t.abortID = snapshotID
+	return SnapshotStatusAborted, nil
+}
+
+// TestAgentHandle_DelegatesToTransport pins the division of labour the seam
+// exists to create. The handle resolves options and validates arguments; the
+// transport receives a request that is already well formed and decides nothing
+// about it. A remote transport can only be a drop-in if that line holds.
+func TestAgentHandle_DelegatesToTransport(t *testing.T) {
+	tr := &recordingTransport{}
+	h := &AgentHandle{name: "researcher", transport: tr}
+	ctx := context.Background()
+
+	// One transport read serves both lookups, which is why it takes the
+	// request rather than splitting into two methods.
+	if _, err := h.GetSnapshot(ctx, "snap-1"); err != nil {
+		t.Fatalf("GetSnapshot: %v", err)
+	}
+	if tr.lookup.SnapshotID != "snap-1" || tr.lookup.SessionID != "" {
+		t.Errorf("GetSnapshot sent %+v, want a snapshot-ID lookup", tr.lookup)
+	}
+	if _, err := h.GetLatestSnapshot(ctx, "sess-1"); err != nil {
+		t.Fatalf("GetLatestSnapshot: %v", err)
+	}
+	if tr.lookup.SessionID != "sess-1" || tr.lookup.SnapshotID != "" {
+		t.Errorf("GetLatestSnapshot sent %+v, want a session-ID lookup", tr.lookup)
+	}
+
+	if _, err := h.WaitForSnapshot(ctx, "snap-2"); err != nil {
+		t.Fatalf("WaitForSnapshot: %v", err)
+	}
+	if tr.waitID != "snap-2" {
+		t.Errorf("WaitForSnapshot sent %q, want %q", tr.waitID, "snap-2")
+	}
+
+	if _, err := h.Abort(ctx, "snap-3"); err != nil {
+		t.Fatalf("Abort: %v", err)
+	}
+	if tr.abortID != "snap-3" {
+		t.Errorf("Abort sent %q, want %q", tr.abortID, "snap-3")
+	}
+
+	// Options are the handle's to resolve: a transport sees a settled init,
+	// never the option values, so every transport agrees on what they mean.
+	if _, err := h.Run(ctx, &AgentInput{Message: ai.NewUserTextMessage("hi")},
+		WithSessionID[json.RawMessage]("sess-9")); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if tr.runInit == nil || tr.runInit.SessionID != "sess-9" {
+		t.Errorf("Run sent init %+v, want the resolved session ID", tr.runInit)
+	}
+	if tr.runHasCB {
+		t.Error("Run passed a stream callback; the handle reports a turn by its final output")
+	}
+
+	// Validation is the handle's too, so a bad argument costs no dispatch and
+	// fails identically wherever the agent lives.
+	before := tr.callCount
+	for _, tc := range []struct {
+		name string
+		call func() error
+	}{
+		{"nil input", func() error { _, err := h.Run(ctx, nil); return err }},
+		{"empty snapshot ID", func() error { _, err := h.GetSnapshot(ctx, ""); return err }},
+		{"empty wait ID", func() error { _, err := h.WaitForSnapshot(ctx, ""); return err }},
+		{"empty session ID", func() error { _, err := h.GetLatestSnapshot(ctx, ""); return err }},
+		{"empty abort ID", func() error { _, err := h.Abort(ctx, ""); return err }},
+	} {
+		if err := tc.call(); !errors.Is(err, status.ErrInvalidArgument) {
+			t.Errorf("%s: error = %v, want INVALID_ARGUMENT", tc.name, err)
+		}
+	}
+	if tr.callCount != before {
+		t.Errorf("%d rejected calls reached the transport", tr.callCount-before)
+	}
+}
+
+// TestActionTransportForwardsStreamChunks covers the one transport argument
+// nothing above reaches: [AgentHandle] passes no stream callback today, so
+// only a direct dispatch shows the parameter is wired rather than decorative.
+// It is in the interface now because a turn streams at this level whatever
+// carries it, and adding it later would reshape the seam.
+func TestActionTransportForwardsStreamChunks(t *testing.T) {
+	reg := newTestRegistry(t)
+	agent := DefineCustomAgent(reg, "streamer",
+		func(ctx context.Context, resp Responder, sess *SessionRunner[any]) (*AgentResult, error) {
+			if err := sess.Run(ctx, func(ctx context.Context, input *AgentInput) (*TurnResult, error) {
+				for _, word := range []string{"one", "two"} {
+					resp.SendModelChunk(&ai.ModelResponseChunk{Content: []*ai.Part{ai.NewTextPart(word)}})
+				}
+				sess.AddMessages(ai.NewModelTextMessage("done"))
+				return nil, nil
+			}); err != nil {
+				return nil, err
+			}
+			return sess.Result(), nil
+		})
+
+	var mu sync.Mutex
+	var streamed []string
+	transport := &actionTransport{name: "streamer", run: agent}
+	out, err := transport.Run(context.Background(), &AgentInput{Message: ai.NewUserTextMessage("go")}, nil,
+		func(ctx context.Context, raw json.RawMessage) error {
+			var chunk AgentStreamChunk
+			if err := json.Unmarshal(raw, &chunk); err != nil {
+				return err
+			}
+			if chunk.ModelChunk == nil {
+				return nil
+			}
+			mu.Lock()
+			defer mu.Unlock()
+			streamed = append(streamed, chunk.ModelChunk.Text())
+			return nil
+		})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if out.Message.Text() != "done" {
+		t.Errorf("Message.Text() = %q, want %q", out.Message.Text(), "done")
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if want := []string{"one", "two"}; !slices.Equal(streamed, want) {
+		t.Errorf("streamed chunks = %q, want %q", streamed, want)
 	}
 }

--- a/go/ai/exp/handle_test.go
+++ b/go/ai/exp/handle_test.go
@@ -707,3 +707,18 @@ func TestActionTransportForwardsStreamChunks(t *testing.T) {
 		t.Errorf("streamed chunks = %q, want %q", streamed, want)
 	}
 }
+
+func TestAgentHandle_MetadataKeepsEagerValue(t *testing.T) {
+	// A transport with no api.Action to derive metadata from (the shape a
+	// remote handle takes) sets meta at construction and leaves metaSrc nil.
+	// The lazy derivation must not run over the nil source and clobber the
+	// eager value back to nil.
+	meta := &AgentMetadata{StateManagement: AgentStateManagementServer, Abortable: true}
+	h := &AgentHandle{name: "remote", meta: meta}
+	for i := 0; i < 2; i++ {
+		got := h.Metadata()
+		if got == nil || got.StateManagement != AgentStateManagementServer || !got.Abortable {
+			t.Fatalf("Metadata() call %d = %+v, want the eagerly set metadata kept", i+1, got)
+		}
+	}
+}

--- a/go/ai/exp/handle_test.go
+++ b/go/ai/exp/handle_test.go
@@ -139,8 +139,8 @@ func TestLookupAgent(t *testing.T) {
 }
 
 // fakeDescAction is an api.Action stub carrying only a descriptor, for
-// AgentMetadataOf's decode paths. The embedded nil interface covers the
-// methods AgentMetadataOf never calls.
+// agentMetadataOf's decode paths. The embedded nil interface covers the
+// methods agentMetadataOf never calls.
 type fakeDescAction struct {
 	api.Action
 	desc api.ActionDesc
@@ -150,17 +150,17 @@ func (f fakeDescAction) Desc() api.ActionDesc { return f.desc }
 
 func TestAgentMetadataOf(t *testing.T) {
 	t.Run("nil action", func(t *testing.T) {
-		if got := AgentMetadataOf(nil); got != nil {
-			t.Fatalf("AgentMetadataOf(nil) = %+v, want nil", got)
+		if got := agentMetadataOf(nil); got != nil {
+			t.Fatalf("agentMetadataOf(nil) = %+v, want nil", got)
 		}
 	})
 
 	t.Run("typed value from a live agent", func(t *testing.T) {
 		reg := newTestRegistry(t)
 		agent := defineEchoAgent(t, reg, "typed")
-		meta := AgentMetadataOf(agent)
+		meta := agentMetadataOf(agent)
 		if meta == nil {
-			t.Fatal("AgentMetadataOf = nil, want metadata")
+			t.Fatal("agentMetadataOf = nil, want metadata")
 		}
 		if meta.StateManagement != AgentStateManagementClient {
 			t.Errorf("StateManagement = %q, want %q", meta.StateManagement, AgentStateManagementClient)
@@ -174,9 +174,9 @@ func TestAgentMetadataOf(t *testing.T) {
 		a := fakeDescAction{desc: api.ActionDesc{Metadata: map[string]any{
 			"agent": &AgentMetadata{StateManagement: AgentStateManagementServer, Abortable: true},
 		}}}
-		meta := AgentMetadataOf(a)
+		meta := agentMetadataOf(a)
 		if meta == nil || meta.StateManagement != AgentStateManagementServer || !meta.Abortable {
-			t.Fatalf("AgentMetadataOf = %+v, want server-managed abortable", meta)
+			t.Fatalf("agentMetadataOf = %+v, want server-managed abortable", meta)
 		}
 	})
 
@@ -193,9 +193,9 @@ func TestAgentMetadataOf(t *testing.T) {
 		if err := json.Unmarshal(b, &decoded); err != nil {
 			t.Fatalf("unmarshal metadata: %v", err)
 		}
-		meta := AgentMetadataOf(fakeDescAction{desc: api.ActionDesc{Metadata: decoded}})
+		meta := agentMetadataOf(fakeDescAction{desc: api.ActionDesc{Metadata: decoded}})
 		if meta == nil {
-			t.Fatal("AgentMetadataOf = nil, want metadata decoded from map")
+			t.Fatal("agentMetadataOf = nil, want metadata decoded from map")
 		}
 		if meta.StateManagement != AgentStateManagementClient {
 			t.Errorf("StateManagement = %q, want %q", meta.StateManagement, AgentStateManagementClient)
@@ -211,8 +211,8 @@ func TestAgentMetadataOf(t *testing.T) {
 		a := fakeDescAction{desc: api.ActionDesc{Metadata: map[string]any{
 			"agent": map[string]any{"stateManagement": "client", "abortable": "true"},
 		}}}
-		if meta := AgentMetadataOf(a); meta != nil {
-			t.Fatalf("AgentMetadataOf = %+v, want nil for a descriptor that did not decode", meta)
+		if meta := agentMetadataOf(a); meta != nil {
+			t.Fatalf("agentMetadataOf = %+v, want nil for a descriptor that did not decode", meta)
 		}
 	})
 
@@ -223,9 +223,9 @@ func TestAgentMetadataOf(t *testing.T) {
 		desc := api.ActionDesc{Metadata: map[string]any{
 			"agent": AgentMetadata{StateSchema: map[string]any{"type": "object"}},
 		}}
-		meta := AgentMetadataOf(fakeDescAction{desc: desc})
+		meta := agentMetadataOf(fakeDescAction{desc: desc})
 		if meta == nil {
-			t.Fatal("AgentMetadataOf = nil, want typed metadata")
+			t.Fatal("agentMetadataOf = nil, want typed metadata")
 		}
 		meta.StateSchema["type"] = "tampered"
 		original := desc.Metadata["agent"].(AgentMetadata)
@@ -236,8 +236,8 @@ func TestAgentMetadataOf(t *testing.T) {
 
 	t.Run("action without agent metadata", func(t *testing.T) {
 		a := fakeDescAction{desc: api.ActionDesc{Metadata: map[string]any{"other": true}}}
-		if got := AgentMetadataOf(a); got != nil {
-			t.Fatalf("AgentMetadataOf = %+v, want nil", got)
+		if got := agentMetadataOf(a); got != nil {
+			t.Fatalf("agentMetadataOf = %+v, want nil", got)
 		}
 	})
 }

--- a/go/ai/exp/option.go
+++ b/go/ai/exp/option.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"time"
 )
 
 // --- AgentOption ---
@@ -373,44 +372,4 @@ func resolveInvocationInit[State any](name string, opts []InvocationOption[State
 		SnapshotID: invOpts.snapshotID,
 		State:      invOpts.state,
 	}, nil
-}
-
-// --- WaitOption ---
-
-// WaitOption configures [DetachedTask.Wait].
-type WaitOption interface {
-	applyWait(*waitOptions) error
-}
-
-type waitOptions struct {
-	pollInterval time.Duration
-	// pollIntervalSet records that WithPollInterval was used, independent of
-	// the value, so a non-positive interval is rejected rather than silently
-	// falling back to the default, and duplicates are counted whatever their
-	// values (mirrors sessionIDSet above).
-	pollIntervalSet bool
-}
-
-// applyWait merges o into opts, rejecting a non-positive interval and
-// duplicate options.
-func (o *waitOptions) applyWait(opts *waitOptions) error {
-	if o.pollIntervalSet {
-		if o.pollInterval <= 0 {
-			return errors.New("poll interval must be positive (WithPollInterval)")
-		}
-		if opts.pollIntervalSet {
-			return errors.New("cannot set poll interval more than once (WithPollInterval)")
-		}
-		opts.pollInterval = o.pollInterval
-		opts.pollIntervalSet = true
-	}
-	return nil
-}
-
-// WithPollInterval sets how often [DetachedTask.Wait] re-reads the task's
-// snapshot while it is pending. The default is 2 seconds; d must be positive.
-// Each read is one getSnapshot companion-action call, so pick an interval the
-// agent's session store can absorb.
-func WithPollInterval(d time.Duration) WaitOption {
-	return &waitOptions{pollInterval: d, pollIntervalSet: true}
 }

--- a/go/ai/exp/option.go
+++ b/go/ai/exp/option.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"time"
 )
 
 // --- AgentOption ---
@@ -371,44 +370,4 @@ func resolveInvocationInit[State any](name string, opts []InvocationOption[State
 		SnapshotID: invOpts.snapshotID,
 		State:      invOpts.state,
 	}, nil
-}
-
-// --- WaitOption ---
-
-// WaitOption configures [DetachedTask.Wait].
-type WaitOption interface {
-	applyWait(*waitOptions) error
-}
-
-type waitOptions struct {
-	pollInterval time.Duration
-	// pollIntervalSet records that WithPollInterval was used, independent of
-	// the value, so a non-positive interval is rejected rather than silently
-	// falling back to the default, and duplicates are counted whatever their
-	// values (mirrors sessionIDSet above).
-	pollIntervalSet bool
-}
-
-// applyWait merges o into opts, rejecting a non-positive interval and
-// duplicate options.
-func (o *waitOptions) applyWait(opts *waitOptions) error {
-	if o.pollIntervalSet {
-		if o.pollInterval <= 0 {
-			return errors.New("poll interval must be positive (WithPollInterval)")
-		}
-		if opts.pollIntervalSet {
-			return errors.New("cannot set poll interval more than once (WithPollInterval)")
-		}
-		opts.pollInterval = o.pollInterval
-		opts.pollIntervalSet = true
-	}
-	return nil
-}
-
-// WithPollInterval sets how often [DetachedTask.Wait] re-reads the task's
-// snapshot while it is pending. The default is 2 seconds; d must be positive.
-// Each read is one getSnapshot companion-action call, so pick an interval the
-// agent's session store can absorb.
-func WithPollInterval(d time.Duration) WaitOption {
-	return &waitOptions{pollInterval: d, pollIntervalSet: true}
 }

--- a/go/ai/exp/option.go
+++ b/go/ai/exp/option.go
@@ -342,6 +342,11 @@ func WithSessionID[State any](id string) InvocationOption[State] {
 // resolveOptions) and [AgentHandle.Run], so typed and untyped callers reject
 // the same inputs with the same wording; name is the agent's, woven into the
 // errors.
+//
+// It returns (nil, nil) when no option set anything: "no init" is decided
+// here, next to the merge a new option must extend, so a caller-side field
+// check cannot silently drop a future [AgentInit] field. A nil init runs the
+// invocation with a fresh session, identical to a zero-valued one.
 func resolveInvocationInit[State any](name string, opts []InvocationOption[State]) (*AgentInit[State], error) {
 	invOpts := &invocationOptions[State]{}
 	for _, opt := range opts {
@@ -355,6 +360,10 @@ func resolveInvocationInit[State any](name string, opts []InvocationOption[State
 	}
 	if invOpts.state != nil && invOpts.sessionIDSet {
 		return nil, fmt.Errorf("Agent %q: WithState and WithSessionID are mutually exclusive; the conversation's identity rides inside the state (SessionState.SessionID)", name)
+	}
+
+	if invOpts.state == nil && invOpts.snapshotID == "" && !invOpts.sessionIDSet {
+		return nil, nil
 	}
 
 	return &AgentInit[State]{
@@ -373,19 +382,25 @@ type WaitOption interface {
 
 type waitOptions struct {
 	pollInterval time.Duration
+	// pollIntervalSet records that WithPollInterval was used, independent of
+	// the value, so a non-positive interval is rejected rather than silently
+	// falling back to the default, and duplicates are counted whatever their
+	// values (mirrors sessionIDSet above).
+	pollIntervalSet bool
 }
 
 // applyWait merges o into opts, rejecting a non-positive interval and
 // duplicate options.
 func (o *waitOptions) applyWait(opts *waitOptions) error {
-	if o.pollInterval != 0 {
-		if o.pollInterval < 0 {
+	if o.pollIntervalSet {
+		if o.pollInterval <= 0 {
 			return errors.New("poll interval must be positive (WithPollInterval)")
 		}
-		if opts.pollInterval != 0 {
+		if opts.pollIntervalSet {
 			return errors.New("cannot set poll interval more than once (WithPollInterval)")
 		}
 		opts.pollInterval = o.pollInterval
+		opts.pollIntervalSet = true
 	}
 	return nil
 }
@@ -395,5 +410,5 @@ func (o *waitOptions) applyWait(opts *waitOptions) error {
 // Each read is one getSnapshot companion-action call, so pick an interval the
 // agent's session store can absorb.
 func WithPollInterval(d time.Duration) WaitOption {
-	return &waitOptions{pollInterval: d}
+	return &waitOptions{pollInterval: d, pollIntervalSet: true}
 }

--- a/go/ai/exp/option.go
+++ b/go/ai/exp/option.go
@@ -19,6 +19,8 @@ package exp
 import (
 	"context"
 	"errors"
+	"fmt"
+	"time"
 )
 
 // --- AgentOption ---
@@ -332,4 +334,68 @@ func WithSnapshotID[State any](id string) InvocationOption[State] {
 // error, not a no-op.
 func WithSessionID[State any](id string) InvocationOption[State] {
 	return &invocationOptions[State]{sessionID: id, sessionIDSet: true}
+}
+
+// resolveInvocationInit merges opts into the invocation's [AgentInit],
+// enforcing the per-option duplicate checks and the mutual-exclusivity rules:
+// WithState excludes both WithSessionID and WithSnapshotID (a client-managed
+// conversation's identity rides inside the state itself), while WithSessionID
+// and WithSnapshotID compose as an assertion. Shared by [Agent.Connect] (via
+// resolveOptions) and [AgentHandle.Run], so typed and untyped callers reject
+// the same inputs with the same wording; name is the agent's, woven into the
+// errors.
+func resolveInvocationInit[State any](name string, opts []InvocationOption[State]) (*AgentInit[State], error) {
+	invOpts := &invocationOptions[State]{}
+	for _, opt := range opts {
+		if err := opt.applyInvocation(invOpts); err != nil {
+			return nil, fmt.Errorf("Agent %q: %w", name, err)
+		}
+	}
+
+	if invOpts.state != nil && invOpts.snapshotID != "" {
+		return nil, fmt.Errorf("Agent %q: WithState and WithSnapshotID are mutually exclusive", name)
+	}
+	if invOpts.state != nil && invOpts.sessionIDSet {
+		return nil, fmt.Errorf("Agent %q: WithState and WithSessionID are mutually exclusive; the conversation's identity rides inside the state (SessionState.SessionID)", name)
+	}
+
+	return &AgentInit[State]{
+		SessionID:  invOpts.sessionID,
+		SnapshotID: invOpts.snapshotID,
+		State:      invOpts.state,
+	}, nil
+}
+
+// --- WaitOption ---
+
+// WaitOption configures [DetachedTask.Wait].
+type WaitOption interface {
+	applyWait(*waitOptions) error
+}
+
+type waitOptions struct {
+	pollInterval time.Duration
+}
+
+// applyWait merges o into opts, rejecting a non-positive interval and
+// duplicate options.
+func (o *waitOptions) applyWait(opts *waitOptions) error {
+	if o.pollInterval != 0 {
+		if o.pollInterval < 0 {
+			return errors.New("poll interval must be positive (WithPollInterval)")
+		}
+		if opts.pollInterval != 0 {
+			return errors.New("cannot set poll interval more than once (WithPollInterval)")
+		}
+		opts.pollInterval = o.pollInterval
+	}
+	return nil
+}
+
+// WithPollInterval sets how often [DetachedTask.Wait] re-reads the task's
+// snapshot while it is pending. The default is 2 seconds; d must be positive.
+// Each read is one getSnapshot companion-action call, so pick an interval the
+// agent's session store can absorb.
+func WithPollInterval(d time.Duration) WaitOption {
+	return &waitOptions{pollInterval: d}
 }

--- a/go/ai/exp/option.go
+++ b/go/ai/exp/option.go
@@ -266,7 +266,7 @@ type invocationOptions[State any] struct {
 // applyInvocation merges o into opts, rejecting duplicate options.
 // Mutual exclusivity (WithState versus WithSessionID/WithSnapshotID) is
 // checked once, after all options are applied, in
-// [Agent.resolveOptions].
+// resolveInvocationInit.
 func (o *invocationOptions[State]) applyInvocation(opts *invocationOptions[State]) error {
 	if o.state != nil {
 		if opts.state != nil {
@@ -339,10 +339,9 @@ func WithSessionID[State any](id string) InvocationOption[State] {
 // enforcing the per-option duplicate checks and the mutual-exclusivity rules:
 // WithState excludes both WithSessionID and WithSnapshotID (a client-managed
 // conversation's identity rides inside the state itself), while WithSessionID
-// and WithSnapshotID compose as an assertion. Shared by [Agent.Connect] (via
-// resolveOptions) and [AgentHandle.Run], so typed and untyped callers reject
-// the same inputs with the same wording; name is the agent's, woven into the
-// errors.
+// and WithSnapshotID compose as an assertion. Shared by [Agent.Connect] and
+// [AgentHandle.Run], so typed and untyped callers reject the same inputs with
+// the same wording; name is the agent's, woven into the errors.
 //
 // It returns (nil, nil) when no option set anything: "no init" is decided
 // here, next to the merge a new option must extend, so a caller-side field

--- a/go/ai/exp/option.go
+++ b/go/ai/exp/option.go
@@ -266,7 +266,7 @@ type invocationOptions[State any] struct {
 // applyInvocation merges o into opts, rejecting duplicate options.
 // Mutual exclusivity (WithState versus WithSessionID/WithSnapshotID) is
 // checked once, after all options are applied, in
-// [Agent.resolveOptions].
+// resolveInvocationInit.
 func (o *invocationOptions[State]) applyInvocation(opts *invocationOptions[State]) error {
 	if o.state != nil {
 		if opts.state != nil {
@@ -337,10 +337,9 @@ func WithSessionID[State any](id string) InvocationOption[State] {
 // enforcing the per-option duplicate checks and the mutual-exclusivity rules:
 // WithState excludes both WithSessionID and WithSnapshotID (a client-managed
 // conversation's identity rides inside the state itself), while WithSessionID
-// and WithSnapshotID compose as an assertion. Shared by [Agent.Connect] (via
-// resolveOptions) and [AgentHandle.Run], so typed and untyped callers reject
-// the same inputs with the same wording; name is the agent's, woven into the
-// errors.
+// and WithSnapshotID compose as an assertion. Shared by [Agent.Connect] and
+// [AgentHandle.Run], so typed and untyped callers reject the same inputs with
+// the same wording; name is the agent's, woven into the errors.
 //
 // It returns (nil, nil) when no option set anything: "no init" is decided
 // here, next to the merge a new option must extend, so a caller-side field

--- a/go/ai/exp/option.go
+++ b/go/ai/exp/option.go
@@ -344,6 +344,11 @@ func WithSessionID[State any](id string) InvocationOption[State] {
 // resolveOptions) and [AgentHandle.Run], so typed and untyped callers reject
 // the same inputs with the same wording; name is the agent's, woven into the
 // errors.
+//
+// It returns (nil, nil) when no option set anything: "no init" is decided
+// here, next to the merge a new option must extend, so a caller-side field
+// check cannot silently drop a future [AgentInit] field. A nil init runs the
+// invocation with a fresh session, identical to a zero-valued one.
 func resolveInvocationInit[State any](name string, opts []InvocationOption[State]) (*AgentInit[State], error) {
 	invOpts := &invocationOptions[State]{}
 	for _, opt := range opts {
@@ -357,6 +362,10 @@ func resolveInvocationInit[State any](name string, opts []InvocationOption[State
 	}
 	if invOpts.state != nil && invOpts.sessionIDSet {
 		return nil, fmt.Errorf("Agent %q: WithState and WithSessionID are mutually exclusive; the conversation's identity rides inside the state (SessionState.SessionID)", name)
+	}
+
+	if invOpts.state == nil && invOpts.snapshotID == "" && !invOpts.sessionIDSet {
+		return nil, nil
 	}
 
 	return &AgentInit[State]{
@@ -375,19 +384,25 @@ type WaitOption interface {
 
 type waitOptions struct {
 	pollInterval time.Duration
+	// pollIntervalSet records that WithPollInterval was used, independent of
+	// the value, so a non-positive interval is rejected rather than silently
+	// falling back to the default, and duplicates are counted whatever their
+	// values (mirrors sessionIDSet above).
+	pollIntervalSet bool
 }
 
 // applyWait merges o into opts, rejecting a non-positive interval and
 // duplicate options.
 func (o *waitOptions) applyWait(opts *waitOptions) error {
-	if o.pollInterval != 0 {
-		if o.pollInterval < 0 {
+	if o.pollIntervalSet {
+		if o.pollInterval <= 0 {
 			return errors.New("poll interval must be positive (WithPollInterval)")
 		}
-		if opts.pollInterval != 0 {
+		if opts.pollIntervalSet {
 			return errors.New("cannot set poll interval more than once (WithPollInterval)")
 		}
 		opts.pollInterval = o.pollInterval
+		opts.pollIntervalSet = true
 	}
 	return nil
 }
@@ -397,5 +412,5 @@ func (o *waitOptions) applyWait(opts *waitOptions) error {
 // Each read is one getSnapshot companion-action call, so pick an interval the
 // agent's session store can absorb.
 func WithPollInterval(d time.Duration) WaitOption {
-	return &waitOptions{pollInterval: d}
+	return &waitOptions{pollInterval: d, pollIntervalSet: true}
 }

--- a/go/ai/exp/option.go
+++ b/go/ai/exp/option.go
@@ -19,6 +19,8 @@ package exp
 import (
 	"context"
 	"errors"
+	"fmt"
+	"time"
 )
 
 // --- AgentOption ---
@@ -330,4 +332,68 @@ func WithSnapshotID[State any](id string) InvocationOption[State] {
 // empty ID is an error, not a no-op.
 func WithSessionID[State any](id string) InvocationOption[State] {
 	return &invocationOptions[State]{sessionID: id, sessionIDSet: true}
+}
+
+// resolveInvocationInit merges opts into the invocation's [AgentInit],
+// enforcing the per-option duplicate checks and the mutual-exclusivity rules:
+// WithState excludes both WithSessionID and WithSnapshotID (a client-managed
+// conversation's identity rides inside the state itself), while WithSessionID
+// and WithSnapshotID compose as an assertion. Shared by [Agent.Connect] (via
+// resolveOptions) and [AgentHandle.Run], so typed and untyped callers reject
+// the same inputs with the same wording; name is the agent's, woven into the
+// errors.
+func resolveInvocationInit[State any](name string, opts []InvocationOption[State]) (*AgentInit[State], error) {
+	invOpts := &invocationOptions[State]{}
+	for _, opt := range opts {
+		if err := opt.applyInvocation(invOpts); err != nil {
+			return nil, fmt.Errorf("Agent %q: %w", name, err)
+		}
+	}
+
+	if invOpts.state != nil && invOpts.snapshotID != "" {
+		return nil, fmt.Errorf("Agent %q: WithState and WithSnapshotID are mutually exclusive", name)
+	}
+	if invOpts.state != nil && invOpts.sessionIDSet {
+		return nil, fmt.Errorf("Agent %q: WithState and WithSessionID are mutually exclusive; the conversation's identity rides inside the state (SessionState.SessionID)", name)
+	}
+
+	return &AgentInit[State]{
+		SessionID:  invOpts.sessionID,
+		SnapshotID: invOpts.snapshotID,
+		State:      invOpts.state,
+	}, nil
+}
+
+// --- WaitOption ---
+
+// WaitOption configures [DetachedTask.Wait].
+type WaitOption interface {
+	applyWait(*waitOptions) error
+}
+
+type waitOptions struct {
+	pollInterval time.Duration
+}
+
+// applyWait merges o into opts, rejecting a non-positive interval and
+// duplicate options.
+func (o *waitOptions) applyWait(opts *waitOptions) error {
+	if o.pollInterval != 0 {
+		if o.pollInterval < 0 {
+			return errors.New("poll interval must be positive (WithPollInterval)")
+		}
+		if opts.pollInterval != 0 {
+			return errors.New("cannot set poll interval more than once (WithPollInterval)")
+		}
+		opts.pollInterval = o.pollInterval
+	}
+	return nil
+}
+
+// WithPollInterval sets how often [DetachedTask.Wait] re-reads the task's
+// snapshot while it is pending. The default is 2 seconds; d must be positive.
+// Each read is one getSnapshot companion-action call, so pick an interval the
+// agent's session store can absorb.
+func WithPollInterval(d time.Duration) WaitOption {
+	return &waitOptions{pollInterval: d}
 }

--- a/go/ai/exp/session.go
+++ b/go/ai/exp/session.go
@@ -22,10 +22,12 @@ import (
 	"fmt"
 	"slices"
 	"sync"
+	"time"
 
 	"github.com/firebase/genkit/go/ai"
 	"github.com/firebase/genkit/go/core"
 	"github.com/firebase/genkit/go/core/api"
+	"github.com/firebase/genkit/go/core/logger"
 	"github.com/firebase/genkit/go/core/status"
 	"github.com/firebase/genkit/go/internal/base"
 )
@@ -208,41 +210,23 @@ func cloneArtifacts(arts []*Artifact) []*Artifact {
 
 // --- Snapshot companion actions ---
 
-// newSnapshotActions creates the agent's companion actions, without
-// registering them, when the agent has a [SessionStore] configured:
-//
-//   - The agent's name under [api.ActionTypeAgentSnapshot] — getSnapshot,
-//     the remote counterpart to [SnapshotReader.GetSnapshot] (by snapshot
-//     ID) and [SnapshotReader.GetLatestSnapshot] (by session ID) for Dev UI
-//     and non-Go clients. Local Go callers use the store reference directly.
-//
-//   - The agent's name under [api.ActionTypeAgentAbort] — abort,
-//     created only when the store also implements [SnapshotSubscriber], so the
-//     runtime can react to the abort it writes via SaveSnapshot.
-//
-// When the agent is client-managed (no store configured), neither action
-// is created: there is no server-side snapshot to fetch or abort.
-// Surfacing actions only when the underlying capabilities exist keeps the
-// reflected API aligned with what the agent can actually do.
-//
-// The [Agent] retains the returned actions (an absent one is nil) and
-// registers them alongside its run action; see [Agent.Register],
-// [Agent.GetSnapshotAction], and [Agent.AbortAction].
 // readSnapshot resolves a snapshot by ID, or by the session's latest when
 // snapshotID is empty, and returns a normalized copy shaped for a client:
 // the documented defaults are applied (empty status means completed, zero
 // UpdatedAt means CreatedAt), a pending row whose heartbeat has gone stale is
 // surfaced as [SnapshotStatusExpired] (computed on read, never written back),
-// and transform shapes the outbound state. It backs both the getSnapshot
-// companion action and the typed [Agent.GetSnapshot] / [Agent.GetLatestSnapshot],
-// so Go callers, the Dev UI, and non-Go clients all observe identically shaped
-// snapshots. At least one of snapshotID / sessionID must be non-empty; callers
-// validate that before calling.
+// and transform shapes the outbound state. It backs the getSnapshot and
+// waitForSnapshot companion actions and the typed [Agent.GetSnapshot] /
+// [Agent.GetLatestSnapshot], so Go callers, the Dev UI, and non-Go clients all
+// observe identically shaped snapshots. At least one of snapshotID / sessionID
+// must be non-empty; callers validate that before calling. op names the
+// operation the read serves, so a failure reports the caller's own name rather
+// than always the read's.
 func readSnapshot[State any](
 	ctx context.Context,
 	store SnapshotReader[State],
 	transform StateTransform[State],
-	snapshotID, sessionID string,
+	op, snapshotID, sessionID string,
 ) (*SessionSnapshot[State], error) {
 	// Resolve the snapshot. A snapshot ID fetches that exact row; a session ID
 	// alone fetches the session's latest row (whatever its status). When both
@@ -255,22 +239,22 @@ func readSnapshot[State any](
 	if snapshotID != "" {
 		snap, err = store.GetSnapshot(ctx, snapshotID)
 		if err != nil {
-			return nil, fmt.Errorf("getSnapshot: %w", err)
+			return nil, fmt.Errorf("%s: %w", op, err)
 		}
 		if snap == nil {
-			return nil, status.PublicErrorf(ErrSnapshotNotFound, "getSnapshot: snapshot %q not found", snapshotID)
+			return nil, status.PublicErrorf(ErrSnapshotNotFound, "%s: snapshot %q not found", op, snapshotID)
 		}
 		if sessionID != "" && snap.SessionID != sessionID {
 			return nil, status.Errorf(status.ErrInvalidArgument,
-				"getSnapshot: snapshot %q does not belong to session %q (snapshot's session: %q)", snapshotID, sessionID, snap.SessionID)
+				"%s: snapshot %q does not belong to session %q (snapshot's session: %q)", op, snapshotID, sessionID, snap.SessionID)
 		}
 	} else {
 		snap, err = store.GetLatestSnapshot(ctx, sessionID)
 		if err != nil {
-			return nil, fmt.Errorf("getSnapshot: %w", err)
+			return nil, fmt.Errorf("%s: %w", op, err)
 		}
 		if snap == nil {
-			return nil, status.PublicErrorf(ErrSnapshotNotFound, "getSnapshot: no snapshot found for session %q", sessionID)
+			return nil, status.PublicErrorf(ErrSnapshotNotFound, "%s: no snapshot found for session %q", op, sessionID)
 		}
 	}
 
@@ -313,13 +297,159 @@ func readSnapshot[State any](
 	return &resp, nil
 }
 
+// Cadences of [waitSnapshot]'s re-reads. Package-level so tests can shorten
+// them.
+var (
+	// snapshotWaitPollInterval is how often a wait re-reads a pending row when
+	// the store cannot push status changes.
+	snapshotWaitPollInterval = 2 * time.Second
+	// snapshotWaitLivenessInterval is how often a subscribed wait re-reads a
+	// pending row to notice a heartbeat that has gone stale. One missed beat is
+	// already the expiry threshold, so beat-rate checks are frequent enough.
+	snapshotWaitLivenessInterval = defaultHeartbeatInterval
+)
+
+const (
+	// snapshotWaitProgressInterval is how often a still-blocked [waitSnapshot]
+	// logs progress, so a long wait stays visible in the logs and in its span
+	// without a line per check.
+	snapshotWaitProgressInterval = 30 * time.Second
+	// snapshotWaitReadTimeout bounds one store read inside a wait. A wait is
+	// long by design and a read is not, and only the wait can tell the two
+	// apart, so this is where a hung store is caught: without it an unbounded
+	// wait would freeze on one rather than surface the read error. It is
+	// generous, because it guards against a hang and not against a slow store.
+	snapshotWaitReadTimeout = 30 * time.Second
+)
+
+// waitSnapshot resolves a snapshot exactly as [readSnapshot] does and then
+// blocks until it settles, returning the terminal snapshot with the same
+// shaping a read applies. A snapshot that is already terminal returns at once,
+// so the wait costs one read in the common case.
+//
+// Where the store implements [SnapshotSubscriber] the wait is push-driven: it
+// subscribes before it would re-read, so a settlement racing the subscription
+// is still delivered (the channel yields the status at subscription time). It
+// still re-reads on an interval, because expiry is not a write: a dead worker
+// leaves the row pending and only its heartbeat goes stale, so no subscription
+// can report it. Without a subscriber that same interval is the whole
+// mechanism, so it is much shorter.
+//
+// Cancelling ctx ends the wait with ctx's error. Callers bound a wait with
+// [context.WithTimeout] and re-read the row afterwards to learn where it stands.
+func waitSnapshot[State any](
+	ctx context.Context,
+	store SessionStore[State],
+	transform StateTransform[State],
+	op, snapshotID, sessionID string,
+) (*SessionSnapshot[State], error) {
+	read := func(snapshotID, sessionID string) (*SessionSnapshot[State], error) {
+		readCtx, cancel := context.WithTimeout(ctx, snapshotWaitReadTimeout)
+		defer cancel()
+		return readSnapshot(readCtx, store, transform, op, snapshotID, sessionID)
+	}
+
+	snap, err := read(snapshotID, sessionID)
+	if err != nil {
+		return nil, err
+	}
+	if snap.Status.Terminal() {
+		return snap, nil
+	}
+	// Anchor the wait on the row the read resolved, not on the request, so a
+	// store that mints its own ID is still followed by that ID.
+	id := snap.SnapshotID
+	if id == "" {
+		id = snapshotID
+	}
+
+	var statusCh <-chan SnapshotStatus
+	if sub, ok := store.(SnapshotSubscriber); ok {
+		subCtx, cancel := context.WithCancel(ctx)
+		defer cancel()
+		statusCh = sub.OnSnapshotStatusChange(subCtx, id)
+	}
+	interval := snapshotWaitPollInterval
+	if statusCh != nil {
+		interval = snapshotWaitLivenessInterval
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	start := time.Now()
+	lastProgress := start
+	logger.Debug(ctx, "waiting for snapshot to settle",
+		"snapshotId", id, "subscribed", statusCh != nil)
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case snapStatus, ok := <-statusCh:
+			if !ok {
+				// The subscription ended under us (the row was removed, or the
+				// store dropped it). Fall back to re-reading, which reports
+				// whatever the row says now, at the unsubscribed cadence.
+				statusCh = nil
+				ticker.Reset(snapshotWaitPollInterval)
+				continue
+			}
+			if !snapStatus.Terminal() {
+				continue
+			}
+			// The subscription carries a status, not the row: re-read to
+			// return the settled snapshot with its cumulative state.
+			return read(id, "")
+		case <-ticker.C:
+			cur, err := read(id, "")
+			if err != nil {
+				return nil, err
+			}
+			if cur.Status.Terminal() {
+				return cur, nil
+			}
+			if time.Since(lastProgress) >= snapshotWaitProgressInterval {
+				lastProgress = time.Now()
+				logger.Debug(ctx, "still waiting for snapshot",
+					"snapshotId", id, "elapsedMs", time.Since(start).Milliseconds())
+			}
+		}
+	}
+}
+
+// newSnapshotActions creates the agent's companion actions, without
+// registering them, when the agent has a [SessionStore] configured:
+//
+//   - The agent's name under [api.ActionTypeAgentSnapshot] — getSnapshot,
+//     the remote counterpart to [SnapshotReader.GetSnapshot] (by snapshot
+//     ID) and [SnapshotReader.GetLatestSnapshot] (by session ID) for Dev UI
+//     and non-Go clients. Local Go callers use the store reference directly.
+//
+//   - The agent's name under [api.ActionTypeAgentWait] — waitForSnapshot,
+//     getSnapshot's blocking counterpart: it resolves the same request and
+//     returns once the snapshot settles. It is how a caller that holds only
+//     actions follows a detached invocation without re-dispatching a read per
+//     tick, which is one call and one span instead of a stream of them.
+//
+//   - The agent's name under [api.ActionTypeAgentAbort] — abort,
+//     created only when the store also implements [SnapshotSubscriber], so the
+//     runtime can react to the abort it writes via SaveSnapshot.
+//
+// When the agent is client-managed (no store configured), no action is created:
+// there is no server-side snapshot to fetch, follow, or abort. Surfacing
+// actions only when the underlying capabilities exist keeps the reflected API
+// aligned with what the agent can actually do.
+//
+// The [Agent] retains the returned actions (an absent one is nil) and
+// registers them alongside its run action; see [Agent.Register],
+// [Agent.GetSnapshotAction], [Agent.WaitForSnapshotAction], and
+// [Agent.AbortAction].
 func newSnapshotActions[State any](
 	agentName string,
 	store SessionStore[State],
 	transform StateTransform[State],
-) (getSnapshot, abort api.Action) {
+) (getSnapshot, waitForSnapshot, abort api.Action) {
 	if store == nil {
-		return nil, nil
+		return nil, nil, nil
 	}
 	getSnapshotAction := core.NewActionOf(api.ActionTypeAgentSnapshot, agentName, nil,
 		func(ctx context.Context, req *GetSnapshotRequest) (*SessionSnapshot[State], error) {
@@ -327,13 +457,27 @@ func newSnapshotActions[State any](
 				return nil, status.Errorf(status.ErrInvalidArgument, "getSnapshot: snapshotId or sessionId is required")
 			}
 
-			return readSnapshot(ctx, store, transform, req.SnapshotID, req.SessionID)
+			return readSnapshot(ctx, store, transform, "getSnapshot", req.SnapshotID, req.SessionID)
+		})
+
+	// waitForSnapshot takes getSnapshot's request, so a caller switching from
+	// one to the other keeps its payload, but it requires the snapshot ID: a
+	// session's latest row is whichever one is latest at resolution time, and
+	// waiting on that is a race with the session's next turn. A session ID may
+	// still accompany the snapshot ID, where it asserts ownership exactly as it
+	// does on a read.
+	waitAction := core.NewActionOf(api.ActionTypeAgentWait, agentName, nil,
+		func(ctx context.Context, req *GetSnapshotRequest) (*SessionSnapshot[State], error) {
+			if req == nil || req.SnapshotID == "" {
+				return nil, status.Errorf(status.ErrInvalidArgument, "waitForSnapshot: snapshotId is required")
+			}
+			return waitSnapshot(ctx, store, transform, "waitForSnapshot", req.SnapshotID, req.SessionID)
 		})
 
 	if _, ok := store.(SnapshotSubscriber); !ok {
 		// Without a subscriber the runtime cannot react to an abort, so the
 		// abort lifecycle is unsupported; don't surface the action.
-		return getSnapshotAction, nil
+		return getSnapshotAction, waitAction, nil
 	}
 	abortAction := core.NewActionOf(api.ActionTypeAgentAbort, agentName, nil,
 		func(ctx context.Context, req *AgentAbortRequest) (*AgentAbortResponse, error) {
@@ -351,7 +495,7 @@ func newSnapshotActions[State any](
 			}
 			return &AgentAbortResponse{SnapshotID: req.SnapshotID, Status: snapStatus}, nil
 		})
-	return getSnapshotAction, abortAction
+	return getSnapshotAction, waitAction, abortAction
 }
 
 // --- Session ---

--- a/go/ai/exp/session.go
+++ b/go/ai/exp/session.go
@@ -19,8 +19,8 @@ package exp
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
+	"slices"
 	"sync"
 	"time"
 
@@ -311,9 +311,20 @@ const (
 // else (a store blip, a read that hit snapshotWaitReadTimeout) is presumed
 // transient.
 func waitReadDeadEnd(err error) bool {
-	return errors.Is(err, status.ErrNotFound) ||
-		errors.Is(err, status.ErrInvalidArgument) ||
-		errors.Is(err, status.ErrFailedPrecondition)
+	// One chain walk, and the set reads as the policy it is. Subtypes carry
+	// their base's status (ErrSnapshotNotFound is a NOT_FOUND), so they land
+	// here too; an unclassified failure is presumed transient.
+	if s, ok := status.Classified(err); ok {
+		return slices.Contains(waitReadDeadEndStatuses, s)
+	}
+	return false
+}
+
+// waitReadDeadEndStatuses are the read failures no retry can help.
+var waitReadDeadEndStatuses = []status.Name{
+	status.NotFound,
+	status.InvalidArgument,
+	status.FailedPrecondition,
 }
 
 // waitSnapshot resolves a snapshot exactly as [readSnapshot] does and then
@@ -329,12 +340,11 @@ func waitReadDeadEnd(err error) bool {
 // can report it. Without a subscriber that same interval is the whole
 // mechanism, so it is much shorter.
 //
-// An in-wait re-read that fails transiently is retried at that same cadence,
-// up to snapshotWaitReadRetries consecutive failures, so a store blip does not
-// fail a long wait; a dead end (the row is gone, the request is rejected)
-// surfaces at once. The initial read is never retried: it prices the common
-// already-terminal case at exactly one read, and its failures reach the caller
-// unchanged (e.g. NOT_FOUND for an unknown snapshot).
+// A read that fails transiently is retried at that same cadence, up to
+// snapshotWaitReadRetries consecutive failures, so a store blip does not fail
+// a long wait; a dead end (the row is gone, the request is rejected) surfaces
+// at once, including on the first read. The success path is unaffected: an
+// already-terminal snapshot still costs exactly one read.
 //
 // Cancelling ctx ends the wait with ctx's error. Callers bound a wait with
 // [context.WithTimeout] and re-read the row afterwards to learn where it stands.
@@ -350,12 +360,22 @@ func waitSnapshot[State any](
 		return readSnapshot(readCtx, store, transform, op, snapshotID, sessionID)
 	}
 
+	// The first read prices the common already-terminal case at exactly one
+	// read. A dead end reaches the caller unchanged (e.g. NOT_FOUND for an
+	// unknown snapshot); a transient failure falls into the wait below and is
+	// retried there on the wait's own cadence, because a store blip at the
+	// moment a wait starts is no more fatal than one in the middle of it.
+	readFailures := 0
 	snap, err := read(snapshotID, sessionID)
-	if err != nil {
-		return nil, err
-	}
-	if snap.Status.Terminal() {
+	switch {
+	case err == nil && snap.Status.Terminal():
 		return snap, nil
+	case err != nil && waitReadDeadEnd(err):
+		return nil, err
+	case err != nil:
+		readFailures = 1
+		logger.Debug(ctx, "first snapshot read failed inside a wait; retrying",
+			"snapshotId", snapshotID, "error", err)
 	}
 
 	var statusCh <-chan SnapshotStatus
@@ -373,7 +393,6 @@ func waitSnapshot[State any](
 
 	start := time.Now()
 	lastProgress := start
-	readFailures := 0
 	// retryRead decides what a failed in-wait re-read means: a dead end or
 	// exhausted retries surface the error, anything else is ridden out at the
 	// wait's own re-read cadence (the next tick retries).
@@ -398,41 +417,47 @@ func waitSnapshot[State any](
 				// store dropped it). Fall back to re-reading, which reports
 				// whatever the row says now, at the unsubscribed cadence.
 				statusCh = nil
-				ticker.Reset(snapshotWaitPollInterval)
+				interval = snapshotWaitPollInterval
+				ticker.Reset(interval)
 				continue
 			}
+			// A notification carries a status, not the row, so it only means
+			// "re-read now": the row is what the caller gets back, and the
+			// shared re-read below is what decides the wait is over.
 			if !snapStatus.Terminal() {
 				continue
 			}
-			// The subscription carries a status, not the row: re-read to
-			// return the settled snapshot with its cumulative state. A
-			// transient failure here falls through to the next tick, whose
-			// re-read finds the same settled row.
-			cur, err := read(snapshotID, "")
-			if err != nil {
-				if err := retryRead(err); err != nil {
-					return nil, err
-				}
-				continue
-			}
-			return cur, nil
 		case <-ticker.C:
-			cur, err := read(snapshotID, "")
-			if err != nil {
-				if err := retryRead(err); err != nil {
-					return nil, err
-				}
-				continue
+		}
+
+		// One re-read serves both wakeups. It keeps sessionID, so the
+		// ownership assertion the caller made holds for the whole wait and not
+		// just its first read, and it settles the wait only on a row that says
+		// so: a store may notify before the write is visible to a reader, and
+		// answering a wait with a pending row would break its contract.
+		cur, err := read(snapshotID, sessionID)
+		if err != nil {
+			if err := retryRead(err); err != nil {
+				return nil, err
 			}
+			// Retry soon rather than on the next liveness beat. A subscribed
+			// wait's terminal notification fires once and has already been
+			// consumed, so after a failure the re-read is the only path left
+			// to the settled row and must not be 30s away.
+			ticker.Reset(snapshotWaitPollInterval)
+			continue
+		}
+		if readFailures > 0 {
 			readFailures = 0
-			if cur.Status.Terminal() {
-				return cur, nil
-			}
-			if time.Since(lastProgress) >= snapshotWaitProgressInterval {
-				lastProgress = time.Now()
-				logger.Debug(ctx, "still waiting for snapshot",
-					"snapshotId", snapshotID, "elapsedMs", time.Since(start).Milliseconds())
-			}
+			ticker.Reset(interval)
+		}
+		if cur.Status.Terminal() {
+			return cur, nil
+		}
+		if time.Since(lastProgress) >= snapshotWaitProgressInterval {
+			lastProgress = time.Now()
+			logger.Debug(ctx, "still waiting for snapshot",
+				"snapshotId", snapshotID, "elapsedMs", time.Since(start).Milliseconds())
 		}
 	}
 }

--- a/go/ai/exp/session.go
+++ b/go/ai/exp/session.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"slices"
 	"sync"
 
 	"github.com/firebase/genkit/go/ai"
@@ -39,6 +40,37 @@ func applyTransform[State any](ctx context.Context, t StateTransform[State], sta
 		return state, nil
 	}
 	return t(ctx, state)
+}
+
+// Terminal reports whether the status is settled: no further transition will
+// happen on its own. [SnapshotStatusPending] is the only non-terminal status
+// (an empty status counts as [SnapshotStatusCompleted], matching the
+// documented default), so waiters stop on completed, failed, aborted, and
+// expired alike. An expired snapshot's raw store row is still pending, but its
+// worker is presumed dead, so nothing will finalize it.
+func (s SnapshotStatus) Terminal() bool {
+	return s != SnapshotStatusPending
+}
+
+// LastModelMessage returns the most recent model message that carries text:
+// the conversation's final response as a reader would quote it. Model messages
+// holding no text (e.g. only tool requests) are skipped, so a conversation
+// whose tip is mid-tool-loop still resolves to the last spoken response. It
+// returns nil when no model message carries text, and tolerates a nil
+// receiver (e.g. a pending snapshot's nil [SessionSnapshot.State]).
+//
+// The returned message points into the state's own message list; treat it as
+// read-only, or deep-copy before mutating.
+func (s *SessionState[State]) LastModelMessage() *ai.Message {
+	if s == nil {
+		return nil
+	}
+	for _, msg := range slices.Backward(s.Messages) {
+		if msg != nil && msg.Role == ai.RoleModel && msg.Text() != "" {
+			return msg
+		}
+	}
+	return nil
 }
 
 // --- Session store ---

--- a/go/ai/exp/session.go
+++ b/go/ai/exp/session.go
@@ -19,6 +19,7 @@ package exp
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"slices"
 	"sync"
@@ -320,7 +321,22 @@ const (
 	// wait would freeze on one rather than surface the read error. It is
 	// generous, because it guards against a hang and not against a slow store.
 	snapshotWaitReadTimeout = 30 * time.Second
+	// snapshotWaitReadRetries is how many consecutive in-wait re-read failures
+	// a wait rides out, at its own re-read cadence, before surfacing the error.
+	// A wait runs for as long as the work does, so one store blip must not
+	// fail it; dead ends (see waitReadDeadEnd) are surfaced at once.
+	snapshotWaitReadRetries = 3
 )
+
+// waitReadDeadEnd reports whether an in-wait re-read failure cannot be helped
+// by retrying: the row is gone or the request itself is rejected. Anything
+// else (a store blip, a read that hit snapshotWaitReadTimeout) is presumed
+// transient.
+func waitReadDeadEnd(err error) bool {
+	return errors.Is(err, status.ErrNotFound) ||
+		errors.Is(err, status.ErrInvalidArgument) ||
+		errors.Is(err, status.ErrFailedPrecondition)
+}
 
 // waitSnapshot resolves a snapshot exactly as [readSnapshot] does and then
 // blocks until it settles, returning the terminal snapshot with the same
@@ -334,6 +350,13 @@ const (
 // leaves the row pending and only its heartbeat goes stale, so no subscription
 // can report it. Without a subscriber that same interval is the whole
 // mechanism, so it is much shorter.
+//
+// An in-wait re-read that fails transiently is retried at that same cadence,
+// up to snapshotWaitReadRetries consecutive failures, so a store blip does not
+// fail a long wait; a dead end (the row is gone, the request is rejected)
+// surfaces at once. The initial read is never retried: it prices the common
+// already-terminal case at exactly one read, and its failures reach the caller
+// unchanged (e.g. NOT_FOUND for an unknown snapshot).
 //
 // Cancelling ctx ends the wait with ctx's error. Callers bound a wait with
 // [context.WithTimeout] and re-read the row afterwards to learn where it stands.
@@ -356,18 +379,12 @@ func waitSnapshot[State any](
 	if snap.Status.Terminal() {
 		return snap, nil
 	}
-	// Anchor the wait on the row the read resolved, not on the request, so a
-	// store that mints its own ID is still followed by that ID.
-	id := snap.SnapshotID
-	if id == "" {
-		id = snapshotID
-	}
 
 	var statusCh <-chan SnapshotStatus
 	if sub, ok := store.(SnapshotSubscriber); ok {
 		subCtx, cancel := context.WithCancel(ctx)
 		defer cancel()
-		statusCh = sub.OnSnapshotStatusChange(subCtx, id)
+		statusCh = sub.OnSnapshotStatusChange(subCtx, snapshotID)
 	}
 	interval := snapshotWaitPollInterval
 	if statusCh != nil {
@@ -378,8 +395,21 @@ func waitSnapshot[State any](
 
 	start := time.Now()
 	lastProgress := start
+	readFailures := 0
+	// retryRead decides what a failed in-wait re-read means: a dead end or
+	// exhausted retries surface the error, anything else is ridden out at the
+	// wait's own re-read cadence (the next tick retries).
+	retryRead := func(err error) error {
+		if waitReadDeadEnd(err) || readFailures >= snapshotWaitReadRetries {
+			return err
+		}
+		readFailures++
+		logger.Debug(ctx, "snapshot re-read failed inside a wait; retrying",
+			"snapshotId", snapshotID, "failures", readFailures, "error", err)
+		return nil
+	}
 	logger.Debug(ctx, "waiting for snapshot to settle",
-		"snapshotId", id, "subscribed", statusCh != nil)
+		"snapshotId", snapshotID, "subscribed", statusCh != nil)
 	for {
 		select {
 		case <-ctx.Done():
@@ -397,20 +427,33 @@ func waitSnapshot[State any](
 				continue
 			}
 			// The subscription carries a status, not the row: re-read to
-			// return the settled snapshot with its cumulative state.
-			return read(id, "")
-		case <-ticker.C:
-			cur, err := read(id, "")
+			// return the settled snapshot with its cumulative state. A
+			// transient failure here falls through to the next tick, whose
+			// re-read finds the same settled row.
+			cur, err := read(snapshotID, "")
 			if err != nil {
-				return nil, err
+				if err := retryRead(err); err != nil {
+					return nil, err
+				}
+				continue
 			}
+			return cur, nil
+		case <-ticker.C:
+			cur, err := read(snapshotID, "")
+			if err != nil {
+				if err := retryRead(err); err != nil {
+					return nil, err
+				}
+				continue
+			}
+			readFailures = 0
 			if cur.Status.Terminal() {
 				return cur, nil
 			}
 			if time.Since(lastProgress) >= snapshotWaitProgressInterval {
 				lastProgress = time.Now()
 				logger.Debug(ctx, "still waiting for snapshot",
-					"snapshotId", id, "elapsedMs", time.Since(start).Milliseconds())
+					"snapshotId", snapshotID, "elapsedMs", time.Since(start).Milliseconds())
 			}
 		}
 	}

--- a/go/ai/exp/session.go
+++ b/go/ai/exp/session.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"slices"
 	"sync"
 	"time"
 
@@ -53,27 +52,6 @@ func applyTransform[State any](ctx context.Context, t StateTransform[State], sta
 // worker is presumed dead, so nothing will finalize it.
 func (s SnapshotStatus) Terminal() bool {
 	return s != SnapshotStatusPending
-}
-
-// LastModelMessage returns the most recent model message that carries text:
-// the conversation's final response as a reader would quote it. Model messages
-// holding no text (e.g. only tool requests) are skipped, so a conversation
-// whose tip is mid-tool-loop still resolves to the last spoken response. It
-// returns nil when no model message carries text, and tolerates a nil
-// receiver (e.g. a pending snapshot's nil [SessionSnapshot.State]).
-//
-// The returned message points into the state's own message list; treat it as
-// read-only, or deep-copy before mutating.
-func (s *SessionState[State]) LastModelMessage() *ai.Message {
-	if s == nil {
-		return nil
-	}
-	for _, msg := range slices.Backward(s.Messages) {
-		if msg != nil && msg.Role == ai.RoleModel && msg.Text() != "" {
-			return msg
-		}
-	}
-	return nil
 }
 
 // --- Session store ---

--- a/go/ai/exp/session.go
+++ b/go/ai/exp/session.go
@@ -54,6 +54,30 @@ func (s SnapshotStatus) Terminal() bool {
 	return s != SnapshotStatusPending
 }
 
+// CarriesResult reports whether a turn that ended for this reason produced an
+// answer its caller can use. True for the reasons that mean the agent spoke and
+// stopped: [AgentFinishReasonStop], the two catch-alls, and the empty reason a
+// turn may report when it names none. Every other reason ended the turn with
+// nothing to hand back.
+//
+// Callers use it to decide whether a turn's final message is the answer or an
+// account of why there is none. That question has one answer per reason, so it
+// belongs on the reason: an agent that reports a turn's outcome and one that
+// folds it into a tool result would otherwise each keep their own list, and a
+// reason added later would be an answer to one of them and not the other.
+//
+// It names the reasons that do carry a result rather than the ones that do
+// not, so a reason added later defaults to "no answer". That default is the
+// safe one: mistaking an explanation for an answer hands a caller partial work
+// as though it were final, while the reverse only asks it to look at the text.
+func (r AgentFinishReason) CarriesResult() bool {
+	switch r {
+	case AgentFinishReasonStop, AgentFinishReasonOther, AgentFinishReasonUnknown, "":
+		return true
+	}
+	return false
+}
+
 // --- Session store ---
 
 // SnapshotReader retrieves snapshots. The minimum any session store must
@@ -283,8 +307,9 @@ var (
 	// the store cannot push status changes.
 	snapshotWaitPollInterval = 2 * time.Second
 	// snapshotWaitLivenessInterval is how often a subscribed wait re-reads a
-	// pending row to notice a heartbeat that has gone stale. One missed beat is
-	// already the expiry threshold, so beat-rate checks are frequent enough.
+	// pending row to notice a heartbeat that has gone stale. Expiry needs two
+	// missed beats (defaultHeartbeatTimeout is twice the interval), so checking
+	// once per beat cannot miss a stale row by more than one beat.
 	snapshotWaitLivenessInterval = defaultHeartbeatInterval
 )
 
@@ -360,22 +385,35 @@ func waitSnapshot[State any](
 		return readSnapshot(readCtx, store, transform, op, snapshotID, sessionID)
 	}
 
+	// retryRead decides what a failed read inside a wait means: a dead end or
+	// exhausted retries surface the error, anything else is ridden out at the
+	// wait's own re-read cadence (the next tick retries). It owns the policy
+	// for the first read and every re-read alike, so a change to the budget or
+	// to what counts as a dead end lands in one place.
+	readFailures := 0
+	retryRead := func(err error) error {
+		if waitReadDeadEnd(err) || readFailures >= snapshotWaitReadRetries {
+			return err
+		}
+		readFailures++
+		logger.Debug(ctx, "snapshot read failed inside a wait; retrying",
+			"snapshotId", snapshotID, "failures", readFailures, "error", err)
+		return nil
+	}
+
 	// The first read prices the common already-terminal case at exactly one
 	// read. A dead end reaches the caller unchanged (e.g. NOT_FOUND for an
 	// unknown snapshot); a transient failure falls into the wait below and is
 	// retried there on the wait's own cadence, because a store blip at the
 	// moment a wait starts is no more fatal than one in the middle of it.
-	readFailures := 0
 	snap, err := read(snapshotID, sessionID)
-	switch {
-	case err == nil && snap.Status.Terminal():
+	if err == nil && snap.Status.Terminal() {
 		return snap, nil
-	case err != nil && waitReadDeadEnd(err):
-		return nil, err
-	case err != nil:
-		readFailures = 1
-		logger.Debug(ctx, "first snapshot read failed inside a wait; retrying",
-			"snapshotId", snapshotID, "error", err)
+	}
+	if err != nil {
+		if err := retryRead(err); err != nil {
+			return nil, err
+		}
 	}
 
 	var statusCh <-chan SnapshotStatus
@@ -393,18 +431,6 @@ func waitSnapshot[State any](
 
 	start := time.Now()
 	lastProgress := start
-	// retryRead decides what a failed in-wait re-read means: a dead end or
-	// exhausted retries surface the error, anything else is ridden out at the
-	// wait's own re-read cadence (the next tick retries).
-	retryRead := func(err error) error {
-		if waitReadDeadEnd(err) || readFailures >= snapshotWaitReadRetries {
-			return err
-		}
-		readFailures++
-		logger.Debug(ctx, "snapshot re-read failed inside a wait; retrying",
-			"snapshotId", snapshotID, "failures", readFailures, "error", err)
-		return nil
-	}
 	logger.Debug(ctx, "waiting for snapshot to settle",
 		"snapshotId", snapshotID, "subscribed", statusCh != nil)
 	for {
@@ -427,6 +453,13 @@ func waitSnapshot[State any](
 			if !snapStatus.Terminal() {
 				continue
 			}
+			// A terminal notification fires once and has now been consumed, so
+			// the re-read below is the only path left to the settled row. Drop
+			// to the poll cadence for the rest of the wait: a store that
+			// notifies ahead of read visibility would otherwise leave the
+			// settled row unseen until the next liveness beat.
+			interval = snapshotWaitPollInterval
+			ticker.Reset(interval)
 		case <-ticker.C:
 		}
 
@@ -444,7 +477,8 @@ func waitSnapshot[State any](
 			// wait's terminal notification fires once and has already been
 			// consumed, so after a failure the re-read is the only path left
 			// to the settled row and must not be 30s away.
-			ticker.Reset(snapshotWaitPollInterval)
+			interval = snapshotWaitPollInterval
+			ticker.Reset(interval)
 			continue
 		}
 		if readFailures > 0 {

--- a/go/ai/exp/session_test.go
+++ b/go/ai/exp/session_test.go
@@ -18,10 +18,15 @@ package exp
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/core/api"
+	"github.com/firebase/genkit/go/core/status"
 	"github.com/firebase/genkit/go/internal/base"
 )
 
@@ -154,5 +159,225 @@ func TestSessionState_LastModelMessage(t *testing.T) {
 	var nilState *SessionState[any]
 	if got := nilState.LastModelMessage(); got != nil {
 		t.Fatalf("nil receiver LastModelMessage() = %+v, want nil", got)
+	}
+}
+
+// --- waitForSnapshot ---
+
+// unsubscribableStore is a [SessionStore] that deliberately does not implement
+// [SnapshotSubscriber], so a wait on it falls back to re-reading. It forwards
+// to testInMemStore rather than embedding it, because embedding would promote
+// the subscription method and defeat the point.
+type unsubscribableStore[State any] struct{ inner *testInMemStore[State] }
+
+func (s unsubscribableStore[State]) GetSnapshot(ctx context.Context, snapshotID string) (*SessionSnapshot[State], error) {
+	return s.inner.GetSnapshot(ctx, snapshotID)
+}
+
+func (s unsubscribableStore[State]) GetLatestSnapshot(ctx context.Context, sessionID string) (*SessionSnapshot[State], error) {
+	return s.inner.GetLatestSnapshot(ctx, sessionID)
+}
+
+func (s unsubscribableStore[State]) SaveSnapshot(
+	ctx context.Context,
+	snapshotID string,
+	fn func(*SessionSnapshot[State]) (*SessionSnapshot[State], error),
+) (*SessionSnapshot[State], error) {
+	return s.inner.SaveSnapshot(ctx, snapshotID, fn)
+}
+
+// putSnapshot writes one row verbatim, so a test can stage a snapshot in any
+// lifecycle state without running an agent.
+func putSnapshot[State any](t *testing.T, store SessionStore[State], snap *SessionSnapshot[State]) {
+	t.Helper()
+	if _, err := store.SaveSnapshot(context.Background(), snap.SnapshotID,
+		func(*SessionSnapshot[State]) (*SessionSnapshot[State], error) { return snap, nil }); err != nil {
+		t.Fatalf("SaveSnapshot(%q): %v", snap.SnapshotID, err)
+	}
+}
+
+// settleSnapshot flips a staged row to a terminal status, as a detached turn's
+// finalize does.
+func settleSnapshot[State any](t *testing.T, store SessionStore[State], snapshotID string, snapStatus SnapshotStatus) {
+	t.Helper()
+	if _, err := store.SaveSnapshot(context.Background(), snapshotID,
+		func(existing *SessionSnapshot[State]) (*SessionSnapshot[State], error) {
+			settled := *existing
+			settled.Status = snapStatus
+			return &settled, nil
+		}); err != nil {
+		t.Fatalf("SaveSnapshot(%q, %q): %v", snapshotID, snapStatus, err)
+	}
+}
+
+func TestWaitSnapshot_TerminalReturnsWithoutWaiting(t *testing.T) {
+	store := newTestInMemStore[any]()
+	putSnapshot(t, store, &SessionSnapshot[any]{
+		SnapshotID: "done", SessionID: "s1", Status: SnapshotStatusCompleted,
+		State: &SessionState[any]{Messages: []*ai.Message{ai.NewModelTextMessage("finished")}},
+	})
+
+	// No deadline: a wait that did not return at once would hang the test.
+	got, err := waitSnapshot(context.Background(), store, nil, "waitForSnapshot", "done", "")
+	if err != nil {
+		t.Fatalf("waitSnapshot: %v", err)
+	}
+	if got.Status != SnapshotStatusCompleted {
+		t.Fatalf("status = %q, want %q", got.Status, SnapshotStatusCompleted)
+	}
+	if text := got.State.LastModelMessage().Text(); text != "finished" {
+		t.Errorf("last model message = %q, want %q", text, "finished")
+	}
+}
+
+func TestWaitSnapshot_SubscriptionDeliversSettlement(t *testing.T) {
+	store := newTestInMemStore[any]()
+	beat := time.Now()
+	putSnapshot(t, store, &SessionSnapshot[any]{
+		SnapshotID: "running", SessionID: "s1", Status: SnapshotStatusPending, HeartbeatAt: &beat,
+	})
+
+	// The liveness re-read is left at its production cadence, so a settlement
+	// observed inside the test's timeout can only have arrived by subscription.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	done := make(chan *SessionSnapshot[any], 1)
+	go func() {
+		snap, err := waitSnapshot(ctx, store, nil, "waitForSnapshot", "running", "")
+		if err != nil {
+			t.Errorf("waitSnapshot: %v", err)
+			close(done)
+			return
+		}
+		done <- snap
+	}()
+
+	settleSnapshot(t, store, "running", SnapshotStatusCompleted)
+	select {
+	case snap := <-done:
+		if snap == nil {
+			t.Fatal("wait failed")
+		}
+		if snap.Status != SnapshotStatusCompleted {
+			t.Fatalf("status = %q, want %q", snap.Status, SnapshotStatusCompleted)
+		}
+	case <-ctx.Done():
+		t.Fatal("wait did not observe the settlement")
+	}
+}
+
+func TestWaitSnapshot_RereadsWithoutSubscriber(t *testing.T) {
+	restore := snapshotWaitPollInterval
+	snapshotWaitPollInterval = 10 * time.Millisecond
+	t.Cleanup(func() { snapshotWaitPollInterval = restore })
+
+	inner := newTestInMemStore[any]()
+	store := unsubscribableStore[any]{inner: inner}
+	beat := time.Now()
+	putSnapshot[any](t, store, &SessionSnapshot[any]{
+		SnapshotID: "running", SessionID: "s1", Status: SnapshotStatusPending, HeartbeatAt: &beat,
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	go func() {
+		time.Sleep(30 * time.Millisecond)
+		settleSnapshot[any](t, store, "running", SnapshotStatusFailed)
+	}()
+
+	got, err := waitSnapshot[any](ctx, store, nil, "waitForSnapshot", "running", "")
+	if err != nil {
+		t.Fatalf("waitSnapshot: %v", err)
+	}
+	if got.Status != SnapshotStatusFailed {
+		t.Fatalf("status = %q, want %q", got.Status, SnapshotStatusFailed)
+	}
+}
+
+func TestWaitSnapshot_ExpiredHeartbeatEndsTheWait(t *testing.T) {
+	restore := snapshotWaitLivenessInterval
+	snapshotWaitLivenessInterval = 10 * time.Millisecond
+	t.Cleanup(func() { snapshotWaitLivenessInterval = restore })
+
+	store := newTestInMemStore[any]()
+	// A worker that died a heartbeat timeout ago: the row stays pending, so no
+	// subscription can report it and only the liveness re-read notices.
+	stale := time.Now().Add(-2 * defaultHeartbeatTimeout)
+	putSnapshot(t, store, &SessionSnapshot[any]{
+		SnapshotID: "orphan", SessionID: "s1", Status: SnapshotStatusPending, HeartbeatAt: &stale,
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	got, err := waitSnapshot(ctx, store, nil, "waitForSnapshot", "orphan", "")
+	if err != nil {
+		t.Fatalf("waitSnapshot: %v", err)
+	}
+	if got.Status != SnapshotStatusExpired {
+		t.Fatalf("status = %q, want %q", got.Status, SnapshotStatusExpired)
+	}
+}
+
+func TestWaitSnapshot_ContextEndsTheWait(t *testing.T) {
+	store := newTestInMemStore[any]()
+	beat := time.Now()
+	putSnapshot(t, store, &SessionSnapshot[any]{
+		SnapshotID: "running", SessionID: "s1", Status: SnapshotStatusPending, HeartbeatAt: &beat,
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	if _, err := waitSnapshot(ctx, store, nil, "waitForSnapshot", "running", ""); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("waitSnapshot error = %v, want DeadlineExceeded", err)
+	}
+}
+
+func TestWaitSnapshot_UnknownSnapshot(t *testing.T) {
+	store := newTestInMemStore[any]()
+	_, err := waitSnapshot(context.Background(), store, nil, "waitForSnapshot", "nope", "")
+	if !errors.Is(err, ErrSnapshotNotFound) {
+		t.Fatalf("waitSnapshot error = %v, want ErrSnapshotNotFound", err)
+	}
+	if got, want := err.Error(), "waitForSnapshot: "; len(got) < len(want) || got[:len(want)] != want {
+		t.Errorf("error = %q, want it to name the operation that failed", got)
+	}
+}
+
+func TestNewSnapshotActions_WaitAction(t *testing.T) {
+	store := newTestInMemStore[any]()
+	putSnapshot(t, store, &SessionSnapshot[any]{
+		SnapshotID: "done", SessionID: "s1", Status: SnapshotStatusCompleted,
+	})
+	_, wait, _ := newSnapshotActions[any]("waiter", store, nil)
+	if wait == nil {
+		t.Fatal("newSnapshotActions returned no wait action for a store-backed agent")
+	}
+	if got := wait.Desc().Type; got != api.ActionTypeAgentWait {
+		t.Errorf("wait action type = %q, want %q", got, api.ActionTypeAgentWait)
+	}
+
+	// A session ID alone resolves whichever row is latest at resolution time,
+	// which is a race with the session's next turn, so the wait requires the
+	// snapshot ID that a read would accept on its own.
+	_, err := wait.RunJSON(context.Background(), json.RawMessage(`{"sessionId":"s1"}`), nil)
+	if !errors.Is(err, status.ErrInvalidArgument) {
+		t.Fatalf("wait by session ID error = %v, want INVALID_ARGUMENT", err)
+	}
+
+	raw, err := wait.RunJSON(context.Background(), json.RawMessage(`{"snapshotId":"done"}`), nil)
+	if err != nil {
+		t.Fatalf("wait action: %v", err)
+	}
+	var snap SessionSnapshot[any]
+	if err := json.Unmarshal(raw, &snap); err != nil {
+		t.Fatalf("unmarshal snapshot: %v", err)
+	}
+	if snap.Status != SnapshotStatusCompleted {
+		t.Errorf("status = %q, want %q", snap.Status, SnapshotStatusCompleted)
+	}
+
+	// A client-managed agent keeps no snapshots, so it gets no wait action.
+	if _, clientWait, _ := newSnapshotActions[any]("clientManaged", nil, nil); clientWait != nil {
+		t.Error("newSnapshotActions returned a wait action for a store-less agent")
 	}
 }

--- a/go/ai/exp/session_test.go
+++ b/go/ai/exp/session_test.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"reflect"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -323,8 +324,8 @@ func TestWaitSnapshot_UnknownSnapshot(t *testing.T) {
 	if !errors.Is(err, ErrSnapshotNotFound) {
 		t.Fatalf("waitSnapshot error = %v, want ErrSnapshotNotFound", err)
 	}
-	if got, want := err.Error(), "waitForSnapshot: "; len(got) < len(want) || got[:len(want)] != want {
-		t.Errorf("error = %q, want it to name the operation that failed", got)
+	if want := "waitForSnapshot: "; !strings.HasPrefix(err.Error(), want) {
+		t.Errorf("error = %q, want it to name the operation that failed", err)
 	}
 }
 
@@ -469,30 +470,11 @@ func TestWaitSnapshot_FirstReadBlipIsRetried(t *testing.T) {
 
 // notifyAheadStore models a store whose status notification outruns the row's
 // read visibility, which the [SnapshotSubscriber] contract permits: it pushes
-// "completed" at subscribe time while reads keep reporting the pending row for
-// pendingReads more reads.
+// "completed" at subscribe time while the scripted reads still report pending.
+// Everything but the subscription is scriptedStore's, so the two agree on what
+// a read costs and on how the script runs out.
 type notifyAheadStore struct {
-	mu           sync.Mutex
-	reads        int
-	pendingReads int
-}
-
-func (s *notifyAheadStore) GetSnapshot(ctx context.Context, snapshotID string) (*SessionSnapshot[any], error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.reads++
-	if s.reads <= s.pendingReads {
-		return scriptedPending(), nil
-	}
-	return &SessionSnapshot[any]{SnapshotID: "job", SessionID: "s1", Status: SnapshotStatusCompleted}, nil
-}
-
-func (s *notifyAheadStore) GetLatestSnapshot(ctx context.Context, sessionID string) (*SessionSnapshot[any], error) {
-	return nil, errors.New("notifyAheadStore: GetLatestSnapshot is not implemented")
-}
-
-func (s *notifyAheadStore) SaveSnapshot(ctx context.Context, snapshotID string, fn func(*SessionSnapshot[any]) (*SessionSnapshot[any], error)) (*SessionSnapshot[any], error) {
-	return nil, errors.New("notifyAheadStore: SaveSnapshot is not implemented")
+	*scriptedStore
 }
 
 func (s *notifyAheadStore) OnSnapshotStatusChange(ctx context.Context, snapshotID string) <-chan SnapshotStatus {
@@ -501,24 +483,51 @@ func (s *notifyAheadStore) OnSnapshotStatusChange(ctx context.Context, snapshotI
 	return ch
 }
 
+// newNotifyAheadStore scripts pendingReads pending reads before the row
+// settles. scriptedStore repeats its last entry, so every later read is
+// completed.
+func newNotifyAheadStore(pendingReads int) *notifyAheadStore {
+	script := make([]scriptedRead, 0, pendingReads+1)
+	for range pendingReads {
+		script = append(script, scriptedRead{snap: scriptedPending()})
+	}
+	script = append(script, scriptedRead{snap: &SessionSnapshot[any]{
+		SnapshotID: "job", SessionID: "s1", Status: SnapshotStatusCompleted,
+	}})
+	return &notifyAheadStore{scriptedStore: &scriptedStore{script: script}}
+}
+
 func TestWaitSnapshot_NotificationAheadOfTheRowKeepsWaiting(t *testing.T) {
-	restore := snapshotWaitLivenessInterval
-	snapshotWaitLivenessInterval = 10 * time.Millisecond
-	t.Cleanup(func() { snapshotWaitLivenessInterval = restore })
+	// Only the poll interval is shortened. The liveness interval keeps its
+	// production value on purpose: a terminal notification is one-shot, so
+	// after the re-read below finds the row still pending, nothing will wake
+	// this wait again and the poll interval is the only thing standing between
+	// the caller and a liveness beat of dead time. Shortening it here would
+	// prove the wait ends correctly and hide how long it took to end.
+	restore := snapshotWaitPollInterval
+	snapshotWaitPollInterval = 10 * time.Millisecond
+	t.Cleanup(func() { snapshotWaitPollInterval = restore })
 
 	// The notification says settled but the row does not yet agree. The row is
 	// what the caller gets back, so the wait must keep going rather than hand
 	// out a pending snapshot as terminal.
-	store := &notifyAheadStore{pendingReads: 2}
+	store := newNotifyAheadStore(2)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
+	start := time.Now()
 	got, err := waitSnapshot[any](ctx, store, nil, "waitForSnapshot", "job", "")
 	if err != nil {
 		t.Fatalf("waitSnapshot: %v", err)
 	}
 	if got.Status != SnapshotStatusCompleted {
 		t.Fatalf("status = %q, want %q", got.Status, SnapshotStatusCompleted)
+	}
+	// Generous next to the 10ms poll interval, and far under the untouched
+	// liveness interval, so this fails if the wait falls back to a beat.
+	if elapsed := time.Since(start); elapsed > snapshotWaitLivenessInterval/2 {
+		t.Errorf("wait took %v after a notification the row had not caught up to; "+
+			"want the poll interval, not a liveness beat (%v)", elapsed, snapshotWaitLivenessInterval)
 	}
 }
 

--- a/go/ai/exp/session_test.go
+++ b/go/ai/exp/session_test.go
@@ -108,26 +108,11 @@ func TestSnapshotStatus_Terminal(t *testing.T) {
 // --- waitForSnapshot ---
 
 // unsubscribableStore is a [SessionStore] that deliberately does not implement
-// [SnapshotSubscriber], so a wait on it falls back to re-reading. It forwards
-// to testInMemStore rather than embedding it, because embedding would promote
-// the subscription method and defeat the point.
-type unsubscribableStore[State any] struct{ inner *testInMemStore[State] }
-
-func (s unsubscribableStore[State]) GetSnapshot(ctx context.Context, snapshotID string) (*SessionSnapshot[State], error) {
-	return s.inner.GetSnapshot(ctx, snapshotID)
-}
-
-func (s unsubscribableStore[State]) GetLatestSnapshot(ctx context.Context, sessionID string) (*SessionSnapshot[State], error) {
-	return s.inner.GetLatestSnapshot(ctx, sessionID)
-}
-
-func (s unsubscribableStore[State]) SaveSnapshot(
-	ctx context.Context,
-	snapshotID string,
-	fn func(*SessionSnapshot[State]) (*SessionSnapshot[State], error),
-) (*SessionSnapshot[State], error) {
-	return s.inner.SaveSnapshot(ctx, snapshotID, fn)
-}
+// [SnapshotSubscriber], so a wait on it falls back to re-reading. It embeds
+// the interface rather than testInMemStore: embedding the interface promotes
+// only its three methods, where embedding the store would promote the
+// subscription method and defeat the point.
+type unsubscribableStore[State any] struct{ SessionStore[State] }
 
 // tipText returns the text of a state's last message: the settled turn's
 // response, as a reader of the persisted conversation sees it.
@@ -225,7 +210,7 @@ func TestWaitSnapshot_RereadsWithoutSubscriber(t *testing.T) {
 	t.Cleanup(func() { snapshotWaitPollInterval = restore })
 
 	inner := newTestInMemStore[any]()
-	store := unsubscribableStore[any]{inner: inner}
+	store := unsubscribableStore[any]{SessionStore: inner}
 	beat := time.Now()
 	putSnapshot[any](t, store, &SessionSnapshot[any]{
 		SnapshotID: "running", SessionID: "s1", Status: SnapshotStatusPending, HeartbeatAt: &beat,

--- a/go/ai/exp/session_test.go
+++ b/go/ai/exp/session_test.go
@@ -247,13 +247,11 @@ func TestWaitSnapshot_RereadsWithoutSubscriber(t *testing.T) {
 }
 
 func TestWaitSnapshot_ExpiredHeartbeatEndsTheWait(t *testing.T) {
-	restore := snapshotWaitLivenessInterval
-	snapshotWaitLivenessInterval = 10 * time.Millisecond
-	t.Cleanup(func() { snapshotWaitLivenessInterval = restore })
-
 	store := newTestInMemStore[any]()
-	// A worker that died a heartbeat timeout ago: the row stays pending, so no
-	// subscription can report it and only the liveness re-read notices.
+	// A worker that died before the wait even started: the read shaping
+	// reports the pending row as expired, which is terminal, so the wait ends
+	// on its first read. TestWaitSnapshot_LivenessRereadCatchesADeadWorker
+	// covers the harder case, where the worker dies mid-wait.
 	stale := time.Now().Add(-2 * defaultHeartbeatTimeout)
 	putSnapshot(t, store, &SessionSnapshot[any]{
 		SnapshotID: "orphan", SessionID: "s1", Status: SnapshotStatusPending, HeartbeatAt: &stale,
@@ -262,6 +260,41 @@ func TestWaitSnapshot_ExpiredHeartbeatEndsTheWait(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	got, err := waitSnapshot(ctx, store, nil, "waitForSnapshot", "orphan", "")
+	if err != nil {
+		t.Fatalf("waitSnapshot: %v", err)
+	}
+	if got.Status != SnapshotStatusExpired {
+		t.Fatalf("status = %q, want %q", got.Status, SnapshotStatusExpired)
+	}
+}
+
+// TestWaitSnapshot_LivenessRereadCatchesADeadWorker covers the one settlement
+// no subscription can deliver: the worker dies, so the row stays pending and
+// only its heartbeat goes stale. Nothing is ever written, so the wait ends only
+// because it keeps re-reading.
+func TestWaitSnapshot_LivenessRereadCatchesADeadWorker(t *testing.T) {
+	restore := snapshotWaitLivenessInterval
+	snapshotWaitLivenessInterval = 10 * time.Millisecond
+	t.Cleanup(func() { snapshotWaitLivenessInterval = restore })
+
+	store := newTestInMemStore[any]()
+	beat := time.Now()
+	putSnapshot(t, store, &SessionSnapshot[any]{
+		SnapshotID: "running", SessionID: "s1", Status: SnapshotStatusPending, HeartbeatAt: &beat,
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	go func() {
+		time.Sleep(30 * time.Millisecond)
+		// Same status, so the store pushes nothing; only the heartbeat ages.
+		stale := time.Now().Add(-2 * defaultHeartbeatTimeout)
+		putSnapshot(t, store, &SessionSnapshot[any]{
+			SnapshotID: "running", SessionID: "s1", Status: SnapshotStatusPending, HeartbeatAt: &stale,
+		})
+	}()
+
+	got, err := waitSnapshot(ctx, store, nil, "waitForSnapshot", "running", "")
 	if err != nil {
 		t.Fatalf("waitSnapshot: %v", err)
 	}
@@ -403,6 +436,89 @@ func TestWaitSnapshot_DeadEndReadFailureFailsFast(t *testing.T) {
 	}
 	if got := store.readCount(); got != 2 {
 		t.Errorf("reads = %d, want 2 (dead ends are not retried)", got)
+	}
+}
+
+func TestWaitSnapshot_FirstReadBlipIsRetried(t *testing.T) {
+	restore := snapshotWaitPollInterval
+	snapshotWaitPollInterval = 10 * time.Millisecond
+	t.Cleanup(func() { snapshotWaitPollInterval = restore })
+
+	// A wait that starts while the store is briefly unreachable is still a
+	// wait: the caller asked to follow work that is running, so one blip at
+	// t=0 must not decide the answer.
+	blip := errors.New("store blip")
+	store := &scriptedStore{script: []scriptedRead{
+		{err: blip},
+		{snap: &SessionSnapshot[any]{SnapshotID: "job", SessionID: "s1", Status: SnapshotStatusCompleted}},
+	}}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	got, err := waitSnapshot[any](ctx, store, nil, "waitForSnapshot", "job", "")
+	if err != nil {
+		t.Fatalf("waitSnapshot: %v", err)
+	}
+	if got.Status != SnapshotStatusCompleted {
+		t.Fatalf("status = %q, want %q", got.Status, SnapshotStatusCompleted)
+	}
+	if got := store.readCount(); got != 2 {
+		t.Errorf("reads = %d, want 2 (the blip, then the settled row)", got)
+	}
+}
+
+// notifyAheadStore models a store whose status notification outruns the row's
+// read visibility, which the [SnapshotSubscriber] contract permits: it pushes
+// "completed" at subscribe time while reads keep reporting the pending row for
+// pendingReads more reads.
+type notifyAheadStore struct {
+	mu           sync.Mutex
+	reads        int
+	pendingReads int
+}
+
+func (s *notifyAheadStore) GetSnapshot(ctx context.Context, snapshotID string) (*SessionSnapshot[any], error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.reads++
+	if s.reads <= s.pendingReads {
+		return scriptedPending(), nil
+	}
+	return &SessionSnapshot[any]{SnapshotID: "job", SessionID: "s1", Status: SnapshotStatusCompleted}, nil
+}
+
+func (s *notifyAheadStore) GetLatestSnapshot(ctx context.Context, sessionID string) (*SessionSnapshot[any], error) {
+	return nil, errors.New("notifyAheadStore: GetLatestSnapshot is not implemented")
+}
+
+func (s *notifyAheadStore) SaveSnapshot(ctx context.Context, snapshotID string, fn func(*SessionSnapshot[any]) (*SessionSnapshot[any], error)) (*SessionSnapshot[any], error) {
+	return nil, errors.New("notifyAheadStore: SaveSnapshot is not implemented")
+}
+
+func (s *notifyAheadStore) OnSnapshotStatusChange(ctx context.Context, snapshotID string) <-chan SnapshotStatus {
+	ch := make(chan SnapshotStatus, 1)
+	ch <- SnapshotStatusCompleted
+	return ch
+}
+
+func TestWaitSnapshot_NotificationAheadOfTheRowKeepsWaiting(t *testing.T) {
+	restore := snapshotWaitLivenessInterval
+	snapshotWaitLivenessInterval = 10 * time.Millisecond
+	t.Cleanup(func() { snapshotWaitLivenessInterval = restore })
+
+	// The notification says settled but the row does not yet agree. The row is
+	// what the caller gets back, so the wait must keep going rather than hand
+	// out a pending snapshot as terminal.
+	store := &notifyAheadStore{pendingReads: 2}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	got, err := waitSnapshot[any](ctx, store, nil, "waitForSnapshot", "job", "")
+	if err != nil {
+		t.Fatalf("waitSnapshot: %v", err)
+	}
+	if got.Status != SnapshotStatusCompleted {
+		t.Fatalf("status = %q, want %q", got.Status, SnapshotStatusCompleted)
 	}
 }
 

--- a/go/ai/exp/session_test.go
+++ b/go/ai/exp/session_test.go
@@ -21,6 +21,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/firebase/genkit/go/ai"
 	"github.com/firebase/genkit/go/internal/base"
 )
 
@@ -74,5 +75,84 @@ func TestPromptStateReflectsLatestCustom(t *testing.T) {
 func TestPromptStateNilWithoutSession(t *testing.T) {
 	if got := base.PromptStateFromContext(context.Background()); got != nil {
 		t.Errorf("PromptStateFromContext() = %#v, want nil", got)
+	}
+}
+
+func TestSnapshotStatus_Terminal(t *testing.T) {
+	cases := []struct {
+		status SnapshotStatus
+		want   bool
+	}{
+		{SnapshotStatusPending, false},
+		{SnapshotStatusCompleted, true},
+		{SnapshotStatusAborted, true},
+		{SnapshotStatusFailed, true},
+		{SnapshotStatusExpired, true},
+		// Empty counts as completed, matching the documented default.
+		{SnapshotStatus(""), true},
+	}
+	for _, tc := range cases {
+		if got := tc.status.Terminal(); got != tc.want {
+			t.Errorf("SnapshotStatus(%q).Terminal() = %v, want %v", tc.status, got, tc.want)
+		}
+	}
+}
+
+func TestSessionState_LastModelMessage(t *testing.T) {
+	toolOnly := &ai.Message{Role: ai.RoleModel, Content: []*ai.Part{
+		ai.NewToolRequestPart(&ai.ToolRequest{Name: "search"}),
+	}}
+
+	cases := []struct {
+		name     string
+		messages []*ai.Message
+		want     string // "" means nil expected
+	}{
+		{name: "empty history"},
+		{name: "no model messages", messages: []*ai.Message{ai.NewUserTextMessage("hi")}},
+		{
+			name: "latest text-bearing model message wins",
+			messages: []*ai.Message{
+				ai.NewUserTextMessage("q1"),
+				ai.NewModelTextMessage("a1"),
+				ai.NewUserTextMessage("q2"),
+				ai.NewModelTextMessage("a2"),
+			},
+			want: "a2",
+		},
+		{
+			name: "tool-request-only tip is skipped",
+			messages: []*ai.Message{
+				ai.NewModelTextMessage("spoken answer"),
+				ai.NewUserTextMessage("follow-up"),
+				toolOnly,
+			},
+			want: "spoken answer",
+		},
+		{
+			name:     "only tool requests",
+			messages: []*ai.Message{toolOnly},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			state := &SessionState[any]{Messages: tc.messages}
+			got := state.LastModelMessage()
+			if tc.want == "" {
+				if got != nil {
+					t.Fatalf("LastModelMessage() = %+v, want nil", got)
+				}
+				return
+			}
+			if got == nil || got.Text() != tc.want {
+				t.Fatalf("LastModelMessage().Text() = %v, want %q", got, tc.want)
+			}
+		})
+	}
+
+	// A nil receiver (e.g. a pending snapshot's nil state) is tolerated.
+	var nilState *SessionState[any]
+	if got := nilState.LastModelMessage(); got != nil {
+		t.Fatalf("nil receiver LastModelMessage() = %+v, want nil", got)
 	}
 }

--- a/go/ai/exp/session_test.go
+++ b/go/ai/exp/session_test.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"reflect"
+	"sync"
 	"testing"
 	"time"
 
@@ -340,6 +341,117 @@ func TestWaitSnapshot_UnknownSnapshot(t *testing.T) {
 	}
 	if got, want := err.Error(), "waitForSnapshot: "; len(got) < len(want) || got[:len(want)] != want {
 		t.Errorf("error = %q, want it to name the operation that failed", got)
+	}
+}
+
+// scriptedStore answers each GetSnapshot from a fixed script, so a test can
+// stage read failures inside a wait deterministically: read n gets entry n-1,
+// and the last entry repeats. It deliberately implements no [SnapshotSubscriber],
+// and the other store methods are never reached by a wait on a snapshot ID.
+type scriptedStore struct {
+	mu     sync.Mutex
+	reads  int
+	script []scriptedRead
+}
+
+type scriptedRead struct {
+	snap *SessionSnapshot[any]
+	err  error
+}
+
+func (s *scriptedStore) GetSnapshot(ctx context.Context, snapshotID string) (*SessionSnapshot[any], error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.reads++
+	entry := s.script[min(s.reads, len(s.script))-1]
+	return entry.snap, entry.err
+}
+
+func (s *scriptedStore) GetLatestSnapshot(ctx context.Context, sessionID string) (*SessionSnapshot[any], error) {
+	return nil, errors.New("scriptedStore: GetLatestSnapshot is not scripted")
+}
+
+func (s *scriptedStore) SaveSnapshot(ctx context.Context, snapshotID string, fn func(*SessionSnapshot[any]) (*SessionSnapshot[any], error)) (*SessionSnapshot[any], error) {
+	return nil, errors.New("scriptedStore: SaveSnapshot is not scripted")
+}
+
+func (s *scriptedStore) readCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.reads
+}
+
+// scriptedPending is a pending row with a live heartbeat, so a scripted read
+// reports it as genuinely pending rather than expired.
+func scriptedPending() *SessionSnapshot[any] {
+	beat := time.Now()
+	return &SessionSnapshot[any]{SnapshotID: "job", SessionID: "s1", Status: SnapshotStatusPending, HeartbeatAt: &beat}
+}
+
+func TestWaitSnapshot_TransientReadFailuresAreRetried(t *testing.T) {
+	restore := snapshotWaitPollInterval
+	snapshotWaitPollInterval = 10 * time.Millisecond
+	t.Cleanup(func() { snapshotWaitPollInterval = restore })
+
+	blip := errors.New("store blip")
+	store := &scriptedStore{script: []scriptedRead{
+		{snap: scriptedPending()}, // the wait's initial read
+		{err: blip},               // two consecutive in-wait blips, both
+		{err: blip},               // within the retry budget
+		{snap: &SessionSnapshot[any]{SnapshotID: "job", SessionID: "s1", Status: SnapshotStatusCompleted}},
+	}}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	got, err := waitSnapshot[any](ctx, store, nil, "waitForSnapshot", "job", "")
+	if err != nil {
+		t.Fatalf("waitSnapshot: %v", err)
+	}
+	if got.Status != SnapshotStatusCompleted {
+		t.Fatalf("status = %q, want %q", got.Status, SnapshotStatusCompleted)
+	}
+	if got := store.readCount(); got != 4 {
+		t.Errorf("reads = %d, want 4 (initial, two retried blips, settled)", got)
+	}
+}
+
+func TestWaitSnapshot_PersistentReadFailureSurfaces(t *testing.T) {
+	restore := snapshotWaitPollInterval
+	snapshotWaitPollInterval = 10 * time.Millisecond
+	t.Cleanup(func() { snapshotWaitPollInterval = restore })
+
+	down := errors.New("store down")
+	store := &scriptedStore{script: []scriptedRead{{snap: scriptedPending()}, {err: down}}}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_, err := waitSnapshot[any](ctx, store, nil, "waitForSnapshot", "job", "")
+	if !errors.Is(err, down) {
+		t.Fatalf("waitSnapshot error = %v, want the store's own error", err)
+	}
+	// The initial read, the retried failures, and the one that surfaced.
+	if got, want := store.readCount(), 2+snapshotWaitReadRetries; got != want {
+		t.Errorf("reads = %d, want %d (retry budget exhausted)", got, want)
+	}
+}
+
+func TestWaitSnapshot_DeadEndReadFailureFailsFast(t *testing.T) {
+	restore := snapshotWaitPollInterval
+	snapshotWaitPollInterval = 10 * time.Millisecond
+	t.Cleanup(func() { snapshotWaitPollInterval = restore })
+
+	// The row disappears mid-wait: the re-read reports NOT_FOUND, which no
+	// retry can help, so it surfaces at once instead of burning the budget.
+	store := &scriptedStore{script: []scriptedRead{{snap: scriptedPending()}, {}}}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_, err := waitSnapshot[any](ctx, store, nil, "waitForSnapshot", "job", "")
+	if !errors.Is(err, ErrSnapshotNotFound) {
+		t.Fatalf("waitSnapshot error = %v, want ErrSnapshotNotFound", err)
+	}
+	if got := store.readCount(); got != 2 {
+		t.Errorf("reads = %d, want 2 (dead ends are not retried)", got)
 	}
 }
 

--- a/go/ai/exp/session_test.go
+++ b/go/ai/exp/session_test.go
@@ -104,65 +104,6 @@ func TestSnapshotStatus_Terminal(t *testing.T) {
 	}
 }
 
-func TestSessionState_LastModelMessage(t *testing.T) {
-	toolOnly := &ai.Message{Role: ai.RoleModel, Content: []*ai.Part{
-		ai.NewToolRequestPart(&ai.ToolRequest{Name: "search"}),
-	}}
-
-	cases := []struct {
-		name     string
-		messages []*ai.Message
-		want     string // "" means nil expected
-	}{
-		{name: "empty history"},
-		{name: "no model messages", messages: []*ai.Message{ai.NewUserTextMessage("hi")}},
-		{
-			name: "latest text-bearing model message wins",
-			messages: []*ai.Message{
-				ai.NewUserTextMessage("q1"),
-				ai.NewModelTextMessage("a1"),
-				ai.NewUserTextMessage("q2"),
-				ai.NewModelTextMessage("a2"),
-			},
-			want: "a2",
-		},
-		{
-			name: "tool-request-only tip is skipped",
-			messages: []*ai.Message{
-				ai.NewModelTextMessage("spoken answer"),
-				ai.NewUserTextMessage("follow-up"),
-				toolOnly,
-			},
-			want: "spoken answer",
-		},
-		{
-			name:     "only tool requests",
-			messages: []*ai.Message{toolOnly},
-		},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			state := &SessionState[any]{Messages: tc.messages}
-			got := state.LastModelMessage()
-			if tc.want == "" {
-				if got != nil {
-					t.Fatalf("LastModelMessage() = %+v, want nil", got)
-				}
-				return
-			}
-			if got == nil || got.Text() != tc.want {
-				t.Fatalf("LastModelMessage().Text() = %v, want %q", got, tc.want)
-			}
-		})
-	}
-
-	// A nil receiver (e.g. a pending snapshot's nil state) is tolerated.
-	var nilState *SessionState[any]
-	if got := nilState.LastModelMessage(); got != nil {
-		t.Fatalf("nil receiver LastModelMessage() = %+v, want nil", got)
-	}
-}
-
 // --- waitForSnapshot ---
 
 // unsubscribableStore is a [SessionStore] that deliberately does not implement
@@ -185,6 +126,16 @@ func (s unsubscribableStore[State]) SaveSnapshot(
 	fn func(*SessionSnapshot[State]) (*SessionSnapshot[State], error),
 ) (*SessionSnapshot[State], error) {
 	return s.inner.SaveSnapshot(ctx, snapshotID, fn)
+}
+
+// tipText returns the text of a state's last message: the settled turn's
+// response, as a reader of the persisted conversation sees it.
+func tipText[State any](t *testing.T, s *SessionState[State]) string {
+	t.Helper()
+	if s == nil || len(s.Messages) == 0 {
+		t.Fatal("state carries no messages")
+	}
+	return s.Messages[len(s.Messages)-1].Text()
 }
 
 // putSnapshot writes one row verbatim, so a test can stage a snapshot in any
@@ -226,8 +177,8 @@ func TestWaitSnapshot_TerminalReturnsWithoutWaiting(t *testing.T) {
 	if got.Status != SnapshotStatusCompleted {
 		t.Fatalf("status = %q, want %q", got.Status, SnapshotStatusCompleted)
 	}
-	if text := got.State.LastModelMessage().Text(); text != "finished" {
-		t.Errorf("last model message = %q, want %q", text, "finished")
+	if text := tipText(t, got.State); text != "finished" {
+		t.Errorf("last message = %q, want %q", text, "finished")
 	}
 }
 

--- a/go/ai/exp/task.go
+++ b/go/ai/exp/task.go
@@ -1,0 +1,130 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package exp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/firebase/genkit/go/core/status"
+)
+
+// DetachedTask tracks a detached (background) agent invocation through its
+// pending snapshot, with custom state typed as State: the agent's own state
+// type for a task the typed [Agent] minted, [json.RawMessage] for one an
+// [AgentHandle] minted. Obtain one from [Agent.RunDetached] or
+// [AgentHandle.RunDetached] when launching, or rehydrate one from a recorded
+// snapshot ID with [Agent.Task] or [AgentHandle.Task]; the two
+// are equivalent, because the snapshot is the only state a task has.
+type DetachedTask[State any] struct {
+	ops        snapshotOps[State]
+	snapshotID string
+}
+
+// snapshotOps is what a [DetachedTask] needs from the surface that minted it.
+// The typed [Agent] and the untyped [AgentHandle] both publish these methods,
+// so a task reads, waits, and aborts exactly as its origin would, differences
+// included: through a handle, aborting a missing snapshot is NOT_FOUND, where
+// [Agent.Abort] reports "".
+type snapshotOps[State any] interface {
+	GetSnapshot(ctx context.Context, snapshotID string) (*SessionSnapshot[State], error)
+	WaitForSnapshot(ctx context.Context, snapshotID string) (*SessionSnapshot[State], error)
+	Abort(ctx context.Context, snapshotID string) (SnapshotStatus, error)
+}
+
+var (
+	_ snapshotOps[any]             = (*Agent[any])(nil)
+	_ snapshotOps[json.RawMessage] = (*AgentHandle)(nil)
+)
+
+// detachedInput returns a copy of input with [AgentInput.Detach] set, whatever
+// the caller set it to. The copy is shallow: the message and resume payloads
+// are shared, not cloned, and nothing mutates them.
+func detachedInput(input *AgentInput) *AgentInput {
+	detached := *input
+	detached.Detach = true
+	return &detached
+}
+
+// detachedTaskFrom folds the output of an invocation delivered with
+// [AgentInput.Detach] into the task tracking it, or the error saying why there
+// is none. ops is the surface the task reads through, and name the agent's,
+// for the messages.
+//
+// A detached finish is the expected outcome. A failed one is the runtime
+// refusing the launch (no session store, or one that cannot observe aborts),
+// surfaced as an error carrying the output's status. Anything else means the
+// agent settled the invocation before the runtime observed the detach
+// directive (nothing orders the intake reader ahead of an agent fn that never
+// consumes its input): a committed turn's snapshot is the settled work's
+// durable record, so the task tracks it and Poll and Wait resolve at once; with
+// nothing recorded there is nothing to track.
+func detachedTaskFrom[State any](name string, ops snapshotOps[State], out *AgentOutput[State]) (*DetachedTask[State], error) {
+	switch out.FinishReason {
+	case AgentFinishReasonDetached:
+		return &DetachedTask[State]{ops: ops, snapshotID: out.SnapshotID}, nil
+	case AgentFinishReasonFailed:
+		var cause error = out.Error
+		if out.Error == nil {
+			cause = status.Errorf(status.ErrInternal, "launch failed without error detail")
+		}
+		return nil, fmt.Errorf("agent %q: background launch failed: %w", name, cause)
+	default:
+		if out.SnapshotID != "" {
+			return &DetachedTask[State]{ops: ops, snapshotID: out.SnapshotID}, nil
+		}
+		return nil, status.Errorf(status.ErrFailedPrecondition,
+			"agent %q: the invocation settled synchronously (finish reason %q, session %q) without recording a snapshot, so there is no background task to track",
+			name, out.FinishReason, out.SessionID)
+	}
+}
+
+// SnapshotID returns the ID of the snapshot tracking the task: pending while
+// the background work runs, finalized in place when it settles. It is the
+// task's durable identity; record it to pick the task up later with
+// [Agent.Task] or [AgentHandle.Task].
+func (t *DetachedTask[State]) SnapshotID() string { return t.snapshotID }
+
+// Poll fetches the task's snapshot once, without waiting. The snapshot's
+// Status says where the task stands: [SnapshotStatusPending] while the work
+// runs, a terminal status once it settles (see [SnapshotStatus.Terminal]),
+// including [SnapshotStatusExpired] when the worker stopped heartbeating and
+// is presumed dead. A terminal snapshot carries the cumulative session state.
+func (t *DetachedTask[State]) Poll(ctx context.Context) (*SessionSnapshot[State], error) {
+	return t.ops.GetSnapshot(ctx, t.snapshotID)
+}
+
+// Wait blocks until the task settles and returns its terminal snapshot: the
+// waiting happens next to the store that knows when the work finished, so the
+// caller neither picks a cadence nor pays a read per tick. A task that failed,
+// aborted, or expired still returns its snapshot rather than an error (inspect
+// [SessionSnapshot.Status] and [SessionSnapshot.Error]), so a non-nil error
+// means the wait itself could not proceed: reads failed past the wait's
+// transient-retry budget, or ctx ended and its error is returned.
+//
+// Use [context.WithTimeout] to bound the wait; on the deadline the wait returns
+// ctx's error, and [DetachedTask.Poll] then reports where the task stands.
+func (t *DetachedTask[State]) Wait(ctx context.Context) (*SessionSnapshot[State], error) {
+	return t.ops.WaitForSnapshot(ctx, t.snapshotID)
+}
+
+// Abort asks the task's background work to stop and returns the snapshot's
+// status after the attempt, as [Agent.Abort] or [AgentHandle.Abort] reports it.
+func (t *DetachedTask[State]) Abort(ctx context.Context) (SnapshotStatus, error) {
+	return t.ops.Abort(ctx, t.snapshotID)
+}

--- a/go/core/api/action.go
+++ b/go/core/api/action.go
@@ -119,6 +119,7 @@ const (
 	ActionTypeUtil             ActionType = "util"
 	ActionTypeCustom           ActionType = "custom"
 	ActionTypeAgentSnapshot    ActionType = "agent-snapshot"
+	ActionTypeAgentWait        ActionType = "agent-wait"
 	ActionTypeAgentAbort       ActionType = "agent-abort"
 	ActionTypeCheckOperation   ActionType = "check-operation"
 	ActionTypeCancelOperation  ActionType = "cancel-operation"

--- a/go/genkit/exp/agent.go
+++ b/go/genkit/exp/agent.go
@@ -204,9 +204,9 @@ func DefineCustomAgent[State any](
 // LookupAgent resolves an agent registered on g by name and returns its
 // [aix.AgentHandle]: the untyped caller-side view for code that does not hold
 // the typed [aix.Agent] value (orchestrators, middleware, tools). The handle
-// runs the agent ([aix.AgentHandle.Run]), launches and tracks background work
-// ([aix.AgentHandle.Start], [aix.AgentHandle.Task]), and reads or aborts
-// snapshots, with custom state as raw JSON.
+// runs the agent ([aix.AgentHandle.Run], [aix.AgentHandle.RunText]), launches
+// and tracks background work ([aix.AgentHandle.Start], [aix.AgentHandle.Task]),
+// and reads or aborts snapshots, with custom state as raw JSON.
 //
 // It returns nil when name resolves to no agent, matching every other Lookup
 // in the framework. Like [ListAgents] it does not require

--- a/go/genkit/exp/agent.go
+++ b/go/genkit/exp/agent.go
@@ -205,8 +205,9 @@ func DefineCustomAgent[State any](
 // [aix.AgentHandle]: the untyped caller-side view for code that does not hold
 // the typed [aix.Agent] value (orchestrators, middleware, tools). The handle
 // runs the agent ([aix.AgentHandle.Run], [aix.AgentHandle.RunText]), launches
-// and tracks background work ([aix.AgentHandle.Start], [aix.AgentHandle.Task]),
-// and reads or aborts snapshots, with custom state as raw JSON.
+// and tracks background work ([aix.AgentHandle.RunDetached],
+// [aix.AgentHandle.Task]), and reads or aborts snapshots, with custom
+// state as raw JSON.
 //
 // It returns nil when name resolves to no agent, matching every other Lookup
 // in the framework. Like [ListAgents] it does not require

--- a/go/genkit/exp/agent.go
+++ b/go/genkit/exp/agent.go
@@ -201,6 +201,22 @@ func DefineCustomAgent[State any](
 	return aix.DefineCustomAgent(genkitbridge.RegistryOf(g), name, fn, opts...)
 }
 
+// LookupAgent resolves an agent registered on g by name and returns its
+// [aix.AgentHandle]: the untyped caller-side view for code that does not hold
+// the typed [aix.Agent] value (orchestrators, middleware, tools). The handle
+// runs the agent ([aix.AgentHandle.Run]), launches and tracks background work
+// ([aix.AgentHandle.Start], [aix.AgentHandle.Task]), and reads or aborts
+// snapshots, with custom state as raw JSON.
+//
+// It returns NOT_FOUND when no agent is registered under name, and
+// INVALID_ARGUMENT when the name resolves to an action that is not an agent.
+// Like [ListAgents] it does not require [genkit.WithExperimental]: it only
+// reads the registry, and an agent can only have been registered through the
+// gated constructors.
+func LookupAgent(g *genkit.Genkit, name string) (*aix.AgentHandle, error) {
+	return aix.LookupAgent(genkitbridge.RegistryOf(g), name)
+}
+
 // ListAgents returns a slice of all [api.Action] instances that represent
 // agents registered with the Genkit instance g. Like [genkit.ListFlows], this
 // is useful for introspection or for dynamically exposing agent endpoints in an

--- a/go/genkit/exp/agent.go
+++ b/go/genkit/exp/agent.go
@@ -208,12 +208,11 @@ func DefineCustomAgent[State any](
 // ([aix.AgentHandle.Start], [aix.AgentHandle.Task]), and reads or aborts
 // snapshots, with custom state as raw JSON.
 //
-// It returns NOT_FOUND when no agent is registered under name, and
-// INVALID_ARGUMENT when the name resolves to an action that is not an agent.
-// Like [ListAgents] it does not require [genkit.WithExperimental]: it only
-// reads the registry, and an agent can only have been registered through the
-// gated constructors.
-func LookupAgent(g *genkit.Genkit, name string) (*aix.AgentHandle, error) {
+// It returns nil when name resolves to no agent, matching every other Lookup
+// in the framework. Like [ListAgents] it does not require
+// [genkit.WithExperimental]: it only reads the registry, and an agent can only
+// have been registered through the gated constructors.
+func LookupAgent(g *genkit.Genkit, name string) *aix.AgentHandle {
 	return aix.LookupAgent(genkitbridge.RegistryOf(g), name)
 }
 

--- a/go/genkit/exp/agent_test.go
+++ b/go/genkit/exp/agent_test.go
@@ -18,12 +18,10 @@ package exp
 
 import (
 	"context"
-	"errors"
 	"testing"
 
 	"github.com/firebase/genkit/go/ai"
 	aix "github.com/firebase/genkit/go/ai/exp"
-	"github.com/firebase/genkit/go/core/status"
 	"github.com/firebase/genkit/go/genkit"
 )
 
@@ -41,10 +39,7 @@ func TestLookupAgent(t *testing.T) {
 				return sess.Result(), nil
 			})
 
-		h, err := LookupAgent(g, "echo")
-		if err != nil {
-			t.Fatalf("LookupAgent: %v", err)
-		}
+		h := LookupAgent(g, "echo")
 		if got := h.Name(); got != "echo" {
 			t.Errorf("Name() = %q, want %q", got, "echo")
 		}
@@ -57,20 +52,20 @@ func TestLookupAgent(t *testing.T) {
 		}
 	})
 
-	t.Run("unknown agent is NOT_FOUND", func(t *testing.T) {
+	t.Run("unknown agent is nil", func(t *testing.T) {
 		g := genkit.Init(context.Background(), genkit.WithExperimental())
-		if _, err := LookupAgent(g, "ghost"); !errors.Is(err, status.ErrNotFound) {
-			t.Fatalf("LookupAgent error = %v, want NOT_FOUND", err)
+		if h := LookupAgent(g, "ghost"); h != nil {
+			t.Fatalf("LookupAgent(unregistered) = %+v, want nil", h)
 		}
 	})
 
 	t.Run("does not require the experimental gate", func(t *testing.T) {
 		// LookupAgent only reads the registry, so unlike the constructors it
 		// must not panic without genkit.WithExperimental; with no agents
-		// registered it simply reports NOT_FOUND.
+		// registered it simply reports nil.
 		g := genkit.Init(context.Background())
-		if _, err := LookupAgent(g, "anything"); !errors.Is(err, status.ErrNotFound) {
-			t.Fatalf("LookupAgent error = %v, want NOT_FOUND", err)
+		if h := LookupAgent(g, "anything"); h != nil {
+			t.Fatalf("LookupAgent(unregistered) = %+v, want nil", h)
 		}
 	})
 }

--- a/go/genkit/exp/agent_test.go
+++ b/go/genkit/exp/agent_test.go
@@ -1,0 +1,76 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package exp
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/firebase/genkit/go/ai"
+	aix "github.com/firebase/genkit/go/ai/exp"
+	"github.com/firebase/genkit/go/core/status"
+	"github.com/firebase/genkit/go/genkit"
+)
+
+func TestLookupAgent(t *testing.T) {
+	t.Run("resolves and runs a defined agent", func(t *testing.T) {
+		g := genkit.Init(context.Background(), genkit.WithExperimental())
+		DefineCustomAgent(g, "echo",
+			func(ctx context.Context, resp aix.Responder, sess *aix.SessionRunner[any]) (*aix.AgentResult, error) {
+				if err := sess.Run(ctx, func(ctx context.Context, input *aix.AgentInput) (*aix.TurnResult, error) {
+					sess.AddMessages(ai.NewModelTextMessage("echo: " + input.Message.Text()))
+					return nil, nil
+				}); err != nil {
+					return nil, err
+				}
+				return sess.Result(), nil
+			})
+
+		h, err := LookupAgent(g, "echo")
+		if err != nil {
+			t.Fatalf("LookupAgent: %v", err)
+		}
+		if got := h.Name(); got != "echo" {
+			t.Errorf("Name() = %q, want %q", got, "echo")
+		}
+		out, err := h.Run(context.Background(), &aix.AgentInput{Message: ai.NewUserTextMessage("hi")})
+		if err != nil {
+			t.Fatalf("Run: %v", err)
+		}
+		if got, want := out.Message.Text(), "echo: hi"; got != want {
+			t.Errorf("Message.Text() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("unknown agent is NOT_FOUND", func(t *testing.T) {
+		g := genkit.Init(context.Background(), genkit.WithExperimental())
+		if _, err := LookupAgent(g, "ghost"); !errors.Is(err, status.ErrNotFound) {
+			t.Fatalf("LookupAgent error = %v, want NOT_FOUND", err)
+		}
+	})
+
+	t.Run("does not require the experimental gate", func(t *testing.T) {
+		// LookupAgent only reads the registry, so unlike the constructors it
+		// must not panic without genkit.WithExperimental; with no agents
+		// registered it simply reports NOT_FOUND.
+		g := genkit.Init(context.Background())
+		if _, err := LookupAgent(g, "anything"); !errors.Is(err, status.ErrNotFound) {
+			t.Fatalf("LookupAgent error = %v, want NOT_FOUND", err)
+		}
+	})
+}

--- a/go/genkit/exp/routes.go
+++ b/go/genkit/exp/routes.go
@@ -79,8 +79,9 @@ func AllAgentRoutes(g *genkit.Genkit) []Route {
 		// client-managed agent has no companions), and buildAgentRoutes omits
 		// the route for a nil companion.
 		snapshot := genkit.LookupAction(g, api.KeyFromName(api.ActionTypeAgentSnapshot, name))
+		wait := genkit.LookupAction(g, api.KeyFromName(api.ActionTypeAgentWait, name))
 		abort := genkit.LookupAction(g, api.KeyFromName(api.ActionTypeAgentAbort, name))
-		routes = append(routes, buildAgentRoutes(name, act, snapshot, abort)...)
+		routes = append(routes, buildAgentRoutes(name, act, snapshot, wait, abort)...)
 	}
 	return routes
 }
@@ -91,9 +92,12 @@ func AllAgentRoutes(g *genkit.Genkit) []Route {
 //
 // The route set mirrors what the agent can do:
 //
-//   - POST /agents/{name}                the agent, one turn per request
-//   - POST /agents/{name}/getSnapshot    getSnapshot (store-backed agents)
-//   - POST /agents/{name}/abort          abort (abortable stores)
+//   - POST /agents/{name}                     the agent, one turn per request
+//   - POST /agents/{name}/getSnapshot         getSnapshot (store-backed agents)
+//   - POST /agents/{name}/waitForSnapshot     waitForSnapshot (store-backed
+//     agents); getSnapshot's blocking counterpart, so a client follows a
+//     detached invocation in one request instead of polling
+//   - POST /agents/{name}/abort               abort (abortable stores)
 //
 // Each takes the {"data": ...} request envelope and returns {"result":
 // ...}; the snapshot ID rides in the body ({"data": {"snapshotId": ...}}),
@@ -101,20 +105,27 @@ func AllAgentRoutes(g *genkit.Genkit) []Route {
 // capabilities the agent lacks; a client-managed agent contributes only
 // its turn route.
 func AgentRoutes[State any](a *aix.Agent[State]) []Route {
-	return buildAgentRoutes(a.Name(), a, a.GetSnapshotAction(), a.AbortAction())
+	return buildAgentRoutes(a.Name(), a, a.GetSnapshotAction(), a.WaitForSnapshotAction(), a.AbortAction())
 }
 
 // buildAgentRoutes builds an agent's route set from its run action and the
-// companion actions it has (either may be nil). Shared by AllAgentRoutes
+// companion actions it has (any may be nil). Shared by AllAgentRoutes
 // (companions looked up by key) and AgentRoutes (companions from the typed
 // ref's accessors).
-func buildAgentRoutes(name string, run, snapshot, abort api.Action) []Route {
+func buildAgentRoutes(name string, run, snapshot, wait, abort api.Action) []Route {
 	routes := []Route{{Method: http.MethodPost, Path: agentBasePath + "/" + name, Action: run}}
 	if snapshot != nil {
 		routes = append(routes, Route{
 			Method: http.MethodPost,
 			Path:   agentBasePath + "/" + name + "/getSnapshot",
 			Action: snapshot,
+		})
+	}
+	if wait != nil {
+		routes = append(routes, Route{
+			Method: http.MethodPost,
+			Path:   agentBasePath + "/" + name + "/waitForSnapshot",
+			Action: wait,
 		})
 	}
 	if abort != nil {

--- a/go/genkit/exp/routes.go
+++ b/go/genkit/exp/routes.go
@@ -114,25 +114,21 @@ func AgentRoutes[State any](a *aix.Agent[State]) []Route {
 // ref's accessors).
 func buildAgentRoutes(name string, run, snapshot, wait, abort api.Action) []Route {
 	routes := []Route{{Method: http.MethodPost, Path: agentBasePath + "/" + name, Action: run}}
-	if snapshot != nil {
+	for _, companion := range []struct {
+		suffix string
+		action api.Action
+	}{
+		{"/getSnapshot", snapshot},
+		{"/waitForSnapshot", wait},
+		{"/abort", abort},
+	} {
+		if companion.action == nil {
+			continue
+		}
 		routes = append(routes, Route{
 			Method: http.MethodPost,
-			Path:   agentBasePath + "/" + name + "/getSnapshot",
-			Action: snapshot,
-		})
-	}
-	if wait != nil {
-		routes = append(routes, Route{
-			Method: http.MethodPost,
-			Path:   agentBasePath + "/" + name + "/waitForSnapshot",
-			Action: wait,
-		})
-	}
-	if abort != nil {
-		routes = append(routes, Route{
-			Method: http.MethodPost,
-			Path:   agentBasePath + "/" + name + "/abort",
-			Action: abort,
+			Path:   agentBasePath + "/" + name + companion.suffix,
+			Action: companion.action,
 		})
 	}
 	return routes

--- a/go/genkit/exp/routes_test.go
+++ b/go/genkit/exp/routes_test.go
@@ -85,6 +85,7 @@ func TestAllAgentRoutes(t *testing.T) {
 		"POST /agents/serverChat",
 		"POST /agents/serverChat/abort",
 		"POST /agents/serverChat/getSnapshot",
+		"POST /agents/serverChat/waitForSnapshot",
 	}
 	if !slices.Equal(got, want) {
 		t.Errorf("AllAgentRoutes layout =\n  %v\nwant\n  %v", got, want)
@@ -119,6 +120,7 @@ func TestAgentRoutes_PicksOneAgentAndMirrorsCapabilities(t *testing.T) {
 		"POST /agents/srv",
 		"POST /agents/srv/abort",
 		"POST /agents/srv/getSnapshot",
+		"POST /agents/srv/waitForSnapshot",
 	}; !slices.Equal(got, want) {
 		t.Errorf("AgentRoutes(server) = %v, want %v", got, want)
 	}

--- a/go/samples/basic-agents-server/main.go
+++ b/go/samples/basic-agents-server/main.go
@@ -23,8 +23,8 @@
 //   - chat has a session store, so the server keeps the state. Each turn
 //     persists a snapshot and the response carries sessionId and snapshotId;
 //     resume with {"init": {"sessionId": ...}}. The store also brings the
-//     companion actions, served under the agent's own path as getSnapshot and
-//     abort.
+//     companion actions, served under the agent's own path as getSnapshot,
+//     waitForSnapshot, and abort.
 //   - statelessChat has no store, so the client keeps the state. The response
 //     carries the whole thing; send it back as {"init": {"state": ...}}.
 //
@@ -62,14 +62,21 @@
 //	  -d '{"data": {"message": {"role": "user", "content": [{"text": "Suggest three day trips from Tokyo."}]}}}'
 //
 // Or detach, which returns immediately with finishReason "detached" and a
-// pending snapshotId while the turn keeps running. Poll getSnapshot until its
-// status leaves "pending", or abort it:
+// pending snapshotId while the turn keeps running. Read where it stands with
+// getSnapshot, block until it settles with waitForSnapshot, or abort it:
 //
 //	curl -X POST http://localhost:8080/agents/chat \
 //	  -H "Content-Type: application/json" \
 //	  -d '{"data": {"message": {"role": "user", "content": [{"text": "Plan a two-week Japan itinerary."}]}, "detach": true}}'
 //
 //	curl -X POST http://localhost:8080/agents/chat/getSnapshot \
+//	  -H "Content-Type: application/json" \
+//	  -d '{"data": {"snapshotId": "SNAPSHOT_ID"}}'
+//
+// waitForSnapshot takes the same payload but answers only once the turn has
+// settled, so one request replaces a polling loop:
+//
+//	curl -X POST http://localhost:8080/agents/chat/waitForSnapshot \
 //	  -H "Content-Type: application/json" \
 //	  -d '{"data": {"snapshotId": "SNAPSHOT_ID"}}'
 //
@@ -139,10 +146,11 @@ func main() {
 	// agent, following each one's capabilities, so the store-backed and
 	// client-managed agents can be served side by side from one call:
 	//
-	//     POST /agents/chat                one turn per request
-	//     POST /agents/chat/getSnapshot    read a snapshot by ID
-	//     POST /agents/chat/abort          abort background work
-	//     POST /agents/statelessChat       one turn per request
+	//     POST /agents/chat                     one turn per request
+	//     POST /agents/chat/getSnapshot         read a snapshot by ID
+	//     POST /agents/chat/waitForSnapshot     block until a snapshot settles
+	//     POST /agents/chat/abort               abort background work
+	//     POST /agents/statelessChat            one turn per request
 	//
 	// route.Pattern() is its "METHOD /path" and route.Handler() builds the
 	// genkit.Handler, so any router works the same way. For a subset use


### PR DESCRIPTION
Base PR of a three-PR train (#6119 background delegation, then #6221 `continue_task`). Adds `AgentHandle` to `ai/exp`: the caller-side view of an agent for code that knows it only by name (orchestrators, middleware, tools), with custom state fixed to `json.RawMessage`. It adds no capability over the agent it names; it removes the wire plumbing name-resolved callers repeat today, and reaches the agent through an unexported transport seam, so an HTTP-backed handle is a second implementation rather than a second surface. Also adds `RunDetached`, the one-shot counterpart of `AgentConnection.Detach`, to the typed `Agent` and the handle alike, returning a `DetachedTask[State]`; and `waitForSnapshot`, the blocking counterpart of `getSnapshot`, which the task's `Wait` runs on. Experimental surface throughout.

## One lookup replaces the wire plumbing

**Before:** what the agents middleware writes on main.

```go
action := genkit.LookupAction(g, "/agent/"+ref.Name)
agent, ok := action.(api.BidiAction)
// nil and non-agent checks ...
inputJSON, err := json.Marshal(&aix.AgentInput{Message: ai.NewUserTextMessage(task)})
var initJSON json.RawMessage
if len(history) > 0 {
    initJSON, err = json.Marshal(aix.AgentInit[json.RawMessage]{
        State: &aix.SessionState[json.RawMessage]{Messages: history},
    })
}
res, err := agent.RunBidiJSON(ctx, inputJSON, nil, &api.BidiJSONOptions{Init: initJSON})
var out aix.AgentOutput[json.RawMessage]
err = json.Unmarshal(res.Result, &out)
```

**After:**

```go
h := genkitx.LookupAgent(g, ref.Name) // nil on a miss, like every Lookup; or agent.Handle()
out, err := h.Run(ctx, task, aix.WithState(&aix.SessionState[json.RawMessage]{Messages: history}))
```

The `InvocationOption` values apply at `json.RawMessage` and resolve through the same code as `Agent.Connect`, so typed and untyped callers reject the same inputs with the same wording. `LookupAgent` needs no `genkit.WithExperimental`: it only reads the registry, and only the gated constructors can register an agent.

## A background invocation is a task any process can rehydrate

```go
task, err := agent.RunDetached(ctx, &aix.AgentInput{Message: msg}) // *DetachedTask[State]; AgentInput.Detach forced on
id := task.SnapshotID()                                             // record it

task = agent.Task(id)           // any process, any time later
snap, err := task.Poll(ctx)     // one shaped read, typed state
snap, err = task.Wait(ctx)      // blocks until it settles
status, err := task.Abort(ctx)
```

`h.RunDetached` and `h.Task` are the same calls through a handle, over `DetachedTask[json.RawMessage]`, so the untyped surface is never the easier one. The snapshot is the task's only state, so `RunDetached`'s return and `Task`'s rehydration are equivalent. `Wait` returns the settled snapshot for failed, aborted, and expired tasks; an error means the wait itself could not proceed. An agent that settles before it observes the detach still yields a task over its committed snapshot. A task reads through the surface that minted it, differences included: aborting a missing snapshot is NOT_FOUND through a handle and `""` through `Agent.Abort`.

## Waiting is one action, not a poll loop

```
POST /agents/{name}/waitForSnapshot    api.ActionTypeAgentWait, on every store-backed agent
```

Same request and shaped response as `getSnapshot`, returned once the row settles, so a non-Go client follows a detached run in one request and a trace carries one span per wait instead of one per tick. The wait is push-driven where the store implements `SnapshotSubscriber`, with an interval re-read either way, because an expiry is not a write and no subscription can report one. Each in-wait read is bounded and a few consecutive failures are ridden out; NOT_FOUND, INVALID_ARGUMENT, and FAILED_PRECONDITION surface at once. The request requires the snapshot ID: a session's latest row can change under a wait.

## Every handle call is shaped like a remote client's

`GetSnapshot`, `GetLatestSnapshot`, `WaitForSnapshot`, and `Abort` dispatch the agent's companion actions, so the configured state transform applies and a stale-heartbeat pending row reads as `expired`, exactly as over HTTP. Errors are matched by status name, never by sentinel identity: a transport that crosses a wire decodes a status name and nothing else, so the in-process transport's live error chain is a convenience of where it runs, not a promise of the surface. Hence `AgentHandle.Abort` on a missing snapshot is NOT_FOUND (the companion action's answer, where `Agent.Abort` reports `""`), and a `RunDetached` rejection cannot be narrowed past FAILED_PRECONDITION.

## New exported surface

```go
// core/api
ActionTypeAgentWait ActionType = "agent-wait"

// genkit/exp
func LookupAgent(g *genkit.Genkit, name string) *aix.AgentHandle   // nil on a miss

// ai/exp
func LookupAgent(r api.Registry, name string) *AgentHandle          // registry-level twin
func (a *Agent[State]) Handle() *AgentHandle
func (a *Agent[State]) RunDetached(ctx, *AgentInput, ...InvocationOption[State]) (*DetachedTask[State], error)
func (a *Agent[State]) Task(snapshotID string) *DetachedTask[State]
func (a *Agent[State]) WaitForSnapshot(ctx, snapshotID string) (*SessionSnapshot[State], error)
func (a *Agent[State]) WaitForSnapshotAction() api.Action
func (s SnapshotStatus) Terminal() bool
func (r AgentFinishReason) CarriesResult() bool

type AgentHandle
    Name() string
    Metadata() *AgentMetadata
    Run(ctx, *AgentInput, ...InvocationOption[json.RawMessage]) (*AgentOutput[json.RawMessage], error)
    RunText(ctx, text string, ...InvocationOption[json.RawMessage]) (*AgentOutput[json.RawMessage], error)
    RunDetached(ctx, *AgentInput, ...InvocationOption[json.RawMessage]) (*DetachedTask[json.RawMessage], error)
    Task(snapshotID string) *DetachedTask[json.RawMessage]
    GetSnapshot(ctx, snapshotID string) (*SessionSnapshot[json.RawMessage], error)
    GetLatestSnapshot(ctx, sessionID string) (*SessionSnapshot[json.RawMessage], error)
    WaitForSnapshot(ctx, snapshotID string) (*SessionSnapshot[json.RawMessage], error)
    Abort(ctx, snapshotID string) (SnapshotStatus, error)

type DetachedTask[State any]
    SnapshotID() string
    Poll(ctx) (*SessionSnapshot[State], error)
    Wait(ctx) (*SessionSnapshot[State], error)
    Abort(ctx) (SnapshotStatus, error)
```

Nothing is renamed or deleted. Handle reads load the full row here; the metadata-only projection (`WithMetadataOnly`) lands in #6221 together with the wire field and store support it depends on.

## What was deliberately deferred

- **`AgentHandle` is a struct, not an interface `Agent[State]` implements.** Go has no overloading, so `Agent.Run` cannot also satisfy the raw-JSON signature; `Agent.Handle()` is the bridge.
- **The transport seam stays unexported and covers no `Connect`.** The HTTP transport over `/agents/{name}/...` is what will settle its shape, and a duplex session is a different problem from four request/response calls.
- **The wait action has no payload timeout and does not stream.** A bounded wait is `context.WithTimeout`; a `timeoutSeconds` field is a shared-schema change (JS Zod plus Go and Python regeneration). A snapshot has one transition, so a status stream would carry two chunks.
- **No streaming on `AgentHandle.Run`**, mirroring `Agent.Run`. The transport's `Run` already takes the callback, so adding it later reshapes nothing.
