### PR TITLE
feat(go/plugins/middleware): add background sub-agent delegation (`Agents.Async`)

### DIFF
--- a/go/README.md
+++ b/go/README.md
@@ -504,7 +504,7 @@ ai.WithUse(&middlewarex.Agents{
 })
 ```
 
-The orchestrator then launches with `{"task": "...", "background": true}`, posts an update while the sub-agent runs, and collects the result later. `wait_for_background_tasks` takes an optional `timeoutSeconds`, so a slow task becomes an interim answer instead of a blocked turn. An abort is safe to call on any task: one that had already finished is left alone and reports its result, so the orchestrator never loses an answer by giving up on it.
+The orchestrator then launches with `{"task": "...", "background": true}`, posts an update while the sub-agent runs, and collects the result later. `wait_for_background_tasks` takes an optional `timeoutSeconds`, so a slow task becomes an interim answer instead of a blocked turn, and `waitFor: "first"` turns the join into a race: the tool returns as soon as any listed task settles while the rest keep running, so the orchestrator can act on the first answer. An abort is safe to call on any task: one that had already finished is left alone and reports its result, so the orchestrator never loses an answer by giving up on it.
 
 Sub-agents are named by `aix.AgentRef`, either captured from an agent value with `agent.Ref()` or written by hand (`aix.AgentRef{Name: "researcher"}`). The middleware composes with the `Artifacts` middleware: give a sub-agent `&middlewarex.Artifacts{}` so it can save output, set `ArtifactStrategy: middlewarex.ArtifactStrategySession` to merge those artifacts into the orchestrator's session instead of inlining them in the tool result, and add `&middlewarex.Artifacts{Readonly: true}` on the orchestrator so it can review them before answering.
 

--- a/go/README.md
+++ b/go/README.md
@@ -446,7 +446,9 @@ Detach requires a store that implements `SnapshotSubscriber` (both bundled local
 > [!WARNING]
 > This API is in preview and may experience breaking changes in minor releases.
 
-The experimental `Agents` middleware (in `plugins/middleware/exp`) lets one agent delegate to others. It injects one `delegate_to_<name>` tool per sub-agent and a `<sub-agents>` listing into the orchestrator's system prompt, then runs the chosen sub-agent and returns its result when the model calls the tool. Each sub-agent's `aix.WithDescription` (captured by `agent.Ref()`) tells the orchestrator when to reach for it:
+The experimental `Agents` middleware (in `plugins/middleware/exp`) lets one agent delegate to others. It injects one `delegate_to_<name>` tool per sub-agent and a `<sub-agents>` listing into the orchestrator's system prompt, then runs the chosen sub-agent and returns its result when the model calls the tool. Each sub-agent's `aix.WithDescription` (captured by `agent.Ref()`) tells the orchestrator when to reach for it.
+
+Set `Async: true` to let the orchestrator keep working while a sub-agent runs: each delegation tool gains a `background` flag that returns a task ID instead of waiting, and two shared tools, `check_background_tasks` and `wait_for_background_tasks`, collect the results. Background delegation needs a sub-agent whose session store supports it (see `AgentMetadata.Abortable`).
 
 ```go
 import (

--- a/go/README.md
+++ b/go/README.md
@@ -448,8 +448,6 @@ Detach requires a store that implements `SnapshotSubscriber` (both bundled local
 
 The experimental `Agents` middleware (in `plugins/middleware/exp`) lets one agent delegate to others. It injects one `delegate_to_<name>` tool per sub-agent and a `<sub-agents>` listing into the orchestrator's system prompt, then runs the chosen sub-agent and returns its result when the model calls the tool. Each sub-agent's `aix.WithDescription` (captured by `agent.Ref()`) tells the orchestrator when to reach for it.
 
-Set `Async: true` to let the orchestrator keep working while a sub-agent runs: each delegation tool gains a `background` flag that returns a task ID instead of waiting, and two shared tools, `check_background_tasks` and `wait_for_background_tasks`, collect the results. Background delegation needs a sub-agent whose session store supports it (see `AgentMetadata.Abortable`).
-
 ```go
 import (
     "github.com/firebase/genkit/go/ai"
@@ -486,6 +484,27 @@ orchestrator := genkitx.DefineAgent(g, "orchestrator",
 out, _ := orchestrator.RunText(ctx, "Research goroutine scheduling and summarize the key ideas.")
 fmt.Println(out.Message.Text())
 ```
+
+Set `Async: true` to let the orchestrator keep working while a sub-agent runs. Each delegation tool gains a `background` flag that returns a task ID instead of waiting, and two shared tools, `check_background_tasks` and `wait_for_background_tasks`, collect the results. The *sub-agent* is what needs the session store here: background work is tracked by a snapshot, so a sub-agent without one can only be delegated to synchronously (see `AgentMetadata.Abortable`).
+
+```go
+// The sub-agent needs its own store to be delegated to in the background.
+researcher := genkitx.DefineAgent(g, "researcher",
+    aix.InlinePrompt{
+        ai.WithModelName("googleai/gemini-flash-latest"),
+        ai.WithSystem("You are a thorough research assistant."),
+    },
+    aix.WithDescription[any]("Researches a topic and summarizes well-sourced findings."),
+    aix.WithSessionStore(localstore.NewInMemorySessionStore[any]()),
+)
+
+ai.WithUse(&middlewarex.Agents{
+    Agents: []aix.AgentRef{researcher.Ref()},
+    Async:  true,
+})
+```
+
+The orchestrator then launches with `{"task": "...", "background": true}`, posts an update while the sub-agent runs, and collects the result later. `wait_for_background_tasks` takes an optional `timeoutSeconds`, so a slow task becomes an interim answer instead of a blocked turn.
 
 Sub-agents are named by `aix.AgentRef`, either captured from an agent value with `agent.Ref()` or written by hand (`aix.AgentRef{Name: "researcher"}`). The middleware composes with the `Artifacts` middleware: give a sub-agent `&middlewarex.Artifacts{}` so it can save output, set `ArtifactStrategy: middlewarex.ArtifactStrategySession` to merge those artifacts into the orchestrator's session instead of inlining them in the tool result, and add `&middlewarex.Artifacts{Readonly: true}` on the orchestrator so it can review them before answering.
 

--- a/go/README.md
+++ b/go/README.md
@@ -404,7 +404,9 @@ Detach requires a store that implements `SnapshotSubscriber` (both bundled local
 > [!WARNING]
 > This API is in preview and may experience breaking changes in minor releases.
 
-The experimental `Agents` middleware (in `plugins/middleware/exp`) lets one agent delegate to others. It injects one `delegate_to_<name>` tool per sub-agent and a `<sub-agents>` listing into the orchestrator's system prompt, then runs the chosen sub-agent and returns its result when the model calls the tool. Each sub-agent's `aix.WithDescription` (captured by `agent.Ref()`) tells the orchestrator when to reach for it:
+The experimental `Agents` middleware (in `plugins/middleware/exp`) lets one agent delegate to others. It injects one `delegate_to_<name>` tool per sub-agent and a `<sub-agents>` listing into the orchestrator's system prompt, then runs the chosen sub-agent and returns its result when the model calls the tool. Each sub-agent's `aix.WithDescription` (captured by `agent.Ref()`) tells the orchestrator when to reach for it.
+
+Set `Async: true` to let the orchestrator keep working while a sub-agent runs: each delegation tool gains a `background` flag that returns a task ID instead of waiting, and two shared tools, `check_background_tasks` and `wait_for_background_tasks`, collect the results. Background delegation needs a sub-agent whose session store supports it (see `AgentMetadata.Abortable`).
 
 ```go
 import (

--- a/go/README.md
+++ b/go/README.md
@@ -485,7 +485,7 @@ out, _ := orchestrator.RunText(ctx, "Research goroutine scheduling and summarize
 fmt.Println(out.Message.Text())
 ```
 
-Set `Async: true` to let the orchestrator keep working while a sub-agent runs. Each delegation tool gains a `background` flag that returns a task ID instead of waiting, and two shared tools, `check_background_tasks` and `wait_for_background_tasks`, collect the results. The *sub-agent* is what needs the session store here: background work is tracked by a snapshot, so a sub-agent without one can only be delegated to synchronously (see `AgentMetadata.Abortable`).
+Set `Async: true` to let the orchestrator keep working while a sub-agent runs. Each delegation tool gains a `background` flag that returns a task ID instead of waiting, and three shared tools give the orchestrator one control per thing it can do with a launched task: `check_background_tasks` reads statuses without waiting, `wait_for_background_tasks` blocks until they settle, and `abort_background_tasks` stops the ones whose results are no longer needed. The *sub-agent* is what needs the session store here: background work is tracked by a snapshot, so a sub-agent without one can only be delegated to synchronously (see `AgentMetadata.Abortable`).
 
 ```go
 // The sub-agent needs its own store to be delegated to in the background.
@@ -504,7 +504,7 @@ ai.WithUse(&middlewarex.Agents{
 })
 ```
 
-The orchestrator then launches with `{"task": "...", "background": true}`, posts an update while the sub-agent runs, and collects the result later. `wait_for_background_tasks` takes an optional `timeoutSeconds`, so a slow task becomes an interim answer instead of a blocked turn.
+The orchestrator then launches with `{"task": "...", "background": true}`, posts an update while the sub-agent runs, and collects the result later. `wait_for_background_tasks` takes an optional `timeoutSeconds`, so a slow task becomes an interim answer instead of a blocked turn. An abort is safe to call on any task: one that had already finished is left alone and reports its result, so the orchestrator never loses an answer by giving up on it.
 
 Sub-agents are named by `aix.AgentRef`, either captured from an agent value with `agent.Ref()` or written by hand (`aix.AgentRef{Name: "researcher"}`). The middleware composes with the `Artifacts` middleware: give a sub-agent `&middlewarex.Artifacts{}` so it can save output, set `ArtifactStrategy: middlewarex.ArtifactStrategySession` to merge those artifacts into the orchestrator's session instead of inlining them in the tool result, and add `&middlewarex.Artifacts{Readonly: true}` on the orchestrator so it can review them before answering.
 

--- a/go/ai/middleware.go
+++ b/go/ai/middleware.go
@@ -291,11 +291,24 @@ type namedHooks struct {
 // from a file-reading New, or a cancelled context as a caller mistake). Only
 // unclassified errors default to INVALID_ARGUMENT, since a bare error from a
 // New is overwhelmingly config validation.
+//
+// The classified case re-states the message on a status error of its own rather
+// than wrapping with fmt.Errorf. Serialization resolves to the outermost
+// *status.Error, so a plain wrap would hand the client the inner message alone,
+// with nothing naming the middleware that failed. Building the envelope here
+// also keeps it non-public, so a New that returns a PublicErrorf does not have
+// its text forwarded to clients by a path that never chose to publish it. The
+// cause stays reachable, so errors.Is still matches the middleware's sentinel.
 func wrapBuildError(name string, err error) error {
-	if _, ok := status.Classified(err); ok {
-		return fmt.Errorf("ai: failed to build middleware %q: %w", name, err)
+	s, ok := status.Classified(err)
+	if !ok {
+		return status.Errorf(status.ErrInvalidArgument, "ai: failed to build middleware %q: %w", name, err)
 	}
-	return status.Errorf(status.ErrInvalidArgument, "ai: failed to build middleware %q: %w", name, err)
+	return (&status.Error{
+		Status:   s,
+		Message:  fmt.Sprintf("ai: failed to build middleware %q: %v", name, err),
+		HTTPCode: s.HTTPCode(),
+	}).WithCause(err)
 }
 
 // resolveRefs resolves [MiddlewareRef] entries to named [Hooks] bundles. If

--- a/go/ai/middleware.go
+++ b/go/ai/middleware.go
@@ -19,7 +19,6 @@ package ai
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"reflect"
 
 	"github.com/firebase/genkit/go/core"
@@ -302,13 +301,14 @@ type namedHooks struct {
 func wrapBuildError(name string, err error) error {
 	s, ok := status.Classified(err)
 	if !ok {
-		return status.Errorf(status.ErrInvalidArgument, "ai: failed to build middleware %q: %w", name, err)
+		// Unclassified build failures are overwhelmingly config validation.
+		s = status.InvalidArgument
 	}
-	return (&status.Error{
-		Status:   s,
-		Message:  fmt.Sprintf("ai: failed to build middleware %q: %v", name, err),
-		HTTPCode: s.HTTPCode(),
-	}).WithCause(err)
+	// status.Base is the sanctioned constructor for a status known only at
+	// runtime. Building the error by hand would leave it without a stack and
+	// without a sentinel to match on, and would drop any Details the cause
+	// carries, since Convert resolves to the outermost classified error.
+	return status.Errorf(status.Base(s), "ai: failed to build middleware %q: %w", name, err)
 }
 
 // resolveRefs resolves [MiddlewareRef] entries to named [Hooks] bundles. If

--- a/go/ai/middleware.go
+++ b/go/ai/middleware.go
@@ -19,6 +19,7 @@ package ai
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"reflect"
 
 	"github.com/firebase/genkit/go/core"
@@ -283,6 +284,20 @@ type namedHooks struct {
 	hooks *Hooks
 }
 
+// wrapBuildError prefixes a middleware build failure with the middleware's
+// name. An error the middleware's New already classified keeps its status
+// (status.Of reports the outermost classified error, so reclassifying here
+// would rebrand e.g. an UNAVAILABLE from a network-backed New, a disk error
+// from a file-reading New, or a cancelled context as a caller mistake). Only
+// unclassified errors default to INVALID_ARGUMENT, since a bare error from a
+// New is overwhelmingly config validation.
+func wrapBuildError(name string, err error) error {
+	if _, ok := status.Classified(err); ok {
+		return fmt.Errorf("ai: failed to build middleware %q: %w", name, err)
+	}
+	return status.Errorf(status.ErrInvalidArgument, "ai: failed to build middleware %q: %w", name, err)
+}
+
 // resolveRefs resolves [MiddlewareRef] entries to named [Hooks] bundles. If
 // ref.Config is a [Middleware] value, its New method is invoked directly
 // (local fast path). Otherwise the descriptor is looked up in the registry
@@ -297,7 +312,7 @@ func resolveRefs(ctx context.Context, r api.Registry, refs []*MiddlewareRef) ([]
 		if mw, ok := ref.Config.(Middleware); ok {
 			h, err := mw.New(ctx)
 			if err != nil {
-				return nil, status.Errorf(status.ErrInvalidArgument, "ai: failed to build middleware %q: %w", ref.Name, err)
+				return nil, wrapBuildError(ref.Name, err)
 			}
 			if h == nil {
 				return nil, status.Errorf(status.ErrInternal, "ai: middleware %q returned nil hooks", ref.Name)
@@ -319,7 +334,7 @@ func resolveRefs(ctx context.Context, r api.Registry, refs []*MiddlewareRef) ([]
 		}
 		h, err := d.buildFromJSON(ctx, configJSON)
 		if err != nil {
-			return nil, status.Errorf(status.ErrInvalidArgument, "ai: failed to build middleware %q: %w", ref.Name, err)
+			return nil, wrapBuildError(ref.Name, err)
 		}
 		if h == nil {
 			return nil, status.Errorf(status.ErrInternal, "ai: middleware %q factory returned nil", ref.Name)

--- a/go/ai/middleware.go
+++ b/go/ai/middleware.go
@@ -19,6 +19,7 @@ package ai
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"reflect"
 
 	"github.com/firebase/genkit/go/core"
@@ -275,6 +276,20 @@ type namedHooks struct {
 	hooks *Hooks
 }
 
+// wrapBuildError prefixes a middleware build failure with the middleware's
+// name. An error the middleware's New already classified keeps its status
+// (status.Of reports the outermost classified error, so reclassifying here
+// would rebrand e.g. an UNAVAILABLE from a network-backed New, a disk error
+// from a file-reading New, or a cancelled context as a caller mistake). Only
+// unclassified errors default to INVALID_ARGUMENT, since a bare error from a
+// New is overwhelmingly config validation.
+func wrapBuildError(name string, err error) error {
+	if _, ok := status.Classified(err); ok {
+		return fmt.Errorf("ai: failed to build middleware %q: %w", name, err)
+	}
+	return status.Errorf(status.ErrInvalidArgument, "ai: failed to build middleware %q: %w", name, err)
+}
+
 // resolveRefs resolves [MiddlewareRef] entries to named [Hooks] bundles. If
 // ref.Config is a [Middleware] value, its New method is invoked directly
 // (local fast path). Otherwise the descriptor is looked up in the registry
@@ -289,7 +304,7 @@ func resolveRefs(ctx context.Context, r api.Registry, refs []*MiddlewareRef) ([]
 		if mw, ok := ref.Config.(Middleware); ok {
 			h, err := mw.New(ctx)
 			if err != nil {
-				return nil, status.Errorf(status.ErrInvalidArgument, "ai: failed to build middleware %q: %w", ref.Name, err)
+				return nil, wrapBuildError(ref.Name, err)
 			}
 			if h == nil {
 				return nil, status.Errorf(status.ErrInternal, "ai: middleware %q returned nil hooks", ref.Name)
@@ -311,7 +326,7 @@ func resolveRefs(ctx context.Context, r api.Registry, refs []*MiddlewareRef) ([]
 		}
 		h, err := d.buildFromJSON(ctx, configJSON)
 		if err != nil {
-			return nil, status.Errorf(status.ErrInvalidArgument, "ai: failed to build middleware %q: %w", ref.Name, err)
+			return nil, wrapBuildError(ref.Name, err)
 		}
 		if h == nil {
 			return nil, status.Errorf(status.ErrInternal, "ai: middleware %q factory returned nil", ref.Name)

--- a/go/ai/middleware.go
+++ b/go/ai/middleware.go
@@ -283,11 +283,24 @@ type namedHooks struct {
 // from a file-reading New, or a cancelled context as a caller mistake). Only
 // unclassified errors default to INVALID_ARGUMENT, since a bare error from a
 // New is overwhelmingly config validation.
+//
+// The classified case re-states the message on a status error of its own rather
+// than wrapping with fmt.Errorf. Serialization resolves to the outermost
+// *status.Error, so a plain wrap would hand the client the inner message alone,
+// with nothing naming the middleware that failed. Building the envelope here
+// also keeps it non-public, so a New that returns a PublicErrorf does not have
+// its text forwarded to clients by a path that never chose to publish it. The
+// cause stays reachable, so errors.Is still matches the middleware's sentinel.
 func wrapBuildError(name string, err error) error {
-	if _, ok := status.Classified(err); ok {
-		return fmt.Errorf("ai: failed to build middleware %q: %w", name, err)
+	s, ok := status.Classified(err)
+	if !ok {
+		return status.Errorf(status.ErrInvalidArgument, "ai: failed to build middleware %q: %w", name, err)
 	}
-	return status.Errorf(status.ErrInvalidArgument, "ai: failed to build middleware %q: %w", name, err)
+	return (&status.Error{
+		Status:   s,
+		Message:  fmt.Sprintf("ai: failed to build middleware %q: %v", name, err),
+		HTTPCode: s.HTTPCode(),
+	}).WithCause(err)
 }
 
 // resolveRefs resolves [MiddlewareRef] entries to named [Hooks] bundles. If

--- a/go/ai/middleware_test.go
+++ b/go/ai/middleware_test.go
@@ -685,6 +685,53 @@ func TestBuildMiddlewareErrorPropagates(t *testing.T) {
 	}
 }
 
+func TestBuildMiddlewareErrorWrapping(t *testing.T) {
+	t.Run("unclassified error becomes INVALID_ARGUMENT and names the middleware", func(t *testing.T) {
+		err := wrapBuildError("vectorstore", errors.New("boom"))
+		if got := status.Of(err); got != status.InvalidArgument {
+			t.Errorf("status = %v, want %v", got, status.InvalidArgument)
+		}
+		if got, want := status.Convert(err).Message, `ai: failed to build middleware "vectorstore": boom`; got != want {
+			t.Errorf("wire message = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("classified error keeps its status", func(t *testing.T) {
+		// A network-backed New reporting UNAVAILABLE is not a caller mistake,
+		// so it must not be rebranded as one.
+		inner := status.Errorf(status.ErrUnavailable, "dial vectors.internal: connection refused")
+		err := wrapBuildError("vectorstore", inner)
+		if got := status.Of(err); got != status.Unavailable {
+			t.Errorf("status = %v, want %v", got, status.Unavailable)
+		}
+		if !errors.Is(err, status.ErrUnavailable) {
+			t.Error("errors.Is(err, ErrUnavailable) = false, want the cause to stay matchable")
+		}
+	})
+
+	t.Run("classified error still names the middleware on the wire", func(t *testing.T) {
+		// Serialization resolves to the outermost status error, so wrapping
+		// with fmt.Errorf would leave a client holding the inner message with
+		// nothing saying which middleware failed to build.
+		inner := status.Errorf(status.ErrUnavailable, "dial vectors.internal: connection refused")
+		got := status.Convert(wrapBuildError("vectorstore", inner)).Message
+		want := `ai: failed to build middleware "vectorstore": dial vectors.internal: connection refused`
+		if got != want {
+			t.Errorf("wire message = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("a New's public message is not republished", func(t *testing.T) {
+		// Building the envelope here is what keeps it non-public: a New that
+		// chose to publish its own text did not choose to publish it through
+		// the middleware-build path.
+		inner := status.PublicErrorf(status.ErrUnavailable, "internal detail")
+		if msg, public := status.PublicMessage(wrapBuildError("vectorstore", inner)); public {
+			t.Errorf("PublicMessage = %q, public = true, want the wrapper to withhold it", msg)
+		}
+	})
+}
+
 // --- tool interrupt from WrapTool ---
 
 func TestWrapToolInterrupts(t *testing.T) {

--- a/go/plugins/middleware/exp/agents.go
+++ b/go/plugins/middleware/exp/agents.go
@@ -105,9 +105,10 @@ func resolveAgent(g *genkit.Genkit, ref aix.AgentRef) (*aix.AgentHandle, error) 
 // snapshot, hands back a task ID immediately, and keeps working in the
 // background, so the orchestrator can continue calling tools and collect the
 // result later through the added check_background_tasks and
-// wait_for_background_tasks tools. The pending snapshot (heartbeated while the
-// worker lives, finalized in place with the cumulative state when the work
-// settles) is the durable record, and task IDs are self-contained
+// wait_for_background_tasks tools, or drop it with abort_background_tasks. The
+// pending snapshot (heartbeated while the worker lives, finalized in place
+// with the cumulative state when the work settles) is the durable record, and
+// task IDs are self-contained
 // ("<agent>:<snapshotId>"), so a re-instantiated orchestrator can pick results
 // up using nothing but the IDs recorded in its conversation history. Background
 // delegation requires server-managed sub-agents whose stores implement
@@ -174,12 +175,14 @@ type Agents struct {
 	ArtifactStrategy ArtifactStrategy `json:"artifactStrategy,omitempty" jsonschema_description:"How sub-agent artifacts are surfaced. \"inline\" adds artifact content to the delegation tool result and merges it into the parent session. \"session\" merges into the session only. Defaults to \"inline\"."`
 	// Async enables background delegation. Delegation tools gain a "background"
 	// input flag that starts the sub-agent through its detach support and
-	// returns a task ID immediately, and two shared tools are added:
-	// check_background_tasks (non-blocking status and results) and
-	// wait_for_background_tasks (blocks until the listed tasks settle).
+	// returns a task ID immediately, and three shared tools are added, one per
+	// control the orchestrator has over a launched task:
+	// check_background_tasks (non-blocking status and results),
+	// wait_for_background_tasks (blocks until the listed tasks settle), and
+	// abort_background_tasks (stops tasks whose results are no longer needed).
 	// Background delegation requires server-managed sub-agents whose stores
 	// implement [aix.SnapshotSubscriber].
-	Async bool `json:"async,omitempty" jsonschema_description:"Enables background delegation: delegation tools accept a \"background\" flag, and the check_background_tasks / wait_for_background_tasks tools are added. Background delegation requires server-managed sub-agents whose session stores support detach."`
+	Async bool `json:"async,omitempty" jsonschema_description:"Enables background delegation: delegation tools accept a \"background\" flag, and the check_background_tasks / wait_for_background_tasks / abort_background_tasks tools are added. Background delegation requires server-managed sub-agents whose session stores support detach."`
 }
 
 func (a Agents) Name() string { return provider + "/agents" }
@@ -234,7 +237,7 @@ func (a Agents) New(ctx context.Context) (*ai.Hooks, error) {
 	// delegation tool landing on a background-task tool's name) would
 	// otherwise surface only at generate time as a duplicate-tool rejection
 	// of the whole request.
-	names := make(map[string]string, len(a.Agents)+2)
+	names := make(map[string]string, len(a.Agents)+3)
 	claimName := func(name, owner string) error {
 		if prev, ok := names[name]; ok {
 			return status.Errorf(status.ErrInvalidArgument,
@@ -244,7 +247,7 @@ func (a Agents) New(ctx context.Context) (*ai.Hooks, error) {
 		return nil
 	}
 
-	tools := make([]ai.Tool, 0, len(a.Agents)+2)
+	tools := make([]ai.Tool, 0, len(a.Agents)+3)
 	for _, ref := range a.Agents {
 		desc := ref.Description
 		if desc == "" {
@@ -263,8 +266,7 @@ func (a Agents) New(ctx context.Context) (*ai.Hooks, error) {
 		}
 	}
 	if a.Async {
-		checkName, waitName := a.backgroundToolNames()
-		for _, n := range []string{checkName, waitName} {
+		for _, n := range a.backgroundToolNames().all() {
 			if err := claimName(n, "the background-task tools"); err != nil {
 				return nil, err
 			}
@@ -308,7 +310,7 @@ type delegationResult struct {
 	Artifacts []delegatedArtifact `json:"artifacts,omitempty"`
 	// TaskID is the background task handle ("<agent>:<snapshotId>") when the
 	// delegation was started with background=true; empty otherwise. It is the
-	// input to check_background_tasks / wait_for_background_tasks.
+	// input to the background-task tools (check, wait, abort).
 	TaskID string `json:"taskId,omitempty"`
 	// Status is "pending" when a background delegation was started; empty for
 	// synchronous delegations.
@@ -554,18 +556,30 @@ func (a *Agents) prefix() string {
 	return *a.ToolPrefix
 }
 
+// taskToolNames are the names of the shared background-task tools for one
+// [Agents] configuration.
+type taskToolNames struct{ check, wait, abort string }
+
+// all returns the names in a fixed order, for collision checking.
+func (n taskToolNames) all() []string { return []string{n.check, n.wait, n.abort} }
+
 // backgroundToolNames returns the names of the shared background-task tools
 // for this configuration. They are the bare well-known names by default and
 // prefixed with an explicitly set [Agents.ToolPrefix], so two Async instances
 // with distinct prefixes can coexist on one generate call without colliding
 // on the shared names (the default delegate_to prefix is a delegation verb,
-// not an instance namespace, so it is deliberately not applied here).
-func (a *Agents) backgroundToolNames() (check, wait string) {
-	if a.ToolPrefix == nil {
-		return checkBackgroundTasksToolName, waitBackgroundTasksToolName
+// not an instance namespace, so it is deliberately not applied here, and a
+// nil prefix is therefore the same as an empty one).
+func (a *Agents) backgroundToolNames() taskToolNames {
+	prefix := ""
+	if a.ToolPrefix != nil {
+		prefix = *a.ToolPrefix
 	}
-	return makeToolName(*a.ToolPrefix, checkBackgroundTasksToolName),
-		makeToolName(*a.ToolPrefix, waitBackgroundTasksToolName)
+	return taskToolNames{
+		check: makeToolName(prefix, checkBackgroundTasksToolName),
+		wait:  makeToolName(prefix, waitBackgroundTasksToolName),
+		abort: makeToolName(prefix, abortBackgroundTasksToolName),
+	}
 }
 
 // strategy resolves the artifact strategy, defaulting to inline.
@@ -608,16 +622,17 @@ func (a *Agents) buildInstructions(g *genkit.Genkit) string {
 	b.WriteString("When a task is better handled by a specialized agent, delegate it using the ")
 	b.WriteString("appropriate tool. Provide a clear, self-contained task description.\n")
 	if a.Async {
-		checkName, waitName := a.backgroundToolNames()
+		names := a.backgroundToolNames()
 		b.WriteString("\n")
 		b.WriteString("Delegations can run in the background: set \"background\": true on a ")
 		b.WriteString("delegation tool call to get a taskId back immediately while the ")
 		b.WriteString("sub-agent keeps working. Continue with other work, then collect ")
-		b.WriteString("results with " + checkName + " (returns current ")
-		b.WriteString("status without waiting) or " + waitName + " ")
-		b.WriteString("(blocks until the tasks settle). Background tasks keep running ")
-		b.WriteString("across turns, and task IDs from earlier tool results stay valid: ")
-		b.WriteString("check them before delegating the same work again.\n")
+		b.WriteString("results with " + names.check + " (returns current ")
+		b.WriteString("status without waiting) or " + names.wait + " ")
+		b.WriteString("(blocks until the tasks settle). Use " + names.abort + " to stop ")
+		b.WriteString("tasks whose results are no longer needed. Background tasks keep ")
+		b.WriteString("running across turns, and task IDs from earlier tool results stay ")
+		b.WriteString("valid: check them before delegating the same work again.\n")
 	}
 	b.WriteString("</sub-agents>")
 	return b.String()

--- a/go/plugins/middleware/exp/agents.go
+++ b/go/plugins/middleware/exp/agents.go
@@ -469,12 +469,11 @@ func (a *Agents) foldDelegationOutput(ctx context.Context, ref aix.AgentRef, out
 			ref.Name, subAgentFailureMessage(out.FinishReason, out.Error, out.Message))}
 	}
 
+	subArtifacts := namedArtifacts(out.Artifacts)
 	result := delegationResult{Response: messageText(out.Message)}
 	if result.Response == "" {
-		result.Response = "(no response)"
+		result.Response = noFinalMessageResponse(len(subArtifacts))
 	}
-
-	subArtifacts := namedArtifacts(out.Artifacts)
 	if len(subArtifacts) > 0 {
 		// Merge into the parent session under both strategies (no-op if there
 		// is no active session, e.g. a plain genkit.Generate call).
@@ -482,6 +481,23 @@ func (a *Agents) foldDelegationOutput(ctx context.Context, ref aix.AgentRef, out
 		result.Artifacts = delegatedArtifacts(invocationID, subArtifacts, a.strategy())
 	}
 	return result
+}
+
+// noFinalMessageResponse is the tool text reported for a run that settled on a
+// result-carrying reason without a final model text: a custom agent that
+// returned no message, or a model whose last message holds only tool requests.
+// It says outright that the run succeeded and where its result is, so the
+// orchestrator neither mistakes the silence for a failure nor repeats finished
+// work.
+func noFinalMessageResponse(artifacts int) string {
+	switch artifacts {
+	case 0:
+		return "The task completed, but the agent gave no final message and produced no artifacts."
+	case 1:
+		return "The task completed, but the agent gave no final message; its result is in the one artifact it produced."
+	default:
+		return fmt.Sprintf("The task completed, but the agent gave no final message; its result is in the %d artifacts it produced.", artifacts)
+	}
 }
 
 // interruptedResponse is the tool text reported when a sub-agent interrupted

--- a/go/plugins/middleware/exp/agents.go
+++ b/go/plugins/middleware/exp/agents.go
@@ -57,26 +57,18 @@ const (
 	ArtifactStrategySession ArtifactStrategy = "session"
 )
 
-// requireGenkit classifies the absence of a Genkit instance on the context as
-// a failed precondition: a wiring gap in how the middleware runs, not anything
-// the caller sent. Both delegation and background-task reads resolve through
-// it.
-func requireGenkit(g *genkit.Genkit) error {
-	if g == nil {
-		return status.Errorf(status.ErrFailedPrecondition,
-			"no Genkit instance on the context (the agents middleware must run within genkit.Generate or a genkit-defined agent)")
-	}
-	return nil
-}
-
 // resolveAgent looks the agent up by name through g and returns its handle.
 // Resolution goes through the Genkit instance (the sanctioned path for
 // third-party middleware) rather than the registry directly; the handle
 // carries the agent's companion actions and capability metadata along with
-// the run surface.
+// the run surface. Both delegation and background-task reads resolve through
+// it.
 func resolveAgent(g *genkit.Genkit, ref aix.AgentRef) (*aix.AgentHandle, error) {
-	if err := requireGenkit(g); err != nil {
-		return nil, err
+	if g == nil {
+		// A failed precondition: a wiring gap in how the middleware runs, not
+		// anything the caller sent.
+		return nil, status.Errorf(status.ErrFailedPrecondition,
+			"no Genkit instance on the context (the agents middleware must run within genkit.Generate or a genkit-defined agent)")
 	}
 	return genkitx.LookupAgent(g, ref.Name)
 }
@@ -335,21 +327,37 @@ func (a *Agents) delegate(ref aix.AgentRef, st *agentsState) func(context.Contex
 	}
 }
 
-// runDelegation is the synchronous delegation body, shared by the plain
-// delegation tool and the async-enabled variant when the model does not
-// request background execution.
-func (a *Agents) runDelegation(ctx context.Context, ref aix.AgentRef, st *agentsState, task string) (delegationResult, error) {
+// beginDelegation is the prologue every delegation shares, synchronous or
+// background: it enforces MaxDelegations, reserves the delegation's invocation
+// number, and resolves the sub-agent, refunding the reserved slot when
+// resolution fails. A non-nil refusal is the tool result to return as-is: the
+// model-facing text for a cap refusal or a resolution failure. conversation is
+// the captured message list for optional history forwarding (see
+// reserveDelegation); background launches ignore it.
+func (a *Agents) beginDelegation(ctx context.Context, ref aix.AgentRef, st *agentsState) (invocationNum int, conversation []*ai.Message, agent *aix.AgentHandle, refusal *delegationResult) {
 	invocationNum, conversation, ok := a.reserveDelegation(st)
 	if !ok {
 		logger.Warn(ctx, "delegation refused, limit reached", "agent", ref.Name, "limit", a.MaxDelegations)
-		return delegationLimitResult(a.MaxDelegations), nil
+		return 0, nil, nil, &delegationResult{Response: fmt.Sprintf(
+			"Delegation limit reached (%d). Complete the task using information already gathered.", a.MaxDelegations)}
 	}
 
 	agent, err := resolveAgent(genkit.FromContext(ctx), ref)
 	if err != nil {
 		a.releaseDelegation(st)
 		logger.Warn(ctx, "sub-agent resolution failed", "agent", ref.Name, "error", err)
-		return delegationResult{Response: "Error: " + err.Error()}, nil
+		return 0, nil, nil, &delegationResult{Response: "Error: " + err.Error()}
+	}
+	return invocationNum, conversation, agent, nil
+}
+
+// runDelegation is the synchronous delegation body, shared by the plain
+// delegation tool and the async-enabled variant when the model does not
+// request background execution.
+func (a *Agents) runDelegation(ctx context.Context, ref aix.AgentRef, st *agentsState, task string) (delegationResult, error) {
+	invocationNum, conversation, agent, refusal := a.beginDelegation(ctx, ref, st)
+	if refusal != nil {
+		return *refusal, nil
 	}
 
 	// History rides in client-managed init state, which server-managed
@@ -408,13 +416,6 @@ func (a *Agents) releaseDelegation(st *agentsState) {
 	st.mu.Lock()
 	defer st.mu.Unlock()
 	st.delegations--
-}
-
-// delegationLimitResult is the refusal returned once MaxDelegations is
-// exhausted.
-func delegationLimitResult(limit int) delegationResult {
-	return delegationResult{Response: fmt.Sprintf(
-		"Delegation limit reached (%d). Complete the task using information already gathered.", limit)}
 }
 
 // foldDelegationOutput turns a settled sub-agent output into a delegation tool

--- a/go/plugins/middleware/exp/agents.go
+++ b/go/plugins/middleware/exp/agents.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/firebase/genkit/go/ai"
 	aix "github.com/firebase/genkit/go/ai/exp"
+	"github.com/firebase/genkit/go/core/api"
 	"github.com/firebase/genkit/go/core/logger"
 	"github.com/firebase/genkit/go/core/status"
 	"github.com/firebase/genkit/go/genkit"
@@ -154,9 +155,11 @@ type Agents struct {
 	// defaults to "delegate_to" (tools become delegate_to_<agent>); a pointer to
 	// the empty string uses bare agent names. An explicitly set, non-empty
 	// prefix also namespaces the [Agents.Async] background-task tools (e.g.
-	// research_check_background_tasks), so two Async instances with distinct
-	// prefixes can share one generate call. New rejects a configuration whose
-	// generated tool names collide.
+	// research_check_background_tasks). Two Async instances in one generate
+	// call therefore need distinct, explicitly set prefixes: left at the
+	// default they both emit the bare background-task tool names, and the
+	// generate call is rejected for duplicate tools. New rejects colliding
+	// names within one instance; it cannot see a sibling.
 	ToolPrefix *string `json:"toolPrefix,omitempty" jsonschema_description:"Prefix for generated delegation tool names. Defaults to \"delegate_to\", so tools become delegate_to_<agent>. Set it to the empty string to use bare agent names. A non-empty prefix also namespaces the async background-task tools."`
 	// MaxDelegations caps the number of sub-agent delegations per generate call,
 	// preventing runaway delegation loops. 0 means unlimited.
@@ -329,11 +332,14 @@ func (a *Agents) delegate(ref aix.AgentRef, st *agentsState) func(context.Contex
 
 // beginDelegation is the prologue every delegation shares, synchronous or
 // background: it enforces MaxDelegations, reserves the delegation's invocation
-// number, and resolves the sub-agent, refunding the reserved slot when
-// resolution fails. A non-nil refusal is the tool result to return as-is: the
-// model-facing text for a cap refusal or a resolution failure. conversation is
-// the captured message list for optional history forwarding (see
-// reserveDelegation); background launches ignore it.
+// number, and resolves the sub-agent. A non-nil refusal is the tool result to
+// return as-is: the model-facing text for a cap refusal or a resolution
+// failure. conversation is the captured message list for optional history
+// forwarding (see reserveDelegation); background launches ignore it.
+//
+// A resolution failure keeps its slot. The agent is misconfigured or missing,
+// so every retry fails the same way, and refunding would mean the cap never
+// bites on exactly the runaway loop it exists to stop.
 func (a *Agents) beginDelegation(ctx context.Context, ref aix.AgentRef, st *agentsState) (invocationNum int, conversation []*ai.Message, agent *aix.AgentHandle, refusal *delegationResult) {
 	invocationNum, conversation, ok := a.reserveDelegation(st)
 	if !ok {
@@ -344,7 +350,6 @@ func (a *Agents) beginDelegation(ctx context.Context, ref aix.AgentRef, st *agen
 
 	agent, err := resolveAgent(genkit.FromContext(ctx), ref)
 	if err != nil {
-		a.releaseDelegation(st)
 		logger.Warn(ctx, "sub-agent resolution failed", "agent", ref.Name, "error", err)
 		return 0, nil, nil, &delegationResult{Response: "Error: " + err.Error()}
 	}
@@ -376,8 +381,8 @@ func (a *Agents) runDelegation(ctx context.Context, ref aix.AgentRef, st *agents
 		// The agent runtime resolves failures and interrupts gracefully (see
 		// foldDelegationOutput), so this only fires for exceptions outside
 		// that handling (e.g. a rejected init payload). Surface it as tool
-		// output; the slot goes back because no sub-agent work ran.
-		a.releaseDelegation(st)
+		// output and keep the slot: the payload is built the same way every
+		// time, so a retry is refused the same way.
 		logger.Warn(ctx, "sub-agent call failed", "agent", ref.Name, "error", err)
 		return delegationResult{Response: fmt.Sprintf("Error calling agent %q: %v", ref.Name, err)}, nil
 	}
@@ -406,12 +411,20 @@ func (a *Agents) reserveDelegation(st *agentsState) (invocationNum int, conversa
 	return st.seq, st.conversation, true
 }
 
-// releaseDelegation returns a reserved cap slot for a delegation that failed
-// before any sub-agent work ran (a resolution failure, a hard call error, or
-// a pre-detach rejection), so the cap only counts delegations that did
-// something. The released slot's invocation number is never reissued (the
-// allocator is the separate seq counter), so a concurrent live delegation
-// cannot end up sharing an artifact namespace with a later one.
+// releaseDelegation returns a reserved cap slot to a delegation whose refusal
+// names a retry that can succeed, which today means only one thing: a
+// background launch refused because the sub-agent cannot detach, whose refusal
+// tells the model to delegate synchronously instead. That retry must not be
+// turned away by a cap the refusal itself consumed.
+//
+// Every other refusal keeps its slot. A refusal that will repeat identically
+// (an unresolvable agent, a rejected init payload, a sub-agent that fails on
+// its own) is precisely the runaway MaxDelegations exists to bound, and
+// refunding those would leave the cap unable to bite at all.
+//
+// The released slot's invocation number is never reissued (the allocator is
+// the separate seq counter), so a concurrent live delegation cannot end up
+// sharing an artifact namespace with a later one.
 func (a *Agents) releaseDelegation(st *agentsState) {
 	st.mu.Lock()
 	defer st.mu.Unlock()
@@ -612,8 +625,14 @@ func (a *Agents) buildInstructions(g *genkit.Genkit) string {
 
 // discoverDescription returns the agent's description from its action
 // descriptor, falling back to the backing prompt's description, or "" if none.
+// The keys are built with [api.KeyFromName] rather than by hand: a prompt
+// registers under "executable-prompt", not "prompt", so a literal key silently
+// finds nothing.
 func discoverDescription(g *genkit.Genkit, name string) string {
-	for _, key := range []string{"/agent/" + name, "/prompt/" + name} {
+	for _, key := range []string{
+		api.KeyFromName(api.ActionTypeAgent, name),
+		api.KeyFromName(api.ActionTypeExecutablePrompt, name),
+	} {
 		if action := genkit.LookupAction(g, key); action != nil {
 			if d := action.Desc().Description; d != "" {
 				return d

--- a/go/plugins/middleware/exp/agents.go
+++ b/go/plugins/middleware/exp/agents.go
@@ -64,6 +64,10 @@ const (
 // carries the agent's companion actions and capability metadata along with
 // the run surface. Both delegation and background-task reads resolve through
 // it.
+// The lookup answers a miss with nil, as every Lookup in the framework does,
+// so the message a miss deserves is written here: this middleware knows the
+// agent was configured on it, which makes an absent registration a deployment
+// mistake worth naming rather than a lookup that came up empty.
 func resolveAgent(g *genkit.Genkit, ref aix.AgentRef) (*aix.AgentHandle, error) {
 	if g == nil {
 		// A failed precondition: a wiring gap in how the middleware runs, not
@@ -71,7 +75,12 @@ func resolveAgent(g *genkit.Genkit, ref aix.AgentRef) (*aix.AgentHandle, error) 
 		return nil, status.Errorf(status.ErrFailedPrecondition,
 			"no Genkit instance on the context (the agents middleware must run within genkit.Generate or a genkit-defined agent)")
 	}
-	return genkitx.LookupAgent(g, ref.Name)
+	agent := genkitx.LookupAgent(g, ref.Name)
+	if agent == nil {
+		return nil, status.Errorf(status.ErrNotFound,
+			"agent %q is configured on the agents middleware but is not registered in this process", ref.Name)
+	}
+	return agent, nil
 }
 
 // Agents is a middleware that enables sub-agent delegation.
@@ -274,6 +283,13 @@ func (a Agents) New(ctx context.Context) (*ai.Hooks, error) {
 		tools = append(tools, a.backgroundTaskTools(st)...)
 	}
 
+	// The <sub-agents> block depends only on the configuration and the
+	// registry, both fixed for this call, so it is built here rather than per
+	// tool-loop turn: New already runs exactly once per generate call, and
+	// re-rendering cost a registry lookup and a descriptor copy per agent per
+	// turn to produce a string the injector then dropped as identical.
+	instructions := a.buildInstructions(genkit.FromContext(ctx))
+
 	wrapGenerate := func(ctx context.Context, params *ai.GenerateParams, next ai.GenerateNext) (*ai.ModelResponse, error) {
 		// Capture the latest messages for optional history forwarding. The
 		// delegation count is intentionally not reset here: this hook runs on
@@ -283,7 +299,6 @@ func (a Agents) New(ctx context.Context) (*ai.Hooks, error) {
 		st.conversation = params.Request.Messages
 		st.mu.Unlock()
 
-		instructions := a.buildInstructions(genkit.FromContext(ctx))
 		params.Request = injectSystemText(params.Request, agentsMarker, instructions)
 		return next(ctx, params)
 	}
@@ -438,14 +453,20 @@ func (a *Agents) releaseDelegation(st *agentsState) {
 // merged into the parent session under invocationID and surfaced per the
 // configured strategy.
 func (a *Agents) foldDelegationOutput(ctx context.Context, ref aix.AgentRef, out *aix.AgentOutput[json.RawMessage], invocationID string) delegationResult {
-	switch out.FinishReason {
-	case aix.AgentFinishReasonInterrupted:
+	// Interrupted first: it is one of the reasons that carry no result, and it
+	// is the one with an explanation of its own worth giving.
+	if out.FinishReason == aix.AgentFinishReasonInterrupted {
 		// Reported as text, not propagated: there is no stateful sub-agent
 		// runtime to resume into, so the orchestrator could never satisfy it.
 		return delegationResult{Response: interruptedResponse(ref.Name)}
-	case aix.AgentFinishReasonFailed:
-		return delegationResult{Response: fmt.Sprintf(
-			"Error calling agent %q: %s", ref.Name, subAgentFailureMessage(out.Error))}
+	}
+	if !out.FinishReason.CarriesResult() {
+		// Blocked, truncated, aborted, or failed. The turn's last message is
+		// whatever the agent got out before it stopped, so it explains the
+		// outcome rather than answering the task, and reporting it as the
+		// answer would hand the orchestrator partial work as if it were final.
+		return delegationResult{Response: fmt.Sprintf("Error calling agent %q: %s",
+			ref.Name, subAgentFailureMessage(out.FinishReason, out.Error, out.Message))}
 	}
 
 	result := delegationResult{Response: messageText(out.Message)}
@@ -472,13 +493,28 @@ func interruptedResponse(agentName string) string {
 			"delegating a more self-contained task.", agentName)
 }
 
-// subAgentFailureMessage extracts a human-readable message from a sub-agent's
-// structured failure.
-func subAgentFailureMessage(err *status.Error) string {
+// subAgentFailureMessage explains to the orchestrator why a sub-agent turn
+// produced no answer. It prefers the structured failure, falls back to whatever
+// the agent managed to say before it stopped, and names the finish reason when
+// it has neither. last may be nil.
+//
+// The fallbacks are not decoration. A snapshot the runtime finalizes as
+// completed carries no Error even when its finish reason says the turn failed,
+// so for a background task the agent's last message is often the only account
+// of what happened, and dropping it leaves the model holding a placeholder it
+// cannot act on.
+func subAgentFailureMessage(reason aix.AgentFinishReason, err *status.Error, last *ai.Message) string {
 	if err != nil && err.Message != "" {
 		return err.Message
 	}
-	return "Unknown sub-agent failure."
+	if reason == "" {
+		return "Unknown sub-agent failure."
+	}
+	msg := fmt.Sprintf("the turn ended as %q without completing the task", reason)
+	if text := messageText(last); text != "" {
+		msg += "; the agent's last message was: " + text
+	}
+	return msg + "."
 }
 
 // runSubAgent runs the agent one-shot with the task. With no history the

--- a/go/plugins/middleware/exp/agents.go
+++ b/go/plugins/middleware/exp/agents.go
@@ -160,8 +160,12 @@ type Agents struct {
 	Agents []aix.AgentRef `json:"agents,omitempty" jsonschema_description:"Sub-agents available for delegation. At least one is required."`
 	// ToolPrefix is the prefix for generated delegation tool names. A nil value
 	// defaults to "delegate_to" (tools become delegate_to_<agent>); a pointer to
-	// the empty string uses bare agent names.
-	ToolPrefix *string `json:"toolPrefix,omitempty" jsonschema_description:"Prefix for generated delegation tool names. Defaults to \"delegate_to\", so tools become delegate_to_<agent>. Set it to the empty string to use bare agent names."`
+	// the empty string uses bare agent names. An explicitly set, non-empty
+	// prefix also namespaces the [Agents.Async] background-task tools (e.g.
+	// research_check_background_tasks), so two Async instances with distinct
+	// prefixes can share one generate call. New rejects a configuration whose
+	// generated tool names collide.
+	ToolPrefix *string `json:"toolPrefix,omitempty" jsonschema_description:"Prefix for generated delegation tool names. Defaults to \"delegate_to\", so tools become delegate_to_<agent>. Set it to the empty string to use bare agent names. A non-empty prefix also namespaces the async background-task tools."`
 	// MaxDelegations caps the number of sub-agent delegations per generate call,
 	// preventing runaway delegation loops. 0 means unlimited.
 	MaxDelegations int `json:"maxDelegations,omitempty" jsonschema_description:"Caps the number of sub-agent delegations per generate call, preventing runaway delegation loops. Defaults to 0, which means unlimited."`
@@ -193,9 +197,23 @@ type agentsState struct {
 	// delegations counts delegations made so far, enforcing MaxDelegations and
 	// providing the per-invocation number used to namespace artifacts.
 	delegations int
+	// seq allocates invocation numbers and never decreases, unlike the
+	// delegations cap counter above: a refunded delegation's number must not
+	// be reissued, because under parallel tool calls the reissued number can
+	// belong to a still-running delegation, and two delegations sharing an
+	// invocation ID overwrite each other's artifacts (AddArtifacts replaces
+	// by name).
+	seq int
 	// conversation is the latest request message list, captured each turn for
 	// optional history forwarding.
 	conversation []*ai.Message
+	// settledReports caches terminal background-task reports by task ID for
+	// the rest of the generate call: completed, failed, and aborted rows
+	// never change, so later re-checks skip the snapshot fetch and artifact
+	// re-merge (and cannot clobber a merged artifact the orchestrator has
+	// since edited). Pending, expired, and unresolvable reports are never
+	// cached; those can still change.
+	settledReports map[string]backgroundTaskReport
 }
 
 // New validates the configuration and returns the hooks: a delegation tool per
@@ -214,7 +232,22 @@ func (a Agents) New(ctx context.Context) (*ai.Hooks, error) {
 	}
 
 	prefix := a.prefix()
-	st := &agentsState{}
+	st := &agentsState{settledReports: make(map[string]backgroundTaskReport)}
+
+	// Every generated tool name is validated against the set as it is built:
+	// a collision (two agents mapping to one delegation tool name, or a
+	// delegation tool landing on a background-task tool's name) would
+	// otherwise surface only at generate time as a duplicate-tool rejection
+	// of the whole request.
+	names := make(map[string]string, len(a.Agents)+2)
+	claimName := func(name, owner string) error {
+		if prev, ok := names[name]; ok {
+			return status.Errorf(status.ErrInvalidArgument,
+				"agents middleware: tool name %q for %s collides with %s; use a different ToolPrefix or agent name", name, owner, prev)
+		}
+		names[name] = owner
+		return nil
+	}
 
 	tools := make([]ai.Tool, 0, len(a.Agents)+2)
 	for _, ref := range a.Agents {
@@ -223,6 +256,9 @@ func (a Agents) New(ctx context.Context) (*ai.Hooks, error) {
 			desc = fmt.Sprintf("Delegates a task to the %q sub-agent.", ref.Name)
 		}
 		name := makeToolName(prefix, ref.Name)
+		if err := claimName(name, fmt.Sprintf("agent %q", ref.Name)); err != nil {
+			return nil, err
+		}
 		// The async variant carries the extra "background" input flag, so the
 		// two modes need distinct input schemas (tool schemas are static).
 		if a.Async {
@@ -232,7 +268,13 @@ func (a Agents) New(ctx context.Context) (*ai.Hooks, error) {
 		}
 	}
 	if a.Async {
-		tools = append(tools, a.backgroundTaskTools()...)
+		checkName, waitName := a.backgroundToolNames()
+		for _, n := range []string{checkName, waitName} {
+			if err := claimName(n, "the background-task tools"); err != nil {
+				return nil, err
+			}
+		}
+		tools = append(tools, a.backgroundTaskTools(st)...)
 	}
 
 	wrapGenerate := func(ctx context.Context, params *ai.GenerateParams, next ai.GenerateNext) (*ai.ModelResponse, error) {
@@ -244,7 +286,7 @@ func (a Agents) New(ctx context.Context) (*ai.Hooks, error) {
 		st.conversation = params.Request.Messages
 		st.mu.Unlock()
 
-		instructions := buildAgentsInstructions(genkit.FromContext(ctx), a.Agents, prefix, a.Async)
+		instructions := a.buildInstructions(genkit.FromContext(ctx))
 		params.Request = injectSystemText(params.Request, agentsMarker, instructions)
 		return next(ctx, params)
 	}
@@ -297,7 +339,7 @@ func (a *Agents) delegate(ref aix.AgentRef, st *agentsState) func(context.Contex
 // delegation tool and the async-enabled variant when the model does not
 // request background execution.
 func (a *Agents) runDelegation(ctx context.Context, ref aix.AgentRef, st *agentsState, task string) (delegationResult, error) {
-	invocationNum, history, ok := a.reserveDelegation(st)
+	invocationNum, conversation, ok := a.reserveDelegation(st)
 	if !ok {
 		logger.Warn(ctx, "delegation refused, limit reached", "agent", ref.Name, "limit", a.MaxDelegations)
 		return delegationLimitResult(a.MaxDelegations), nil
@@ -305,14 +347,17 @@ func (a *Agents) runDelegation(ctx context.Context, ref aix.AgentRef, st *agents
 
 	agent, err := resolveAgent(genkit.FromContext(ctx), ref)
 	if err != nil {
+		a.releaseDelegation(st)
 		logger.Warn(ctx, "sub-agent resolution failed", "agent", ref.Name, "error", err)
 		return delegationResult{Response: "Error: " + err.Error()}, nil
 	}
 
 	// History rides in client-managed init state, which server-managed
-	// agents reject; forward it only to client-managed sub-agents.
-	if len(history) > 0 && !isClientManaged(agent) {
-		history = nil
+	// agents reject; forward it only to client-managed sub-agents. The
+	// filtering copy runs outside the state mutex.
+	var history []*ai.Message
+	if isClientManaged(agent) {
+		history = recentTextHistory(conversation, a.HistoryLength)
 	}
 
 	logger.Debug(ctx, "delegating to sub-agent",
@@ -323,7 +368,8 @@ func (a *Agents) runDelegation(ctx context.Context, ref aix.AgentRef, st *agents
 		// The agent runtime resolves failures and interrupts gracefully (see
 		// foldDelegationOutput), so this only fires for exceptions outside
 		// that handling (e.g. a rejected init payload). Surface it as tool
-		// output.
+		// output; the slot goes back because no sub-agent work ran.
+		a.releaseDelegation(st)
 		logger.Warn(ctx, "sub-agent call failed", "agent", ref.Name, "error", err)
 		return delegationResult{Response: fmt.Sprintf("Error calling agent %q: %v", ref.Name, err)}, nil
 	}
@@ -336,23 +382,28 @@ func (a *Agents) runDelegation(ctx context.Context, ref aix.AgentRef, st *agents
 }
 
 // reserveDelegation enforces MaxDelegations and reserves the next delegation's
-// invocation number, atomically, before any work happens. It also snapshots the
-// conversation history for optional forwarding. ok is false when the cap is
-// reached.
-func (a *Agents) reserveDelegation(st *agentsState) (invocationNum int, history []*ai.Message, ok bool) {
+// invocation number, atomically, before any work happens. ok is false when the
+// cap is reached. The returned conversation is the raw captured message list
+// for optional history forwarding: treat it as read-only (the generate hook
+// replaces the slice header wholesale under the mutex; messages are never
+// mutated in place), and filter it outside the lock.
+func (a *Agents) reserveDelegation(st *agentsState) (invocationNum int, conversation []*ai.Message, ok bool) {
 	st.mu.Lock()
 	defer st.mu.Unlock()
 	if a.MaxDelegations > 0 && st.delegations >= a.MaxDelegations {
 		return 0, nil, false
 	}
 	st.delegations++
-	return st.delegations, recentTextHistory(st.conversation, a.HistoryLength), true
+	st.seq++
+	return st.seq, st.conversation, true
 }
 
-// releaseDelegation returns a reserved slot for a delegation the sub-agent
-// rejected before any work ran, so the cap only counts delegations that did
-// something. Number reuse by a later delegation is harmless: a rejected
-// delegation produced no artifacts under its invocation ID.
+// releaseDelegation returns a reserved cap slot for a delegation that failed
+// before any sub-agent work ran (a resolution failure, a hard call error, or
+// a pre-detach rejection), so the cap only counts delegations that did
+// something. The released slot's invocation number is never reissued (the
+// allocator is the separate seq counter), so a concurrent live delegation
+// cannot end up sharing an artifact namespace with a later one.
 func (a *Agents) releaseDelegation(st *agentsState) {
 	st.mu.Lock()
 	defer st.mu.Unlock()
@@ -489,6 +540,20 @@ func (a *Agents) prefix() string {
 	return *a.ToolPrefix
 }
 
+// backgroundToolNames returns the names of the shared background-task tools
+// for this configuration. They are the bare well-known names by default and
+// prefixed with an explicitly set [Agents.ToolPrefix], so two Async instances
+// with distinct prefixes can coexist on one generate call without colliding
+// on the shared names (the default delegate_to prefix is a delegation verb,
+// not an instance namespace, so it is deliberately not applied here).
+func (a *Agents) backgroundToolNames() (check, wait string) {
+	if a.ToolPrefix == nil {
+		return checkBackgroundTasksToolName, waitBackgroundTasksToolName
+	}
+	return makeToolName(*a.ToolPrefix, checkBackgroundTasksToolName),
+		makeToolName(*a.ToolPrefix, waitBackgroundTasksToolName)
+}
+
 // strategy resolves the artifact strategy, defaulting to inline.
 func (a *Agents) strategy() ArtifactStrategy {
 	if a.ArtifactStrategy == ArtifactStrategySession {
@@ -506,15 +571,16 @@ func makeToolName(prefix, agentName string) string {
 	return prefix + "_" + agentName
 }
 
-// buildAgentsInstructions renders the <sub-agents> system prompt block. g may be
+// buildInstructions renders the <sub-agents> system prompt block. g may be
 // nil (e.g. outside an agent/Generate context), in which case only configured
-// descriptions are used. With async set, the block also explains background
-// delegation and the background-task tools.
-func buildAgentsInstructions(g *genkit.Genkit, refs []aix.AgentRef, prefix string, async bool) string {
+// descriptions are used. With [Agents.Async] set, the block also explains
+// background delegation and names this configuration's background-task tools.
+func (a *Agents) buildInstructions(g *genkit.Genkit) string {
+	prefix := a.prefix()
 	var b strings.Builder
 	b.WriteString("<sub-agents>\n")
 	b.WriteString("You can delegate tasks to specialized sub-agents using their delegation tools:\n")
-	for _, ref := range refs {
+	for _, ref := range a.Agents {
 		desc := ref.Description
 		if desc == "" && g != nil {
 			desc = discoverDescription(g, ref.Name)
@@ -527,13 +593,14 @@ func buildAgentsInstructions(g *genkit.Genkit, refs []aix.AgentRef, prefix strin
 	b.WriteString("\n")
 	b.WriteString("When a task is better handled by a specialized agent, delegate it using the ")
 	b.WriteString("appropriate tool. Provide a clear, self-contained task description.\n")
-	if async {
+	if a.Async {
+		checkName, waitName := a.backgroundToolNames()
 		b.WriteString("\n")
 		b.WriteString("Delegations can run in the background: set \"background\": true on a ")
 		b.WriteString("delegation tool call to get a taskId back immediately while the ")
 		b.WriteString("sub-agent keeps working. Continue with other work, then collect ")
-		b.WriteString("results with " + checkBackgroundTasksToolName + " (returns current ")
-		b.WriteString("status without waiting) or " + waitBackgroundTasksToolName + " ")
+		b.WriteString("results with " + checkName + " (returns current ")
+		b.WriteString("status without waiting) or " + waitName + " ")
 		b.WriteString("(blocks until the tasks settle). Background tasks keep running ")
 		b.WriteString("across turns, and task IDs from earlier tool results stay valid: ")
 		b.WriteString("check them before delegating the same work again.\n")

--- a/go/plugins/middleware/exp/agents.go
+++ b/go/plugins/middleware/exp/agents.go
@@ -20,13 +20,17 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/firebase/genkit/go/ai"
 	aix "github.com/firebase/genkit/go/ai/exp"
-	"github.com/firebase/genkit/go/core/api"
+	"github.com/firebase/genkit/go/core/logger"
+	"github.com/firebase/genkit/go/core/status"
 	"github.com/firebase/genkit/go/genkit"
+	genkitx "github.com/firebase/genkit/go/genkit/exp"
 )
 
 // agentsMarker tags the system prompt part injected by this middleware. The
@@ -53,22 +57,28 @@ const (
 	ArtifactStrategySession ArtifactStrategy = "session"
 )
 
-// resolveAgent looks the agent up by name through g. Resolution goes through
-// the Genkit instance (the sanctioned path for third-party middleware) rather
-// than the registry directly.
-func resolveAgent(g *genkit.Genkit, ref aix.AgentRef) (api.BidiAction, error) {
+// requireGenkit classifies the absence of a Genkit instance on the context as
+// a failed precondition: a wiring gap in how the middleware runs, not anything
+// the caller sent. Both delegation and background-task reads resolve through
+// it.
+func requireGenkit(g *genkit.Genkit) error {
 	if g == nil {
-		return nil, fmt.Errorf("no Genkit instance on the context (the agents middleware must run within genkit.Generate or a genkit-defined agent)")
+		return status.Errorf(status.ErrFailedPrecondition,
+			"no Genkit instance on the context (the agents middleware must run within genkit.Generate or a genkit-defined agent)")
 	}
-	action := genkit.LookupAction(g, "/agent/"+ref.Name)
-	if action == nil {
-		return nil, fmt.Errorf("agent %q not found in registry", ref.Name)
+	return nil
+}
+
+// resolveAgent looks the agent up by name through g and returns its handle.
+// Resolution goes through the Genkit instance (the sanctioned path for
+// third-party middleware) rather than the registry directly; the handle
+// carries the agent's companion actions and capability metadata along with
+// the run surface.
+func resolveAgent(g *genkit.Genkit, ref aix.AgentRef) (*aix.AgentHandle, error) {
+	if err := requireGenkit(g); err != nil {
+		return nil, err
 	}
-	agent, ok := action.(api.BidiAction)
-	if !ok {
-		return nil, fmt.Errorf("%q is registered but is not an agent", ref.Name)
-	}
-	return agent, nil
+	return genkitx.LookupAgent(g, ref.Name)
 }
 
 // Agents is a middleware that enables sub-agent delegation.
@@ -95,6 +105,28 @@ func resolveAgent(g *genkit.Genkit, ref aix.AgentRef) (api.BidiAction, error) {
 // orchestrator as a normal tool response, not propagated as an interrupt: there
 // is no stateful sub-agent runtime to resume into, so interactive sub-agent
 // interaction is a future feature.
+//
+// With [Agents.Async] set, delegation tools additionally accept a "background"
+// flag. A background delegation starts the sub-agent through its detach support
+// ([aix.AgentInput.Detach]): the sub-agent's runtime persists a pending
+// snapshot, hands back a task ID immediately, and keeps working in the
+// background, so the orchestrator can continue calling tools and collect the
+// result later through the added check_background_tasks and
+// wait_for_background_tasks tools. The pending snapshot (heartbeated while the
+// worker lives, finalized in place with the cumulative state when the work
+// settles) is the durable record, and task IDs are self-contained
+// ("<agent>:<snapshotId>"), so a re-instantiated orchestrator can pick results
+// up using nothing but the IDs recorded in its conversation history. Background
+// delegation requires server-managed sub-agents whose stores implement
+// [aix.SnapshotSubscriber] (e.g. the localstore stores); launches on other
+// agents are rejected by the sub-agent runtime and reported as tool text.
+//
+// Task handles are not access-scoped: the background-task tools read any
+// snapshot ID belonging to a configured sub-agent, whether or not this
+// conversation launched it (mirroring the sub-agent's getSnapshot companion
+// action, which is itself unscoped). In multi-tenant deployments treat
+// snapshot IDs as capability-like secrets: text that reaches the orchestrator
+// model can steer these tools at any ID it names.
 //
 // The middleware resolves agents through genkit.FromContext, which is seeded by
 // genkit.Generate and by agents defined via the genkit/exp constructors
@@ -141,6 +173,14 @@ type Agents struct {
 	// ArtifactStrategy controls how sub-agent artifacts are surfaced. Defaults to
 	// ArtifactStrategyInline.
 	ArtifactStrategy ArtifactStrategy `json:"artifactStrategy,omitempty" jsonschema_description:"How sub-agent artifacts are surfaced. \"inline\" adds artifact content to the delegation tool result and merges it into the parent session. \"session\" merges into the session only. Defaults to \"inline\"."`
+	// Async enables background delegation. Delegation tools gain a "background"
+	// input flag that starts the sub-agent through its detach support and
+	// returns a task ID immediately, and two shared tools are added:
+	// check_background_tasks (non-blocking status and results) and
+	// wait_for_background_tasks (blocks until the listed tasks settle).
+	// Background delegation requires server-managed sub-agents whose stores
+	// implement [aix.SnapshotSubscriber].
+	Async bool `json:"async,omitempty" jsonschema_description:"Enables background delegation: delegation tools accept a \"background\" flag, and the check_background_tasks / wait_for_background_tasks tools are added. Background delegation requires server-managed sub-agents whose session stores support detach."`
 }
 
 func (a Agents) Name() string { return provider + "/agents" }
@@ -163,24 +203,36 @@ type agentsState struct {
 // captures conversation history.
 func (a Agents) New(ctx context.Context) (*ai.Hooks, error) {
 	if len(a.Agents) == 0 {
-		return nil, fmt.Errorf("agents middleware requires at least one agent in the \"agents\" option")
+		return nil, status.Errorf(status.ErrInvalidArgument,
+			"agents middleware requires at least one agent in the \"agents\" option")
 	}
 	for _, ref := range a.Agents {
 		if ref.Name == "" {
-			return nil, fmt.Errorf("agents middleware: every agent reference must have a name")
+			return nil, status.Errorf(status.ErrInvalidArgument,
+				"agents middleware: every agent reference must have a name")
 		}
 	}
 
 	prefix := a.prefix()
 	st := &agentsState{}
 
-	tools := make([]ai.Tool, 0, len(a.Agents))
+	tools := make([]ai.Tool, 0, len(a.Agents)+2)
 	for _, ref := range a.Agents {
 		desc := ref.Description
 		if desc == "" {
 			desc = fmt.Sprintf("Delegates a task to the %q sub-agent.", ref.Name)
 		}
-		tools = append(tools, aix.NewTool(makeToolName(prefix, ref.Name), desc, a.delegate(ref, st)))
+		name := makeToolName(prefix, ref.Name)
+		// The async variant carries the extra "background" input flag, so the
+		// two modes need distinct input schemas (tool schemas are static).
+		if a.Async {
+			tools = append(tools, aix.NewTool(name, desc, a.delegateAsync(ref, st)))
+		} else {
+			tools = append(tools, aix.NewTool(name, desc, a.delegate(ref, st)))
+		}
+	}
+	if a.Async {
+		tools = append(tools, a.backgroundTaskTools()...)
 	}
 
 	wrapGenerate := func(ctx context.Context, params *ai.GenerateParams, next ai.GenerateNext) (*ai.ModelResponse, error) {
@@ -192,7 +244,7 @@ func (a Agents) New(ctx context.Context) (*ai.Hooks, error) {
 		st.conversation = params.Request.Messages
 		st.mu.Unlock()
 
-		instructions := buildAgentsInstructions(genkit.FromContext(ctx), a.Agents, prefix)
+		instructions := buildAgentsInstructions(genkit.FromContext(ctx), a.Agents, prefix, a.Async)
 		params.Request = injectSystemText(params.Request, agentsMarker, instructions)
 		return next(ctx, params)
 	}
@@ -210,11 +262,20 @@ type delegateInput struct {
 
 // delegationResult is the output of a delegation tool.
 type delegationResult struct {
-	// Response is the sub-agent's text response.
+	// Response is the sub-agent's text response. For a background delegation it
+	// describes the launch instead; the sub-agent's response arrives later via
+	// the background-task tools.
 	Response string `json:"response"`
 	// Artifacts are the sub-agent's artifacts. Content is populated only under
 	// ArtifactStrategyInline.
 	Artifacts []delegatedArtifact `json:"artifacts,omitempty"`
+	// TaskID is the background task handle ("<agent>:<snapshotId>") when the
+	// delegation was started with background=true; empty otherwise. It is the
+	// input to check_background_tasks / wait_for_background_tasks.
+	TaskID string `json:"taskId,omitempty"`
+	// Status is "pending" when a background delegation was started; empty for
+	// synchronous delegations.
+	Status string `json:"status,omitempty"`
 }
 
 type delegatedArtifact struct {
@@ -228,104 +289,145 @@ type delegatedArtifact struct {
 // agent resolution, sub-agent execution, and artifact merging.
 func (a *Agents) delegate(ref aix.AgentRef, st *agentsState) func(context.Context, delegateInput) (delegationResult, error) {
 	return func(ctx context.Context, in delegateInput) (delegationResult, error) {
-		// Guard rail: enforce the delegation cap and reserve this delegation's
-		// number, atomically, before doing any work.
-		st.mu.Lock()
-		if a.MaxDelegations > 0 && st.delegations >= a.MaxDelegations {
-			st.mu.Unlock()
-			return delegationResult{Response: fmt.Sprintf(
-				"Delegation limit reached (%d). Complete the task using information already gathered.",
-				a.MaxDelegations)}, nil
-		}
-		st.delegations++
-		invocationNum := st.delegations
-		history := recentTextHistory(st.conversation, a.HistoryLength)
-		st.mu.Unlock()
-
-		agent, err := resolveAgent(genkit.FromContext(ctx), ref)
-		if err != nil {
-			return delegationResult{Response: "Error: " + err.Error()}, nil
-		}
-
-		// History rides in client-managed init state, which server-managed
-		// agents reject; forward it only to client-managed sub-agents.
-		if len(history) > 0 && !isClientManaged(agent) {
-			history = nil
-		}
-
-		out, err := runSubAgent(ctx, agent, in.Task, history)
-		if err != nil {
-			// The agent runtime resolves failures and interrupts gracefully (see
-			// below), so this only fires for exceptions outside that handling
-			// (e.g. a rejected init payload). Surface it as tool output.
-			return delegationResult{Response: fmt.Sprintf("Error calling agent %q: %v", ref.Name, err)}, nil
-		}
-
-		switch out.FinishReason {
-		case aix.AgentFinishReasonInterrupted:
-			// Reported as text, not propagated: there is no stateful sub-agent
-			// runtime to resume into, so the orchestrator could never satisfy it.
-			return delegationResult{Response: fmt.Sprintf(
-				"Sub-agent %q interrupted for additional input and could not complete the "+
-					"task. Interactive sub-agent interrupts are not currently supported; try "+
-					"delegating a more self-contained task.", ref.Name)}, nil
-		case aix.AgentFinishReasonFailed:
-			msg := "Unknown sub-agent failure."
-			if out.Error != nil && out.Error.Message != "" {
-				msg = out.Error.Message
-			}
-			return delegationResult{Response: fmt.Sprintf("Error calling agent %q: %s", ref.Name, msg)}, nil
-		}
-
-		result := delegationResult{Response: messageText(out.Message)}
-		if result.Response == "" {
-			result.Response = "(no response)"
-		}
-
-		subArtifacts := namedArtifacts(out.Artifacts)
-		if len(subArtifacts) > 0 {
-			invocationID := fmt.Sprintf("%s_%d", ref.Name, invocationNum)
-			// Merge into the parent session under both strategies (no-op if there
-			// is no active session, e.g. a plain genkit.Generate call).
-			mergeArtifacts(ctx, ref.Name, invocationID, subArtifacts)
-			result.Artifacts = delegatedArtifacts(invocationID, subArtifacts, a.strategy())
-		}
-		return result, nil
+		return a.runDelegation(ctx, ref, st, in.Task)
 	}
 }
 
-// runSubAgent runs the agent one-shot with the task. Agents are bidi actions,
-// so this always goes through RunBidiJSON: with no history the init is empty (a
-// fresh one-shot session); with history it carries the messages as client-
-// managed init state, which callers forward only to client-managed agents. The
-// output is decoded with json.RawMessage as the custom-state type since the
-// sub-agent's State is unknown here.
-func runSubAgent(ctx context.Context, agent api.BidiAction, task string, history []*ai.Message) (*aix.AgentOutput[json.RawMessage], error) {
-	inputJSON, err := json.Marshal(&aix.AgentInput{Message: ai.NewUserTextMessage(task)})
-	if err != nil {
-		return nil, err
+// runDelegation is the synchronous delegation body, shared by the plain
+// delegation tool and the async-enabled variant when the model does not
+// request background execution.
+func (a *Agents) runDelegation(ctx context.Context, ref aix.AgentRef, st *agentsState, task string) (delegationResult, error) {
+	invocationNum, history, ok := a.reserveDelegation(st)
+	if !ok {
+		logger.Warn(ctx, "delegation refused, limit reached", "agent", ref.Name, "limit", a.MaxDelegations)
+		return delegationLimitResult(a.MaxDelegations), nil
 	}
 
-	var initJSON json.RawMessage
+	agent, err := resolveAgent(genkit.FromContext(ctx), ref)
+	if err != nil {
+		logger.Warn(ctx, "sub-agent resolution failed", "agent", ref.Name, "error", err)
+		return delegationResult{Response: "Error: " + err.Error()}, nil
+	}
+
+	// History rides in client-managed init state, which server-managed
+	// agents reject; forward it only to client-managed sub-agents.
+	if len(history) > 0 && !isClientManaged(agent) {
+		history = nil
+	}
+
+	logger.Debug(ctx, "delegating to sub-agent",
+		"agent", ref.Name, "invocation", invocationNum, "historyMessages", len(history))
+	start := time.Now()
+	out, err := runSubAgent(ctx, agent, task, history, false)
+	if err != nil {
+		// The agent runtime resolves failures and interrupts gracefully (see
+		// foldDelegationOutput), so this only fires for exceptions outside
+		// that handling (e.g. a rejected init payload). Surface it as tool
+		// output.
+		logger.Warn(ctx, "sub-agent call failed", "agent", ref.Name, "error", err)
+		return delegationResult{Response: fmt.Sprintf("Error calling agent %q: %v", ref.Name, err)}, nil
+	}
+
+	result := a.foldDelegationOutput(ctx, ref, out, fmt.Sprintf("%s_%d", ref.Name, invocationNum))
+	logger.Debug(ctx, "sub-agent delegation finished",
+		"agent", ref.Name, "finishReason", string(out.FinishReason),
+		"durationMs", time.Since(start).Milliseconds(), "artifacts", len(result.Artifacts))
+	return result, nil
+}
+
+// reserveDelegation enforces MaxDelegations and reserves the next delegation's
+// invocation number, atomically, before any work happens. It also snapshots the
+// conversation history for optional forwarding. ok is false when the cap is
+// reached.
+func (a *Agents) reserveDelegation(st *agentsState) (invocationNum int, history []*ai.Message, ok bool) {
+	st.mu.Lock()
+	defer st.mu.Unlock()
+	if a.MaxDelegations > 0 && st.delegations >= a.MaxDelegations {
+		return 0, nil, false
+	}
+	st.delegations++
+	return st.delegations, recentTextHistory(st.conversation, a.HistoryLength), true
+}
+
+// releaseDelegation returns a reserved slot for a delegation the sub-agent
+// rejected before any work ran, so the cap only counts delegations that did
+// something. Number reuse by a later delegation is harmless: a rejected
+// delegation produced no artifacts under its invocation ID.
+func (a *Agents) releaseDelegation(st *agentsState) {
+	st.mu.Lock()
+	defer st.mu.Unlock()
+	st.delegations--
+}
+
+// delegationLimitResult is the refusal returned once MaxDelegations is
+// exhausted.
+func delegationLimitResult(limit int) delegationResult {
+	return delegationResult{Response: fmt.Sprintf(
+		"Delegation limit reached (%d). Complete the task using information already gathered.", limit)}
+}
+
+// foldDelegationOutput turns a settled sub-agent output into a delegation tool
+// result: interrupts and failures become explanatory text, and artifacts are
+// merged into the parent session under invocationID and surfaced per the
+// configured strategy.
+func (a *Agents) foldDelegationOutput(ctx context.Context, ref aix.AgentRef, out *aix.AgentOutput[json.RawMessage], invocationID string) delegationResult {
+	switch out.FinishReason {
+	case aix.AgentFinishReasonInterrupted:
+		// Reported as text, not propagated: there is no stateful sub-agent
+		// runtime to resume into, so the orchestrator could never satisfy it.
+		return delegationResult{Response: interruptedResponse(ref.Name)}
+	case aix.AgentFinishReasonFailed:
+		return delegationResult{Response: fmt.Sprintf(
+			"Error calling agent %q: %s", ref.Name, subAgentFailureMessage(out.Error))}
+	}
+
+	result := delegationResult{Response: messageText(out.Message)}
+	if result.Response == "" {
+		result.Response = "(no response)"
+	}
+
+	subArtifacts := namedArtifacts(out.Artifacts)
+	if len(subArtifacts) > 0 {
+		// Merge into the parent session under both strategies (no-op if there
+		// is no active session, e.g. a plain genkit.Generate call).
+		mergeArtifacts(ctx, ref.Name, invocationID, subArtifacts)
+		result.Artifacts = delegatedArtifacts(invocationID, subArtifacts, a.strategy())
+	}
+	return result
+}
+
+// interruptedResponse is the tool text reported when a sub-agent interrupted
+// for input the orchestrator can never provide.
+func interruptedResponse(agentName string) string {
+	return fmt.Sprintf(
+		"Sub-agent %q interrupted for additional input and could not complete the "+
+			"task. Interactive sub-agent interrupts are not currently supported; try "+
+			"delegating a more self-contained task.", agentName)
+}
+
+// subAgentFailureMessage extracts a human-readable message from a sub-agent's
+// structured failure.
+func subAgentFailureMessage(err *status.Error) string {
+	if err != nil && err.Message != "" {
+		return err.Message
+	}
+	return "Unknown sub-agent failure."
+}
+
+// runSubAgent runs the agent one-shot with the task. With no history the
+// invocation starts a fresh session; with history the messages ride as
+// client-managed init state ([aix.WithState]), which callers forward only to
+// client-managed agents. With detach set, the input asks the sub-agent
+// runtime to move the work to the background immediately: the returned output
+// then carries the pending snapshot's ID and [aix.AgentFinishReasonDetached]
+// while the sub-agent keeps working. Custom state is json.RawMessage
+// throughout ([aix.AgentHandle]) since the sub-agent's State is unknown here.
+func runSubAgent(ctx context.Context, agent *aix.AgentHandle, task string, history []*ai.Message, detach bool) (*aix.AgentOutput[json.RawMessage], error) {
+	var opts []aix.InvocationOption[json.RawMessage]
 	if len(history) > 0 {
-		initJSON, err = json.Marshal(aix.AgentInit[json.RawMessage]{
-			State: &aix.SessionState[json.RawMessage]{Messages: history},
-		})
-		if err != nil {
-			return nil, err
-		}
+		opts = append(opts, aix.WithState(&aix.SessionState[json.RawMessage]{Messages: history}))
 	}
-
-	res, err := agent.RunBidiJSON(ctx, inputJSON, nil, &api.BidiJSONOptions{Init: initJSON})
-	if err != nil {
-		return nil, err
-	}
-
-	var out aix.AgentOutput[json.RawMessage]
-	if err := json.Unmarshal(res.Result, &out); err != nil {
-		return nil, err
-	}
-	return &out, nil
+	return agent.Run(ctx, &aix.AgentInput{Detach: detach, Message: ai.NewUserTextMessage(task)}, opts...)
 }
 
 // isClientManaged reports whether the agent owns its state on the client (no
@@ -337,22 +439,9 @@ func runSubAgent(ctx context.Context, agent api.BidiAction, task string, history
 // forwards history unless state management is explicitly "server"; for
 // genkit-defined agents the metadata is always set, so the two agree in
 // practice.
-func isClientManaged(agent api.BidiAction) bool {
-	meta := agent.Desc().Metadata
-	if meta == nil {
-		return false
-	}
-	switch m := meta["agent"].(type) {
-	case aix.AgentMetadata:
-		return m.StateManagement == aix.AgentStateManagementClient
-	case *aix.AgentMetadata:
-		return m != nil && m.StateManagement == aix.AgentStateManagementClient
-	case map[string]any:
-		s, _ := m["stateManagement"].(string)
-		return aix.AgentStateManagement(s) == aix.AgentStateManagementClient
-	default:
-		return false
-	}
+func isClientManaged(agent *aix.AgentHandle) bool {
+	meta := agent.Metadata()
+	return meta != nil && meta.StateManagement == aix.AgentStateManagementClient
 }
 
 // mergeArtifacts namespaces the sub-agent's artifacts by invocation ID, tags
@@ -366,9 +455,7 @@ func mergeArtifacts(ctx context.Context, source, invocationID string, arts []*ai
 	namespaced := make([]*aix.Artifact, 0, len(arts))
 	for _, a := range arts {
 		md := make(map[string]any, len(a.Metadata)+2)
-		for k, v := range a.Metadata {
-			md[k] = v
-		}
+		maps.Copy(md, a.Metadata)
 		md["source"] = source
 		md["invocationId"] = invocationID
 		namespaced = append(namespaced, &aix.Artifact{
@@ -421,8 +508,9 @@ func makeToolName(prefix, agentName string) string {
 
 // buildAgentsInstructions renders the <sub-agents> system prompt block. g may be
 // nil (e.g. outside an agent/Generate context), in which case only configured
-// descriptions are used.
-func buildAgentsInstructions(g *genkit.Genkit, refs []aix.AgentRef, prefix string) string {
+// descriptions are used. With async set, the block also explains background
+// delegation and the background-task tools.
+func buildAgentsInstructions(g *genkit.Genkit, refs []aix.AgentRef, prefix string, async bool) string {
 	var b strings.Builder
 	b.WriteString("<sub-agents>\n")
 	b.WriteString("You can delegate tasks to specialized sub-agents using their delegation tools:\n")
@@ -439,6 +527,17 @@ func buildAgentsInstructions(g *genkit.Genkit, refs []aix.AgentRef, prefix strin
 	b.WriteString("\n")
 	b.WriteString("When a task is better handled by a specialized agent, delegate it using the ")
 	b.WriteString("appropriate tool. Provide a clear, self-contained task description.\n")
+	if async {
+		b.WriteString("\n")
+		b.WriteString("Delegations can run in the background: set \"background\": true on a ")
+		b.WriteString("delegation tool call to get a taskId back immediately while the ")
+		b.WriteString("sub-agent keeps working. Continue with other work, then collect ")
+		b.WriteString("results with " + checkBackgroundTasksToolName + " (returns current ")
+		b.WriteString("status without waiting) or " + waitBackgroundTasksToolName + " ")
+		b.WriteString("(blocks until the tasks settle). Background tasks keep running ")
+		b.WriteString("across turns, and task IDs from earlier tool results stay valid: ")
+		b.WriteString("check them before delegating the same work again.\n")
+	}
 	b.WriteString("</sub-agents>")
 	return b.String()
 }

--- a/go/plugins/middleware/exp/agents_async.go
+++ b/go/plugins/middleware/exp/agents_async.go
@@ -72,6 +72,12 @@ const taskStatusUnknown = "unknown"
 // without task IDs.
 const noTaskIDsNote = "No task IDs given. Pass the taskId values returned by background delegations."
 
+// Join semantics of the wait tool ([waitBackgroundTasksInput.WaitFor]).
+const (
+	waitForAll   = "all"
+	waitForFirst = "first"
+)
+
 // asyncDelegateInput is the delegation tool input when [Agents.Async] is set:
 // the plain task plus the background flag.
 type asyncDelegateInput struct {
@@ -98,6 +104,12 @@ type backgroundTasksInput struct {
 type waitBackgroundTasksInput struct {
 	backgroundTasksInput
 	TimeoutSeconds int `json:"timeoutSeconds,omitempty" jsonschema_description:"Maximum seconds to wait before returning the current statuses. 0 or omitted waits until every task settles; a negative value returns the current statuses immediately. Values too large to represent are treated as unbounded."`
+	// WaitFor selects the join: "all" (default) blocks until every listed
+	// task settles, "first" turns the join into a race and returns as soon
+	// as any one does, the rest reporting their current status. First-settled
+	// is what lets an orchestrator act on the first answer while the others
+	// keep working.
+	WaitFor string `json:"waitFor,omitempty" jsonschema_description:"\"all\" (default) waits until every listed task settles. \"first\" returns as soon as any one settles; the remaining tasks report their current status and keep running."`
 }
 
 // backgroundTaskReport is the per-task entry returned by the check and wait
@@ -247,7 +259,7 @@ func (a *Agents) backgroundTaskTools(st *agentsState) []ai.Tool {
 			"Returns the current status of background sub-agent tasks without waiting, including results for tasks that finished.",
 			a.taskReportTool(st, readSnapshotOnce)),
 		aix.NewTool(names.wait,
-			"Waits until the given background sub-agent tasks finish and returns their results. Set timeoutSeconds to bound the wait; on timeout the current statuses are returned.",
+			"Waits until the given background sub-agent tasks finish and returns their results. Set timeoutSeconds to bound the wait; on timeout the current statuses are returned. Set waitFor to \"first\" to return as soon as any one task settles.",
 			a.waitForBackgroundTasks(st)),
 		aix.NewTool(names.abort,
 			"Stops background sub-agent tasks whose results are no longer needed, and returns where that left each one. A task that had already finished is unaffected and reports its result.",
@@ -290,6 +302,18 @@ func (a *Agents) waitForBackgroundTasks(st *agentsState) func(context.Context, w
 		if len(in.TaskIDs) == 0 {
 			return backgroundTasksResult{Note: noTaskIDsNote}, nil
 		}
+		first := false
+		switch in.WaitFor {
+		case "", waitForAll:
+		case waitForFirst:
+			first = true
+		default:
+			// A recoverable mistake, answered like an empty ID list: guidance
+			// the model can correct, not a decode failure that kills the turn.
+			return backgroundTasksResult{Note: fmt.Sprintf(
+				"Unknown waitFor value %q. Use %q (the default) to wait for every task, or %q to return when any one settles.",
+				in.WaitFor, waitForAll, waitForFirst)}, nil
+		}
 		// A negative timeout means "don't wait": report the current statuses.
 		if in.TimeoutSeconds < 0 {
 			return a.reportTasks(ctx, st, in.TaskIDs, readSnapshotOnce)
@@ -314,9 +338,14 @@ func (a *Agents) waitForBackgroundTasks(st *agentsState) func(context.Context, w
 			"tasks", len(in.TaskIDs), "timeoutSeconds", in.TimeoutSeconds)
 
 		g := genkit.FromContext(ctx)
-		reports := collectReports(in.TaskIDs, func(taskID string) backgroundTaskReport {
-			return a.awaitTask(waitCtx, g, st, taskID, start)
-		})
+		var reports []backgroundTaskReport
+		if first {
+			reports = a.collectFirstSettled(waitCtx, g, st, in.TaskIDs, start)
+		} else {
+			reports = collectReports(in.TaskIDs, func(taskID string) backgroundTaskReport {
+				return a.awaitTask(waitCtx, g, st, taskID, start)
+			})
+		}
 
 		// The calling context ending is cancellation, not a timeout; let it
 		// fail the tool call rather than dressing it up as a settled result.
@@ -336,6 +365,14 @@ func (a *Agents) waitForBackgroundTasks(st *agentsState) func(context.Context, w
 			}
 		}
 		if pending > 0 {
+			if first && pending < len(reports) {
+				// The race was won, not timed out: at least one task settled
+				// and the return is the caller's chosen semantics.
+				logger.Debug(ctx, "wait for background tasks returned on first settle",
+					"pending", pending, "elapsedMs", time.Since(start).Milliseconds())
+				res.Note = "Returned on the first settled task; the remaining tasks report their current status and keep running."
+				return res, nil
+			}
 			logger.Debug(ctx, "wait for background tasks timed out",
 				"pending", pending, "elapsedMs", time.Since(start).Milliseconds())
 			res.TimedOut = true
@@ -391,6 +428,39 @@ func (a *Agents) reportTasks(ctx context.Context, st *agentsState, taskIDs []str
 		return backgroundTasksResult{}, err
 	}
 	return res, nil
+}
+
+// collectFirstSettled runs one follow per task concurrently and returns as
+// soon as any of them settles, cancelling the remaining follows so each
+// reports its task as it stands. "Settles" is the same rule the wait loop
+// counts by (Terminal()), unknown included: an unresolvable handle is an
+// answer the caller must act on, not something to keep waiting behind.
+// Reports come back in input order.
+func (a *Agents) collectFirstSettled(ctx context.Context, g *genkit.Genkit, st *agentsState, taskIDs []string, start time.Time) []backgroundTaskReport {
+	raceCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	type indexed struct {
+		i      int
+		report backgroundTaskReport
+	}
+	ch := make(chan indexed, len(taskIDs))
+	for i, taskID := range taskIDs {
+		go func(i int, taskID string) {
+			ch <- indexed{i, a.awaitTask(raceCtx, g, st, taskID, start)}
+		}(i, taskID)
+	}
+	reports := make([]backgroundTaskReport, len(taskIDs))
+	for range taskIDs {
+		res := <-ch
+		reports[res.i] = res.report
+		if aix.SnapshotStatus(res.report.Status).Terminal() {
+			// The first settle ends the race. Cancelling is idempotent, so
+			// later settles that raced the cancellation just land in their
+			// slots.
+			cancel()
+		}
+	}
+	return reports
 }
 
 // collectReports builds one report per entry of taskIDs, fetching each

--- a/go/plugins/middleware/exp/agents_async.go
+++ b/go/plugins/middleware/exp/agents_async.go
@@ -623,12 +623,12 @@ func (a *Agents) reportTask(ctx context.Context, g *genkit.Genkit, st *agentsSta
 		// artifacts whether it ran in the background or not, with one caveat:
 		// this reads the snapshot through the agent's own companion action, so
 		// a sub-agent configured WithStateTransform has already shaped what is
-		// read here, while the synchronous path sees the output unshaped. The response is
-		// the persisted conversation's tip, which is the literal final message
-		// the sub-agent returned (SessionRunner.Result), rather than older text
-		// it spoke mid-tool-loop; an interrupt carries the same limitation as
-		// the synchronous path, since it cannot be resumed from here.
-		tip := snapshotTip(snap)
+		// read here, while the synchronous path sees the output unshaped. The
+		// response is the conversation's last model message, what the sub-agent
+		// last said, rather than whatever the transcript happens to end on; an
+		// interrupt carries the same limitation as the synchronous path, since
+		// it cannot be resumed from here.
+		tip := lastModelMessage(snap)
 		var arts []*aix.Artifact
 		if snap.State != nil {
 			arts = snap.State.Artifacts
@@ -655,7 +655,7 @@ func (a *Agents) reportTask(ctx context.Context, g *genkit.Genkit, st *agentsSta
 			report.Error = folded.Response
 		}
 	case aix.SnapshotStatusFailed:
-		report.Error = subAgentFailureMessage(snap.FinishReason, snap.Error, snapshotTip(snap))
+		report.Error = subAgentFailureMessage(snap.FinishReason, snap.Error, lastModelMessage(snap))
 	case aix.SnapshotStatusAborted:
 		report.Error = "The task was aborted before it finished."
 	case aix.SnapshotStatusExpired:
@@ -673,20 +673,25 @@ func (a *Agents) reportTask(ctx context.Context, g *genkit.Genkit, st *agentsSta
 	return report, nil
 }
 
-// snapshotTip returns the persisted conversation's last message, which is the
-// literal final message the sub-agent returned (SessionRunner.Result) rather
-// than older text it spoke mid-tool-loop. Nil when the row carries no state or
-// no messages.
+// lastModelMessage returns the persisted conversation's final model message:
+// what the sub-agent last said. The transcript's tip is not that for every
+// agent; a custom agent can end its turn on a tool response, or on input it
+// appended itself, and reporting either as the answer would put someone else's
+// words in the sub-agent's mouth. Nil when the row carries no state or no
+// model message.
 //
 // It serves both the completed and failed arms. A failed detach-finalize
-// writes the full final state, so the tip is there too, and for a row whose
-// Error is empty it is the only account of what the agent managed to do.
-func snapshotTip(snap *aix.SessionSnapshot[json.RawMessage]) *ai.Message {
+// writes the full final state, so the message is there too, and for a row
+// whose Error is empty it is the only account of what the agent managed to do.
+func lastModelMessage(snap *aix.SessionSnapshot[json.RawMessage]) *ai.Message {
 	if snap.State == nil {
 		return nil
 	}
-	if n := len(snap.State.Messages); n > 0 {
-		return snap.State.Messages[n-1]
+	msgs := snap.State.Messages
+	for i := len(msgs) - 1; i >= 0; i-- {
+		if msgs[i] != nil && msgs[i].Role == ai.RoleModel {
+			return msgs[i]
+		}
 	}
 	return nil
 }

--- a/go/plugins/middleware/exp/agents_async.go
+++ b/go/plugins/middleware/exp/agents_async.go
@@ -1,0 +1,510 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package exp
+
+// Background delegation for the [Agents] middleware ([Agents.Async]).
+//
+// A background delegation launches the sub-agent with [aix.AgentInput.Detach]:
+// the sub-agent's runtime persists a pending snapshot, returns its ID at once,
+// and keeps running the turn on a context decoupled from this tool call. The
+// pending snapshot is the durable record of the task: it is heartbeated while
+// the worker lives, finalized in place with the cumulative session state when
+// the work settles, and surfaced as expired by readers once the heartbeat goes
+// stale (worker presumed dead).
+//
+// The middleware itself keeps no task registry. The task handle
+// ("<agent>:<snapshotId>") is self-contained and rides in the delegation tool
+// result, so it is recorded in the orchestrator's conversation history; a
+// re-instantiated orchestrator resumes tracking from the IDs in its history.
+// Status reads go through the sub-agent's [aix.AgentHandle] (resolved with
+// [genkitx.LookupAgent], the sanctioned path for third-party middleware),
+// whose GetSnapshot dispatches the agent's getSnapshot companion action.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/firebase/genkit/go/ai"
+	aix "github.com/firebase/genkit/go/ai/exp"
+	"github.com/firebase/genkit/go/core/logger"
+	"github.com/firebase/genkit/go/core/status"
+	"github.com/firebase/genkit/go/genkit"
+	genkitx "github.com/firebase/genkit/go/genkit/exp"
+)
+
+// Names of the shared background-task tools added when [Agents.Async] is set.
+const (
+	checkBackgroundTasksToolName = "check_background_tasks"
+	waitBackgroundTasksToolName  = "wait_for_background_tasks"
+)
+
+// backgroundTaskPollInterval is how often the wait tool re-reads a pending
+// task's snapshot. Package-level so tests can shorten it.
+var backgroundTaskPollInterval = 5 * time.Second
+
+// waitProgressInterval is how often a still-blocked wait tool logs progress,
+// so a long silent wait stays visible in the logs without a line per poll.
+const waitProgressInterval = 60 * time.Second
+
+// transientReadRetries is how many consecutive failed reads of one task the
+// wait tool absorbs (retrying on the poll interval) before it gives up on that
+// task and surfaces the read error. It rides out isolated store blips while
+// keeping the wait bounded on a persistently broken store.
+const transientReadRetries = 3
+
+// taskStatusUnknown is the report status for a task that could not be resolved
+// (malformed ID, unconfigured agent, missing snapshot, or read error). It is
+// terminal for waiting purposes: pending is the only status that can still
+// change on its own.
+const taskStatusUnknown = "unknown"
+
+// noTaskIDsNote is the guidance returned when a background-task tool is called
+// without task IDs.
+const noTaskIDsNote = "No task IDs given. Pass the taskId values returned by background delegations."
+
+// asyncDelegateInput is the delegation tool input when [Agents.Async] is set:
+// the plain task plus the background flag.
+type asyncDelegateInput struct {
+	Task       string `json:"task" jsonschema_description:"A clear, self-contained description of the task to delegate."`
+	Background bool   `json:"background,omitempty" jsonschema_description:"Run the delegation in the background. The tool returns immediately with a taskId; collect the result later with check_background_tasks or wait_for_background_tasks."`
+}
+
+// backgroundTasksInput is the input of the check tool.
+type backgroundTasksInput struct {
+	TaskIDs []string `json:"taskIds" jsonschema_description:"Task IDs returned by background delegations (form \"<agent>:<snapshotId>\")."`
+}
+
+// waitBackgroundTasksInput is the input of the wait tool.
+type waitBackgroundTasksInput struct {
+	TaskIDs        []string `json:"taskIds" jsonschema_description:"Task IDs returned by background delegations (form \"<agent>:<snapshotId>\")."`
+	TimeoutSeconds int      `json:"timeoutSeconds,omitempty" jsonschema_description:"Maximum seconds to wait before returning the current statuses. 0 or omitted waits until every task settles; a negative value returns the current statuses immediately."`
+}
+
+// backgroundTaskReport is the per-task entry returned by the check and wait
+// tools.
+type backgroundTaskReport struct {
+	// TaskID is the handle the report describes.
+	TaskID string `json:"taskId"`
+	// Agent is the sub-agent running the task.
+	Agent string `json:"agent,omitempty"`
+	// Status is the task's lifecycle state: "pending", "completed", "failed",
+	// "aborted", "expired" (worker presumed dead), or "unknown" (the ID could
+	// not be resolved; see Error).
+	Status string `json:"status"`
+	// Response is the sub-agent's final text response, for completed tasks.
+	Response string `json:"response,omitempty"`
+	// Artifacts are the completed task's artifacts. Content is populated only
+	// under ArtifactStrategyInline.
+	Artifacts []delegatedArtifact `json:"artifacts,omitempty"`
+	// Error describes why no response is available (failure, abort, expiry, or
+	// an unresolvable task ID).
+	Error string `json:"error,omitempty"`
+}
+
+// backgroundTasksResult is the output of the check and wait tools.
+type backgroundTasksResult struct {
+	Tasks []backgroundTaskReport `json:"tasks,omitempty"`
+	// TimedOut is set when the wait returned because timeoutSeconds elapsed
+	// while some tasks were still pending.
+	TimedOut bool `json:"timedOut,omitempty"`
+	// Note carries usage guidance when the call itself was unusable (e.g. no
+	// task IDs given).
+	Note string `json:"note,omitempty"`
+}
+
+// delegateAsync is the async-enabled delegation tool function: it behaves like
+// [Agents.delegate] unless the model sets background, in which case it launches
+// the task and returns its handle without waiting.
+func (a *Agents) delegateAsync(ref aix.AgentRef, st *agentsState) func(context.Context, asyncDelegateInput) (delegationResult, error) {
+	return func(ctx context.Context, in asyncDelegateInput) (delegationResult, error) {
+		if !in.Background {
+			return a.runDelegation(ctx, ref, st, in.Task)
+		}
+		return a.launchDelegation(ctx, ref, st, in.Task)
+	}
+}
+
+// launchDelegation starts a background delegation through the sub-agent's
+// detach support and returns the task handle without waiting for the work.
+// Launches count against MaxDelegations like synchronous delegations, but a
+// launch rejected before any work ran returns its slot, so a retry (e.g. the
+// synchronous fallback hinted below) is not refused by a cap the rejection
+// consumed. History is never forwarded: detach requires a server-managed
+// sub-agent, and server-managed init rejects seeded state.
+func (a *Agents) launchDelegation(ctx context.Context, ref aix.AgentRef, st *agentsState, task string) (delegationResult, error) {
+	invocationNum, _, ok := a.reserveDelegation(st)
+	if !ok {
+		logger.Warn(ctx, "delegation refused, limit reached", "agent", ref.Name, "limit", a.MaxDelegations)
+		return delegationLimitResult(a.MaxDelegations), nil
+	}
+
+	agent, err := resolveAgent(genkit.FromContext(ctx), ref)
+	if err != nil {
+		a.releaseDelegation(st)
+		logger.Warn(ctx, "sub-agent resolution failed", "agent", ref.Name, "error", err)
+		return delegationResult{Response: "Error: " + err.Error()}, nil
+	}
+
+	out, err := runSubAgent(ctx, agent, task, nil, true)
+	if err != nil {
+		a.releaseDelegation(st)
+		logger.Warn(ctx, "background launch failed", "agent", ref.Name, "error", err)
+		return delegationResult{Response: fmt.Sprintf("Error calling agent %q: %v", ref.Name, err)}, nil
+	}
+
+	switch out.FinishReason {
+	case aix.AgentFinishReasonDetached:
+		taskID := formatTaskID(ref.Name, out.SnapshotID)
+		logger.Debug(ctx, "background task started",
+			"agent", ref.Name, "taskId", taskID, "sessionId", out.SessionID)
+		return delegationResult{
+			TaskID: taskID,
+			Status: string(aix.SnapshotStatusPending),
+			Response: fmt.Sprintf(
+				"Background task %s started for agent %q. Collect the result with %s or %s.",
+				taskID, ref.Name, checkBackgroundTasksToolName, waitBackgroundTasksToolName),
+		}, nil
+	case aix.AgentFinishReasonFailed:
+		// A failed launch is a pre-detach rejection: with detach on the first
+		// input, the invocation either detaches or fails before a turn runs,
+		// so no sub-agent work happened and the reserved slot goes back.
+		a.releaseDelegation(st)
+		// FAILED_PRECONDITION is how the runtime rejects a detach-incapable
+		// agent (no session store, or one without subscriber support). The
+		// error was decoded from the wire, which keeps only the status name
+		// (never the sentinel), and the status is the runtime's general
+		// precondition category, so the hint is phrased conditionally rather
+		// than asserting the cause.
+		msg := subAgentFailureMessage(out.Error)
+		errStatus := ""
+		if out.Error != nil {
+			errStatus = string(out.Error.Status)
+		}
+		logger.Warn(ctx, "background launch rejected",
+			"agent", ref.Name, "status", errStatus, "error", msg)
+		if out.Error != nil && out.Error.Status == status.FailedPrecondition {
+			msg += " If this agent lacks a session store that supports background work, delegate to it without \"background\" instead."
+		}
+		return delegationResult{Response: fmt.Sprintf("Error calling agent %q: %s", ref.Name, msg)}, nil
+	default:
+		// The invocation settled before the detach landed; fold it like a
+		// synchronous delegation.
+		logger.Debug(ctx, "background launch settled synchronously",
+			"agent", ref.Name, "finishReason", string(out.FinishReason))
+		return a.foldDelegationOutput(ctx, ref, out, fmt.Sprintf("%s_%d", ref.Name, invocationNum)), nil
+	}
+}
+
+// backgroundTaskTools builds the shared status tools added when [Agents.Async]
+// is set.
+func (a *Agents) backgroundTaskTools() []ai.Tool {
+	return []ai.Tool{
+		aix.NewTool(checkBackgroundTasksToolName,
+			"Returns the current status of background sub-agent tasks without waiting, including results for tasks that finished.",
+			a.checkBackgroundTasks()),
+		aix.NewTool(waitBackgroundTasksToolName,
+			"Waits until the given background sub-agent tasks finish and returns their results. Set timeoutSeconds to bound the wait; on timeout the current statuses are returned.",
+			a.waitForBackgroundTasks()),
+	}
+}
+
+// checkBackgroundTasks is the non-blocking status tool: one snapshot read per
+// task, no waiting.
+func (a *Agents) checkBackgroundTasks() func(context.Context, backgroundTasksInput) (backgroundTasksResult, error) {
+	return func(ctx context.Context, in backgroundTasksInput) (backgroundTasksResult, error) {
+		if len(in.TaskIDs) == 0 {
+			return backgroundTasksResult{Note: noTaskIDsNote}, nil
+		}
+		return a.reportTasks(ctx, in.TaskIDs), nil
+	}
+}
+
+// waitForBackgroundTasks is the blocking status tool: it polls the tasks'
+// snapshots until every task settles, the optional timeout elapses, or the
+// calling context ends. A settled task's report is cached for the rest of the
+// call (no snapshot re-reads or artifact re-merges on later ticks), transient
+// read errors are retried for transientReadRetries consecutive polls before
+// the error is surfaced, and each read is bounded by the timeout so a hung
+// store read cannot outlive it. A timeout returns the current statuses rather
+// than an error so the orchestrator can do other work and come back;
+// cancellation of the calling context propagates as an error.
+func (a *Agents) waitForBackgroundTasks() func(context.Context, waitBackgroundTasksInput) (backgroundTasksResult, error) {
+	return func(ctx context.Context, in waitBackgroundTasksInput) (backgroundTasksResult, error) {
+		if len(in.TaskIDs) == 0 {
+			return backgroundTasksResult{Note: noTaskIDsNote}, nil
+		}
+		// A negative timeout means "don't wait": report the current statuses.
+		if in.TimeoutSeconds < 0 {
+			return a.reportTasks(ctx, in.TaskIDs), nil
+		}
+
+		waitCtx := ctx
+		if in.TimeoutSeconds > 0 {
+			var cancel context.CancelFunc
+			waitCtx, cancel = context.WithTimeout(ctx, time.Duration(in.TimeoutSeconds)*time.Second)
+			defer cancel()
+		}
+
+		start := time.Now()
+		logger.Debug(ctx, "waiting for background tasks",
+			"tasks", len(in.TaskIDs), "timeoutSeconds", in.TimeoutSeconds)
+
+		g := genkit.FromContext(ctx)
+		// settled holds tasks that need no further polling: terminal statuses,
+		// unresolvable IDs, and reads that exhausted their retries. lastKnown
+		// holds each task's most recent report so the timeout path surfaces
+		// real statuses even when the final tick's reads were cut short.
+		// failures counts consecutive transient read errors per task.
+		settled := make(map[string]backgroundTaskReport, len(in.TaskIDs))
+		lastKnown := make(map[string]backgroundTaskReport, len(in.TaskIDs))
+		failures := make(map[string]int)
+
+		assemble := func() backgroundTasksResult {
+			res := backgroundTasksResult{Tasks: make([]backgroundTaskReport, 0, len(in.TaskIDs))}
+			for _, id := range in.TaskIDs {
+				if report, ok := settled[id]; ok {
+					res.Tasks = append(res.Tasks, report)
+				} else {
+					res.Tasks = append(res.Tasks, lastKnown[id])
+				}
+			}
+			return res
+		}
+
+		ticker := time.NewTicker(backgroundTaskPollInterval)
+		defer ticker.Stop()
+		lastProgress := start
+		for {
+			waiting := false
+			for _, id := range in.TaskIDs {
+				if _, ok := settled[id]; ok {
+					continue
+				}
+				// Bounded by waitCtx so a hung read cannot outlive the
+				// timeout; a read the timeout cuts short lands in the
+				// transient branch and lastKnown keeps the prior report.
+				report, transient := a.reportTask(waitCtx, g, id)
+				if transient {
+					if _, ok := lastKnown[id]; !ok {
+						lastKnown[id] = report
+					}
+					failures[id]++
+					if failures[id] >= transientReadRetries {
+						settled[id] = report // give up; surface the read error
+						logger.Warn(ctx, "background task read retries exhausted",
+							"taskId", id, "attempts", failures[id])
+					} else {
+						waiting = true
+					}
+					continue
+				}
+				lastKnown[id] = report
+				delete(failures, id)
+				if report.Status == string(aix.SnapshotStatusPending) {
+					waiting = true
+				} else {
+					settled[id] = report
+					logger.Debug(ctx, "background task settled",
+						"taskId", id, "status", report.Status,
+						"elapsedMs", time.Since(start).Milliseconds())
+				}
+			}
+			if !waiting {
+				logger.Debug(ctx, "wait for background tasks finished",
+					"tasks", len(in.TaskIDs), "elapsedMs", time.Since(start).Milliseconds())
+				return assemble(), nil
+			}
+			// A long blocked wait stays visible without a log line per poll.
+			if time.Since(lastProgress) >= waitProgressInterval {
+				lastProgress = time.Now()
+				logger.Debug(ctx, "still waiting for background tasks",
+					"pending", len(in.TaskIDs)-len(settled),
+					"elapsedMs", time.Since(start).Milliseconds())
+			}
+			select {
+			case <-waitCtx.Done():
+				// The calling context ending is cancellation, not a timeout;
+				// let it fail the tool call rather than dressing it up as a
+				// settled result.
+				if ctx.Err() != nil {
+					return backgroundTasksResult{}, ctx.Err()
+				}
+				logger.Debug(ctx, "wait for background tasks timed out",
+					"pending", len(in.TaskIDs)-len(settled),
+					"elapsedMs", time.Since(start).Milliseconds())
+				res := assemble()
+				res.TimedOut = true
+				res.Note = "Stopped waiting; the pending tasks are still running. Check them again later."
+				return res, nil
+			case <-ticker.C:
+			}
+		}
+	}
+}
+
+// reportTasks builds one report per task ID. Failures are isolated per task
+// (an unresolvable ID never fails the whole call), so one bad handle cannot
+// hide the status of the others.
+func (a *Agents) reportTasks(ctx context.Context, taskIDs []string) backgroundTasksResult {
+	g := genkit.FromContext(ctx)
+	res := backgroundTasksResult{Tasks: make([]backgroundTaskReport, 0, len(taskIDs))}
+	for _, id := range taskIDs {
+		report, _ := a.reportTask(ctx, g, id)
+		res.Tasks = append(res.Tasks, report)
+	}
+	return res
+}
+
+// reportTask resolves one task handle and shapes its snapshot into a report.
+// Completed tasks surface the sub-agent's final response and artifacts;
+// terminal non-success statuses surface an explanatory error instead. The
+// second return reports whether a failed read looked transient (a store or
+// transport error rather than a sentinel-classified dead end); the wait tool
+// retries transient reads a few polls before surfacing them.
+func (a *Agents) reportTask(ctx context.Context, g *genkit.Genkit, taskID string) (backgroundTaskReport, bool) {
+	ref, snapshotID, err := a.resolveTaskID(taskID)
+	if err != nil {
+		logger.Debug(ctx, "background task id did not resolve", "taskId", taskID, "error", err)
+		return backgroundTaskReport{TaskID: taskID, Status: taskStatusUnknown, Error: err.Error()}, false
+	}
+
+	report := backgroundTaskReport{TaskID: taskID, Agent: ref.Name}
+	snap, err := fetchTaskSnapshot(ctx, g, ref.Name, snapshotID)
+	if err != nil {
+		logger.Debug(ctx, "background task read failed",
+			"taskId", taskID, "agent", ref.Name, "error", err)
+		report.Status = taskStatusUnknown
+		// The handle dispatches the companion action in-process, so the error
+		// chain is live and status matching works, subtypes included
+		// (aix.ErrSnapshotNotFound is an ErrNotFound,
+		// aix.ErrSessionStoreNotConfigured an ErrFailedPrecondition).
+		// Classified dead ends stop retries; anything else is presumed
+		// transient. NOT_FOUND covers a missing snapshot and an unregistered
+		// agent alike; the wrapped cause names which.
+		switch {
+		case errors.Is(err, status.ErrNotFound):
+			report.Error = fmt.Sprintf("No record of this task exists (%v). Delegate the task again if the result is still needed.", err)
+		case errors.Is(err, status.ErrFailedPrecondition), errors.Is(err, status.ErrInvalidArgument):
+			report.Error = err.Error()
+		default:
+			report.Error = fmt.Sprintf("Could not read the task's status: %v. Check again later.", err)
+			return report, true
+		}
+		return report, false
+	}
+	report.Status = string(snap.Status)
+
+	switch snap.Status {
+	case aix.SnapshotStatusPending:
+		// Still running; nothing to report yet.
+	case aix.SnapshotStatusCompleted:
+		if snap.FinishReason == aix.AgentFinishReasonInterrupted {
+			// Same limitation as synchronous delegation: the interrupt cannot
+			// be resumed from here.
+			report.Response = interruptedResponse(ref.Name)
+			return report, false
+		}
+		var arts []*aix.Artifact
+		if snap.State != nil {
+			arts = snap.State.Artifacts
+		}
+		report.Response = messageText(snap.State.LastModelMessage())
+		if report.Response == "" {
+			report.Response = "(no response)"
+		}
+		if sub := namedArtifacts(arts); len(sub) > 0 {
+			// Deterministic namespace (unlike the sync path's per-call
+			// counter): AddArtifacts replaces by name, so a re-check after the
+			// orchestrator restarts overwrites the same artifact names instead
+			// of duplicating them.
+			invocationID := fmt.Sprintf("%s_%s", ref.Name, shortSnapshotID(snapshotID))
+			mergeArtifacts(ctx, ref.Name, invocationID, sub)
+			report.Artifacts = delegatedArtifacts(invocationID, sub, a.strategy())
+		}
+	case aix.SnapshotStatusFailed:
+		report.Error = subAgentFailureMessage(snap.Error)
+	case aix.SnapshotStatusAborted:
+		report.Error = "The task was aborted before it finished."
+	case aix.SnapshotStatusExpired:
+		report.Error = "The background worker stopped reporting progress and is presumed dead. Delegate the task again if the result is still needed."
+	}
+	return report, false
+}
+
+// formatTaskID builds the model-facing handle of a background delegation. The
+// handle is self-contained ("<agent>:<snapshotId>") so it can be parsed back
+// after the orchestrator is re-instantiated with nothing but its conversation
+// history.
+func formatTaskID(agentName, snapshotID string) string {
+	return agentName + ":" + snapshotID
+}
+
+// resolveTaskID parses a task handle by matching it against the configured
+// agents, taking the longest matching name so a configured name containing ':'
+// cannot have its tasks claimed by a shorter configured prefix of it. Snapshot
+// IDs are runtime-minted UUIDs and never contain ':', so the longest configured
+// prefix is always the launching agent. Matching against the configuration also
+// confines the background-task tools to the agents this middleware was
+// configured with.
+func (a *Agents) resolveTaskID(taskID string) (aix.AgentRef, string, error) {
+	var (
+		best    aix.AgentRef
+		bestLen int
+	)
+	for _, ref := range a.Agents {
+		prefix := ref.Name + ":"
+		if len(taskID) > len(prefix) && strings.HasPrefix(taskID, prefix) && len(prefix) > bestLen {
+			best, bestLen = ref, len(prefix)
+		}
+	}
+	if bestLen == 0 {
+		return aix.AgentRef{}, "", status.Errorf(status.ErrInvalidArgument,
+			"task ID %q does not match any configured agent (expected \"<agent>:<snapshotId>\")", taskID)
+	}
+	return best, taskID[bestLen:], nil
+}
+
+// fetchTaskSnapshot reads the task's snapshot through the sub-agent's handle,
+// whose GetSnapshot dispatches the getSnapshot companion action and so applies
+// the runtime's read shaping: a pending row whose heartbeat went stale is
+// surfaced as expired. The handle classifies the permanent setup gaps itself
+// (an unregistered agent is NOT_FOUND, a storeless one FAILED_PRECONDITION via
+// [aix.ErrSessionStoreNotConfigured]), so callers can tell them apart from a
+// transient read failure.
+func fetchTaskSnapshot(ctx context.Context, g *genkit.Genkit, agentName, snapshotID string) (*aix.SessionSnapshot[json.RawMessage], error) {
+	if err := requireGenkit(g); err != nil {
+		return nil, err
+	}
+	agent, err := genkitx.LookupAgent(g, agentName)
+	if err != nil {
+		return nil, err
+	}
+	return agent.GetSnapshot(ctx, snapshotID)
+}
+
+// shortSnapshotID trims a snapshot ID to a compact artifact-namespace
+// component.
+func shortSnapshotID(id string) string {
+	if len(id) > 8 {
+		return id[:8]
+	}
+	return id
+}

--- a/go/plugins/middleware/exp/agents_async.go
+++ b/go/plugins/middleware/exp/agents_async.go
@@ -60,16 +60,6 @@ const (
 	waitBackgroundTasksToolName  = "wait_for_background_tasks"
 )
 
-// transientReadRetries is the number of attempts the wait tool makes on one
-// task before it gives up and surfaces the read error. It rides out isolated
-// store blips while keeping the wait bounded on a persistently broken store. A
-// wait cut short by its own deadline is not a failure and does not count.
-const transientReadRetries = 3
-
-// transientRetryDelay is how long the wait tool pauses before it tries a task
-// again after a failed read, so a broken store is retried rather than spun on.
-var transientRetryDelay = time.Second
-
 // taskStatusUnknown is the report status for a task that could not be resolved
 // (malformed ID, unconfigured agent, missing snapshot, or read error). It is
 // terminal for waiting purposes: pending is the only status that can still
@@ -150,17 +140,9 @@ func (a *Agents) delegateAsync(ref aix.AgentRef, st *agentsState) func(context.C
 // consumed. History is never forwarded: detach requires a server-managed
 // sub-agent, and server-managed init rejects seeded state.
 func (a *Agents) launchDelegation(ctx context.Context, ref aix.AgentRef, st *agentsState, task string) (delegationResult, error) {
-	invocationNum, _, ok := a.reserveDelegation(st)
-	if !ok {
-		logger.Warn(ctx, "delegation refused, limit reached", "agent", ref.Name, "limit", a.MaxDelegations)
-		return delegationLimitResult(a.MaxDelegations), nil
-	}
-
-	agent, err := resolveAgent(genkit.FromContext(ctx), ref)
-	if err != nil {
-		a.releaseDelegation(st)
-		logger.Warn(ctx, "sub-agent resolution failed", "agent", ref.Name, "error", err)
-		return delegationResult{Response: "Error: " + err.Error()}, nil
+	invocationNum, _, agent, refusal := a.beginDelegation(ctx, ref, st)
+	if refusal != nil {
+		return *refusal, nil
 	}
 
 	// Pre-flight detach capability from the agent's own metadata: Abortable
@@ -301,16 +283,9 @@ func (a *Agents) waitForBackgroundTasks(st *agentsState) func(context.Context, w
 			"tasks", len(in.TaskIDs), "timeoutSeconds", in.TimeoutSeconds)
 
 		g := genkit.FromContext(ctx)
-		reports := make([]backgroundTaskReport, len(in.TaskIDs))
-		var wg sync.WaitGroup
-		for i, id := range in.TaskIDs {
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
-				reports[i] = a.awaitTask(waitCtx, g, st, id, start)
-			}()
-		}
-		wg.Wait()
+		reports := collectReports(in.TaskIDs, func(taskID string) backgroundTaskReport {
+			return a.awaitTask(waitCtx, g, st, taskID, start)
+		})
 
 		// The calling context ending is cancellation, not a timeout; let it
 		// fail the tool call rather than dressing it up as a settled result.
@@ -321,10 +296,11 @@ func (a *Agents) waitForBackgroundTasks(st *agentsState) func(context.Context, w
 		res := backgroundTasksResult{Tasks: reports}
 		pending := 0
 		for _, report := range reports {
-			// taskStatusUnknown deliberately counts as terminal here: it only
-			// arrives after a read failure was classified as a dead end, so
-			// there is nothing left to wait for.
-			if !aix.SnapshotStatus(report.Status).Terminal() {
+			// Pending is the only report status that can still change on its
+			// own; taskStatusUnknown is a settled dead end (it only arrives
+			// once a read failure was classified unhelpable), so it does not
+			// hold the wait open.
+			if report.Status == string(aix.SnapshotStatusPending) {
 				pending++
 			}
 		}
@@ -341,51 +317,70 @@ func (a *Agents) waitForBackgroundTasks(st *agentsState) func(context.Context, w
 	}
 }
 
-// awaitTask follows one task to its end and returns its report, retrying a
-// failed read a few times before it surfaces the error. When ctx ends first
-// (the wait's own timeout, or the caller's cancellation) the task is still
-// running by definition, so it is reported as pending rather than as a read
-// that did not finish; start is the wait's start, for the settlement log line.
+// awaitTask follows one task to its end and returns its report. Transient
+// store blips are ridden out inside the waitForSnapshot dispatch itself, so a
+// fetch error that reaches this level is a dead end worth reporting. When ctx
+// ends before the task settles (the wait's own timeout, or the caller's
+// cancellation) the task is still running by definition, so an interrupted
+// fetch is reported as pending rather than as a read that did not finish;
+// start is the wait's start, for the settlement log line.
 func (a *Agents) awaitTask(ctx context.Context, g *genkit.Genkit, st *agentsState, taskID string, start time.Time) backgroundTaskReport {
-	for attempt := 1; ; attempt++ {
-		report, transient := a.reportTask(ctx, g, st, taskID, awaitSnapshot)
-		if ctx.Err() != nil {
-			report.Status = string(aix.SnapshotStatusPending)
-			report.Error = ""
-			return report
-		}
-		if !transient {
-			logger.Debug(ctx, "background task settled",
-				"taskId", taskID, "status", report.Status,
-				"elapsedMs", time.Since(start).Milliseconds())
-			return report
-		}
-		if attempt >= transientReadRetries {
-			logger.Warn(ctx, "background task read retries exhausted",
-				"taskId", taskID, "attempts", attempt)
-			return report
-		}
-		select {
-		case <-ctx.Done():
-			report.Status = string(aix.SnapshotStatusPending)
-			report.Error = ""
-			return report
-		case <-time.After(transientRetryDelay):
-		}
+	report := a.reportTask(ctx, g, st, taskID, awaitSnapshot)
+	if report.Status == taskStatusUnknown && ctx.Err() != nil {
+		// ctx cut the fetch short; a report that already settled (e.g. from
+		// the cache) stands as-is.
+		report.Status = string(aix.SnapshotStatusPending)
+		report.Error = ""
+		return report
 	}
+	logger.Debug(ctx, "background task settled",
+		"taskId", taskID, "status", report.Status,
+		"elapsedMs", time.Since(start).Milliseconds())
+	return report
 }
 
-// reportTasks builds one report per task ID. Failures are isolated per task
-// (an unresolvable ID never fails the whole call), so one bad handle cannot
-// hide the status of the others.
+// reportTasks builds one report per task ID with a single read each, for the
+// check tool and the wait tool's don't-wait path.
 func (a *Agents) reportTasks(ctx context.Context, st *agentsState, taskIDs []string) backgroundTasksResult {
 	g := genkit.FromContext(ctx)
-	res := backgroundTasksResult{Tasks: make([]backgroundTaskReport, 0, len(taskIDs))}
+	return backgroundTasksResult{Tasks: collectReports(taskIDs, func(taskID string) backgroundTaskReport {
+		return a.reportTask(ctx, g, st, taskID, readSnapshotOnce)
+	})}
+}
+
+// collectReports builds one report per entry of taskIDs, fetching each
+// distinct ID once and copying its report to every duplicate (the IDs are
+// model-authored, so repeats happen). The fetches run concurrently: each
+// dispatches a store-backed companion action, so the slowest distinct task
+// sets the wall clock rather than the sum. Failures stay isolated per task
+// (an unresolvable ID never fails the whole call), so one bad handle cannot
+// hide the status of the others.
+func collectReports(taskIDs []string, report func(taskID string) backgroundTaskReport) []backgroundTaskReport {
+	distinct := make([]string, 0, len(taskIDs))
+	slot := make(map[string]int, len(taskIDs))
 	for _, id := range taskIDs {
-		report, _ := a.reportTask(ctx, g, st, id, readSnapshotOnce)
-		res.Tasks = append(res.Tasks, report)
+		if _, ok := slot[id]; !ok {
+			slot[id] = len(distinct)
+			distinct = append(distinct, id)
+		}
 	}
-	return res
+
+	fetched := make([]backgroundTaskReport, len(distinct))
+	var wg sync.WaitGroup
+	for i, id := range distinct {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			fetched[i] = report(id)
+		}()
+	}
+	wg.Wait()
+
+	reports := make([]backgroundTaskReport, len(taskIDs))
+	for i, id := range taskIDs {
+		reports[i] = fetched[slot[id]]
+	}
+	return reports
 }
 
 // snapshotFetch is how a task's snapshot is obtained: read once for the check
@@ -406,28 +401,25 @@ var (
 // reportTask resolves one task handle, obtains its snapshot through fetch, and
 // shapes the result into a report. Completed tasks surface the sub-agent's
 // final response and artifacts; terminal non-success statuses surface an
-// explanatory error instead. The second return reports whether a failed fetch
-// looked transient (a store or transport error rather than a
-// sentinel-classified dead end); the wait tool retries transient fetches a few
-// times before surfacing them.
+// explanatory error instead.
 //
 // Reports for completed, failed, and aborted tasks are cached on st for the
 // rest of the generate call: those rows never change, so a re-check skips the
 // snapshot fetch and artifact re-merge (and cannot clobber a merged artifact
 // the orchestrator has since edited). Pending, expired, and unresolvable
 // reports can still change on their own and are never cached.
-func (a *Agents) reportTask(ctx context.Context, g *genkit.Genkit, st *agentsState, taskID string, fetch snapshotFetch) (backgroundTaskReport, bool) {
+func (a *Agents) reportTask(ctx context.Context, g *genkit.Genkit, st *agentsState, taskID string, fetch snapshotFetch) backgroundTaskReport {
 	st.mu.Lock()
 	cached, ok := st.settledReports[taskID]
 	st.mu.Unlock()
 	if ok {
-		return cached, false
+		return cached
 	}
 
 	ref, snapshotID, err := a.resolveTaskID(taskID)
 	if err != nil {
 		logger.Debug(ctx, "background task id did not resolve", "taskId", taskID, "error", err)
-		return backgroundTaskReport{TaskID: taskID, Status: taskStatusUnknown, Error: err.Error()}, false
+		return backgroundTaskReport{TaskID: taskID, Status: taskStatusUnknown, Error: err.Error()}
 	}
 
 	report := backgroundTaskReport{TaskID: taskID, Agent: ref.Name}
@@ -446,10 +438,11 @@ func (a *Agents) reportTask(ctx context.Context, g *genkit.Genkit, st *agentsSta
 		// The handle dispatches the companion action in-process, so the error
 		// chain is live and status matching works, subtypes included
 		// (aix.ErrSnapshotNotFound is an ErrNotFound,
-		// aix.ErrSessionStoreNotConfigured an ErrFailedPrecondition).
-		// Classified dead ends stop retries; anything else is presumed
-		// transient. NOT_FOUND covers a missing snapshot and an unregistered
-		// agent alike; the wrapped cause names which.
+		// aix.ErrSessionStoreNotConfigured an ErrFailedPrecondition). A wait
+		// fetch has already ridden out transient store blips inside the
+		// companion action, so whatever surfaces here is worth reporting.
+		// NOT_FOUND covers a missing snapshot and an unregistered agent
+		// alike; the wrapped cause names which.
 		switch {
 		case errors.Is(err, status.ErrNotFound):
 			report.Error = fmt.Sprintf("No record of this task exists (%v). Delegate the task again if the result is still needed.", err)
@@ -457,9 +450,8 @@ func (a *Agents) reportTask(ctx context.Context, g *genkit.Genkit, st *agentsSta
 			report.Error = err.Error()
 		default:
 			report.Error = fmt.Sprintf("Could not read the task's status: %v. Check again later.", err)
-			return report, true
 		}
-		return report, false
+		return report
 	}
 	report.Status = string(snap.Status)
 
@@ -467,17 +459,13 @@ func (a *Agents) reportTask(ctx context.Context, g *genkit.Genkit, st *agentsSta
 	case aix.SnapshotStatusPending:
 		// Still running; nothing to report yet.
 	case aix.SnapshotStatusCompleted:
-		if snap.FinishReason == aix.AgentFinishReasonInterrupted {
-			// Same limitation as synchronous delegation: the interrupt cannot
-			// be resumed from here.
-			report.Response = interruptedResponse(ref.Name)
-			break
-		}
-		// Mirror the synchronous path, whose response is the literal final
-		// message (SessionRunner.Result): the persisted conversation's tip is
-		// that same message, so a delegation reports the same answer whether
-		// it ran in the background or not, rather than walking back to older
-		// text the model spoke mid-tool-loop.
+		// Fold the settled snapshot exactly as a synchronous delegation folds
+		// its output, so a delegation reports the same answer and the same
+		// artifacts whether it ran in the background or not. The response is
+		// the persisted conversation's tip, which is the literal final message
+		// the sub-agent returned (SessionRunner.Result), rather than older text
+		// it spoke mid-tool-loop; an interrupt carries the same limitation as
+		// the synchronous path, since it cannot be resumed from here.
 		var tip *ai.Message
 		var arts []*aix.Artifact
 		if snap.State != nil {
@@ -486,19 +474,16 @@ func (a *Agents) reportTask(ctx context.Context, g *genkit.Genkit, st *agentsSta
 			}
 			arts = snap.State.Artifacts
 		}
-		report.Response = messageText(tip)
-		if report.Response == "" {
-			report.Response = "(no response)"
-		}
-		if sub := namedArtifacts(arts); len(sub) > 0 {
-			// Deterministic namespace (unlike the sync path's per-call
-			// counter): AddArtifacts replaces by name, so a re-check after the
-			// orchestrator restarts overwrites the same artifact names instead
-			// of duplicating them.
-			invocationID := fmt.Sprintf("%s_%s", ref.Name, shortSnapshotID(snapshotID))
-			mergeArtifacts(ctx, ref.Name, invocationID, sub)
-			report.Artifacts = delegatedArtifacts(invocationID, sub, a.strategy())
-		}
+		// Deterministic namespace (unlike the sync path's per-call counter):
+		// AddArtifacts replaces by name, so a re-check after the orchestrator
+		// restarts overwrites the same artifact names instead of duplicating
+		// them.
+		folded := a.foldDelegationOutput(ctx, ref, &aix.AgentOutput[json.RawMessage]{
+			FinishReason: snap.FinishReason,
+			Message:      tip,
+			Artifacts:    arts,
+		}, fmt.Sprintf("%s_%s", ref.Name, shortSnapshotID(snapshotID)))
+		report.Response, report.Artifacts = folded.Response, folded.Artifacts
 	case aix.SnapshotStatusFailed:
 		report.Error = subAgentFailureMessage(snap.Error)
 	case aix.SnapshotStatusAborted:
@@ -513,7 +498,7 @@ func (a *Agents) reportTask(ctx context.Context, g *genkit.Genkit, st *agentsSta
 		st.settledReports[taskID] = report
 		st.mu.Unlock()
 	}
-	return report, false
+	return report
 }
 
 // formatTaskID builds the model-facing handle of a background delegation. The

--- a/go/plugins/middleware/exp/agents_async.go
+++ b/go/plugins/middleware/exp/agents_async.go
@@ -30,15 +30,17 @@ package exp
 // ("<agent>:<snapshotId>") is self-contained and rides in the delegation tool
 // result, so it is recorded in the orchestrator's conversation history; a
 // re-instantiated orchestrator resumes tracking from the IDs in its history.
-// Status reads go through the sub-agent's [aix.AgentHandle] (resolved with
-// [genkitx.LookupAgent], the sanctioned path for third-party middleware),
-// whose GetSnapshot dispatches the agent's getSnapshot companion action.
+// Status reads go through the sub-agent's [aix.AgentHandle] (resolved via
+// resolveAgent, i.e. genkit/exp.LookupAgent, the sanctioned path for
+// third-party middleware), whose GetSnapshot dispatches the agent's
+// getSnapshot companion action.
 
 import (
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"strings"
 	"time"
 
@@ -47,7 +49,6 @@ import (
 	"github.com/firebase/genkit/go/core/logger"
 	"github.com/firebase/genkit/go/core/status"
 	"github.com/firebase/genkit/go/genkit"
-	genkitx "github.com/firebase/genkit/go/genkit/exp"
 )
 
 // Names of the shared background-task tools added when [Agents.Async] is set.
@@ -64,10 +65,11 @@ var backgroundTaskPollInterval = 5 * time.Second
 // so a long silent wait stays visible in the logs without a line per poll.
 const waitProgressInterval = 60 * time.Second
 
-// transientReadRetries is how many consecutive failed reads of one task the
-// wait tool absorbs (retrying on the poll interval) before it gives up on that
-// task and surfaces the read error. It rides out isolated store blips while
-// keeping the wait bounded on a persistently broken store.
+// transientReadRetries is the number of consecutive failed reads of one task
+// after which the wait tool gives up on it and surfaces the read error: the
+// preceding failures are absorbed by retrying on the poll interval. It rides
+// out isolated store blips while keeping the wait bounded on a persistently
+// broken store. Reads cut short by the wait's own deadline do not count.
 const transientReadRetries = 3
 
 // taskStatusUnknown is the report status for a task that could not be resolved
@@ -95,7 +97,7 @@ type backgroundTasksInput struct {
 // waitBackgroundTasksInput is the input of the wait tool.
 type waitBackgroundTasksInput struct {
 	TaskIDs        []string `json:"taskIds" jsonschema_description:"Task IDs returned by background delegations (form \"<agent>:<snapshotId>\")."`
-	TimeoutSeconds int      `json:"timeoutSeconds,omitempty" jsonschema_description:"Maximum seconds to wait before returning the current statuses. 0 or omitted waits until every task settles; a negative value returns the current statuses immediately."`
+	TimeoutSeconds int      `json:"timeoutSeconds,omitempty" jsonschema_description:"Maximum seconds to wait before returning the current statuses. 0 or omitted waits until every task settles; a negative value returns the current statuses immediately. Values too large to represent are treated as unbounded."`
 }
 
 // backgroundTaskReport is the per-task entry returned by the check and wait
@@ -163,6 +165,20 @@ func (a *Agents) launchDelegation(ctx context.Context, ref aix.AgentRef, st *age
 		return delegationResult{Response: "Error: " + err.Error()}, nil
 	}
 
+	// Pre-flight detach capability from the agent's own metadata: Abortable
+	// is derived at definition time from exactly the store conditions the
+	// runtime's detach check enforces, so a genkit-defined agent that cannot
+	// detach is rejected here deterministically, without a wasted invocation
+	// and without the hedged post-hoc wording below (which remains only for
+	// metadata-less agents).
+	if meta := agent.Metadata(); meta != nil && !meta.Abortable {
+		a.releaseDelegation(st)
+		logger.Warn(ctx, "background launch refused, agent cannot detach", "agent", ref.Name)
+		return delegationResult{Response: fmt.Sprintf(
+			"Error calling agent %q: this agent lacks a session store that supports background work, so it cannot run tasks in the background. Delegate to it without \"background\" instead.",
+			ref.Name)}, nil
+	}
+
 	out, err := runSubAgent(ctx, agent, task, nil, true)
 	if err != nil {
 		a.releaseDelegation(st)
@@ -173,6 +189,7 @@ func (a *Agents) launchDelegation(ctx context.Context, ref aix.AgentRef, st *age
 	switch out.FinishReason {
 	case aix.AgentFinishReasonDetached:
 		taskID := formatTaskID(ref.Name, out.SnapshotID)
+		checkName, waitName := a.backgroundToolNames()
 		logger.Debug(ctx, "background task started",
 			"agent", ref.Name, "taskId", taskID, "sessionId", out.SessionID)
 		return delegationResult{
@@ -180,7 +197,7 @@ func (a *Agents) launchDelegation(ctx context.Context, ref aix.AgentRef, st *age
 			Status: string(aix.SnapshotStatusPending),
 			Response: fmt.Sprintf(
 				"Background task %s started for agent %q. Collect the result with %s or %s.",
-				taskID, ref.Name, checkBackgroundTasksToolName, waitBackgroundTasksToolName),
+				taskID, ref.Name, checkName, waitName),
 		}, nil
 	case aix.AgentFinishReasonFailed:
 		// A failed launch is a pre-detach rejection: with detach on the first
@@ -192,7 +209,10 @@ func (a *Agents) launchDelegation(ctx context.Context, ref aix.AgentRef, st *age
 		// error was decoded from the wire, which keeps only the status name
 		// (never the sentinel), and the status is the runtime's general
 		// precondition category, so the hint is phrased conditionally rather
-		// than asserting the cause.
+		// than asserting the cause. It applies only to metadata-less agents:
+		// a genkit-defined agent that cannot detach was already rejected by
+		// the pre-flight above, so its other FAILED_PRECONDITIONs (e.g. from
+		// the agent fn itself) must not carry a misleading capability hint.
 		msg := subAgentFailureMessage(out.Error)
 		errStatus := ""
 		if out.Error != nil {
@@ -200,7 +220,7 @@ func (a *Agents) launchDelegation(ctx context.Context, ref aix.AgentRef, st *age
 		}
 		logger.Warn(ctx, "background launch rejected",
 			"agent", ref.Name, "status", errStatus, "error", msg)
-		if out.Error != nil && out.Error.Status == status.FailedPrecondition {
+		if out.Error != nil && out.Error.Status == status.FailedPrecondition && agent.Metadata() == nil {
 			msg += " If this agent lacks a session store that supports background work, delegate to it without \"background\" instead."
 		}
 		return delegationResult{Response: fmt.Sprintf("Error calling agent %q: %s", ref.Name, msg)}, nil
@@ -214,53 +234,66 @@ func (a *Agents) launchDelegation(ctx context.Context, ref aix.AgentRef, st *age
 }
 
 // backgroundTaskTools builds the shared status tools added when [Agents.Async]
-// is set.
-func (a *Agents) backgroundTaskTools() []ai.Tool {
+// is set, named per this configuration (see [Agents.backgroundToolNames]).
+// st carries the per-call cache of terminal reports.
+func (a *Agents) backgroundTaskTools(st *agentsState) []ai.Tool {
+	checkName, waitName := a.backgroundToolNames()
 	return []ai.Tool{
-		aix.NewTool(checkBackgroundTasksToolName,
+		aix.NewTool(checkName,
 			"Returns the current status of background sub-agent tasks without waiting, including results for tasks that finished.",
-			a.checkBackgroundTasks()),
-		aix.NewTool(waitBackgroundTasksToolName,
+			a.checkBackgroundTasks(st)),
+		aix.NewTool(waitName,
 			"Waits until the given background sub-agent tasks finish and returns their results. Set timeoutSeconds to bound the wait; on timeout the current statuses are returned.",
-			a.waitForBackgroundTasks()),
+			a.waitForBackgroundTasks(st)),
 	}
 }
 
 // checkBackgroundTasks is the non-blocking status tool: one snapshot read per
 // task, no waiting.
-func (a *Agents) checkBackgroundTasks() func(context.Context, backgroundTasksInput) (backgroundTasksResult, error) {
+func (a *Agents) checkBackgroundTasks(st *agentsState) func(context.Context, backgroundTasksInput) (backgroundTasksResult, error) {
 	return func(ctx context.Context, in backgroundTasksInput) (backgroundTasksResult, error) {
 		if len(in.TaskIDs) == 0 {
 			return backgroundTasksResult{Note: noTaskIDsNote}, nil
 		}
-		return a.reportTasks(ctx, in.TaskIDs), nil
+		return a.reportTasks(ctx, st, in.TaskIDs), nil
 	}
 }
 
 // waitForBackgroundTasks is the blocking status tool: it polls the tasks'
 // snapshots until every task settles, the optional timeout elapses, or the
 // calling context ends. A settled task's report is cached for the rest of the
-// call (no snapshot re-reads or artifact re-merges on later ticks), transient
-// read errors are retried for transientReadRetries consecutive polls before
-// the error is surfaced, and each read is bounded by the timeout so a hung
-// store read cannot outlive it. A timeout returns the current statuses rather
-// than an error so the orchestrator can do other work and come back;
-// cancellation of the calling context propagates as an error.
-func (a *Agents) waitForBackgroundTasks() func(context.Context, waitBackgroundTasksInput) (backgroundTasksResult, error) {
+// call (no snapshot re-reads or artifact re-merges on later ticks), and a
+// transient read failure is retried across polls until it has failed
+// transientReadRetries consecutive times, at which point the read error is
+// surfaced. Each read is additionally bounded to one poll interval, so a hung
+// store read degrades into that retry path instead of stalling the pass (or,
+// on an unbounded wait, the whole tool call); a read cut short by the wait's
+// own deadline is not a store failure and does not count. A timeout returns
+// the current statuses rather than an error so the orchestrator can do other
+// work and come back; cancellation of the calling context propagates as an
+// error.
+func (a *Agents) waitForBackgroundTasks(st *agentsState) func(context.Context, waitBackgroundTasksInput) (backgroundTasksResult, error) {
 	return func(ctx context.Context, in waitBackgroundTasksInput) (backgroundTasksResult, error) {
 		if len(in.TaskIDs) == 0 {
 			return backgroundTasksResult{Note: noTaskIDsNote}, nil
 		}
 		// A negative timeout means "don't wait": report the current statuses.
 		if in.TimeoutSeconds < 0 {
-			return a.reportTasks(ctx, in.TaskIDs), nil
+			return a.reportTasks(ctx, st, in.TaskIDs), nil
 		}
 
 		waitCtx := ctx
 		if in.TimeoutSeconds > 0 {
-			var cancel context.CancelFunc
-			waitCtx, cancel = context.WithTimeout(ctx, time.Duration(in.TimeoutSeconds)*time.Second)
-			defer cancel()
+			// A model-supplied value large enough to overflow the nanosecond
+			// multiplication (about 292 years) is effectively unbounded, the
+			// same as 0; without the clamp it wraps negative and the wait
+			// would return instantly with an already-expired context.
+			const maxWaitSeconds = math.MaxInt64 / int64(time.Second)
+			if int64(in.TimeoutSeconds) <= maxWaitSeconds {
+				var cancel context.CancelFunc
+				waitCtx, cancel = context.WithTimeout(ctx, time.Duration(in.TimeoutSeconds)*time.Second)
+				defer cancel()
+			}
 		}
 
 		start := time.Now()
@@ -289,6 +322,11 @@ func (a *Agents) waitForBackgroundTasks() func(context.Context, waitBackgroundTa
 			return res
 		}
 
+		// Each read is bounded to one poll interval (floored so shortened
+		// test intervals do not starve healthy reads), keeping a hung store
+		// from freezing an unbounded wait.
+		readTimeout := max(backgroundTaskPollInterval, time.Second)
+
 		ticker := time.NewTicker(backgroundTaskPollInterval)
 		defer ticker.Stop()
 		lastProgress := start
@@ -298,11 +336,24 @@ func (a *Agents) waitForBackgroundTasks() func(context.Context, waitBackgroundTa
 				if _, ok := settled[id]; ok {
 					continue
 				}
-				// Bounded by waitCtx so a hung read cannot outlive the
-				// timeout; a read the timeout cuts short lands in the
-				// transient branch and lastKnown keeps the prior report.
-				report, transient := a.reportTask(waitCtx, g, id)
+				if waitCtx.Err() != nil {
+					// The wait ended mid-pass; the Done arm below reports
+					// lastKnown for everything still unsettled.
+					waiting = true
+					break
+				}
+				readCtx, cancelRead := context.WithTimeout(waitCtx, readTimeout)
+				report, transient := a.reportTask(readCtx, g, st, id)
+				cancelRead()
 				if transient {
+					if waitCtx.Err() != nil {
+						// The wait itself ended mid-read: not a store
+						// failure, so it does not count against the retry
+						// budget and must not settle the task with a read
+						// error over lastKnown's real status.
+						waiting = true
+						break
+					}
 					if _, ok := lastKnown[id]; !ok {
 						lastKnown[id] = report
 					}
@@ -318,7 +369,10 @@ func (a *Agents) waitForBackgroundTasks() func(context.Context, waitBackgroundTa
 				}
 				lastKnown[id] = report
 				delete(failures, id)
-				if report.Status == string(aix.SnapshotStatusPending) {
+				// taskStatusUnknown deliberately counts as terminal here: it
+				// only arrives after a read failure was classified as a dead
+				// end, so there is nothing left to wait for.
+				if !aix.SnapshotStatus(report.Status).Terminal() {
 					waiting = true
 				} else {
 					settled[id] = report
@@ -363,11 +417,11 @@ func (a *Agents) waitForBackgroundTasks() func(context.Context, waitBackgroundTa
 // reportTasks builds one report per task ID. Failures are isolated per task
 // (an unresolvable ID never fails the whole call), so one bad handle cannot
 // hide the status of the others.
-func (a *Agents) reportTasks(ctx context.Context, taskIDs []string) backgroundTasksResult {
+func (a *Agents) reportTasks(ctx context.Context, st *agentsState, taskIDs []string) backgroundTasksResult {
 	g := genkit.FromContext(ctx)
 	res := backgroundTasksResult{Tasks: make([]backgroundTaskReport, 0, len(taskIDs))}
 	for _, id := range taskIDs {
-		report, _ := a.reportTask(ctx, g, id)
+		report, _ := a.reportTask(ctx, g, st, id)
 		res.Tasks = append(res.Tasks, report)
 	}
 	return res
@@ -379,7 +433,20 @@ func (a *Agents) reportTasks(ctx context.Context, taskIDs []string) backgroundTa
 // second return reports whether a failed read looked transient (a store or
 // transport error rather than a sentinel-classified dead end); the wait tool
 // retries transient reads a few polls before surfacing them.
-func (a *Agents) reportTask(ctx context.Context, g *genkit.Genkit, taskID string) (backgroundTaskReport, bool) {
+//
+// Reports for completed, failed, and aborted tasks are cached on st for the
+// rest of the generate call: those rows never change, so a re-check skips the
+// snapshot fetch and artifact re-merge (and cannot clobber a merged artifact
+// the orchestrator has since edited). Pending, expired, and unresolvable
+// reports can still change on their own and are never cached.
+func (a *Agents) reportTask(ctx context.Context, g *genkit.Genkit, st *agentsState, taskID string) (backgroundTaskReport, bool) {
+	st.mu.Lock()
+	cached, ok := st.settledReports[taskID]
+	st.mu.Unlock()
+	if ok {
+		return cached, false
+	}
+
 	ref, snapshotID, err := a.resolveTaskID(taskID)
 	if err != nil {
 		logger.Debug(ctx, "background task id did not resolve", "taskId", taskID, "error", err)
@@ -387,7 +454,14 @@ func (a *Agents) reportTask(ctx context.Context, g *genkit.Genkit, taskID string
 	}
 
 	report := backgroundTaskReport{TaskID: taskID, Agent: ref.Name}
-	snap, err := fetchTaskSnapshot(ctx, g, ref.Name, snapshotID)
+	// The handle's GetSnapshot dispatches the getSnapshot companion action,
+	// which applies the runtime's read shaping: a pending row whose heartbeat
+	// went stale is surfaced as expired.
+	agent, err := resolveAgent(g, ref)
+	var snap *aix.SessionSnapshot[json.RawMessage]
+	if err == nil {
+		snap, err = agent.GetSnapshot(ctx, snapshotID)
+	}
 	if err != nil {
 		logger.Debug(ctx, "background task read failed",
 			"taskId", taskID, "agent", ref.Name, "error", err)
@@ -420,13 +494,22 @@ func (a *Agents) reportTask(ctx context.Context, g *genkit.Genkit, taskID string
 			// Same limitation as synchronous delegation: the interrupt cannot
 			// be resumed from here.
 			report.Response = interruptedResponse(ref.Name)
-			return report, false
+			break
 		}
+		// Mirror the synchronous path, whose response is the literal final
+		// message (SessionRunner.Result): the persisted conversation's tip is
+		// that same message, so a delegation reports the same answer whether
+		// it ran in the background or not, rather than walking back to older
+		// text the model spoke mid-tool-loop.
+		var tip *ai.Message
 		var arts []*aix.Artifact
 		if snap.State != nil {
+			if n := len(snap.State.Messages); n > 0 {
+				tip = snap.State.Messages[n-1]
+			}
 			arts = snap.State.Artifacts
 		}
-		report.Response = messageText(snap.State.LastModelMessage())
+		report.Response = messageText(tip)
 		if report.Response == "" {
 			report.Response = "(no response)"
 		}
@@ -446,6 +529,13 @@ func (a *Agents) reportTask(ctx context.Context, g *genkit.Genkit, taskID string
 	case aix.SnapshotStatusExpired:
 		report.Error = "The background worker stopped reporting progress and is presumed dead. Delegate the task again if the result is still needed."
 	}
+
+	switch snap.Status {
+	case aix.SnapshotStatusCompleted, aix.SnapshotStatusFailed, aix.SnapshotStatusAborted:
+		st.mu.Lock()
+		st.settledReports[taskID] = report
+		st.mu.Unlock()
+	}
 	return report, false
 }
 
@@ -459,11 +549,13 @@ func formatTaskID(agentName, snapshotID string) string {
 
 // resolveTaskID parses a task handle by matching it against the configured
 // agents, taking the longest matching name so a configured name containing ':'
-// cannot have its tasks claimed by a shorter configured prefix of it. Snapshot
-// IDs are runtime-minted UUIDs and never contain ':', so the longest configured
-// prefix is always the launching agent. Matching against the configuration also
-// confines the background-task tools to the agents this middleware was
-// configured with.
+// cannot have its tasks claimed by a shorter configured prefix of it. The
+// agent runtime mints the detach pending row's ID itself (a UUID, never
+// containing ':'; see the detach handler in ai/exp), so the longest configured
+// prefix is always the launching agent; anchoring the parse on the finite set
+// of configured names, rather than on the ID's shape, is also what keeps it
+// robust and confines the background-task tools to the agents this middleware
+// was configured with.
 func (a *Agents) resolveTaskID(taskID string) (aix.AgentRef, string, error) {
 	var (
 		best    aix.AgentRef
@@ -480,24 +572,6 @@ func (a *Agents) resolveTaskID(taskID string) (aix.AgentRef, string, error) {
 			"task ID %q does not match any configured agent (expected \"<agent>:<snapshotId>\")", taskID)
 	}
 	return best, taskID[bestLen:], nil
-}
-
-// fetchTaskSnapshot reads the task's snapshot through the sub-agent's handle,
-// whose GetSnapshot dispatches the getSnapshot companion action and so applies
-// the runtime's read shaping: a pending row whose heartbeat went stale is
-// surfaced as expired. The handle classifies the permanent setup gaps itself
-// (an unregistered agent is NOT_FOUND, a storeless one FAILED_PRECONDITION via
-// [aix.ErrSessionStoreNotConfigured]), so callers can tell them apart from a
-// transient read failure.
-func fetchTaskSnapshot(ctx context.Context, g *genkit.Genkit, agentName, snapshotID string) (*aix.SessionSnapshot[json.RawMessage], error) {
-	if err := requireGenkit(g); err != nil {
-		return nil, err
-	}
-	agent, err := genkitx.LookupAgent(g, agentName)
-	if err != nil {
-		return nil, err
-	}
-	return agent.GetSnapshot(ctx, snapshotID)
 }
 
 // shortSnapshotID trims a snapshot ID to a compact artifact-namespace

--- a/go/plugins/middleware/exp/agents_async.go
+++ b/go/plugins/middleware/exp/agents_async.go
@@ -97,7 +97,10 @@ type backgroundTaskReport struct {
 	Agent string `json:"agent,omitempty"`
 	// Status is the task's lifecycle state: "pending", "completed", "failed",
 	// "aborted", "expired" (worker presumed dead), or "unknown" (the ID could
-	// not be resolved; see Error).
+	// not be resolved; see Error). It answers what the reader must act on
+	// rather than mirroring the stored row, so a task that committed without
+	// producing an answer reports "failed" and explains itself in Error.
+	// "completed" always carries a Response.
 	Status string `json:"status"`
 	// Response is the sub-agent's final text response, for completed tasks.
 	Response string `json:"response,omitempty"`
@@ -493,12 +496,13 @@ func (a *Agents) reportTask(ctx context.Context, g *genkit.Genkit, st *agentsSta
 		}, fmt.Sprintf("%s_%s", ref.Name, shortSnapshotID(snapshotID)))
 		switch snap.FinishReason {
 		case aix.AgentFinishReasonFailed, aix.AgentFinishReasonInterrupted:
-			// The row committed, so the status is completed, but the agent
-			// declared a reason that carries no answer (it can do so without
-			// erroring, which is why the two disagree). The fold produced
-			// explanatory text, not a response: report it as the error it is,
-			// or the report would claim success in one field and failure in
-			// the next.
+			// The row committed, so the stored status is completed, but the
+			// agent declared a reason that carries no answer (it can do so
+			// without erroring, which is why the two disagree). Report the
+			// outcome the reader has to act on, not the row's bookkeeping: a
+			// model that sees "completed" moves on and never reads the error.
+			// Which of the two it was, and what to do about it, is in Error.
+			report.Status = string(aix.SnapshotStatusFailed)
 			report.Error = folded.Response
 		default:
 			report.Response, report.Artifacts = folded.Response, folded.Artifacts

--- a/go/plugins/middleware/exp/agents_async.go
+++ b/go/plugins/middleware/exp/agents_async.go
@@ -33,9 +33,10 @@ package exp
 // Status goes through the sub-agent's [aix.AgentHandle] (resolved via
 // resolveAgent, i.e. genkit/exp.LookupAgent, the sanctioned path for
 // third-party middleware): the check tool dispatches the agent's getSnapshot
-// companion action, and the wait tool its waitForSnapshot counterpart, which
+// companion action, the wait tool its waitForSnapshot counterpart, which
 // blocks next to the store rather than making this middleware re-read on a
-// timer.
+// timer, and the abort tool its abort counterpart, which flips a pending row
+// to aborted so the sub-agent's runtime cancels the work.
 
 import (
 	"context"
@@ -58,6 +59,7 @@ import (
 const (
 	checkBackgroundTasksToolName = "check_background_tasks"
 	waitBackgroundTasksToolName  = "wait_for_background_tasks"
+	abortBackgroundTasksToolName = "abort_background_tasks"
 )
 
 // taskStatusUnknown is the report status for a task that could not be resolved
@@ -77,7 +79,8 @@ type asyncDelegateInput struct {
 	Background bool   `json:"background,omitempty" jsonschema_description:"Run the delegation in the background. The tool returns immediately with a taskId; collect the result later with check_background_tasks or wait_for_background_tasks."`
 }
 
-// backgroundTasksInput is the input of the check tool.
+// backgroundTasksInput is the input of the check and abort tools: a bare list
+// of handles, the whole of what either needs.
 type backgroundTasksInput struct {
 	TaskIDs []string `json:"taskIds" jsonschema_description:"Task IDs returned by background delegations (form \"<agent>:<snapshotId>\")."`
 }
@@ -171,15 +174,15 @@ func (a *Agents) launchDelegation(ctx context.Context, ref aix.AgentRef, st *age
 	switch out.FinishReason {
 	case aix.AgentFinishReasonDetached:
 		taskID := formatTaskID(ref.Name, out.SnapshotID)
-		checkName, waitName := a.backgroundToolNames()
+		names := a.backgroundToolNames()
 		logger.Debug(ctx, "background task started",
 			"agent", ref.Name, "taskId", taskID, "sessionId", out.SessionID)
 		return delegationResult{
 			TaskID: taskID,
 			Status: string(aix.SnapshotStatusPending),
 			Response: fmt.Sprintf(
-				"Background task %s started for agent %q. Collect the result with %s or %s.",
-				taskID, ref.Name, checkName, waitName),
+				"Background task %s started for agent %q. Collect the result with %s or %s, or stop it with %s.",
+				taskID, ref.Name, names.check, names.wait, names.abort),
 		}, nil
 	case aix.AgentFinishReasonFailed:
 		// FAILED_PRECONDITION is how the runtime rejects a detach-incapable
@@ -219,29 +222,36 @@ func (a *Agents) launchDelegation(ctx context.Context, ref aix.AgentRef, st *age
 	}
 }
 
-// backgroundTaskTools builds the shared status tools added when [Agents.Async]
-// is set, named per this configuration (see [Agents.backgroundToolNames]).
-// st carries the per-call cache of terminal reports.
+// backgroundTaskTools builds the shared background-task tools added when
+// [Agents.Async] is set, one per control the orchestrator has over a launched
+// task, named per this configuration (see [Agents.backgroundToolNames]). st
+// carries the per-call cache of terminal reports.
 func (a *Agents) backgroundTaskTools(st *agentsState) []ai.Tool {
-	checkName, waitName := a.backgroundToolNames()
+	names := a.backgroundToolNames()
 	return []ai.Tool{
-		aix.NewTool(checkName,
+		aix.NewTool(names.check,
 			"Returns the current status of background sub-agent tasks without waiting, including results for tasks that finished.",
-			a.checkBackgroundTasks(st)),
-		aix.NewTool(waitName,
+			a.taskReportTool(st, readSnapshotOnce)),
+		aix.NewTool(names.wait,
 			"Waits until the given background sub-agent tasks finish and returns their results. Set timeoutSeconds to bound the wait; on timeout the current statuses are returned.",
 			a.waitForBackgroundTasks(st)),
+		aix.NewTool(names.abort,
+			"Stops background sub-agent tasks whose results are no longer needed, and returns where that left each one. A task that had already finished is unaffected and reports its result.",
+			a.taskReportTool(st, abortSnapshot)),
 	}
 }
 
-// checkBackgroundTasks is the non-blocking status tool: one snapshot read per
-// task, no waiting.
-func (a *Agents) checkBackgroundTasks(st *agentsState) func(context.Context, backgroundTasksInput) (backgroundTasksResult, error) {
+// taskReportTool builds a non-blocking background-task tool: one companion
+// dispatch per task, then a report of where that left it. The dispatch is the
+// only difference between the two tools built this way. The check tool reads a
+// task's row; the abort tool stops the task first and reports the row it left
+// behind.
+func (a *Agents) taskReportTool(st *agentsState, fetch snapshotFetch) func(context.Context, backgroundTasksInput) (backgroundTasksResult, error) {
 	return func(ctx context.Context, in backgroundTasksInput) (backgroundTasksResult, error) {
 		if len(in.TaskIDs) == 0 {
 			return backgroundTasksResult{Note: noTaskIDsNote}, nil
 		}
-		return a.reportTasks(ctx, st, in.TaskIDs), nil
+		return a.reportTasks(ctx, st, in.TaskIDs, fetch), nil
 	}
 }
 
@@ -268,7 +278,7 @@ func (a *Agents) waitForBackgroundTasks(st *agentsState) func(context.Context, w
 		}
 		// A negative timeout means "don't wait": report the current statuses.
 		if in.TimeoutSeconds < 0 {
-			return a.reportTasks(ctx, st, in.TaskIDs), nil
+			return a.reportTasks(ctx, st, in.TaskIDs, readSnapshotOnce), nil
 		}
 
 		waitCtx := ctx
@@ -348,14 +358,14 @@ func (a *Agents) awaitTask(ctx context.Context, g *genkit.Genkit, st *agentsStat
 	return report
 }
 
-// reportTasks builds one report per task ID with a single read each, for the
-// check tool and the wait tool's don't-wait path.
-func (a *Agents) reportTasks(ctx context.Context, st *agentsState, taskIDs []string) backgroundTasksResult {
+// reportTasks builds one report per task ID with a single fetch each, for the
+// check and abort tools and the wait tool's don't-wait path.
+func (a *Agents) reportTasks(ctx context.Context, st *agentsState, taskIDs []string, fetch snapshotFetch) backgroundTasksResult {
 	g := genkit.FromContext(ctx)
 	return backgroundTasksResult{Tasks: collectReports(taskIDs, func(taskID string) backgroundTaskReport {
-		// A check never waits, so a failure is the report; the raw error is
-		// only of interest to the wait tool, which classifies it.
-		report, _ := a.reportTask(ctx, g, st, taskID, readSnapshotOnce)
+		// None of these callers wait, so a failure is the report; the raw
+		// error is only of interest to the wait tool, which classifies it.
+		report, _ := a.reportTask(ctx, g, st, taskID, fetch)
 		return report
 	})}
 }
@@ -392,9 +402,11 @@ func collectReports(taskIDs []string, report func(taskID string) backgroundTaskR
 }
 
 // snapshotFetch is how a task's snapshot is obtained: read once for the check
-// tool, waited for by the wait tool. Both dispatch a companion action of the
-// sub-agent, so both apply the runtime's read shaping and both keep the error
-// chain live for classification.
+// tool, waited for by the wait tool, aborted first by the abort tool. All three
+// dispatch companion actions of the sub-agent, so all three apply the runtime's
+// read shaping and all three keep the error chain live for classification.
+// Ending on the row, rather than on each tool's own idea of an outcome, is what
+// lets one report path serve every tool.
 type snapshotFetch func(context.Context, *aix.AgentHandle, string) (*aix.SessionSnapshot[json.RawMessage], error)
 
 var (
@@ -403,6 +415,20 @@ var (
 	}
 	awaitSnapshot snapshotFetch = func(ctx context.Context, agent *aix.AgentHandle, snapshotID string) (*aix.SessionSnapshot[json.RawMessage], error) {
 		return agent.WaitForSnapshot(ctx, snapshotID)
+	}
+	// abortSnapshot stops the work, then reads the row the abort left behind.
+	// The read is not redundant with the abort's own return value: the abort
+	// reports a status and nothing else, while a task that had already
+	// finished still owes the caller the response and artifacts only the row
+	// carries. Reading is safe because the abort settles the row before it
+	// returns (the sub-agent's runtime observes the flip and cancels the work
+	// afterwards), so the read that follows sees the outcome rather than a
+	// lingering pending.
+	abortSnapshot snapshotFetch = func(ctx context.Context, agent *aix.AgentHandle, snapshotID string) (*aix.SessionSnapshot[json.RawMessage], error) {
+		if _, err := agent.Abort(ctx, snapshotID); err != nil {
+			return nil, err
+		}
+		return agent.GetSnapshot(ctx, snapshotID)
 	}
 )
 

--- a/go/plugins/middleware/exp/agents_async.go
+++ b/go/plugins/middleware/exp/agents_async.go
@@ -81,14 +81,23 @@ type asyncDelegateInput struct {
 
 // backgroundTasksInput is the input of the check and abort tools: a bare list
 // of handles, the whole of what either needs.
+//
+// taskIds is omitempty so the schema does not mark it required. A model that
+// calls one of these tools with no arguments is making a recoverable mistake,
+// and the tools answer it with noTaskIDsNote; a required field would instead
+// fail decoding, which surfaces as a tool error that fails the whole generate
+// call rather than a turn the model can correct.
 type backgroundTasksInput struct {
-	TaskIDs []string `json:"taskIds" jsonschema_description:"Task IDs returned by background delegations (form \"<agent>:<snapshotId>\")."`
+	TaskIDs []string `json:"taskIds,omitempty" jsonschema_description:"Task IDs returned by background delegations (form \"<agent>:<snapshotId>\")."`
 }
 
-// waitBackgroundTasksInput is the input of the wait tool.
+// waitBackgroundTasksInput is the input of the wait tool: the shared handle
+// list plus a bound on how long to block. The embedded struct keeps one
+// description of taskIds, so the two tools cannot teach the model two
+// different handle formats.
 type waitBackgroundTasksInput struct {
-	TaskIDs        []string `json:"taskIds" jsonschema_description:"Task IDs returned by background delegations (form \"<agent>:<snapshotId>\")."`
-	TimeoutSeconds int      `json:"timeoutSeconds,omitempty" jsonschema_description:"Maximum seconds to wait before returning the current statuses. 0 or omitted waits until every task settles; a negative value returns the current statuses immediately. Values too large to represent are treated as unbounded."`
+	backgroundTasksInput
+	TimeoutSeconds int `json:"timeoutSeconds,omitempty" jsonschema_description:"Maximum seconds to wait before returning the current statuses. 0 or omitted waits until every task settles; a negative value returns the current statuses immediately. Values too large to represent are treated as unbounded."`
 }
 
 // backgroundTaskReport is the per-task entry returned by the check and wait
@@ -194,23 +203,28 @@ func (a *Agents) launchDelegation(ctx context.Context, ref aix.AgentRef, st *age
 		// a genkit-defined agent that cannot detach was already rejected by
 		// the pre-flight above, so its other FAILED_PRECONDITIONs (e.g. from
 		// the agent fn itself) must not carry a misleading capability hint.
-		msg := subAgentFailureMessage(out.Error)
+		msg := subAgentFailureMessage(out.FinishReason, out.Error, out.Message)
 		errStatus := ""
 		if out.Error != nil {
 			errStatus = string(out.Error.Status)
 		}
 		logger.Warn(ctx, "background launch rejected",
 			"agent", ref.Name, "status", errStatus, "error", msg)
-		if out.Error != nil && out.Error.Status == status.FailedPrecondition {
-			// Only this failure earns its slot back: it is the detach
-			// rejection, and the retry it points at is the synchronous
-			// delegation. A failure of any other status is the sub-agent's
-			// own, and it ran to produce it, so it counts against the cap or
-			// an agent that always fails could be delegated to forever.
+		if agent.Metadata() == nil && out.Error != nil && out.Error.Status == status.FailedPrecondition {
+			// Only this failure earns its slot back, and only for an agent
+			// that published no metadata. The retry it points at is the
+			// synchronous delegation, so the cap must not turn that retry
+			// away. Every other failure is the sub-agent's own, and it ran to
+			// produce it, so it counts against the cap or an agent that always
+			// fails could be delegated to forever.
+			//
+			// The metadata check is what keeps the two apart. An agent that
+			// publishes metadata was already refused by the pre-flight above
+			// if it cannot detach, so a FAILED_PRECONDITION arriving here is
+			// by definition not the detach rejection: it came from the agent's
+			// own turn, and refunding it would leave the cap unable to bite.
 			a.releaseDelegation(st)
-			if agent.Metadata() == nil {
-				msg += " If this agent lacks a session store that supports background work, delegate to it without \"background\" instead."
-			}
+			msg += " If this agent lacks a session store that supports background work, delegate to it without \"background\" instead."
 		}
 		return delegationResult{Response: fmt.Sprintf("Error calling agent %q: %s", ref.Name, msg)}, nil
 	default:
@@ -251,7 +265,7 @@ func (a *Agents) taskReportTool(st *agentsState, fetch snapshotFetch) func(conte
 		if len(in.TaskIDs) == 0 {
 			return backgroundTasksResult{Note: noTaskIDsNote}, nil
 		}
-		return a.reportTasks(ctx, st, in.TaskIDs, fetch), nil
+		return a.reportTasks(ctx, st, in.TaskIDs, fetch)
 	}
 }
 
@@ -278,7 +292,7 @@ func (a *Agents) waitForBackgroundTasks(st *agentsState) func(context.Context, w
 		}
 		// A negative timeout means "don't wait": report the current statuses.
 		if in.TimeoutSeconds < 0 {
-			return a.reportTasks(ctx, st, in.TaskIDs, readSnapshotOnce), nil
+			return a.reportTasks(ctx, st, in.TaskIDs, readSnapshotOnce)
 		}
 
 		waitCtx := ctx
@@ -313,11 +327,11 @@ func (a *Agents) waitForBackgroundTasks(st *agentsState) func(context.Context, w
 		res := backgroundTasksResult{Tasks: reports}
 		pending := 0
 		for _, report := range reports {
-			// Pending is the only report status that can still change on its
-			// own; taskStatusUnknown is a settled dead end (it only arrives
-			// once a read failure was classified unhelpable), so it does not
-			// hold the wait open.
-			if report.Status == string(aix.SnapshotStatusPending) {
+			// Terminal() is the same rule the runtime applies, so a status
+			// added there cannot leave this loop counting it as settled.
+			// taskStatusUnknown reads terminal, which is right: it only
+			// arrives once a read failure was classified unhelpable.
+			if !aix.SnapshotStatus(report.Status).Terminal() {
 				pending++
 			}
 		}
@@ -360,14 +374,23 @@ func (a *Agents) awaitTask(ctx context.Context, g *genkit.Genkit, st *agentsStat
 
 // reportTasks builds one report per task ID with a single fetch each, for the
 // check and abort tools and the wait tool's don't-wait path.
-func (a *Agents) reportTasks(ctx context.Context, st *agentsState, taskIDs []string, fetch snapshotFetch) backgroundTasksResult {
+func (a *Agents) reportTasks(ctx context.Context, st *agentsState, taskIDs []string, fetch snapshotFetch) (backgroundTasksResult, error) {
 	g := genkit.FromContext(ctx)
-	return backgroundTasksResult{Tasks: collectReports(taskIDs, func(taskID string) backgroundTaskReport {
+	res := backgroundTasksResult{Tasks: collectReports(taskIDs, func(taskID string) backgroundTaskReport {
 		// None of these callers wait, so a failure is the report; the raw
 		// error is only of interest to the wait tool, which classifies it.
 		report, _ := a.reportTask(ctx, g, st, taskID, fetch)
 		return report
 	})}
+	// A dead caller context fails every dispatch, and each failure reads back
+	// as "could not read this task, check again later". Reported together that
+	// is a settled-looking answer claiming the caller's live tasks are
+	// unreadable, so let the cancellation be the result instead. The rule
+	// lives here, with the fan-out, so a tool added later cannot forget it.
+	if err := ctx.Err(); err != nil {
+		return backgroundTasksResult{}, err
+	}
+	return res, nil
 }
 
 // collectReports builds one report per entry of taskIDs, fetching each
@@ -378,25 +401,23 @@ func (a *Agents) reportTasks(ctx context.Context, st *agentsState, taskIDs []str
 // (an unresolvable ID never fails the whole call), so one bad handle cannot
 // hide the status of the others.
 func collectReports(taskIDs []string, report func(taskID string) backgroundTaskReport) []backgroundTaskReport {
-	distinct := make([]string, 0, len(taskIDs))
-	slot := make(map[string]int, len(taskIDs))
+	// One slot per distinct ID, each written by its own goroutine and read
+	// back after Wait, so duplicates cost one fetch and share its answer.
+	fetched := make(map[string]*backgroundTaskReport, len(taskIDs))
 	for _, id := range taskIDs {
-		if _, ok := slot[id]; !ok {
-			slot[id] = len(distinct)
-			distinct = append(distinct, id)
+		if _, ok := fetched[id]; !ok {
+			fetched[id] = new(backgroundTaskReport)
 		}
 	}
-
-	fetched := make([]backgroundTaskReport, len(distinct))
 	var wg sync.WaitGroup
-	for i, id := range distinct {
-		wg.Go(func() { fetched[i] = report(id) })
+	for id, slot := range fetched {
+		wg.Go(func() { *slot = report(id) })
 	}
 	wg.Wait()
 
 	reports := make([]backgroundTaskReport, len(taskIDs))
 	for i, id := range taskIDs {
-		reports[i] = fetched[slot[id]]
+		reports[i] = *fetched[id]
 	}
 	return reports
 }
@@ -416,18 +437,43 @@ var (
 	awaitSnapshot snapshotFetch = func(ctx context.Context, agent *aix.AgentHandle, snapshotID string) (*aix.SessionSnapshot[json.RawMessage], error) {
 		return agent.WaitForSnapshot(ctx, snapshotID)
 	}
-	// abortSnapshot stops the work, then reads the row the abort left behind.
-	// The read is not redundant with the abort's own return value: the abort
-	// reports a status and nothing else, while a task that had already
-	// finished still owes the caller the response and artifacts only the row
-	// carries. Reading is safe because the abort settles the row before it
-	// returns (the sub-agent's runtime observes the flip and cancels the work
-	// afterwards), so the read that follows sees the outcome rather than a
-	// lingering pending.
+	// abortSnapshot reads before it stops anything, because there are rows an
+	// abort must not touch. Expiry is decided on read, not stored: a worker
+	// that stopped heartbeating leaves a row that is still pending in the
+	// store and reads as expired. Aborting that row overwrites the one signal
+	// telling the model the work is gone and should be delegated again, and
+	// the report caches as terminal, so nothing later can recover it.
+	//
+	// The read is not an extra cost. A task that already settled needs no
+	// abort at all and is answered from the row alone, which is one dispatch
+	// where aborting first then reading took two. Only a genuinely live task
+	// pays for both, and it is the one the caller asked to stop.
 	abortSnapshot snapshotFetch = func(ctx context.Context, agent *aix.AgentHandle, snapshotID string) (*aix.SessionSnapshot[json.RawMessage], error) {
-		if _, err := agent.Abort(ctx, snapshotID); err != nil {
+		cur, err := agent.GetSnapshot(ctx, snapshotID)
+		if err != nil {
 			return nil, err
 		}
+		if cur.Status.Terminal() {
+			// Nothing to stop. Expired, completed, failed and already-aborted
+			// rows each report themselves, which is what the caller needs to
+			// know about a task that outlived the request to cancel it.
+			return cur, nil
+		}
+		st, err := agent.Abort(ctx, snapshotID)
+		if err != nil {
+			return nil, err
+		}
+		if st == aix.SnapshotStatusAborted {
+			// The abort settled the row, and the row just read is the same one
+			// with a new status. Restamping it beats rebuilding a partial
+			// snapshot from the few fields this path happens to need, and it
+			// keeps the abort's own outcome out of reach of a re-read that
+			// could fail on its own.
+			cur.Status = st
+			return cur, nil
+		}
+		// The task settled between the read and the abort, so the abort was a
+		// no-op on a terminal row. Re-read for the answer it now carries.
 		return agent.GetSnapshot(ctx, snapshotID)
 	}
 )
@@ -460,11 +506,20 @@ func (a *Agents) reportTask(ctx context.Context, g *genkit.Genkit, st *agentsSta
 	// Both fetches dispatch a companion action of the sub-agent, which applies
 	// the runtime's read shaping: a pending row whose heartbeat went stale is
 	// surfaced as expired.
+	// Resolving the agent and reading its snapshot fail for unrelated reasons,
+	// so they are reported separately. Chained, both arrive as NOT_FOUND and
+	// an unregistered agent gets the missing-snapshot advice, which tells the
+	// model to delegate again into a delegation tool that fails identically.
 	agent, err := resolveAgent(g, ref)
-	var snap *aix.SessionSnapshot[json.RawMessage]
-	if err == nil {
-		snap, err = fetch(ctx, agent, snapshotID)
+	if err != nil {
+		logger.Debug(ctx, "background task agent did not resolve",
+			"taskId", taskID, "agent", ref.Name, "error", err)
+		report.Status = taskStatusUnknown
+		report.Error = fmt.Sprintf("%v. This task cannot be collected here; report it as unavailable rather than delegating it again.", err)
+		return report, err
 	}
+
+	snap, err := fetch(ctx, agent, snapshotID)
 	if err != nil {
 		logger.Debug(ctx, "background task read failed",
 			"taskId", taskID, "agent", ref.Name, "error", err)
@@ -474,9 +529,9 @@ func (a *Agents) reportTask(ctx context.Context, g *genkit.Genkit, st *agentsSta
 		// (aix.ErrSnapshotNotFound is an ErrNotFound,
 		// aix.ErrSessionStoreNotConfigured an ErrFailedPrecondition). A wait
 		// fetch has already ridden out transient store blips inside the
-		// companion action, so whatever surfaces here is worth reporting.
-		// NOT_FOUND covers a missing snapshot and an unregistered agent
-		// alike; the wrapped cause names which.
+		// companion action, so whatever surfaces here is worth reporting. The
+		// agent resolved above, so NOT_FOUND here is the snapshot and nothing
+		// else, and re-delegating is genuinely the way to get the work done.
 		switch {
 		case errors.Is(err, status.ErrNotFound):
 			report.Error = fmt.Sprintf("No record of this task exists (%v). Delegate the task again if the result is still needed.", err)
@@ -503,12 +558,9 @@ func (a *Agents) reportTask(ctx context.Context, g *genkit.Genkit, st *agentsSta
 		// the sub-agent returned (SessionRunner.Result), rather than older text
 		// it spoke mid-tool-loop; an interrupt carries the same limitation as
 		// the synchronous path, since it cannot be resumed from here.
-		var tip *ai.Message
+		tip := snapshotTip(snap)
 		var arts []*aix.Artifact
 		if snap.State != nil {
-			if n := len(snap.State.Messages); n > 0 {
-				tip = snap.State.Messages[n-1]
-			}
 			arts = snap.State.Artifacts
 		}
 		// Deterministic namespace (unlike the sync path's per-call counter):
@@ -520,34 +572,53 @@ func (a *Agents) reportTask(ctx context.Context, g *genkit.Genkit, st *agentsSta
 			Message:      tip,
 			Artifacts:    arts,
 		}, fmt.Sprintf("%s_%s", ref.Name, shortSnapshotID(snapshotID)))
-		switch snap.FinishReason {
-		case aix.AgentFinishReasonFailed, aix.AgentFinishReasonInterrupted:
+		if snap.FinishReason.CarriesResult() {
+			report.Response, report.Artifacts = folded.Response, folded.Artifacts
+		} else {
 			// The row committed, so the stored status is completed, but the
 			// agent declared a reason that carries no answer (it can do so
 			// without erroring, which is why the two disagree). Report the
 			// outcome the reader has to act on, not the row's bookkeeping: a
 			// model that sees "completed" moves on and never reads the error.
-			// Which of the two it was, and what to do about it, is in Error.
+			// Which reason it was, and what the agent last said, is in Error.
 			report.Status = string(aix.SnapshotStatusFailed)
 			report.Error = folded.Response
-		default:
-			report.Response, report.Artifacts = folded.Response, folded.Artifacts
 		}
 	case aix.SnapshotStatusFailed:
-		report.Error = subAgentFailureMessage(snap.Error)
+		report.Error = subAgentFailureMessage(snap.FinishReason, snap.Error, snapshotTip(snap))
 	case aix.SnapshotStatusAborted:
 		report.Error = "The task was aborted before it finished."
 	case aix.SnapshotStatusExpired:
 		report.Error = "The background worker stopped reporting progress and is presumed dead. Delegate the task again if the result is still needed."
 	}
 
-	switch snap.Status {
-	case aix.SnapshotStatusCompleted, aix.SnapshotStatusFailed, aix.SnapshotStatusAborted:
+	// Expired is the one terminal read that can still change its mind: the
+	// worker may be alive and merely slow to beat, so a later read can find it
+	// settled properly. Everything else terminal is final and worth caching.
+	if snap.Status.Terminal() && snap.Status != aix.SnapshotStatusExpired {
 		st.mu.Lock()
 		st.settledReports[taskID] = report
 		st.mu.Unlock()
 	}
 	return report, nil
+}
+
+// snapshotTip returns the persisted conversation's last message, which is the
+// literal final message the sub-agent returned (SessionRunner.Result) rather
+// than older text it spoke mid-tool-loop. Nil when the row carries no state or
+// no messages.
+//
+// It serves both the completed and failed arms. A failed detach-finalize
+// writes the full final state, so the tip is there too, and for a row whose
+// Error is empty it is the only account of what the agent managed to do.
+func snapshotTip(snap *aix.SessionSnapshot[json.RawMessage]) *ai.Message {
+	if snap.State == nil {
+		return nil
+	}
+	if n := len(snap.State.Messages); n > 0 {
+		return snap.State.Messages[n-1]
+	}
+	return nil
 }
 
 // formatTaskID builds the model-facing handle of a background delegation. The

--- a/go/plugins/middleware/exp/agents_async.go
+++ b/go/plugins/middleware/exp/agents_async.go
@@ -134,11 +134,11 @@ func (a *Agents) delegateAsync(ref aix.AgentRef, st *agentsState) func(context.C
 
 // launchDelegation starts a background delegation through the sub-agent's
 // detach support and returns the task handle without waiting for the work.
-// Launches count against MaxDelegations like synchronous delegations, but a
-// launch rejected before any work ran returns its slot, so a retry (e.g. the
-// synchronous fallback hinted below) is not refused by a cap the rejection
-// consumed. History is never forwarded: detach requires a server-managed
-// sub-agent, and server-managed init rejects seeded state.
+// Launches count against MaxDelegations like synchronous delegations, except
+// for a launch the sub-agent cannot support at all: that refusal returns its
+// slot, so the synchronous fallback it hints at is not refused by a cap the
+// refusal consumed. History is never forwarded: detach requires a
+// server-managed sub-agent, and server-managed init rejects seeded state.
 func (a *Agents) launchDelegation(ctx context.Context, ref aix.AgentRef, st *agentsState, task string) (delegationResult, error) {
 	invocationNum, _, agent, refusal := a.beginDelegation(ctx, ref, st)
 	if refusal != nil {
@@ -161,7 +161,6 @@ func (a *Agents) launchDelegation(ctx context.Context, ref aix.AgentRef, st *age
 
 	out, err := runSubAgent(ctx, agent, task, nil, true)
 	if err != nil {
-		a.releaseDelegation(st)
 		logger.Warn(ctx, "background launch failed", "agent", ref.Name, "error", err)
 		return delegationResult{Response: fmt.Sprintf("Error calling agent %q: %v", ref.Name, err)}, nil
 	}
@@ -180,10 +179,6 @@ func (a *Agents) launchDelegation(ctx context.Context, ref aix.AgentRef, st *age
 				taskID, ref.Name, checkName, waitName),
 		}, nil
 	case aix.AgentFinishReasonFailed:
-		// A failed launch is a pre-detach rejection: with detach on the first
-		// input, the invocation either detaches or fails before a turn runs,
-		// so no sub-agent work happened and the reserved slot goes back.
-		a.releaseDelegation(st)
 		// FAILED_PRECONDITION is how the runtime rejects a detach-incapable
 		// agent (no session store, or one without subscriber support). The
 		// error was decoded from the wire, which keeps only the status name
@@ -200,8 +195,16 @@ func (a *Agents) launchDelegation(ctx context.Context, ref aix.AgentRef, st *age
 		}
 		logger.Warn(ctx, "background launch rejected",
 			"agent", ref.Name, "status", errStatus, "error", msg)
-		if out.Error != nil && out.Error.Status == status.FailedPrecondition && agent.Metadata() == nil {
-			msg += " If this agent lacks a session store that supports background work, delegate to it without \"background\" instead."
+		if out.Error != nil && out.Error.Status == status.FailedPrecondition {
+			// Only this failure earns its slot back: it is the detach
+			// rejection, and the retry it points at is the synchronous
+			// delegation. A failure of any other status is the sub-agent's
+			// own, and it ran to produce it, so it counts against the cap or
+			// an agent that always fails could be delegated to forever.
+			a.releaseDelegation(st)
+			if agent.Metadata() == nil {
+				msg += " If this agent lacks a session store that supports background work, delegate to it without \"background\" instead."
+			}
 		}
 		return delegationResult{Response: fmt.Sprintf("Error calling agent %q: %s", ref.Name, msg)}, nil
 	default:
@@ -249,9 +252,10 @@ func (a *Agents) checkBackgroundTasks(st *agentsState) func(context.Context, bac
 // tick. The waits run concurrently, so the slowest task sets the wall clock.
 //
 // A settled task's report is cached for the rest of the generate call (no
-// snapshot re-reads or artifact re-merges when the model checks again), and a
-// failed read is retried up to transientReadRetries times before the error is
-// surfaced. A timeout returns the current statuses rather than an error so the
+// snapshot re-reads or artifact re-merges when the model checks again), and
+// transient store blips are ridden out inside the companion action itself, so
+// a read error that reaches here is already a dead end. A timeout returns the
+// current statuses rather than an error so the
 // orchestrator can do other work and come back; cancellation of the calling
 // context propagates as an error.
 func (a *Agents) waitForBackgroundTasks(st *agentsState) func(context.Context, waitBackgroundTasksInput) (backgroundTasksResult, error) {
@@ -319,16 +323,18 @@ func (a *Agents) waitForBackgroundTasks(st *agentsState) func(context.Context, w
 
 // awaitTask follows one task to its end and returns its report. Transient
 // store blips are ridden out inside the waitForSnapshot dispatch itself, so a
-// fetch error that reaches this level is a dead end worth reporting. When ctx
-// ends before the task settles (the wait's own timeout, or the caller's
-// cancellation) the task is still running by definition, so an interrupted
-// fetch is reported as pending rather than as a read that did not finish;
-// start is the wait's start, for the settlement log line.
+// fetch error that reaches this level is a dead end worth reporting. The one
+// exception is ctx ending (the wait's own timeout, or the caller's
+// cancellation): the task is still running by definition, so a follow cut
+// short that way is reported as pending rather than as a read that did not
+// finish. That is decided from the failure itself, not from ctx alone: a
+// handle that never resolved, or an agent that is not registered, is not ctx's
+// doing and keeps its error however the wait ended, or the model would be told
+// to keep re-checking an ID that can never settle. start is the wait's start,
+// for the settlement log line.
 func (a *Agents) awaitTask(ctx context.Context, g *genkit.Genkit, st *agentsState, taskID string, start time.Time) backgroundTaskReport {
-	report := a.reportTask(ctx, g, st, taskID, awaitSnapshot)
-	if report.Status == taskStatusUnknown && ctx.Err() != nil {
-		// ctx cut the fetch short; a report that already settled (e.g. from
-		// the cache) stands as-is.
+	report, err := a.reportTask(ctx, g, st, taskID, awaitSnapshot)
+	if err != nil && ctx.Err() != nil && errors.Is(err, ctx.Err()) {
 		report.Status = string(aix.SnapshotStatusPending)
 		report.Error = ""
 		return report
@@ -344,7 +350,10 @@ func (a *Agents) awaitTask(ctx context.Context, g *genkit.Genkit, st *agentsStat
 func (a *Agents) reportTasks(ctx context.Context, st *agentsState, taskIDs []string) backgroundTasksResult {
 	g := genkit.FromContext(ctx)
 	return backgroundTasksResult{Tasks: collectReports(taskIDs, func(taskID string) backgroundTaskReport {
-		return a.reportTask(ctx, g, st, taskID, readSnapshotOnce)
+		// A check never waits, so a failure is the report; the raw error is
+		// only of interest to the wait tool, which classifies it.
+		report, _ := a.reportTask(ctx, g, st, taskID, readSnapshotOnce)
+		return report
 	})}
 }
 
@@ -368,11 +377,7 @@ func collectReports(taskIDs []string, report func(taskID string) backgroundTaskR
 	fetched := make([]backgroundTaskReport, len(distinct))
 	var wg sync.WaitGroup
 	for i, id := range distinct {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			fetched[i] = report(id)
-		}()
+		wg.Go(func() { fetched[i] = report(id) })
 	}
 	wg.Wait()
 
@@ -408,18 +413,18 @@ var (
 // snapshot fetch and artifact re-merge (and cannot clobber a merged artifact
 // the orchestrator has since edited). Pending, expired, and unresolvable
 // reports can still change on their own and are never cached.
-func (a *Agents) reportTask(ctx context.Context, g *genkit.Genkit, st *agentsState, taskID string, fetch snapshotFetch) backgroundTaskReport {
+func (a *Agents) reportTask(ctx context.Context, g *genkit.Genkit, st *agentsState, taskID string, fetch snapshotFetch) (backgroundTaskReport, error) {
 	st.mu.Lock()
 	cached, ok := st.settledReports[taskID]
 	st.mu.Unlock()
 	if ok {
-		return cached
+		return cached, nil
 	}
 
 	ref, snapshotID, err := a.resolveTaskID(taskID)
 	if err != nil {
 		logger.Debug(ctx, "background task id did not resolve", "taskId", taskID, "error", err)
-		return backgroundTaskReport{TaskID: taskID, Status: taskStatusUnknown, Error: err.Error()}
+		return backgroundTaskReport{TaskID: taskID, Status: taskStatusUnknown, Error: err.Error()}, err
 	}
 
 	report := backgroundTaskReport{TaskID: taskID, Agent: ref.Name}
@@ -451,7 +456,7 @@ func (a *Agents) reportTask(ctx context.Context, g *genkit.Genkit, st *agentsSta
 		default:
 			report.Error = fmt.Sprintf("Could not read the task's status: %v. Check again later.", err)
 		}
-		return report
+		return report, err
 	}
 	report.Status = string(snap.Status)
 
@@ -461,7 +466,10 @@ func (a *Agents) reportTask(ctx context.Context, g *genkit.Genkit, st *agentsSta
 	case aix.SnapshotStatusCompleted:
 		// Fold the settled snapshot exactly as a synchronous delegation folds
 		// its output, so a delegation reports the same answer and the same
-		// artifacts whether it ran in the background or not. The response is
+		// artifacts whether it ran in the background or not, with one caveat:
+		// this reads the snapshot through the agent's own companion action, so
+		// a sub-agent configured WithStateTransform has already shaped what is
+		// read here, while the synchronous path sees the output unshaped. The response is
 		// the persisted conversation's tip, which is the literal final message
 		// the sub-agent returned (SessionRunner.Result), rather than older text
 		// it spoke mid-tool-loop; an interrupt carries the same limitation as
@@ -483,7 +491,18 @@ func (a *Agents) reportTask(ctx context.Context, g *genkit.Genkit, st *agentsSta
 			Message:      tip,
 			Artifacts:    arts,
 		}, fmt.Sprintf("%s_%s", ref.Name, shortSnapshotID(snapshotID)))
-		report.Response, report.Artifacts = folded.Response, folded.Artifacts
+		switch snap.FinishReason {
+		case aix.AgentFinishReasonFailed, aix.AgentFinishReasonInterrupted:
+			// The row committed, so the status is completed, but the agent
+			// declared a reason that carries no answer (it can do so without
+			// erroring, which is why the two disagree). The fold produced
+			// explanatory text, not a response: report it as the error it is,
+			// or the report would claim success in one field and failure in
+			// the next.
+			report.Error = folded.Response
+		default:
+			report.Response, report.Artifacts = folded.Response, folded.Artifacts
+		}
 	case aix.SnapshotStatusFailed:
 		report.Error = subAgentFailureMessage(snap.Error)
 	case aix.SnapshotStatusAborted:
@@ -498,7 +517,7 @@ func (a *Agents) reportTask(ctx context.Context, g *genkit.Genkit, st *agentsSta
 		st.settledReports[taskID] = report
 		st.mu.Unlock()
 	}
-	return report
+	return report, nil
 }
 
 // formatTaskID builds the model-facing handle of a background delegation. The

--- a/go/plugins/middleware/exp/agents_async.go
+++ b/go/plugins/middleware/exp/agents_async.go
@@ -30,10 +30,12 @@ package exp
 // ("<agent>:<snapshotId>") is self-contained and rides in the delegation tool
 // result, so it is recorded in the orchestrator's conversation history; a
 // re-instantiated orchestrator resumes tracking from the IDs in its history.
-// Status reads go through the sub-agent's [aix.AgentHandle] (resolved via
+// Status goes through the sub-agent's [aix.AgentHandle] (resolved via
 // resolveAgent, i.e. genkit/exp.LookupAgent, the sanctioned path for
-// third-party middleware), whose GetSnapshot dispatches the agent's
-// getSnapshot companion action.
+// third-party middleware): the check tool dispatches the agent's getSnapshot
+// companion action, and the wait tool its waitForSnapshot counterpart, which
+// blocks next to the store rather than making this middleware re-read on a
+// timer.
 
 import (
 	"context"
@@ -42,6 +44,7 @@ import (
 	"fmt"
 	"math"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/firebase/genkit/go/ai"
@@ -57,20 +60,15 @@ const (
 	waitBackgroundTasksToolName  = "wait_for_background_tasks"
 )
 
-// backgroundTaskPollInterval is how often the wait tool re-reads a pending
-// task's snapshot. Package-level so tests can shorten it.
-var backgroundTaskPollInterval = 5 * time.Second
-
-// waitProgressInterval is how often a still-blocked wait tool logs progress,
-// so a long silent wait stays visible in the logs without a line per poll.
-const waitProgressInterval = 60 * time.Second
-
-// transientReadRetries is the number of consecutive failed reads of one task
-// after which the wait tool gives up on it and surfaces the read error: the
-// preceding failures are absorbed by retrying on the poll interval. It rides
-// out isolated store blips while keeping the wait bounded on a persistently
-// broken store. Reads cut short by the wait's own deadline do not count.
+// transientReadRetries is the number of attempts the wait tool makes on one
+// task before it gives up and surfaces the read error. It rides out isolated
+// store blips while keeping the wait bounded on a persistently broken store. A
+// wait cut short by its own deadline is not a failure and does not count.
 const transientReadRetries = 3
+
+// transientRetryDelay is how long the wait tool pauses before it tries a task
+// again after a failed read, so a broken store is retried rather than spun on.
+var transientRetryDelay = time.Second
 
 // taskStatusUnknown is the report status for a task that could not be resolved
 // (malformed ID, unconfigured agent, missing snapshot, or read error). It is
@@ -259,19 +257,21 @@ func (a *Agents) checkBackgroundTasks(st *agentsState) func(context.Context, bac
 	}
 }
 
-// waitForBackgroundTasks is the blocking status tool: it polls the tasks'
-// snapshots until every task settles, the optional timeout elapses, or the
-// calling context ends. A settled task's report is cached for the rest of the
-// call (no snapshot re-reads or artifact re-merges on later ticks), and a
-// transient read failure is retried across polls until it has failed
-// transientReadRetries consecutive times, at which point the read error is
-// surfaced. Each read is additionally bounded to one poll interval, so a hung
-// store read degrades into that retry path instead of stalling the pass (or,
-// on an unbounded wait, the whole tool call); a read cut short by the wait's
-// own deadline is not a store failure and does not count. A timeout returns
-// the current statuses rather than an error so the orchestrator can do other
-// work and come back; cancellation of the calling context propagates as an
-// error.
+// waitForBackgroundTasks is the blocking status tool: it follows every task to
+// its end, or returns the current statuses when the optional timeout elapses.
+// Each task is followed by the sub-agent's waitForSnapshot companion action, so
+// the waiting happens next to the store that knows when the work finished
+// rather than as a snapshot read per tick here: one action dispatch per task
+// for the whole wait, which is one span each in a trace instead of a stream of
+// them, and a settlement is observed as it happens rather than on the next
+// tick. The waits run concurrently, so the slowest task sets the wall clock.
+//
+// A settled task's report is cached for the rest of the generate call (no
+// snapshot re-reads or artifact re-merges when the model checks again), and a
+// failed read is retried up to transientReadRetries times before the error is
+// surfaced. A timeout returns the current statuses rather than an error so the
+// orchestrator can do other work and come back; cancellation of the calling
+// context propagates as an error.
 func (a *Agents) waitForBackgroundTasks(st *agentsState) func(context.Context, waitBackgroundTasksInput) (backgroundTasksResult, error) {
 	return func(ctx context.Context, in waitBackgroundTasksInput) (backgroundTasksResult, error) {
 		if len(in.TaskIDs) == 0 {
@@ -301,115 +301,76 @@ func (a *Agents) waitForBackgroundTasks(st *agentsState) func(context.Context, w
 			"tasks", len(in.TaskIDs), "timeoutSeconds", in.TimeoutSeconds)
 
 		g := genkit.FromContext(ctx)
-		// settled holds tasks that need no further polling: terminal statuses,
-		// unresolvable IDs, and reads that exhausted their retries. lastKnown
-		// holds each task's most recent report so the timeout path surfaces
-		// real statuses even when the final tick's reads were cut short.
-		// failures counts consecutive transient read errors per task.
-		settled := make(map[string]backgroundTaskReport, len(in.TaskIDs))
-		lastKnown := make(map[string]backgroundTaskReport, len(in.TaskIDs))
-		failures := make(map[string]int)
+		reports := make([]backgroundTaskReport, len(in.TaskIDs))
+		var wg sync.WaitGroup
+		for i, id := range in.TaskIDs {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				reports[i] = a.awaitTask(waitCtx, g, st, id, start)
+			}()
+		}
+		wg.Wait()
 
-		assemble := func() backgroundTasksResult {
-			res := backgroundTasksResult{Tasks: make([]backgroundTaskReport, 0, len(in.TaskIDs))}
-			for _, id := range in.TaskIDs {
-				if report, ok := settled[id]; ok {
-					res.Tasks = append(res.Tasks, report)
-				} else {
-					res.Tasks = append(res.Tasks, lastKnown[id])
-				}
-			}
-			return res
+		// The calling context ending is cancellation, not a timeout; let it
+		// fail the tool call rather than dressing it up as a settled result.
+		if ctx.Err() != nil {
+			return backgroundTasksResult{}, ctx.Err()
 		}
 
-		// Each read is bounded to one poll interval (floored so shortened
-		// test intervals do not starve healthy reads), keeping a hung store
-		// from freezing an unbounded wait.
-		readTimeout := max(backgroundTaskPollInterval, time.Second)
+		res := backgroundTasksResult{Tasks: reports}
+		pending := 0
+		for _, report := range reports {
+			// taskStatusUnknown deliberately counts as terminal here: it only
+			// arrives after a read failure was classified as a dead end, so
+			// there is nothing left to wait for.
+			if !aix.SnapshotStatus(report.Status).Terminal() {
+				pending++
+			}
+		}
+		if pending > 0 {
+			logger.Debug(ctx, "wait for background tasks timed out",
+				"pending", pending, "elapsedMs", time.Since(start).Milliseconds())
+			res.TimedOut = true
+			res.Note = "Stopped waiting; the pending tasks are still running. Check them again later."
+			return res, nil
+		}
+		logger.Debug(ctx, "wait for background tasks finished",
+			"tasks", len(in.TaskIDs), "elapsedMs", time.Since(start).Milliseconds())
+		return res, nil
+	}
+}
 
-		ticker := time.NewTicker(backgroundTaskPollInterval)
-		defer ticker.Stop()
-		lastProgress := start
-		for {
-			waiting := false
-			for _, id := range in.TaskIDs {
-				if _, ok := settled[id]; ok {
-					continue
-				}
-				if waitCtx.Err() != nil {
-					// The wait ended mid-pass; the Done arm below reports
-					// lastKnown for everything still unsettled.
-					waiting = true
-					break
-				}
-				readCtx, cancelRead := context.WithTimeout(waitCtx, readTimeout)
-				report, transient := a.reportTask(readCtx, g, st, id)
-				cancelRead()
-				if transient {
-					if waitCtx.Err() != nil {
-						// The wait itself ended mid-read: not a store
-						// failure, so it does not count against the retry
-						// budget and must not settle the task with a read
-						// error over lastKnown's real status.
-						waiting = true
-						break
-					}
-					if _, ok := lastKnown[id]; !ok {
-						lastKnown[id] = report
-					}
-					failures[id]++
-					if failures[id] >= transientReadRetries {
-						settled[id] = report // give up; surface the read error
-						logger.Warn(ctx, "background task read retries exhausted",
-							"taskId", id, "attempts", failures[id])
-					} else {
-						waiting = true
-					}
-					continue
-				}
-				lastKnown[id] = report
-				delete(failures, id)
-				// taskStatusUnknown deliberately counts as terminal here: it
-				// only arrives after a read failure was classified as a dead
-				// end, so there is nothing left to wait for.
-				if !aix.SnapshotStatus(report.Status).Terminal() {
-					waiting = true
-				} else {
-					settled[id] = report
-					logger.Debug(ctx, "background task settled",
-						"taskId", id, "status", report.Status,
-						"elapsedMs", time.Since(start).Milliseconds())
-				}
-			}
-			if !waiting {
-				logger.Debug(ctx, "wait for background tasks finished",
-					"tasks", len(in.TaskIDs), "elapsedMs", time.Since(start).Milliseconds())
-				return assemble(), nil
-			}
-			// A long blocked wait stays visible without a log line per poll.
-			if time.Since(lastProgress) >= waitProgressInterval {
-				lastProgress = time.Now()
-				logger.Debug(ctx, "still waiting for background tasks",
-					"pending", len(in.TaskIDs)-len(settled),
-					"elapsedMs", time.Since(start).Milliseconds())
-			}
-			select {
-			case <-waitCtx.Done():
-				// The calling context ending is cancellation, not a timeout;
-				// let it fail the tool call rather than dressing it up as a
-				// settled result.
-				if ctx.Err() != nil {
-					return backgroundTasksResult{}, ctx.Err()
-				}
-				logger.Debug(ctx, "wait for background tasks timed out",
-					"pending", len(in.TaskIDs)-len(settled),
-					"elapsedMs", time.Since(start).Milliseconds())
-				res := assemble()
-				res.TimedOut = true
-				res.Note = "Stopped waiting; the pending tasks are still running. Check them again later."
-				return res, nil
-			case <-ticker.C:
-			}
+// awaitTask follows one task to its end and returns its report, retrying a
+// failed read a few times before it surfaces the error. When ctx ends first
+// (the wait's own timeout, or the caller's cancellation) the task is still
+// running by definition, so it is reported as pending rather than as a read
+// that did not finish; start is the wait's start, for the settlement log line.
+func (a *Agents) awaitTask(ctx context.Context, g *genkit.Genkit, st *agentsState, taskID string, start time.Time) backgroundTaskReport {
+	for attempt := 1; ; attempt++ {
+		report, transient := a.reportTask(ctx, g, st, taskID, awaitSnapshot)
+		if ctx.Err() != nil {
+			report.Status = string(aix.SnapshotStatusPending)
+			report.Error = ""
+			return report
+		}
+		if !transient {
+			logger.Debug(ctx, "background task settled",
+				"taskId", taskID, "status", report.Status,
+				"elapsedMs", time.Since(start).Milliseconds())
+			return report
+		}
+		if attempt >= transientReadRetries {
+			logger.Warn(ctx, "background task read retries exhausted",
+				"taskId", taskID, "attempts", attempt)
+			return report
+		}
+		select {
+		case <-ctx.Done():
+			report.Status = string(aix.SnapshotStatusPending)
+			report.Error = ""
+			return report
+		case <-time.After(transientRetryDelay):
 		}
 	}
 }
@@ -421,25 +382,41 @@ func (a *Agents) reportTasks(ctx context.Context, st *agentsState, taskIDs []str
 	g := genkit.FromContext(ctx)
 	res := backgroundTasksResult{Tasks: make([]backgroundTaskReport, 0, len(taskIDs))}
 	for _, id := range taskIDs {
-		report, _ := a.reportTask(ctx, g, st, id)
+		report, _ := a.reportTask(ctx, g, st, id, readSnapshotOnce)
 		res.Tasks = append(res.Tasks, report)
 	}
 	return res
 }
 
-// reportTask resolves one task handle and shapes its snapshot into a report.
-// Completed tasks surface the sub-agent's final response and artifacts;
-// terminal non-success statuses surface an explanatory error instead. The
-// second return reports whether a failed read looked transient (a store or
-// transport error rather than a sentinel-classified dead end); the wait tool
-// retries transient reads a few polls before surfacing them.
+// snapshotFetch is how a task's snapshot is obtained: read once for the check
+// tool, waited for by the wait tool. Both dispatch a companion action of the
+// sub-agent, so both apply the runtime's read shaping and both keep the error
+// chain live for classification.
+type snapshotFetch func(context.Context, *aix.AgentHandle, string) (*aix.SessionSnapshot[json.RawMessage], error)
+
+var (
+	readSnapshotOnce snapshotFetch = func(ctx context.Context, agent *aix.AgentHandle, snapshotID string) (*aix.SessionSnapshot[json.RawMessage], error) {
+		return agent.GetSnapshot(ctx, snapshotID)
+	}
+	awaitSnapshot snapshotFetch = func(ctx context.Context, agent *aix.AgentHandle, snapshotID string) (*aix.SessionSnapshot[json.RawMessage], error) {
+		return agent.WaitForSnapshot(ctx, snapshotID)
+	}
+)
+
+// reportTask resolves one task handle, obtains its snapshot through fetch, and
+// shapes the result into a report. Completed tasks surface the sub-agent's
+// final response and artifacts; terminal non-success statuses surface an
+// explanatory error instead. The second return reports whether a failed fetch
+// looked transient (a store or transport error rather than a
+// sentinel-classified dead end); the wait tool retries transient fetches a few
+// times before surfacing them.
 //
 // Reports for completed, failed, and aborted tasks are cached on st for the
 // rest of the generate call: those rows never change, so a re-check skips the
 // snapshot fetch and artifact re-merge (and cannot clobber a merged artifact
 // the orchestrator has since edited). Pending, expired, and unresolvable
 // reports can still change on their own and are never cached.
-func (a *Agents) reportTask(ctx context.Context, g *genkit.Genkit, st *agentsState, taskID string) (backgroundTaskReport, bool) {
+func (a *Agents) reportTask(ctx context.Context, g *genkit.Genkit, st *agentsState, taskID string, fetch snapshotFetch) (backgroundTaskReport, bool) {
 	st.mu.Lock()
 	cached, ok := st.settledReports[taskID]
 	st.mu.Unlock()
@@ -454,13 +431,13 @@ func (a *Agents) reportTask(ctx context.Context, g *genkit.Genkit, st *agentsSta
 	}
 
 	report := backgroundTaskReport{TaskID: taskID, Agent: ref.Name}
-	// The handle's GetSnapshot dispatches the getSnapshot companion action,
-	// which applies the runtime's read shaping: a pending row whose heartbeat
-	// went stale is surfaced as expired.
+	// Both fetches dispatch a companion action of the sub-agent, which applies
+	// the runtime's read shaping: a pending row whose heartbeat went stale is
+	// surfaced as expired.
 	agent, err := resolveAgent(g, ref)
 	var snap *aix.SessionSnapshot[json.RawMessage]
 	if err == nil {
-		snap, err = agent.GetSnapshot(ctx, snapshotID)
+		snap, err = fetch(ctx, agent, snapshotID)
 	}
 	if err != nil {
 		logger.Debug(ctx, "background task read failed",

--- a/go/plugins/middleware/exp/agents_async_test.go
+++ b/go/plugins/middleware/exp/agents_async_test.go
@@ -246,6 +246,87 @@ func TestAgentsBackgroundTasksPickUpAcrossInstantiations(t *testing.T) {
 	}
 }
 
+// TestAgentsBackgroundCompletedWithoutAnswerReportsFailed covers the case where
+// the stored row and the agent's own verdict disagree: the turn committed, so
+// the snapshot is "completed", but the agent declared a finish reason that
+// carries no answer. The report has to say what the reader must act on, since a
+// model that sees "completed" moves on and never reads the error.
+func TestAgentsBackgroundCompletedWithoutAnswerReportsFailed(t *testing.T) {
+	g := newTestGenkit(t)
+
+	// Gate the turn so the detach lands before the agent settles; the fn then
+	// declares failure without returning an error, so the runtime commits the
+	// row as completed with a finish reason of failed.
+	gate := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() { releaseOnce.Do(func() { close(gate) }) }
+	t.Cleanup(release)
+
+	genkitx.DefineCustomAgent[any](g, "researcher",
+		func(ctx context.Context, resp aix.Responder, sess *aix.SessionRunner[any]) (*aix.AgentResult, error) {
+			err := sess.Run(ctx, func(ctx context.Context, input *aix.AgentInput) (*aix.TurnResult, error) {
+				select {
+				case <-gate:
+				case <-ctx.Done():
+					return nil, ctx.Err()
+				}
+				sess.AddMessages(ai.NewModelTextMessage("partial notes"))
+				return &aix.TurnResult{FinishReason: aix.AgentFinishReasonFailed}, nil
+			})
+			if err != nil {
+				return nil, err
+			}
+			return &aix.AgentResult{}, nil
+		},
+		aix.WithSessionStore[any](localstore.NewInMemorySessionStore[any]()),
+	)
+
+	orch := toolModel(t, g, "test/orch-no-answer", func(ctx context.Context, req *ai.ModelRequest, cb ai.ModelStreamCallback) (*ai.ModelResponse, error) {
+		launches := toolOutputs(req.Messages, "delegate_to_researcher")
+		waits := toolOutputs(req.Messages, waitBackgroundTasksToolName)
+		switch {
+		case len(launches) == 0:
+			return toolReqResp(req, &ai.ToolRequest{
+				Name:  "delegate_to_researcher",
+				Input: map[string]any{"task": "dig into X", "background": true},
+			}), nil
+		case len(waits) == 0:
+			release()
+			return toolReqResp(req, &ai.ToolRequest{
+				Name:  waitBackgroundTasksToolName,
+				Input: map[string]any{"taskIds": []string{lenientDelegation(launches[0]).TaskID}},
+			}), nil
+		default:
+			return textResp(req, "done"), nil
+		}
+	})
+
+	resp, err := genkit.Generate(ctx, g, ai.WithModel(orch), ai.WithPrompt("research X"),
+		ai.WithUse(&Agents{Agents: []aix.AgentRef{{Name: "researcher"}}, Async: true}))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	waitOuts := toolOutputs(resp.History(), waitBackgroundTasksToolName)
+	if len(waitOuts) != 1 {
+		t.Fatalf("expected 1 wait response, got %d", len(waitOuts))
+	}
+	res := decodeToolOutput[backgroundTasksResult](t, waitOuts[0])
+	if len(res.Tasks) != 1 {
+		t.Fatalf("expected 1 task report, got %+v", res.Tasks)
+	}
+	got := res.Tasks[0]
+	if got.Status != string(aix.SnapshotStatusFailed) {
+		t.Errorf("Status = %q, want %q: the task produced no answer", got.Status, aix.SnapshotStatusFailed)
+	}
+	if got.Error == "" {
+		t.Error("Error is empty, want the reason the task carries no answer")
+	}
+	if got.Response != "" {
+		t.Errorf("Response = %q, want empty: there is no answer to report", got.Response)
+	}
+}
+
 // TestAgentsWaitTimeoutKeepsUnresolvableErrors covers the two halves of what a
 // timed-out wait must report. A task that is genuinely still running comes back
 // pending, because the wait ran out of time rather than learning anything. A

--- a/go/plugins/middleware/exp/agents_async_test.go
+++ b/go/plugins/middleware/exp/agents_async_test.go
@@ -31,12 +31,13 @@ import (
 	genkitx "github.com/firebase/genkit/go/genkit/exp"
 )
 
-// fastTaskPolling shortens the wait tool's poll interval for the test.
+// fastTaskPolling shortens the wait tool's retry pause for the test. A healthy
+// wait needs no shortening: it settles when the store says so.
 func fastTaskPolling(t *testing.T) {
 	t.Helper()
-	restore := backgroundTaskPollInterval
-	backgroundTaskPollInterval = 10 * time.Millisecond
-	t.Cleanup(func() { backgroundTaskPollInterval = restore })
+	restore := transientRetryDelay
+	transientRetryDelay = 10 * time.Millisecond
+	t.Cleanup(func() { transientRetryDelay = restore })
 }
 
 // toolOutputs collects the raw outputs of every tool response for toolName.

--- a/go/plugins/middleware/exp/agents_async_test.go
+++ b/go/plugins/middleware/exp/agents_async_test.go
@@ -573,3 +573,163 @@ func TestAgentsWaitTimeoutOverflowIsUnbounded(t *testing.T) {
 		t.Errorf("expected the missing snapshot to settle as unknown/not-found, got %+v", res.Tasks)
 	}
 }
+
+// TestAgentsAbortBackgroundTask drives the abort control end to end. The task
+// is stopped mid-flight, so the abort has to reach the work and not just the
+// row, and a later check has to agree: an orchestrator told "pending" after it
+// aborted would go back to waiting on work that is gone.
+func TestAgentsAbortBackgroundTask(t *testing.T) {
+	g := newTestGenkit(t)
+
+	// The sub-agent never finishes on its own, so the abort is the only thing
+	// that can end this task. It signals its own cancellation, which is how
+	// the test tells a stopped task from a merely rewritten row.
+	stopped := make(chan struct{})
+	var stopOnce sync.Once
+	genkitx.DefineCustomAgent[any](g, "researcher",
+		func(ctx context.Context, resp aix.Responder, sess *aix.SessionRunner[any]) (*aix.AgentResult, error) {
+			err := sess.Run(ctx, func(ctx context.Context, input *aix.AgentInput) (*aix.TurnResult, error) {
+				<-ctx.Done()
+				stopOnce.Do(func() { close(stopped) })
+				return nil, ctx.Err()
+			})
+			if err != nil {
+				return nil, err
+			}
+			return &aix.AgentResult{}, nil
+		},
+		aix.WithSessionStore[any](localstore.NewInMemorySessionStore[any]()),
+	)
+
+	// Scripted orchestrator: launch in background, abort, then check that the
+	// abort stuck.
+	var capturedSystem string
+	orch := toolModel(t, g, "test/orch-abort", func(ctx context.Context, req *ai.ModelRequest, cb ai.ModelStreamCallback) (*ai.ModelResponse, error) {
+		if sys := findSystem(req.Messages); sys != nil {
+			capturedSystem = systemText(sys)
+		}
+		launches := toolOutputs(req.Messages, "delegate_to_researcher")
+		aborts := toolOutputs(req.Messages, abortBackgroundTasksToolName)
+		checks := toolOutputs(req.Messages, checkBackgroundTasksToolName)
+		switch {
+		case len(launches) == 0:
+			return toolReqResp(req, &ai.ToolRequest{
+				Name:  "delegate_to_researcher",
+				Input: map[string]any{"task": "dig into X", "background": true},
+			}), nil
+		case len(aborts) == 0:
+			return toolReqResp(req, &ai.ToolRequest{
+				Name:  abortBackgroundTasksToolName,
+				Input: map[string]any{"taskIds": []string{lenientDelegation(launches[0]).TaskID}},
+			}), nil
+		case len(checks) == 0:
+			return toolReqResp(req, &ai.ToolRequest{
+				Name:  checkBackgroundTasksToolName,
+				Input: map[string]any{"taskIds": []string{lenientDelegation(launches[0]).TaskID}},
+			}), nil
+		default:
+			return textResp(req, "done"), nil
+		}
+	})
+
+	resp, err := genkit.Generate(ctx, g, ai.WithModel(orch), ai.WithPrompt("research X"),
+		ai.WithUse(&Agents{Agents: []aix.AgentRef{{Name: "researcher"}}, Async: true}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	history := resp.History()
+
+	if !strings.Contains(capturedSystem, abortBackgroundTasksToolName) {
+		t.Errorf("async system prompt missing %q; got:\n%s", abortBackgroundTasksToolName, capturedSystem)
+	}
+
+	abortOuts := toolOutputs(history, abortBackgroundTasksToolName)
+	if len(abortOuts) != 1 {
+		t.Fatalf("expected 1 abort response, got %d", len(abortOuts))
+	}
+	aborted := decodeToolOutput[backgroundTasksResult](t, abortOuts[0])
+	if len(aborted.Tasks) != 1 {
+		t.Fatalf("expected 1 aborted task, got %+v", aborted.Tasks)
+	}
+	if got := aborted.Tasks[0]; got.Status != string(aix.SnapshotStatusAborted) || got.Error == "" {
+		t.Errorf("unexpected abort report: %+v", got)
+	}
+
+	// The row said aborted; the runtime observes that flip and cancels the
+	// work, which is the half a status write alone would not prove.
+	select {
+	case <-stopped:
+	case <-time.After(5 * time.Second):
+		t.Error("the sub-agent was never cancelled: the abort reached the row but not the work")
+	}
+
+	checkOuts := toolOutputs(history, checkBackgroundTasksToolName)
+	if len(checkOuts) != 1 {
+		t.Fatalf("expected 1 check response, got %d", len(checkOuts))
+	}
+	checked := decodeToolOutput[backgroundTasksResult](t, checkOuts[0])
+	if len(checked.Tasks) != 1 || checked.Tasks[0].Status != string(aix.SnapshotStatusAborted) {
+		t.Errorf("check after abort: want 1 aborted task, got %+v", checked.Tasks)
+	}
+}
+
+// TestAgentsAbortAfterCompletionReportsTheResult pins what an abort owes a
+// caller when there was nothing left to stop. The abort action returns a bare
+// status, so reporting that alone would answer "completed" and strand the
+// answer the sub-agent had already produced; the abort reads the row it left
+// behind instead and folds it like any other report.
+func TestAgentsAbortAfterCompletionReportsTheResult(t *testing.T) {
+	g := newTestGenkit(t)
+	genkitx.DefineCustomAgent[any](g, "researcher",
+		func(ctx context.Context, resp aix.Responder, sess *aix.SessionRunner[any]) (*aix.AgentResult, error) {
+			var last *ai.Message
+			err := sess.Run(ctx, func(ctx context.Context, input *aix.AgentInput) (*aix.TurnResult, error) {
+				resp.SendArtifact(&aix.Artifact{
+					Name:  "findings.md",
+					Parts: []*ai.Part{ai.NewTextPart("the findings body")},
+				})
+				last = ai.NewModelTextMessage("research complete")
+				sess.AddMessages(last)
+				return &aix.TurnResult{FinishReason: aix.AgentFinishReasonStop}, nil
+			})
+			if err != nil {
+				return nil, err
+			}
+			return &aix.AgentResult{Message: last, Artifacts: sess.Artifacts()}, nil
+		},
+		aix.WithSessionStore[any](localstore.NewInMemorySessionStore[any]()),
+	)
+
+	// Launch and settle the task outside the middleware. Collecting it through
+	// the tools first would cache its report, and the abort would then answer
+	// from that cache without ever dispatching the call under test.
+	h, err := genkitx.LookupAgent(g, "researcher")
+	if err != nil {
+		t.Fatal(err)
+	}
+	task, err := h.Start(ctx, &aix.AgentInput{Message: ai.NewUserTextMessage("dig into X")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := h.WaitForSnapshot(ctx, task.SnapshotID()); err != nil {
+		t.Fatal(err)
+	}
+
+	a := &Agents{Agents: []aix.AgentRef{{Name: "researcher"}}, Async: true}
+	st := &agentsState{settledReports: map[string]backgroundTaskReport{}}
+	got, err := a.reportTask(ctx, g, st, formatTaskID("researcher", task.SnapshotID()), abortSnapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != string(aix.SnapshotStatusCompleted) {
+		t.Errorf("Status = %q, want %q: the abort had nothing to stop", got.Status, aix.SnapshotStatusCompleted)
+	}
+	if got.Response != "research complete" {
+		t.Errorf("Response = %q, want the answer the task had already produced", got.Response)
+	}
+	wantArtifact := "researcher_" + shortSnapshotID(task.SnapshotID()) + "/findings.md"
+	if len(got.Artifacts) != 1 || got.Artifacts[0].Name != wantArtifact ||
+		!strings.Contains(got.Artifacts[0].Content, "the findings body") {
+		t.Errorf("unexpected artifacts (want %q with inline content): %+v", wantArtifact, got.Artifacts)
+	}
+}

--- a/go/plugins/middleware/exp/agents_async_test.go
+++ b/go/plugins/middleware/exp/agents_async_test.go
@@ -830,7 +830,7 @@ func TestAgentsAbortAfterCompletionReportsTheResult(t *testing.T) {
 	// the tools first would cache its report, and the abort would then answer
 	// from that cache without ever dispatching the call under test.
 	h := genkitx.LookupAgent(g, "researcher")
-	task, err := h.Start(ctx, &aix.AgentInput{Message: ai.NewUserTextMessage("dig into X")})
+	task, err := h.RunDetached(ctx, &aix.AgentInput{Message: ai.NewUserTextMessage("dig into X")})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go/plugins/middleware/exp/agents_async_test.go
+++ b/go/plugins/middleware/exp/agents_async_test.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/firebase/genkit/go/ai"
 	aix "github.com/firebase/genkit/go/ai/exp"
@@ -242,6 +243,106 @@ func TestAgentsBackgroundTasksPickUpAcrossInstantiations(t *testing.T) {
 	}
 	if res.TimedOut {
 		t.Errorf("wait should settle without timing out, got %+v", res)
+	}
+}
+
+// TestAgentsWaitTimeoutKeepsUnresolvableErrors covers the two halves of what a
+// timed-out wait must report. A task that is genuinely still running comes back
+// pending, because the wait ran out of time rather than learning anything. A
+// handle that can never resolve keeps its error, because nothing about the
+// deadline makes it more likely to settle later; reporting it as pending would
+// send the orchestrator back to re-check it forever.
+func TestAgentsWaitTimeoutKeepsUnresolvableErrors(t *testing.T) {
+	g := newTestGenkit(t)
+
+	// The sub-agent never finishes, so its task is pending for the whole wait.
+	gate := make(chan struct{})
+	t.Cleanup(func() { close(gate) })
+	genkitx.DefineCustomAgent[any](g, "researcher",
+		func(ctx context.Context, resp aix.Responder, sess *aix.SessionRunner[any]) (*aix.AgentResult, error) {
+			err := sess.Run(ctx, func(ctx context.Context, input *aix.AgentInput) (*aix.TurnResult, error) {
+				select {
+				case <-gate:
+				case <-ctx.Done():
+				}
+				return nil, ctx.Err()
+			})
+			if err != nil {
+				return nil, err
+			}
+			return &aix.AgentResult{}, nil
+		},
+		aix.WithSessionStore[any](localstore.NewInMemorySessionStore[any]()),
+	)
+
+	orch := toolModel(t, g, "test/orch-wait-timeout", func(ctx context.Context, req *ai.ModelRequest, cb ai.ModelStreamCallback) (*ai.ModelResponse, error) {
+		launches := toolOutputs(req.Messages, "delegate_to_researcher")
+		waits := toolOutputs(req.Messages, waitBackgroundTasksToolName)
+		switch {
+		case len(launches) == 0:
+			return toolReqResp(req, &ai.ToolRequest{
+				Name:  "delegate_to_researcher",
+				Input: map[string]any{"task": "dig into X", "background": true},
+			}), nil
+		case len(waits) == 0:
+			return toolReqResp(req, &ai.ToolRequest{
+				Name: waitBackgroundTasksToolName,
+				Input: map[string]any{
+					"taskIds":        []string{lenientDelegation(launches[0]).TaskID, "ghost:whatever"},
+					"timeoutSeconds": float64(1),
+				},
+			}), nil
+		default:
+			return textResp(req, "done"), nil
+		}
+	})
+
+	resp, err := genkit.Generate(ctx, g, ai.WithModel(orch), ai.WithPrompt("research X"),
+		ai.WithUse(&Agents{Agents: []aix.AgentRef{{Name: "researcher"}}, Async: true}))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	waitOuts := toolOutputs(resp.History(), waitBackgroundTasksToolName)
+	if len(waitOuts) != 1 {
+		t.Fatalf("expected 1 wait response, got %d", len(waitOuts))
+	}
+	res := decodeToolOutput[backgroundTasksResult](t, waitOuts[0])
+	if len(res.Tasks) != 2 {
+		t.Fatalf("expected 2 task reports, got %+v", res.Tasks)
+	}
+	if !res.TimedOut {
+		t.Errorf("TimedOut = false, want true with a task still running: %+v", res)
+	}
+	if got := res.Tasks[0]; got.Status != string(aix.SnapshotStatusPending) || got.Error != "" {
+		t.Errorf("running task: want pending with no error, got %+v", got)
+	}
+	if got := res.Tasks[1]; got.Status != taskStatusUnknown ||
+		!strings.Contains(got.Error, "does not match any configured agent") {
+		t.Errorf("unconfigured agent: want unknown with its error kept past the deadline, got %+v", got)
+	}
+}
+
+// TestAwaitTaskKeepsUnresolvableErrorPastCancellation isolates the half of the
+// timed-out wait that a full generate call cannot stage reliably: a report that
+// failed for a reason ctx had nothing to do with, produced while ctx is already
+// over. Deciding "still pending" from ctx alone would blank the error here and
+// send the orchestrator back to re-check a handle that can never settle.
+func TestAwaitTaskKeepsUnresolvableErrorPastCancellation(t *testing.T) {
+	a := &Agents{Agents: []aix.AgentRef{{Name: "researcher"}}}
+	st := &agentsState{settledReports: map[string]backgroundTaskReport{}}
+
+	over, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	// The handle names no configured agent, so it fails before any I/O and
+	// stays unresolvable however long anyone waits.
+	got := a.awaitTask(over, nil, st, "ghost:whatever", time.Now())
+	if got.Status != taskStatusUnknown {
+		t.Errorf("Status = %q, want %q", got.Status, taskStatusUnknown)
+	}
+	if !strings.Contains(got.Error, "does not match any configured agent") {
+		t.Errorf("Error = %q, want the resolution failure kept", got.Error)
 	}
 }
 

--- a/go/plugins/middleware/exp/agents_async_test.go
+++ b/go/plugins/middleware/exp/agents_async_test.go
@@ -22,7 +22,6 @@ import (
 	"strings"
 	"sync"
 	"testing"
-	"time"
 
 	"github.com/firebase/genkit/go/ai"
 	aix "github.com/firebase/genkit/go/ai/exp"
@@ -30,15 +29,6 @@ import (
 	"github.com/firebase/genkit/go/genkit"
 	genkitx "github.com/firebase/genkit/go/genkit/exp"
 )
-
-// fastTaskPolling shortens the wait tool's retry pause for the test. A healthy
-// wait needs no shortening: it settles when the store says so.
-func fastTaskPolling(t *testing.T) {
-	t.Helper()
-	restore := transientRetryDelay
-	transientRetryDelay = 10 * time.Millisecond
-	t.Cleanup(func() { transientRetryDelay = restore })
-}
 
 // toolOutputs collects the raw outputs of every tool response for toolName.
 func toolOutputs(msgs []*ai.Message, toolName string) []any {
@@ -84,7 +74,6 @@ func lenientDelegation(v any) delegationResult {
 // tool while the sub-agent is still gated, then release the gate and collect
 // the completed result (response and inline artifact) via the wait tool.
 func TestAgentsAsyncDelegationLifecycle(t *testing.T) {
-	fastTaskPolling(t)
 	g := newTestGenkit(t)
 
 	// Gate the sub-agent so the task stays pending until the orchestrator has
@@ -209,7 +198,6 @@ func TestAgentsAsyncDelegationLifecycle(t *testing.T) {
 // history: the pickup path a re-instantiated orchestrator relies on. The wait
 // also carries two unusable handles to verify per-task error isolation.
 func TestAgentsBackgroundTasksPickUpAcrossInstantiations(t *testing.T) {
-	fastTaskPolling(t)
 	g := newTestGenkit(t)
 
 	genkitx.DefineAgent[any](g, "researcher",
@@ -387,7 +375,6 @@ func TestAgentsAsyncInstancesCoexistWithPrefixes(t *testing.T) {
 // the wait still settles its tasks normally instead of returning instantly
 // with timedOut and unresolved statuses.
 func TestAgentsWaitTimeoutOverflowIsUnbounded(t *testing.T) {
-	fastTaskPolling(t)
 	g := newTestGenkit(t)
 
 	genkitx.DefineAgent[any](g, "researcher",

--- a/go/plugins/middleware/exp/agents_async_test.go
+++ b/go/plugins/middleware/exp/agents_async_test.go
@@ -19,6 +19,7 @@ package exp
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"slices"
 	"strings"
 	"sync"
@@ -573,6 +574,128 @@ func TestAgentsWaitTimeoutOverflowIsUnbounded(t *testing.T) {
 	if len(res.Tasks) != 1 || res.Tasks[0].Status != taskStatusUnknown ||
 		!strings.Contains(res.Tasks[0].Error, "not found") {
 		t.Errorf("expected the missing snapshot to settle as unknown/not-found, got %+v", res.Tasks)
+	}
+}
+
+// TestAgentsWaitForFirstSettled pins the wait tool's race join: with
+// waitFor "first" the tool returns as soon as any listed task settles, the
+// still-running tasks report as pending, and the return is not a timeout.
+func TestAgentsWaitForFirstSettled(t *testing.T) {
+	g := newTestGenkit(t)
+
+	genkitx.DefineAgent[any](g, "quick",
+		aix.InlinePrompt{ai.WithModel(toolModel(t, g, "test/quick", func(ctx context.Context, req *ai.ModelRequest, cb ai.ModelStreamCallback) (*ai.ModelResponse, error) {
+			return textResp(req, "quick answer"), nil
+		}))},
+		aix.WithSessionStore[any](localstore.NewInMemorySessionStore[any]()),
+	)
+	// The slow sub-agent finishes only when released, so the race can only be
+	// won by the quick one.
+	release := make(chan struct{})
+	t.Cleanup(func() { close(release) })
+	genkitx.DefineCustomAgent[any](g, "slow",
+		func(ctx context.Context, resp aix.Responder, sess *aix.SessionRunner[any]) (*aix.AgentResult, error) {
+			err := sess.Run(ctx, func(ctx context.Context, input *aix.AgentInput) (*aix.TurnResult, error) {
+				select {
+				case <-release:
+				case <-ctx.Done():
+				}
+				return nil, errors.New("released")
+			})
+			if err != nil {
+				return nil, err
+			}
+			return &aix.AgentResult{}, nil
+		},
+		aix.WithSessionStore[any](localstore.NewInMemorySessionStore[any]()),
+	)
+
+	orch := toolModel(t, g, "test/orch-race", func(ctx context.Context, req *ai.ModelRequest, cb ai.ModelStreamCallback) (*ai.ModelResponse, error) {
+		slowLaunches := toolOutputs(req.Messages, "delegate_to_slow")
+		quickLaunches := toolOutputs(req.Messages, "delegate_to_quick")
+		switch {
+		case len(slowLaunches) == 0:
+			return toolReqResp(req, &ai.ToolRequest{
+				Name:  "delegate_to_slow",
+				Input: map[string]any{"task": "dig forever", "background": true},
+			}), nil
+		case len(quickLaunches) == 0:
+			return toolReqResp(req, &ai.ToolRequest{
+				Name:  "delegate_to_quick",
+				Input: map[string]any{"task": "answer fast", "background": true},
+			}), nil
+		case len(toolOutputs(req.Messages, waitBackgroundTasksToolName)) == 0:
+			// The slow task first in the list, so a settled result in slot 1
+			// proves the join raced instead of following input order.
+			return toolReqResp(req, &ai.ToolRequest{
+				Name: waitBackgroundTasksToolName,
+				Input: map[string]any{
+					"taskIds": []string{
+						lenientDelegation(slowLaunches[0]).TaskID,
+						lenientDelegation(quickLaunches[0]).TaskID,
+					},
+					"waitFor": "first",
+				},
+			}), nil
+		default:
+			return textResp(req, "done"), nil
+		}
+	})
+
+	resp, err := genkit.Generate(ctx, g, ai.WithModel(orch), ai.WithPrompt("go"),
+		ai.WithUse(&Agents{Agents: []aix.AgentRef{{Name: "quick"}, {Name: "slow"}}, Async: true}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	waits := toolOutputs(resp.History(), waitBackgroundTasksToolName)
+	if len(waits) != 1 {
+		t.Fatalf("expected 1 wait result, got %d", len(waits))
+	}
+	res := decodeToolOutput[backgroundTasksResult](t, waits[0])
+	if res.TimedOut {
+		t.Errorf("a won race must not report TimedOut: %+v", res)
+	}
+	if len(res.Tasks) != 2 {
+		t.Fatalf("expected 2 reports, got %+v", res.Tasks)
+	}
+	if got := res.Tasks[0]; got.Status != string(aix.SnapshotStatusPending) {
+		t.Errorf("slow task report = %+v, want pending", got)
+	}
+	if got := res.Tasks[1]; got.Status != string(aix.SnapshotStatusCompleted) || got.Response != "quick answer" {
+		t.Errorf("quick task report = %+v, want the settled answer", got)
+	}
+	if !strings.Contains(res.Note, "first settled") {
+		t.Errorf("expected the race note, got %q", res.Note)
+	}
+}
+
+// TestAgentsWaitForUnknownJoinRefused pins the recoverable guidance for a
+// waitFor value the tool does not know.
+func TestAgentsWaitForUnknownJoinRefused(t *testing.T) {
+	g := newTestGenkit(t)
+	genkitx.DefineAgent[any](g, "quick",
+		aix.InlinePrompt{ai.WithModel(toolModel(t, g, "test/quick2", func(ctx context.Context, req *ai.ModelRequest, cb ai.ModelStreamCallback) (*ai.ModelResponse, error) {
+			return textResp(req, "unused"), nil
+		}))},
+		aix.WithSessionStore[any](localstore.NewInMemorySessionStore[any]()),
+	)
+	orch := toolModel(t, g, "test/orch-badjoin", func(ctx context.Context, req *ai.ModelRequest, cb ai.ModelStreamCallback) (*ai.ModelResponse, error) {
+		if len(toolOutputs(req.Messages, waitBackgroundTasksToolName)) > 0 {
+			return textResp(req, "done"), nil
+		}
+		return toolReqResp(req, &ai.ToolRequest{
+			Name:  waitBackgroundTasksToolName,
+			Input: map[string]any{"taskIds": []string{"quick:whatever"}, "waitFor": "any"},
+		}), nil
+	})
+	resp, err := genkit.Generate(ctx, g, ai.WithModel(orch), ai.WithPrompt("go"),
+		ai.WithUse(&Agents{Agents: []aix.AgentRef{{Name: "quick"}}, Async: true}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	res := decodeToolOutput[backgroundTasksResult](t, toolOutputs(resp.History(), waitBackgroundTasksToolName)[0])
+	if !strings.Contains(res.Note, `"first"`) || len(res.Tasks) != 0 {
+		t.Fatalf("expected join guidance and no reports, got %+v", res)
 	}
 }
 

--- a/go/plugins/middleware/exp/agents_async_test.go
+++ b/go/plugins/middleware/exp/agents_async_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"slices"
 	"strings"
 	"sync"
@@ -905,6 +906,171 @@ func TestFoldDelegationNonAnswerReasons(t *testing.T) {
 		&aix.AgentOutput[json.RawMessage]{FinishReason: aix.AgentFinishReasonStop, Message: tip}, "researcher_x")
 	if got.Response != "partial notes: found 3 of 5 sources" {
 		t.Errorf("Response = %q, want the message reported as the answer", got.Response)
+	}
+}
+
+func TestFoldDelegationNoFinalMessage(t *testing.T) {
+	a := &Agents{Agents: []aix.AgentRef{{Name: "researcher"}}}
+	ref := aix.AgentRef{Name: "researcher"}
+	toolOnly := &ai.Message{Role: ai.RoleModel, Content: []*ai.Part{
+		ai.NewToolRequestPart(&ai.ToolRequest{Name: "search", Input: map[string]any{"q": "x"}}),
+	}}
+	arts := func(n int) []*aix.Artifact {
+		var out []*aix.Artifact
+		for i := range n {
+			out = append(out, &aix.Artifact{Name: fmt.Sprintf("a%d.md", i), Parts: []*ai.Part{ai.NewTextPart("body")}})
+		}
+		return out
+	}
+
+	// A silent success must read as a success, and say where the result is.
+	got := a.foldDelegationOutput(t.Context(), ref,
+		&aix.AgentOutput[json.RawMessage]{FinishReason: aix.AgentFinishReasonStop}, "researcher_x")
+	if !strings.Contains(got.Response, "completed") || !strings.Contains(got.Response, "no final message") || !strings.Contains(got.Response, "no artifacts") {
+		t.Errorf("Response = %q, want a completed-without-message notice naming the missing artifacts", got.Response)
+	}
+	got = a.foldDelegationOutput(t.Context(), ref,
+		&aix.AgentOutput[json.RawMessage]{FinishReason: aix.AgentFinishReasonStop, Message: toolOnly, Artifacts: arts(2)}, "researcher_x")
+	if !strings.Contains(got.Response, "no final message") || !strings.Contains(got.Response, "2 artifacts") {
+		t.Errorf("Response = %q, want the notice to point at the 2 artifacts", got.Response)
+	}
+	if len(got.Artifacts) != 2 {
+		t.Errorf("Artifacts = %d, want 2 surfaced alongside the notice", len(got.Artifacts))
+	}
+	got = a.foldDelegationOutput(t.Context(), ref,
+		&aix.AgentOutput[json.RawMessage]{FinishReason: aix.AgentFinishReasonStop, Artifacts: arts(1)}, "researcher_x")
+	if !strings.Contains(got.Response, "one artifact") {
+		t.Errorf("Response = %q, want the notice to point at the one artifact", got.Response)
+	}
+}
+
+func TestLastModelMessage(t *testing.T) {
+	said := ai.NewModelTextMessage("working on it")
+	toolMsg := &ai.Message{Role: ai.RoleTool, Content: []*ai.Part{
+		ai.NewToolResponsePart(&ai.ToolResponse{Name: "search", Output: "raw results"}),
+	}}
+	snap := func(msgs ...*ai.Message) *aix.SessionSnapshot[json.RawMessage] {
+		return &aix.SessionSnapshot[json.RawMessage]{State: &aix.SessionState[json.RawMessage]{Messages: msgs}}
+	}
+
+	// The transcript's tip is a tool response; the answer is what the model
+	// said before it.
+	if got := lastModelMessage(snap(ai.NewUserTextMessage("go"), said, toolMsg)); got != said {
+		t.Errorf("lastModelMessage = %+v, want the model message before the tool response", got)
+	}
+	if got := lastModelMessage(snap(ai.NewUserTextMessage("go"), toolMsg)); got != nil {
+		t.Errorf("lastModelMessage = %+v, want nil when no model message exists", got)
+	}
+	if got := lastModelMessage(&aix.SessionSnapshot[json.RawMessage]{}); got != nil {
+		t.Errorf("lastModelMessage = %+v, want nil for a stateless row", got)
+	}
+}
+
+// TestAgentsBackgroundReportUsesLastModelMessage pins the report's answer to
+// what the sub-agent said, through a run whose transcript ends on something
+// else. The first case ends on a tool response after the model spoke, so the
+// report carries the model's words, not the tool's; the second ends on a model
+// message holding only a tool request, so there is nothing the model said and
+// the report says so, pointing at the artifact that holds the result.
+func TestAgentsBackgroundReportUsesLastModelMessage(t *testing.T) {
+	toolMsg := &ai.Message{Role: ai.RoleTool, Content: []*ai.Part{
+		ai.NewToolResponsePart(&ai.ToolResponse{Name: "search", Output: "raw results"}),
+	}}
+	toolOnly := &ai.Message{Role: ai.RoleModel, Content: []*ai.Part{
+		ai.NewToolRequestPart(&ai.ToolRequest{Name: "search", Input: map[string]any{"q": "x"}}),
+	}}
+	cases := []struct {
+		name         string
+		turn         func(resp aix.Responder, sess *aix.SessionRunner[any])
+		wantResponse string
+	}{
+		{
+			name: "tool response ends the transcript",
+			turn: func(_ aix.Responder, sess *aix.SessionRunner[any]) {
+				sess.AddMessages(ai.NewModelTextMessage("working on it"), toolMsg)
+			},
+			wantResponse: "working on it",
+		},
+		{
+			name: "model ends on a bare tool request",
+			turn: func(resp aix.Responder, sess *aix.SessionRunner[any]) {
+				resp.SendArtifact(&aix.Artifact{Name: "report.md", Parts: []*ai.Part{ai.NewTextPart("the report body")}})
+				sess.AddMessages(toolOnly)
+			},
+			wantResponse: noFinalMessageResponse(1),
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := newTestGenkit(t)
+			gate := make(chan struct{})
+			var releaseOnce sync.Once
+			release := func() { releaseOnce.Do(func() { close(gate) }) }
+			t.Cleanup(release)
+
+			genkitx.DefineCustomAgent[any](g, "researcher",
+				func(ctx context.Context, resp aix.Responder, sess *aix.SessionRunner[any]) (*aix.AgentResult, error) {
+					err := sess.Run(ctx, func(ctx context.Context, input *aix.AgentInput) (*aix.TurnResult, error) {
+						select {
+						case <-gate:
+						case <-ctx.Done():
+							return nil, ctx.Err()
+						}
+						tc.turn(resp, sess)
+						return &aix.TurnResult{FinishReason: aix.AgentFinishReasonStop}, nil
+					})
+					if err != nil {
+						return nil, err
+					}
+					return &aix.AgentResult{Artifacts: sess.Artifacts()}, nil
+				},
+				aix.WithSessionStore[any](localstore.NewInMemorySessionStore[any]()),
+			)
+
+			orch := toolModel(t, g, "test/orch-last-model-"+tc.name, func(ctx context.Context, req *ai.ModelRequest, cb ai.ModelStreamCallback) (*ai.ModelResponse, error) {
+				launches := toolOutputs(req.Messages, "delegate_to_researcher")
+				waits := toolOutputs(req.Messages, waitBackgroundTasksToolName)
+				switch {
+				case len(launches) == 0:
+					return toolReqResp(req, &ai.ToolRequest{
+						Name:  "delegate_to_researcher",
+						Input: map[string]any{"task": "dig into X", "background": true},
+					}), nil
+				case len(waits) == 0:
+					release()
+					return toolReqResp(req, &ai.ToolRequest{
+						Name:  waitBackgroundTasksToolName,
+						Input: map[string]any{"taskIds": []string{lenientDelegation(launches[0]).TaskID}},
+					}), nil
+				default:
+					return textResp(req, "done"), nil
+				}
+			})
+
+			resp, err := genkit.Generate(ctx, g, ai.WithModel(orch), ai.WithPrompt("research X"),
+				ai.WithUse(&Agents{Agents: []aix.AgentRef{{Name: "researcher"}}, Async: true}))
+			if err != nil {
+				t.Fatal(err)
+			}
+			waitOuts := toolOutputs(resp.History(), waitBackgroundTasksToolName)
+			if len(waitOuts) != 1 {
+				t.Fatalf("expected 1 wait response, got %d", len(waitOuts))
+			}
+			res := decodeToolOutput[backgroundTasksResult](t, waitOuts[0])
+			if len(res.Tasks) != 1 {
+				t.Fatalf("expected 1 task report, got %+v", res.Tasks)
+			}
+			got := res.Tasks[0]
+			if got.Status != string(aix.SnapshotStatusCompleted) {
+				t.Errorf("Status = %q, want %q", got.Status, aix.SnapshotStatusCompleted)
+			}
+			if got.Response != tc.wantResponse {
+				t.Errorf("Response = %q, want %q", got.Response, tc.wantResponse)
+			}
+			if got.Error != "" {
+				t.Errorf("Error = %q, want empty: the task succeeded", got.Error)
+			}
+		})
 	}
 }
 

--- a/go/plugins/middleware/exp/agents_async_test.go
+++ b/go/plugins/middleware/exp/agents_async_test.go
@@ -347,3 +347,87 @@ func TestAgentsBackgroundLaunchRejectedWithoutStore(t *testing.T) {
 		}
 	}
 }
+
+// TestAgentsAsyncInstancesCoexistWithPrefixes pins that two Async middleware
+// instances with distinct explicit prefixes can share one generate call: the
+// background-task tools are namespaced per instance, so the request is not
+// rejected as carrying duplicate tools.
+func TestAgentsAsyncInstancesCoexistWithPrefixes(t *testing.T) {
+	g := newTestGenkit(t)
+
+	genkitx.DefineAgent[any](g, "researcher",
+		aix.InlinePrompt{ai.WithModel(toolModel(t, g, "test/researcher-coexist", func(ctx context.Context, req *ai.ModelRequest, cb ai.ModelStreamCallback) (*ai.ModelResponse, error) {
+			return textResp(req, "unused"), nil
+		}))},
+		aix.WithSessionStore[any](localstore.NewInMemorySessionStore[any]()),
+	)
+
+	model := toolModel(t, g, "test/orch-coexist", func(ctx context.Context, req *ai.ModelRequest, cb ai.ModelStreamCallback) (*ai.ModelResponse, error) {
+		return textResp(req, "done"), nil
+	})
+
+	research, code := "research", "code"
+	resp, err := genkit.Generate(ctx, g, ai.WithModel(model), ai.WithPrompt("go"),
+		ai.WithUse(
+			&Agents{Agents: []aix.AgentRef{{Name: "researcher"}}, ToolPrefix: &research, Async: true},
+			&Agents{Agents: []aix.AgentRef{{Name: "researcher"}}, ToolPrefix: &code, Async: true},
+		))
+	if err != nil {
+		t.Fatalf("two prefixed Async instances should coexist, got %v", err)
+	}
+	if resp.Text() != "done" {
+		t.Fatalf("unexpected response: %q", resp.Text())
+	}
+}
+
+// TestAgentsWaitTimeoutOverflowIsUnbounded pins the timeoutSeconds overflow
+// clamp: a value too large for the nanosecond multiplication is treated as
+// unbounded rather than wrapping negative into an already-expired context, so
+// the wait still settles its tasks normally instead of returning instantly
+// with timedOut and unresolved statuses.
+func TestAgentsWaitTimeoutOverflowIsUnbounded(t *testing.T) {
+	fastTaskPolling(t)
+	g := newTestGenkit(t)
+
+	genkitx.DefineAgent[any](g, "researcher",
+		aix.InlinePrompt{ai.WithModel(toolModel(t, g, "test/researcher-overflow", func(ctx context.Context, req *ai.ModelRequest, cb ai.ModelStreamCallback) (*ai.ModelResponse, error) {
+			return textResp(req, "unused"), nil
+		}))},
+		aix.WithSessionStore[any](localstore.NewInMemorySessionStore[any]()),
+	)
+
+	// A missing snapshot on a configured agent settles on the first pass
+	// (NOT_FOUND is a dead end), so the wait returns without waiting out the
+	// absurd timeout; before the clamp, the dead context instead failed every
+	// read and the result came back timedOut with a read error.
+	waiter := toolModel(t, g, "test/orch-overflow", func(ctx context.Context, req *ai.ModelRequest, cb ai.ModelStreamCallback) (*ai.ModelResponse, error) {
+		if hasToolResponse(req.Messages) {
+			return textResp(req, "collected"), nil
+		}
+		return toolReqResp(req, &ai.ToolRequest{
+			Name: waitBackgroundTasksToolName,
+			Input: map[string]any{
+				"taskIds":        []string{"researcher:no-such-snapshot"},
+				"timeoutSeconds": float64(10000000000),
+			},
+		}), nil
+	})
+	resp, err := genkit.Generate(ctx, g, ai.WithModel(waiter), ai.WithPrompt("collect"),
+		ai.WithUse(&Agents{Agents: []aix.AgentRef{{Name: "researcher"}}, Async: true}))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	waitOuts := toolOutputs(resp.History(), waitBackgroundTasksToolName)
+	if len(waitOuts) != 1 {
+		t.Fatalf("expected 1 wait response, got %d", len(waitOuts))
+	}
+	res := decodeTaskReports(t, waitOuts[0])
+	if res.TimedOut {
+		t.Errorf("overflowed timeout must behave as unbounded, got timedOut result: %+v", res)
+	}
+	if len(res.Tasks) != 1 || res.Tasks[0].Status != taskStatusUnknown ||
+		!strings.Contains(res.Tasks[0].Error, "not found") {
+		t.Errorf("expected the missing snapshot to settle as unknown/not-found, got %+v", res.Tasks)
+	}
+}

--- a/go/plugins/middleware/exp/agents_async_test.go
+++ b/go/plugins/middleware/exp/agents_async_test.go
@@ -30,37 +30,9 @@ import (
 	genkitx "github.com/firebase/genkit/go/genkit/exp"
 )
 
-// toolOutputs collects the raw outputs of every tool response for toolName.
-func toolOutputs(msgs []*ai.Message, toolName string) []any {
-	var out []any
-	for _, m := range msgs {
-		for _, p := range m.Content {
-			if p.IsToolResponse() && p.ToolResponse != nil && p.ToolResponse.Name == toolName {
-				out = append(out, p.ToolResponse.Output)
-			}
-		}
-	}
-	return out
-}
-
-// decodeTaskReports re-decodes a tool response output into a
-// backgroundTasksResult, tolerating either the raw struct or a JSON-normalized
-// map.
-func decodeTaskReports(t *testing.T, v any) backgroundTasksResult {
-	t.Helper()
-	b, err := json.Marshal(v)
-	if err != nil {
-		t.Fatalf("marshal tool output: %v", err)
-	}
-	var res backgroundTasksResult
-	if err := json.Unmarshal(b, &res); err != nil {
-		t.Fatalf("unmarshal backgroundTasksResult: %v", err)
-	}
-	return res
-}
-
 // lenientDelegation decodes a delegation tool output without failing the test,
-// for use inside model functions.
+// for use inside model functions, where t.Fatalf would fire on the wrong
+// goroutine.
 func lenientDelegation(v any) delegationResult {
 	var dr delegationResult
 	if b, err := json.Marshal(v); err == nil {
@@ -167,7 +139,7 @@ func TestAgentsAsyncDelegationLifecycle(t *testing.T) {
 	if len(checkOuts) != 1 {
 		t.Fatalf("expected 1 check response, got %d", len(checkOuts))
 	}
-	check := decodeTaskReports(t, checkOuts[0])
+	check := decodeToolOutput[backgroundTasksResult](t, checkOuts[0])
 	if len(check.Tasks) != 1 || check.Tasks[0].Status != "pending" {
 		t.Errorf("check while gated: want 1 pending task, got %+v", check.Tasks)
 	}
@@ -176,7 +148,7 @@ func TestAgentsAsyncDelegationLifecycle(t *testing.T) {
 	if len(waitOuts) != 1 {
 		t.Fatalf("expected 1 wait response, got %d", len(waitOuts))
 	}
-	wait := decodeTaskReports(t, waitOuts[0])
+	wait := decodeToolOutput[backgroundTasksResult](t, waitOuts[0])
 	if len(wait.Tasks) != 1 {
 		t.Fatalf("expected 1 waited task, got %+v", wait.Tasks)
 	}
@@ -251,7 +223,7 @@ func TestAgentsBackgroundTasksPickUpAcrossInstantiations(t *testing.T) {
 	if len(waitOuts) != 1 {
 		t.Fatalf("expected 1 wait response, got %d", len(waitOuts))
 	}
-	res := decodeTaskReports(t, waitOuts[0])
+	res := decodeToolOutput[backgroundTasksResult](t, waitOuts[0])
 	if len(res.Tasks) != 3 {
 		t.Fatalf("expected 3 task reports, got %+v", res.Tasks)
 	}
@@ -410,7 +382,7 @@ func TestAgentsWaitTimeoutOverflowIsUnbounded(t *testing.T) {
 	if len(waitOuts) != 1 {
 		t.Fatalf("expected 1 wait response, got %d", len(waitOuts))
 	}
-	res := decodeTaskReports(t, waitOuts[0])
+	res := decodeToolOutput[backgroundTasksResult](t, waitOuts[0])
 	if res.TimedOut {
 		t.Errorf("overflowed timeout must behave as unbounded, got timedOut result: %+v", res)
 	}

--- a/go/plugins/middleware/exp/agents_async_test.go
+++ b/go/plugins/middleware/exp/agents_async_test.go
@@ -19,6 +19,7 @@ package exp
 import (
 	"context"
 	"encoding/json"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -27,6 +28,7 @@ import (
 	"github.com/firebase/genkit/go/ai"
 	aix "github.com/firebase/genkit/go/ai/exp"
 	"github.com/firebase/genkit/go/ai/exp/localstore"
+	"github.com/firebase/genkit/go/core/status"
 	"github.com/firebase/genkit/go/genkit"
 	genkitx "github.com/firebase/genkit/go/genkit/exp"
 )
@@ -703,10 +705,7 @@ func TestAgentsAbortAfterCompletionReportsTheResult(t *testing.T) {
 	// Launch and settle the task outside the middleware. Collecting it through
 	// the tools first would cache its report, and the abort would then answer
 	// from that cache without ever dispatching the call under test.
-	h, err := genkitx.LookupAgent(g, "researcher")
-	if err != nil {
-		t.Fatal(err)
-	}
+	h := genkitx.LookupAgent(g, "researcher")
 	task, err := h.Start(ctx, &aix.AgentInput{Message: ai.NewUserTextMessage("dig into X")})
 	if err != nil {
 		t.Fatal(err)
@@ -731,5 +730,104 @@ func TestAgentsAbortAfterCompletionReportsTheResult(t *testing.T) {
 	if len(got.Artifacts) != 1 || got.Artifacts[0].Name != wantArtifact ||
 		!strings.Contains(got.Artifacts[0].Content, "the findings body") {
 		t.Errorf("unexpected artifacts (want %q with inline content): %+v", wantArtifact, got.Artifacts)
+	}
+}
+
+// TestFoldDelegationNonAnswerReasons pins what an orchestrator is told when a
+// turn ends without an answer. Every reason that carries no result has to read
+// as a failure and has to say what actually happened: reporting the agent's
+// last words as the response hands partial work over as if it were final, and
+// reporting a bare placeholder discards the only account of the outcome a
+// completed-but-failed row ever carries.
+func TestFoldDelegationNonAnswerReasons(t *testing.T) {
+	a := &Agents{Agents: []aix.AgentRef{{Name: "researcher"}}}
+	ref := aix.AgentRef{Name: "researcher"}
+	tip := ai.NewModelTextMessage("partial notes: found 3 of 5 sources")
+
+	for _, reason := range []aix.AgentFinishReason{
+		aix.AgentFinishReasonFailed,
+		aix.AgentFinishReasonBlocked,
+		aix.AgentFinishReasonLength,
+		aix.AgentFinishReasonAborted,
+	} {
+		t.Run(string(reason), func(t *testing.T) {
+			got := a.foldDelegationOutput(t.Context(), ref,
+				&aix.AgentOutput[json.RawMessage]{FinishReason: reason, Message: tip}, "researcher_x")
+			if !strings.Contains(got.Response, "Error calling agent") {
+				t.Errorf("Response = %q, want it reported as a failure", got.Response)
+			}
+			if !strings.Contains(got.Response, string(reason)) {
+				t.Errorf("Response = %q, want it to name the finish reason %q", got.Response, reason)
+			}
+			// The agent's last words explain the outcome; losing them leaves
+			// the model with nothing it can act on.
+			if !strings.Contains(got.Response, "found 3 of 5 sources") {
+				t.Errorf("Response = %q, want the agent's last message kept", got.Response)
+			}
+		})
+	}
+
+	// A structured failure still wins: it is the better explanation.
+	got := a.foldDelegationOutput(t.Context(), ref, &aix.AgentOutput[json.RawMessage]{
+		FinishReason: aix.AgentFinishReasonFailed,
+		Message:      tip,
+		Error:        &status.Error{Status: status.Internal, Message: "upstream model refused"},
+	}, "researcher_x")
+	if !strings.Contains(got.Response, "upstream model refused") {
+		t.Errorf("Response = %q, want the structured failure preferred", got.Response)
+	}
+
+	// A reason that does carry a result is untouched.
+	got = a.foldDelegationOutput(t.Context(), ref,
+		&aix.AgentOutput[json.RawMessage]{FinishReason: aix.AgentFinishReasonStop, Message: tip}, "researcher_x")
+	if got.Response != "partial notes: found 3 of 5 sources" {
+		t.Errorf("Response = %q, want the message reported as the answer", got.Response)
+	}
+}
+
+// TestBackgroundTaskToolsAcceptNoArguments covers the call a model makes by
+// mistake. taskIds must be omissible: a required field fails decoding, and a
+// tool-input decode failure is not a turn the model can correct, it fails the
+// whole generate call.
+func TestBackgroundTaskToolsAcceptNoArguments(t *testing.T) {
+	g := newTestGenkit(t)
+	genkitx.DefineCustomAgent[any](g, "researcher",
+		func(ctx context.Context, resp aix.Responder, sess *aix.SessionRunner[any]) (*aix.AgentResult, error) {
+			return &aix.AgentResult{}, nil
+		},
+		aix.WithSessionStore[any](localstore.NewInMemorySessionStore[any]()),
+	)
+
+	mw := &Agents{Agents: []aix.AgentRef{{Name: "researcher"}}, Async: true}
+	hooks, err := mw.New(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	names := mw.backgroundToolNames().all()
+	byName := map[string]ai.Tool{}
+	for _, tool := range hooks.Tools {
+		byName[tool.Name()] = tool
+	}
+	for _, name := range names {
+		t.Run(name, func(t *testing.T) {
+			tool, ok := byName[name]
+			if !ok {
+				t.Fatalf("tool %q not registered", name)
+			}
+			// The schema must not require taskIds. Asserting on that field
+			// rather than on an empty required list keeps this passing if a
+			// genuinely required field is added later.
+			if req, _ := tool.Definition().InputSchema["required"].([]any); slices.Contains(req, any("taskIds")) {
+				t.Errorf("input schema requires %v; an omitted taskIds must decode", req)
+			}
+			out, err := tool.RunRaw(ctx, map[string]any{})
+			if err != nil {
+				t.Fatalf("calling %q with no arguments returned an error, which fails the whole generate: %v", name, err)
+			}
+			res := decodeToolOutput[backgroundTasksResult](t, out)
+			if res.Note == "" {
+				t.Errorf("Note is empty; want the guidance that tells the model what to pass")
+			}
+		})
 	}
 }

--- a/go/plugins/middleware/exp/agents_async_test.go
+++ b/go/plugins/middleware/exp/agents_async_test.go
@@ -1,0 +1,349 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package exp
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/firebase/genkit/go/ai"
+	aix "github.com/firebase/genkit/go/ai/exp"
+	"github.com/firebase/genkit/go/ai/exp/localstore"
+	"github.com/firebase/genkit/go/genkit"
+	genkitx "github.com/firebase/genkit/go/genkit/exp"
+)
+
+// fastTaskPolling shortens the wait tool's poll interval for the test.
+func fastTaskPolling(t *testing.T) {
+	t.Helper()
+	restore := backgroundTaskPollInterval
+	backgroundTaskPollInterval = 10 * time.Millisecond
+	t.Cleanup(func() { backgroundTaskPollInterval = restore })
+}
+
+// toolOutputs collects the raw outputs of every tool response for toolName.
+func toolOutputs(msgs []*ai.Message, toolName string) []any {
+	var out []any
+	for _, m := range msgs {
+		for _, p := range m.Content {
+			if p.IsToolResponse() && p.ToolResponse != nil && p.ToolResponse.Name == toolName {
+				out = append(out, p.ToolResponse.Output)
+			}
+		}
+	}
+	return out
+}
+
+// decodeTaskReports re-decodes a tool response output into a
+// backgroundTasksResult, tolerating either the raw struct or a JSON-normalized
+// map.
+func decodeTaskReports(t *testing.T, v any) backgroundTasksResult {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal tool output: %v", err)
+	}
+	var res backgroundTasksResult
+	if err := json.Unmarshal(b, &res); err != nil {
+		t.Fatalf("unmarshal backgroundTasksResult: %v", err)
+	}
+	return res
+}
+
+// lenientDelegation decodes a delegation tool output without failing the test,
+// for use inside model functions.
+func lenientDelegation(v any) delegationResult {
+	var dr delegationResult
+	if b, err := json.Marshal(v); err == nil {
+		_ = json.Unmarshal(b, &dr)
+	}
+	return dr
+}
+
+// TestAgentsAsyncDelegationLifecycle drives the full background flow in one
+// generate call: launch with background=true, observe pending via the check
+// tool while the sub-agent is still gated, then release the gate and collect
+// the completed result (response and inline artifact) via the wait tool.
+func TestAgentsAsyncDelegationLifecycle(t *testing.T) {
+	fastTaskPolling(t)
+	g := newTestGenkit(t)
+
+	// Gate the sub-agent so the task stays pending until the orchestrator has
+	// observed the pending status.
+	gate := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() { releaseOnce.Do(func() { close(gate) }) }
+	t.Cleanup(release)
+
+	genkitx.DefineCustomAgent[any](g, "researcher",
+		func(ctx context.Context, resp aix.Responder, sess *aix.SessionRunner[any]) (*aix.AgentResult, error) {
+			var last *ai.Message
+			err := sess.Run(ctx, func(ctx context.Context, input *aix.AgentInput) (*aix.TurnResult, error) {
+				select {
+				case <-gate:
+				case <-ctx.Done():
+					return nil, ctx.Err()
+				}
+				resp.SendArtifact(&aix.Artifact{
+					Name:  "findings.md",
+					Parts: []*ai.Part{ai.NewTextPart("the findings body")},
+				})
+				last = ai.NewModelTextMessage("research complete")
+				sess.AddMessages(last)
+				return &aix.TurnResult{FinishReason: aix.AgentFinishReasonStop}, nil
+			})
+			if err != nil {
+				return nil, err
+			}
+			return &aix.AgentResult{Message: last, Artifacts: sess.Artifacts()}, nil
+		},
+		aix.WithSessionStore[any](localstore.NewInMemorySessionStore[any]()),
+	)
+
+	// Scripted orchestrator: launch in background, check, release the gate,
+	// wait, then finish. Each step keys off the tool responses accumulated in
+	// the request so far.
+	var capturedSystem string
+	orch := toolModel(t, g, "test/orch-async", func(ctx context.Context, req *ai.ModelRequest, cb ai.ModelStreamCallback) (*ai.ModelResponse, error) {
+		if sys := findSystem(req.Messages); sys != nil {
+			capturedSystem = systemText(sys)
+		}
+		launches := toolOutputs(req.Messages, "delegate_to_researcher")
+		checks := toolOutputs(req.Messages, checkBackgroundTasksToolName)
+		waits := toolOutputs(req.Messages, waitBackgroundTasksToolName)
+		switch {
+		case len(launches) == 0:
+			return toolReqResp(req, &ai.ToolRequest{
+				Name:  "delegate_to_researcher",
+				Input: map[string]any{"task": "dig into X", "background": true},
+			}), nil
+		case len(checks) == 0:
+			return toolReqResp(req, &ai.ToolRequest{
+				Name:  checkBackgroundTasksToolName,
+				Input: map[string]any{"taskIds": []string{lenientDelegation(launches[0]).TaskID}},
+			}), nil
+		case len(waits) == 0:
+			release()
+			return toolReqResp(req, &ai.ToolRequest{
+				Name:  waitBackgroundTasksToolName,
+				Input: map[string]any{"taskIds": []string{lenientDelegation(launches[0]).TaskID}},
+			}), nil
+		default:
+			return textResp(req, "done"), nil
+		}
+	})
+
+	mw := &Agents{Agents: []aix.AgentRef{{Name: "researcher"}}, Async: true}
+	resp, err := genkit.Generate(ctx, g, ai.WithModel(orch), ai.WithPrompt("research X"), ai.WithUse(mw))
+	if err != nil {
+		t.Fatal(err)
+	}
+	history := resp.History()
+
+	for _, want := range []string{"background", checkBackgroundTasksToolName, waitBackgroundTasksToolName} {
+		if !strings.Contains(capturedSystem, want) {
+			t.Errorf("async system prompt missing %q; got:\n%s", want, capturedSystem)
+		}
+	}
+
+	launches := delegationResponses(t, history, "delegate_to_researcher")
+	if len(launches) != 1 {
+		t.Fatalf("expected 1 launch response, got %d", len(launches))
+	}
+	launch := launches[0]
+	if launch.Status != "pending" || !strings.HasPrefix(launch.TaskID, "researcher:") {
+		t.Fatalf("unexpected launch result: %+v", launch)
+	}
+
+	checkOuts := toolOutputs(history, checkBackgroundTasksToolName)
+	if len(checkOuts) != 1 {
+		t.Fatalf("expected 1 check response, got %d", len(checkOuts))
+	}
+	check := decodeTaskReports(t, checkOuts[0])
+	if len(check.Tasks) != 1 || check.Tasks[0].Status != "pending" {
+		t.Errorf("check while gated: want 1 pending task, got %+v", check.Tasks)
+	}
+
+	waitOuts := toolOutputs(history, waitBackgroundTasksToolName)
+	if len(waitOuts) != 1 {
+		t.Fatalf("expected 1 wait response, got %d", len(waitOuts))
+	}
+	wait := decodeTaskReports(t, waitOuts[0])
+	if len(wait.Tasks) != 1 {
+		t.Fatalf("expected 1 waited task, got %+v", wait.Tasks)
+	}
+	task := wait.Tasks[0]
+	if task.Status != "completed" || task.Response != "research complete" || task.Agent != "researcher" {
+		t.Errorf("unexpected completed report: %+v", task)
+	}
+	snapshotID := strings.TrimPrefix(launch.TaskID, "researcher:")
+	wantArtifact := "researcher_" + shortSnapshotID(snapshotID) + "/findings.md"
+	if len(task.Artifacts) != 1 || task.Artifacts[0].Name != wantArtifact ||
+		!strings.Contains(task.Artifacts[0].Content, "the findings body") {
+		t.Errorf("unexpected artifacts (want %q with inline content): %+v", wantArtifact, task.Artifacts)
+	}
+}
+
+// TestAgentsBackgroundTasksPickUpAcrossInstantiations launches a background
+// task in one generate call and collects it in a second call through a fresh
+// middleware instance, using only the task ID recorded in the first call's
+// history: the pickup path a re-instantiated orchestrator relies on. The wait
+// also carries two unusable handles to verify per-task error isolation.
+func TestAgentsBackgroundTasksPickUpAcrossInstantiations(t *testing.T) {
+	fastTaskPolling(t)
+	g := newTestGenkit(t)
+
+	genkitx.DefineAgent[any](g, "researcher",
+		aix.InlinePrompt{ai.WithModel(toolModel(t, g, "test/researcher-bg", func(ctx context.Context, req *ai.ModelRequest, cb ai.ModelStreamCallback) (*ai.ModelResponse, error) {
+			return textResp(req, "background answer"), nil
+		}))},
+		aix.WithSessionStore[any](localstore.NewInMemorySessionStore[any]()),
+	)
+
+	// First call: launch in the background and stop without waiting.
+	launcher := toolModel(t, g, "test/orch-launch", func(ctx context.Context, req *ai.ModelRequest, cb ai.ModelStreamCallback) (*ai.ModelResponse, error) {
+		if hasToolResponse(req.Messages) {
+			return textResp(req, "launched"), nil
+		}
+		return toolReqResp(req, &ai.ToolRequest{
+			Name:  "delegate_to_researcher",
+			Input: map[string]any{"task": "long dig", "background": true},
+		}), nil
+	})
+	resp1, err := genkit.Generate(ctx, g, ai.WithModel(launcher), ai.WithPrompt("go"),
+		ai.WithUse(&Agents{Agents: []aix.AgentRef{{Name: "researcher"}}, Async: true}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	launches := delegationResponses(t, resp1.History(), "delegate_to_researcher")
+	if len(launches) != 1 || launches[0].TaskID == "" {
+		t.Fatalf("expected a launch with a task ID, got %+v", launches)
+	}
+	taskID := launches[0].TaskID
+
+	// Second call, fresh middleware instance: wait on the recorded task ID
+	// plus a missing snapshot and an unconfigured agent.
+	badSnapshot := "researcher:no-such-snapshot"
+	badAgent := "ghost:whatever"
+	waiter := toolModel(t, g, "test/orch-wait", func(ctx context.Context, req *ai.ModelRequest, cb ai.ModelStreamCallback) (*ai.ModelResponse, error) {
+		if hasToolResponse(req.Messages) {
+			return textResp(req, "collected"), nil
+		}
+		return toolReqResp(req, &ai.ToolRequest{
+			Name:  waitBackgroundTasksToolName,
+			Input: map[string]any{"taskIds": []string{taskID, badSnapshot, badAgent}},
+		}), nil
+	})
+	resp2, err := genkit.Generate(ctx, g, ai.WithModel(waiter), ai.WithPrompt("collect"),
+		ai.WithUse(&Agents{Agents: []aix.AgentRef{{Name: "researcher"}}, Async: true}))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	waitOuts := toolOutputs(resp2.History(), waitBackgroundTasksToolName)
+	if len(waitOuts) != 1 {
+		t.Fatalf("expected 1 wait response, got %d", len(waitOuts))
+	}
+	res := decodeTaskReports(t, waitOuts[0])
+	if len(res.Tasks) != 3 {
+		t.Fatalf("expected 3 task reports, got %+v", res.Tasks)
+	}
+	if got := res.Tasks[0]; got.Status != "completed" || got.Response != "background answer" {
+		t.Errorf("picked-up task: want completed with the sub-agent's answer, got %+v", got)
+	}
+	// "Delegate the task again" is the not-found sentinel branch: it proves
+	// errors.Is matched aix.ErrSnapshotNotFound through the companion action,
+	// rather than the generic read-failure branch relaying the same text.
+	if got := res.Tasks[1]; got.Status != taskStatusUnknown ||
+		!strings.Contains(got.Error, "not found") || !strings.Contains(got.Error, "Delegate the task again") {
+		t.Errorf("missing snapshot: want unknown with the not-found guidance, got %+v", got)
+	}
+	if got := res.Tasks[2]; got.Status != taskStatusUnknown || !strings.Contains(got.Error, "does not match any configured agent") {
+		t.Errorf("unconfigured agent: want unknown with a no-match error, got %+v", got)
+	}
+	if res.TimedOut {
+		t.Errorf("wait should settle without timing out, got %+v", res)
+	}
+}
+
+// TestResolveTaskIDLongestPrefix pins the longest-prefix rule: a configured
+// name containing ':' keeps its tasks even when another configured name is a
+// prefix of it, regardless of configuration order.
+func TestResolveTaskIDLongestPrefix(t *testing.T) {
+	a := &Agents{Agents: []aix.AgentRef{{Name: "a"}, {Name: "a:b"}}}
+	ref, snap, err := a.resolveTaskID("a:b:1234")
+	if err != nil || ref.Name != "a:b" || snap != "1234" {
+		t.Fatalf("resolveTaskID(a:b:1234) = %q, %q, %v; want a:b, 1234", ref.Name, snap, err)
+	}
+	ref, snap, err = a.resolveTaskID("a:5678")
+	if err != nil || ref.Name != "a" || snap != "5678" {
+		t.Fatalf("resolveTaskID(a:5678) = %q, %q, %v; want a, 5678", ref.Name, snap, err)
+	}
+	if _, _, err := a.resolveTaskID("ghost:1"); err == nil {
+		t.Error("expected an error for an unconfigured agent")
+	}
+	if _, _, err := a.resolveTaskID("a:"); err == nil {
+		t.Error("expected an error for an empty snapshot ID")
+	}
+}
+
+// TestAgentsBackgroundLaunchRejectedWithoutStore verifies that launching a
+// background delegation on a sub-agent that cannot detach (no session store)
+// reports the runtime's rejection plus the synchronous-fallback hint. The hint
+// hangs off the FAILED_PRECONDITION status of the wire-decoded error: the
+// sentinel itself does not survive JSON, so the status name is the contract.
+func TestAgentsBackgroundLaunchRejectedWithoutStore(t *testing.T) {
+	g := newTestGenkit(t)
+
+	genkitx.DefineAgent[any](g, "researcher",
+		aix.InlinePrompt{ai.WithModel(toolModel(t, g, "test/researcher-nostore", func(ctx context.Context, req *ai.ModelRequest, cb ai.ModelStreamCallback) (*ai.ModelResponse, error) {
+			return textResp(req, "should never be needed"), nil
+		}))},
+	)
+
+	orch := toolModel(t, g, "test/orch-nostore", func(ctx context.Context, req *ai.ModelRequest, cb ai.ModelStreamCallback) (*ai.ModelResponse, error) {
+		if hasToolResponse(req.Messages) {
+			return textResp(req, "done"), nil
+		}
+		return toolReqResp(req, &ai.ToolRequest{
+			Name:  "delegate_to_researcher",
+			Input: map[string]any{"task": "dig", "background": true},
+		}), nil
+	})
+
+	resp, err := genkit.Generate(ctx, g, ai.WithModel(orch), ai.WithPrompt("go"),
+		ai.WithUse(&Agents{Agents: []aix.AgentRef{{Name: "researcher"}}, Async: true}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := delegationResponses(t, resp.History(), "delegate_to_researcher")
+	if len(got) != 1 {
+		t.Fatalf("expected 1 delegation response, got %d", len(got))
+	}
+	if got[0].TaskID != "" {
+		t.Errorf("rejected launch must not hand out a task ID, got %+v", got[0])
+	}
+	for _, want := range []string{"Error calling agent", "session store that supports background work", "without \"background\""} {
+		if !strings.Contains(got[0].Response, want) {
+			t.Errorf("rejection response missing %q; got %q", want, got[0].Response)
+		}
+	}
+}

--- a/go/plugins/middleware/exp/agents_test.go
+++ b/go/plugins/middleware/exp/agents_test.go
@@ -87,31 +87,40 @@ func delegateOnceModel(t *testing.T, g *genkit.Genkit, name, toolName, task stri
 	})
 }
 
-// decodeDelegation re-decodes a tool response output into a delegationResult,
-// tolerating either the raw struct or a JSON-normalized map.
-func decodeDelegation(t *testing.T, v any) delegationResult {
+// toolOutputs collects the raw outputs of every tool response for toolName.
+func toolOutputs(msgs []*ai.Message, toolName string) []any {
+	var out []any
+	for _, m := range msgs {
+		for _, p := range m.Content {
+			if p.IsToolResponse() && p.ToolResponse != nil && p.ToolResponse.Name == toolName {
+				out = append(out, p.ToolResponse.Output)
+			}
+		}
+	}
+	return out
+}
+
+// decodeToolOutput re-decodes a tool response output into T, tolerating either
+// the raw struct or a JSON-normalized map.
+func decodeToolOutput[T any](t *testing.T, v any) T {
 	t.Helper()
+	var decoded T
 	b, err := json.Marshal(v)
 	if err != nil {
 		t.Fatalf("marshal tool output: %v", err)
 	}
-	var dr delegationResult
-	if err := json.Unmarshal(b, &dr); err != nil {
-		t.Fatalf("unmarshal delegationResult: %v", err)
+	if err := json.Unmarshal(b, &decoded); err != nil {
+		t.Fatalf("unmarshal %T: %v", decoded, err)
 	}
-	return dr
+	return decoded
 }
 
 // delegationResponses collects every delegation tool response for toolName.
 func delegationResponses(t *testing.T, msgs []*ai.Message, toolName string) []delegationResult {
 	t.Helper()
 	var out []delegationResult
-	for _, m := range msgs {
-		for _, p := range m.Content {
-			if p.IsToolResponse() && p.ToolResponse != nil && p.ToolResponse.Name == toolName {
-				out = append(out, decodeDelegation(t, p.ToolResponse.Output))
-			}
-		}
+	for _, v := range toolOutputs(msgs, toolName) {
+		out = append(out, decodeToolOutput[delegationResult](t, v))
 	}
 	return out
 }

--- a/go/plugins/middleware/exp/agents_test.go
+++ b/go/plugins/middleware/exp/agents_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/firebase/genkit/go/ai"
 	aix "github.com/firebase/genkit/go/ai/exp"
+	"github.com/firebase/genkit/go/core/status"
 	"github.com/firebase/genkit/go/genkit"
 	genkitx "github.com/firebase/genkit/go/genkit/exp"
 )
@@ -116,11 +117,11 @@ func delegationResponses(t *testing.T, msgs []*ai.Message, toolName string) []de
 }
 
 func TestAgentsValidation(t *testing.T) {
-	if _, err := (&Agents{}).New(ctx); err == nil {
-		t.Error("expected error when no agents are configured")
+	if _, err := (&Agents{}).New(ctx); !errors.Is(err, status.ErrInvalidArgument) {
+		t.Errorf("expected an INVALID_ARGUMENT error when no agents are configured, got %v", err)
 	}
-	if _, err := (&Agents{Agents: []aix.AgentRef{{Name: ""}}}).New(ctx); err == nil {
-		t.Error("expected error when an agent reference has no name")
+	if _, err := (&Agents{Agents: []aix.AgentRef{{Name: ""}}}).New(ctx); !errors.Is(err, status.ErrInvalidArgument) {
+		t.Errorf("expected an INVALID_ARGUMENT error when an agent reference has no name, got %v", err)
 	}
 	if _, err := (&Agents{Agents: []aix.AgentRef{{Name: "ok"}}}).New(ctx); err != nil {
 		t.Errorf("unexpected error for a valid config: %v", err)
@@ -526,6 +527,7 @@ func TestAgentsConfigSerialization(t *testing.T) {
 		MaxDelegations:   3,
 		HistoryLength:    2,
 		ArtifactStrategy: ArtifactStrategySession,
+		Async:            true,
 	}
 	b, err := json.Marshal(cfg)
 	if err != nil {
@@ -543,6 +545,9 @@ func TestAgentsConfigSerialization(t *testing.T) {
 	}
 	if got.ArtifactStrategy != ArtifactStrategySession {
 		t.Errorf("artifactStrategy lost in round trip: %q", got.ArtifactStrategy)
+	}
+	if !got.Async {
+		t.Error("async lost in round trip")
 	}
 }
 

--- a/go/plugins/middleware/exp/agents_test.go
+++ b/go/plugins/middleware/exp/agents_test.go
@@ -126,7 +126,51 @@ func TestAgentsValidation(t *testing.T) {
 	if _, err := (&Agents{Agents: []aix.AgentRef{{Name: "ok"}}}).New(ctx); err != nil {
 		t.Errorf("unexpected error for a valid config: %v", err)
 	}
+
+	// Generated tool names are validated as a set at New time, so collisions
+	// surface as a config error instead of a generate-time duplicate-tool
+	// rejection of the whole request.
+	if _, err := (&Agents{Agents: []aix.AgentRef{{Name: "dup"}, {Name: "dup"}}}).New(ctx); !errors.Is(err, status.ErrInvalidArgument) {
+		t.Errorf("expected an INVALID_ARGUMENT error for duplicate agent names, got %v", err)
+	}
+	// With a bare prefix, a delegation tool can land exactly on a shared
+	// background-task tool's name.
+	bare := ""
+	collide := &Agents{
+		Agents:     []aix.AgentRef{{Name: "check_background_tasks"}},
+		ToolPrefix: &bare,
+		Async:      true,
+	}
+	if _, err := collide.New(ctx); !errors.Is(err, status.ErrInvalidArgument) {
+		t.Errorf("expected an INVALID_ARGUMENT error when a delegation tool collides with a background-task tool, got %v", err)
+	}
 }
+
+func TestAgentsBackgroundToolNames(t *testing.T) {
+	// Default and empty prefixes keep the well-known bare names; an explicit
+	// non-empty prefix namespaces them so two Async instances can coexist.
+	cases := []struct {
+		name      string
+		prefix    *string
+		wantCheck string
+		wantWait  string
+	}{
+		{name: "nil prefix", prefix: nil, wantCheck: "check_background_tasks", wantWait: "wait_for_background_tasks"},
+		{name: "empty prefix", prefix: ptr(""), wantCheck: "check_background_tasks", wantWait: "wait_for_background_tasks"},
+		{name: "custom prefix", prefix: ptr("research"), wantCheck: "research_check_background_tasks", wantWait: "research_wait_for_background_tasks"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			a := &Agents{ToolPrefix: tc.prefix}
+			check, wait := a.backgroundToolNames()
+			if check != tc.wantCheck || wait != tc.wantWait {
+				t.Errorf("backgroundToolNames() = %q, %q; want %q, %q", check, wait, tc.wantCheck, tc.wantWait)
+			}
+		})
+	}
+}
+
+func ptr[T any](v T) *T { return &v }
 
 func TestAgentsInjectsSystemPrompt(t *testing.T) {
 	g := newTestGenkit(t)

--- a/go/plugins/middleware/exp/agents_test.go
+++ b/go/plugins/middleware/exp/agents_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"slices"
 	"strings"
 	"testing"
 
@@ -157,23 +158,26 @@ func TestAgentsValidation(t *testing.T) {
 
 func TestAgentsBackgroundToolNames(t *testing.T) {
 	// Default and empty prefixes keep the well-known bare names; an explicit
-	// non-empty prefix namespaces them so two Async instances can coexist.
+	// non-empty prefix namespaces all three so two Async instances can coexist.
+	bare := []string{"check_background_tasks", "wait_for_background_tasks", "abort_background_tasks"}
 	cases := []struct {
-		name      string
-		prefix    *string
-		wantCheck string
-		wantWait  string
+		name   string
+		prefix *string
+		want   []string
 	}{
-		{name: "nil prefix", prefix: nil, wantCheck: "check_background_tasks", wantWait: "wait_for_background_tasks"},
-		{name: "empty prefix", prefix: ptr(""), wantCheck: "check_background_tasks", wantWait: "wait_for_background_tasks"},
-		{name: "custom prefix", prefix: ptr("research"), wantCheck: "research_check_background_tasks", wantWait: "research_wait_for_background_tasks"},
+		{name: "nil prefix", prefix: nil, want: bare},
+		{name: "empty prefix", prefix: ptr(""), want: bare},
+		{name: "custom prefix", prefix: ptr("research"), want: []string{
+			"research_check_background_tasks",
+			"research_wait_for_background_tasks",
+			"research_abort_background_tasks",
+		}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			a := &Agents{ToolPrefix: tc.prefix}
-			check, wait := a.backgroundToolNames()
-			if check != tc.wantCheck || wait != tc.wantWait {
-				t.Errorf("backgroundToolNames() = %q, %q; want %q, %q", check, wait, tc.wantCheck, tc.wantWait)
+			if got := a.backgroundToolNames().all(); !slices.Equal(got, tc.want) {
+				t.Errorf("backgroundToolNames().all() = %q; want %q", got, tc.want)
 			}
 		})
 	}

--- a/go/plugins/middleware/exp/agents_test.go
+++ b/go/plugins/middleware/exp/agents_test.go
@@ -262,9 +262,14 @@ func TestAgentsUnknownAgentReportsError(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	// The refusal names the agent and says it is not registered, which is the
+	// deployment mistake it actually is: the name was configured on this
+	// middleware, so an empty lookup means nothing defined it in this process.
 	got := delegationResponses(t, resp.History(), "delegate_to_ghost")
-	if len(got) != 1 || !strings.Contains(got[0].Response, "not found") {
-		t.Fatalf("expected a 'not found' delegation response, got %+v", got)
+	if len(got) != 1 ||
+		!strings.Contains(got[0].Response, `"ghost"`) ||
+		!strings.Contains(got[0].Response, "not registered") {
+		t.Fatalf("expected a refusal naming the unregistered agent, got %+v", got)
 	}
 }
 

--- a/go/plugins/middleware/exp/artifacts_test.go
+++ b/go/plugins/middleware/exp/artifacts_test.go
@@ -18,7 +18,6 @@ package exp
 
 import (
 	"context"
-	"encoding/json"
 	"strings"
 	"testing"
 
@@ -27,31 +26,6 @@ import (
 	"github.com/firebase/genkit/go/genkit"
 	genkitx "github.com/firebase/genkit/go/genkit/exp"
 )
-
-func toolResponseByName(t *testing.T, msgs []*ai.Message, name string) (any, bool) {
-	t.Helper()
-	for _, m := range msgs {
-		for _, p := range m.Content {
-			if p.IsToolResponse() && p.ToolResponse != nil && p.ToolResponse.Name == name {
-				return p.ToolResponse.Output, true
-			}
-		}
-	}
-	return nil, false
-}
-
-func decodeReadArtifact(t *testing.T, v any) readArtifactOutput {
-	t.Helper()
-	b, err := json.Marshal(v)
-	if err != nil {
-		t.Fatalf("marshal: %v", err)
-	}
-	var o readArtifactOutput
-	if err := json.Unmarshal(b, &o); err != nil {
-		t.Fatalf("unmarshal readArtifactOutput: %v", err)
-	}
-	return o
-}
 
 func TestArtifactsReadonlyOmitsWriteTool(t *testing.T) {
 	hooks, err := (&Artifacts{Readonly: true}).New(ctx)
@@ -110,11 +84,11 @@ func TestArtifactsWriteThenRead(t *testing.T) {
 	}
 
 	// read_artifact returned the content written by write_artifact.
-	v, ok := toolResponseByName(t, statemessages(out), "read_artifact")
-	if !ok {
+	reads := toolOutputs(statemessages(out), "read_artifact")
+	if len(reads) == 0 {
 		t.Fatal("no read_artifact tool response found")
 	}
-	read := decodeReadArtifact(t, v)
+	read := decodeToolOutput[readArtifactOutput](t, reads[0])
 	if !read.Found || read.Content != "hello world" {
 		t.Errorf("read_artifact = %+v, want found with content %q", read, "hello world")
 	}
@@ -192,11 +166,11 @@ func TestArtifactsNoSession(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	v, ok := toolResponseByName(t, resp.History(), "read_artifact")
-	if !ok {
+	reads := toolOutputs(resp.History(), "read_artifact")
+	if len(reads) == 0 {
 		t.Fatal("no read_artifact tool response found")
 	}
-	read := decodeReadArtifact(t, v)
+	read := decodeToolOutput[readArtifactOutput](t, reads[0])
 	if read.Found || !strings.Contains(read.Content, "no active session") {
 		t.Errorf("expected a no-active-session result, got %+v", read)
 	}

--- a/go/samples/basic-agents/cli.go
+++ b/go/samples/basic-agents/cli.go
@@ -987,68 +987,19 @@ func summarizeLatest[State any](ctx context.Context, a *aix.Agent[State], sessio
 		shortID(latest.SnapshotID), latest.Status, msgs, when), ansiDim)
 }
 
-// orphanPoll is how often waitForFinalize re-reads a snapshot it is waiting
-// on. Comfortably under the runtime's heartbeat timeout, so a worker that
-// died is noticed a poll or two after the row goes stale rather than a minute
-// later.
-const orphanPoll = 10 * time.Second
-
-// waitForFinalize subscribes to a snapshot's status and blocks until it
-// transitions out of pending. The returned snapshot is the final one (or
-// nil if it disappeared). OnSnapshotStatusChange yields the current
-// status first, so a snapshot that finalized just before the
-// subscription is observed immediately.
+// waitForFinalize blocks until a snapshot leaves pending and returns the final
+// one, or nil if it disappeared while we waited.
 //
-// The subscription reports the status as stored, which stays pending forever
-// if the background worker died: nothing writes a terminal in its place. So
-// the wait also polls, because a read through the agent surfaces a stale
-// heartbeat as expired and gives the caller something to act on.
-//
-// The status subscription is the optional SnapshotSubscriber capability of
-// the store contract. A store without it cannot stream background progress,
-// so we fall back to reading the snapshot once and returning it as-is.
+// WaitForSnapshot does the waiting, so the CLI does not care how the store it
+// was given observes the change: the agent subscribes where the store can push
+// and re-reads otherwise, and either way a worker that stopped heartbeating
+// ends the wait as expired rather than leaving it hanging.
 func waitForFinalize[State any](ctx context.Context, a *aix.Agent[State], snapshotID string) (*aix.SessionSnapshot[State], error) {
-	// A snapshot that vanished under us reads as an error through the agent
-	// where the raw store returns nil; the callers treat both as "gone".
-	read := func() (*aix.SessionSnapshot[State], error) {
-		snap, err := a.GetSnapshot(ctx, snapshotID)
-		if errors.Is(err, aix.ErrSnapshotNotFound) {
-			return nil, nil
-		}
-		return snap, err
+	final, err := a.WaitForSnapshot(ctx, snapshotID)
+	if errors.Is(err, aix.ErrSnapshotNotFound) {
+		return nil, nil
 	}
-	subscriber, ok := a.Store().(aix.SnapshotSubscriber)
-	if !ok {
-		return read()
-	}
-	subCtx, cancel := context.WithCancel(ctx)
-	defer cancel()
-	statusCh := subscriber.OnSnapshotStatusChange(subCtx, snapshotID)
-	ticker := time.NewTicker(orphanPoll)
-	defer ticker.Stop()
-	for {
-		select {
-		case <-ctx.Done():
-			return nil, ctx.Err()
-		case <-ticker.C:
-			// Expired is not a status anything writes, so it arrives only on
-			// a read. Stop waiting on it: the worker is presumed dead and no
-			// terminal is coming.
-			snap, err := read()
-			if err != nil || snap == nil || snap.Status != aix.SnapshotStatusPending {
-				return snap, err
-			}
-		case status, ok := <-statusCh:
-			if !ok {
-				// Subscription closed (e.g. snapshot deleted under us).
-				return read()
-			}
-			if status == aix.SnapshotStatusPending {
-				continue
-			}
-			return read()
-		}
-	}
+	return final, err
 }
 
 // printHistory replays prior turns in the format the live REPL uses, so a

--- a/go/samples/basic-agents/cli.go
+++ b/go/samples/basic-agents/cli.go
@@ -820,39 +820,19 @@ func summarizeLatest[State any](ctx context.Context, a *aix.Agent[State], sessio
 		shortID(latest.SnapshotID), latest.Status, msgs, when), ansiDim)
 }
 
-// waitForFinalize subscribes to a snapshot's status and blocks until it
-// transitions out of pending. The returned snapshot is the final one (or
-// nil if it disappeared). OnSnapshotStatusChange yields the current
-// status first, so a snapshot that finalized just before the
-// subscription is observed immediately.
+// waitForFinalize blocks until a snapshot leaves pending and returns the final
+// one, or nil if it disappeared while we waited.
 //
-// The status subscription is the optional SnapshotSubscriber capability of
-// the store contract. A store without it cannot stream background progress,
-// so we fall back to reading the snapshot once and returning it as-is.
+// WaitForSnapshot does the waiting, so the CLI does not care how the store it
+// was given observes the change: the agent subscribes where the store can push
+// and re-reads otherwise, and either way a worker that stopped heartbeating
+// ends the wait as expired rather than leaving it hanging.
 func waitForFinalize[State any](ctx context.Context, a *aix.Agent[State], snapshotID string) (*aix.SessionSnapshot[State], error) {
-	store := a.Store()
-	subscriber, ok := store.(aix.SnapshotSubscriber)
-	if !ok {
-		return store.GetSnapshot(ctx, snapshotID)
+	final, err := a.WaitForSnapshot(ctx, snapshotID)
+	if errors.Is(err, aix.ErrSnapshotNotFound) {
+		return nil, nil
 	}
-	subCtx, cancel := context.WithCancel(ctx)
-	defer cancel()
-	statusCh := subscriber.OnSnapshotStatusChange(subCtx, snapshotID)
-	for {
-		select {
-		case <-ctx.Done():
-			return nil, ctx.Err()
-		case status, ok := <-statusCh:
-			if !ok {
-				// Subscription closed (e.g. snapshot deleted under us).
-				return store.GetSnapshot(ctx, snapshotID)
-			}
-			if status == aix.SnapshotStatusPending {
-				continue
-			}
-			return store.GetSnapshot(ctx, snapshotID)
-		}
-	}
+	return final, err
 }
 
 // printHistory replays prior turns in the format the live REPL uses, so a

--- a/go/samples/basic-agents/commander.go
+++ b/go/samples/basic-agents/commander.go
@@ -70,9 +70,9 @@ package main
 import (
 	"context"
 	"fmt"
+	"maps"
 	"math/rand/v2"
 	"slices"
-	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -335,10 +335,6 @@ func slowBackend(ctx context.Context, d time.Duration) error {
 // unknownService names the services that exist instead of failing the turn,
 // so a guessed name costs one tool call rather than the investigation.
 func unknownService(name string, known map[string]string) string {
-	names := make([]string, 0, len(known))
-	for service := range known {
-		names = append(names, service)
-	}
-	sort.Strings(names)
+	names := slices.Sorted(maps.Keys(known))
 	return fmt.Sprintf("No records for %q. Known services: %s.", name, strings.Join(names, ", "))
 }

--- a/go/samples/basic-agents/commander.go
+++ b/go/samples/basic-agents/commander.go
@@ -30,7 +30,8 @@
 // The parts worth reading:
 //
 //   - Agents.Async on the middleware. It adds the "background" flag to every
-//     delegation tool and the two collection tools that go with it.
+//     delegation tool and the three task tools that go with it: check, wait
+//     and abort.
 //   - Both sub-agents have a session store. A background delegation records a
 //     pending snapshot as the durable task, so a store is what makes an agent
 //     able to run in the background at all; a store-less agent is refused at

--- a/go/samples/basic-agents/commander.go
+++ b/go/samples/basic-agents/commander.go
@@ -1,0 +1,268 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// commander.go is the background sub-agent demo.
+//
+// The orchestrator agent delegates and waits: its turn is blocked for as long
+// as the sub-agent runs. This agent cannot afford that. It is an incident
+// commander, and an incident has two clocks that do not agree. The
+// investigation takes as long as it takes. The status update is owed now.
+//
+// So every investigation starts with "background": true. The delegation tool
+// returns a task ID at once and the sub-agent keeps running on a context that
+// outlives the tool call, so the commander posts its first update while the
+// investigators are still reading logs. It collects the results afterwards
+// with wait_for_background_tasks: first with a short timeout, so a slow
+// investigation turns into an interim update instead of silence, then without
+// one.
+//
+// The parts worth reading:
+//
+//   - Agents.Async on the middleware. It adds the "background" flag to every
+//     delegation tool and the two collection tools that go with it.
+//   - Both sub-agents have a session store. A background delegation records a
+//     pending snapshot as the durable task, so a store is what makes an agent
+//     able to run in the background at all; a store-less agent is refused at
+//     launch and the commander is told to delegate to it synchronously.
+//   - The task ID ("<agent>:<snapshotId>") comes back in the delegation tool
+//     result, so it lands in the conversation. Nothing else tracks the task,
+//     which is why a commander rebuilt from its history alone can still
+//     collect the answer.
+//   - Neither investigator is told anything about this conversation. History
+//     is never forwarded to a sub-agent that has a store, so the task text has
+//     to stand alone and each investigator pulls its own input with tools.
+//   - WithMaxTurns. Launching, posting, waiting, posting and waiting again are
+//     all tool rounds, so an orchestrator that collects in the background
+//     needs a higher ceiling than one that blocks on each delegation.
+//
+// Try it with:
+//
+//	checkout-api is throwing 500s and customers can't pay
+//
+// Watch the order of the tool call lines: two delegations, then post_status,
+// then the waits. The task IDs are visible in the wait tool's input.
+//
+// The snapshot outlives the process but the worker does not. Quit while a task
+// is still pending and its heartbeat goes stale, so a later check reports it
+// as expired rather than resuming it. Let the tasks settle first and their
+// results are still on disk for the next run.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/firebase/genkit/go/ai"
+	aix "github.com/firebase/genkit/go/ai/exp"
+	"github.com/firebase/genkit/go/genkit"
+	genkitx "github.com/firebase/genkit/go/genkit/exp"
+	"github.com/firebase/genkit/go/plugins/middleware"
+	middlewarex "github.com/firebase/genkit/go/plugins/middleware/exp"
+)
+
+// The incident: checkout-api started failing at 14:03. The logs and the deploy
+// history each hold one half of the answer, and neither investigator can reach
+// the other's half. That is what makes the two of them worth running at the
+// same time rather than one after the other.
+var serviceLogs = map[string]string{
+	"checkout-api": `14:02:58 INFO  rollout v2026.8.19-a1 complete (12/12 pods ready)
+14:03:11 WARN  db pool: waited 1.9s for a connection (in use 5/5)
+14:03:14 ERROR db pool: timed out after 5s (in use 5/5, waiters 63)
+14:03:14 ERROR POST /v1/checkout 500 (db pool timeout)
+14:04:02 ERROR db pool: timed out after 5s (in use 5/5, waiters 148)
+14:05:30 WARN  p99 latency 8.4s (210ms at 13:55)
+14:06:00 ERROR POST /v1/checkout 500 (db pool timeout) x412 in 60s`,
+	"payments-api": `14:03:20 WARN  upstream checkout-api slow: 8.1s
+14:03:44 INFO  circuit breaker half-open for checkout-api
+14:05:10 WARN  upstream checkout-api slow: 9.6s`,
+}
+
+var serviceDeploys = map[string]string{
+	"checkout-api": `v2026.8.19-a1  13:58  r.patel   cut the db pool from 20 to 5 to fit the smaller instance
+v2026.8.18-c7  09:12  s.okafor  add a request id to the access logs`,
+	"payments-api": `v2026.8.19-b3  13:41  m.lindqvist  update the vendor integration docs`,
+}
+
+// A real log scan reads tens of gigabytes and a real deploy lookup calls a
+// release service. That slowness is the reason a delegation is worth
+// backgrounding, so the demo keeps it. The scan is the slower of the two, so
+// the investigations settle at different times.
+const (
+	logScanLatency      = 12 * time.Second
+	deployLookupLatency = 5 * time.Second
+)
+
+// statusPage is the incident channel the commander posts to: process state,
+// like the banker's account balance, and reset on restart.
+var statusPage struct {
+	sync.Mutex
+	updates []string
+}
+
+// defineCommanderAgent registers the incident tools, two investigator
+// sub-agents, and the commander that runs them in the background.
+func defineCommanderAgent(g *genkit.Genkit) *aix.Agent[any] {
+	queryLogs := genkitx.DefineTool(g, "query_logs",
+		"Scans the last 30 minutes of warnings and errors for one service. The scan is slow.",
+		func(ctx context.Context, in struct {
+			Service string `json:"service" jsonschema_description:"The service to scan e.g. checkout-api"`
+		}) (string, error) {
+			if err := slowBackend(ctx, logScanLatency); err != nil {
+				return "", err
+			}
+			logs, ok := serviceLogs[in.Service]
+			if !ok {
+				return unknownService(in.Service, serviceLogs), nil
+			}
+			return logs, nil
+		})
+
+	recentDeploys := genkitx.DefineTool(g, "recent_deploys",
+		"Lists what shipped to one service in the last 24 hours, newest first.",
+		func(ctx context.Context, in struct {
+			Service string `json:"service" jsonschema_description:"The service to list deploys for e.g. checkout-api"`
+		}) (string, error) {
+			if err := slowBackend(ctx, deployLookupLatency); err != nil {
+				return "", err
+			}
+			deploys, ok := serviceDeploys[in.Service]
+			if !ok {
+				return unknownService(in.Service, serviceDeploys), nil
+			}
+			return deploys, nil
+		})
+
+	postStatus := genkitx.DefineTool(g, "post_status",
+		"Posts an update to the incident channel. Use it to keep responders informed while the investigation runs.",
+		func(ctx context.Context, in struct {
+			Message string `json:"message" jsonschema_description:"The update to post, one or two sentences"`
+		}) (string, error) {
+			statusPage.Lock()
+			defer statusPage.Unlock()
+			statusPage.updates = append(statusPage.updates, in.Message)
+			return fmt.Sprintf("Posted update #%d to the incident channel.", len(statusPage.updates)), nil
+		})
+
+	// Each investigator gets a session store. That is what lets the commander
+	// launch it in the background: the runtime writes a pending snapshot for
+	// the detached invocation and finalizes it in place when the work settles.
+	// Both descriptions mention the latency, because they reach the
+	// commander's model in the injected <sub-agents> block and tell it which
+	// delegations are worth backgrounding.
+	logAnalyst := genkitx.DefineAgent(g, "log_analyst",
+		aix.InlinePrompt{
+			ai.WithModel(model),
+			ai.WithTools(queryLogs),
+			ai.WithSystem("You are a log analyst on an incident call. Scan the logs of the " +
+				"service you are given, and of any other service those logs implicate. " +
+				"Report the failure signature, when it started, and how it spread. Report " +
+				"only what the logs show: naming the cause is someone else's job. Answer " +
+				"in at most five lines."),
+			// A transient model error settles the task as failed, and the only
+			// recovery from there is a fresh delegation.
+			ai.WithUse(&middleware.Retry{MaxRetries: 5}),
+		},
+		aix.WithSessionStore(mustStore[any]("log_analyst")),
+		aix.WithDescription[any]("Scans service logs and reports the failure signature. Slow: a scan takes tens of seconds."),
+	)
+
+	deployAuditor := genkitx.DefineAgent(g, "deploy_auditor",
+		aix.InlinePrompt{
+			ai.WithModel(model),
+			ai.WithTools(recentDeploys),
+			ai.WithSystem("You are a release auditor on an incident call. List what shipped " +
+				"to the service you are given near the time of the incident. Name the " +
+				"deploy most likely to be responsible, say what in it could cause the " +
+				"symptoms, and name the deploys you rule out. Answer in at most five lines."),
+			ai.WithUse(&middleware.Retry{MaxRetries: 5}),
+		},
+		aix.WithSessionStore(mustStore[any]("deploy_auditor")),
+		aix.WithDescription[any]("Reviews recent deploys around an incident and names the likely culprit. Slow: a lookup takes several seconds."),
+	)
+
+	return genkitx.DefineAgent(g, "commander",
+		aix.InlinePrompt{
+			ai.WithModel(model),
+			ai.WithTools(postStatus),
+			// Collecting in the background costs tool rounds a blocking
+			// delegation does not: launch, post, wait, post, wait, post is six
+			// before the commander says anything. The default cap is five.
+			ai.WithMaxTurns(12),
+			// The middleware already explains how background delegation works,
+			// so the runbook says only when to use it. Without a rule this
+			// explicit the model often delegates synchronously, which is
+			// correct but leaves the channel silent until the work ends.
+			ai.WithSystem("You are the incident commander for an on-call rotation. You run the " +
+				"incident. You do not investigate it yourself.\n\n" +
+				"Your runbook:\n" +
+				"1. Start every investigation in the background, with \"background\": true. " +
+				"Start all of them in one turn. The investigators are slow and the incident " +
+				"channel will not wait for them.\n" +
+				"2. Post the first status update as soon as the investigations are running. " +
+				"Never hold the first update back for a result.\n" +
+				"3. Then wait for the tasks with timeoutSeconds 10. If the wait times out, " +
+				"post an interim update naming what is still outstanding, then wait again " +
+				"with no timeout.\n" +
+				"4. When the results are in, post a final update with the cause and the fix, " +
+				"then give the user the same answer in two or three lines.\n" +
+				"5. If a task comes back failed or expired, say so and start that one again, " +
+				"once. Do not restart a task that returned a result.\n\n" +
+				"Say what you are about to do in one short sentence before each tool call. " +
+				"Keep every message short enough to read on a phone."),
+			ai.WithUse(
+				// Async is the only difference from the orchestrator agent's
+				// configuration. HistoryLength is left at 0 on purpose: both
+				// sub-agents have stores, and history is never forwarded to a
+				// sub-agent with a store, so setting it would suggest a
+				// context the investigators never receive.
+				&middlewarex.Agents{
+					Agents:         []aix.AgentRef{logAnalyst.Ref(), deployAuditor.Ref()},
+					Async:          true,
+					MaxDelegations: 6,
+				},
+				&middleware.Retry{MaxRetries: 5},
+			),
+		},
+		aix.WithSessionStore(mustStore[any]("commander")),
+		aix.WithDescription[any]("Incident commander (runs sub-agents in the background via the agents middleware)"),
+	)
+}
+
+// slowBackend blocks for d, or returns early if the task is aborted. An
+// aborted background task should stop the work it started, so the wait
+// watches the context rather than sleeping through it.
+func slowBackend(ctx context.Context, d time.Duration) error {
+	select {
+	case <-time.After(d):
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// unknownService names the services that exist instead of failing the turn,
+// so a guessed name costs one tool call rather than the investigation.
+func unknownService(name string, known map[string]string) string {
+	names := make([]string, 0, len(known))
+	for service := range known {
+		names = append(names, service)
+	}
+	sort.Strings(names)
+	return fmt.Sprintf("No records for %q. Known services: %s.", name, strings.Join(names, ", "))
+}

--- a/go/samples/basic-agents/commander.go
+++ b/go/samples/basic-agents/commander.go
@@ -42,16 +42,23 @@
 //   - Neither investigator is told anything about this conversation. History
 //     is never forwarded to a sub-agent that has a store, so the task text has
 //     to stand alone and each investigator pulls its own input with tools.
-//   - WithMaxTurns. Launching, posting, waiting, posting and waiting again are
-//     all tool rounds, so an orchestrator that collects in the background
-//     needs a higher ceiling than one that blocks on each delegation.
+//   - read_status_board is work the commander can do with the time background
+//     delegation gives it back. A blocking orchestrator has no such time: its
+//     turn is inside the sub-agent call. The board answers with one useful
+//     line and one useless one, drawn at random, so the commander has to read
+//     it more than once and has to judge what it gets.
+//   - WithMaxTurns. Launching, posting, reading the board, waiting, posting
+//     and waiting again are all tool rounds, so an orchestrator that collects
+//     in the background needs a higher ceiling than one that blocks on each
+//     delegation.
 //
 // Try it with:
 //
 //	checkout-api is throwing 500s and customers can't pay
 //
 // Watch the order of the tool call lines: two delegations, then post_status,
-// then the waits. The task IDs are visible in the wait tool's input.
+// then the waits, with read_status_board filling the time in between. The task
+// IDs are visible in the wait tool's input.
 //
 // The snapshot outlives the process but the worker does not. Quit while a task
 // is still pending and its heartbeat goes stale, so a later check reports it
@@ -63,6 +70,8 @@ package main
 import (
 	"context"
 	"fmt"
+	"math/rand/v2"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -115,6 +124,34 @@ var statusPage struct {
 	updates []string
 }
 
+// What other responders drop into the incident channel while the commander
+// waits. A real channel carries both kinds at once, and the commander cannot
+// tell which it is about to get, so read_status_board returns one of each at
+// random: the point of the tool is that reading the board is worth a turn even
+// though most reads are not.
+var (
+	// usefulChatter changes what the commander knows. Each line is a fact
+	// neither investigator can reach: they read logs and deploys, not people.
+	usefulChatter = []string{
+		"@s.okafor: staging ran the same rollout an hour ago and is fine. staging runs 2 pods though, not 12.",
+		"@r.patel: the pool change was mine. i sized it off the old instance type and nobody caught it in review.",
+		"@m.lindqvist: payments-api is only failing on calls that go through checkout. its own health checks are green.",
+		"@on-call-db: connection count on the primary is flat at 60. the pool is the ceiling, the database is bored.",
+		"@t.abara: rolling back v2026.8.19-a1 in staging brought p99 back to 200ms in about a minute.",
+	}
+	// noiseChatter is the rest of the channel: real, well meant, and not
+	// actionable. It is here so the commander has to sort signal from volume
+	// rather than treating every read as a finding.
+	noiseChatter = []string{
+		"@j.reyes: is this why my dashboard looks weird?",
+		"@k.tran: +1, seeing it too",
+		"@d.singh: should we open a bridge call for this?",
+		"@a.novak: who is running point? i lost the thread above.",
+		"@support: three customer tickets so far, all about checkout. linking them here for later.",
+		"@b.cho: reminder that the release freeze starts friday, unrelated but worth flagging",
+	}
+)
+
 // defineCommanderAgent registers the incident tools, two investigator
 // sub-agents, and the commander that runs them in the background.
 func defineCommanderAgent(g *genkit.Genkit) *aix.Agent[any] {
@@ -146,6 +183,12 @@ func defineCommanderAgent(g *genkit.Genkit) *aix.Agent[any] {
 				return unknownService(in.Service, serviceDeploys), nil
 			}
 			return deploys, nil
+		})
+
+	readStatusBoard := genkitx.DefineTool(g, "read_status_board",
+		"Reads the incident channel: the updates posted so far, plus whatever other responders have said since. Cheap and safe to call while waiting on an investigation.",
+		func(ctx context.Context, in struct{}) (string, error) {
+			return renderStatusBoard(), nil
 		})
 
 	postStatus := genkitx.DefineTool(g, "post_status",
@@ -199,11 +242,12 @@ func defineCommanderAgent(g *genkit.Genkit) *aix.Agent[any] {
 	return genkitx.DefineAgent(g, "commander",
 		aix.InlinePrompt{
 			ai.WithModel(model),
-			ai.WithTools(postStatus),
+			ai.WithTools(postStatus, readStatusBoard),
 			// Collecting in the background costs tool rounds a blocking
-			// delegation does not: launch, post, wait, post, wait, post is six
-			// before the commander says anything. The default cap is five.
-			ai.WithMaxTurns(12),
+			// delegation does not: launch, post, wait, read the board, post,
+			// wait, post is seven before the commander says anything, and it
+			// may read the board more than once. The default cap is five.
+			ai.WithMaxTurns(15),
 			// The middleware already explains how background delegation works,
 			// so the runbook says only when to use it. Without a rule this
 			// explicit the model often delegates synchronously, which is
@@ -217,7 +261,8 @@ func defineCommanderAgent(g *genkit.Genkit) *aix.Agent[any] {
 				"2. Post the first status update as soon as the investigations are running. " +
 				"Never hold the first update back for a result.\n" +
 				"3. Then wait for the tasks with timeoutSeconds 10. If the wait times out, " +
-				"post an interim update naming what is still outstanding, then wait again " +
+				"read the status board, post an interim update naming what is still " +
+				"outstanding, and fold in anything the board told you. Then wait again " +
 				"with no timeout.\n" +
 				"4. When the results are in, post a final update with the cause and the fix, " +
 				"then give the user the same answer in two or three lines.\n" +
@@ -242,6 +287,37 @@ func defineCommanderAgent(g *genkit.Genkit) *aix.Agent[any] {
 		aix.WithSessionStore(mustStore[any]("commander")),
 		aix.WithDescription[any]("Incident commander (runs sub-agents in the background via the agents middleware)"),
 	)
+}
+
+// renderStatusBoard renders the incident channel: the updates the commander
+// has posted, then one useful line and one useless one from the other
+// responders, in an order it cannot predict. Reading the board is therefore
+// worth doing more than once and never reliably worth doing twice in a row,
+// which is the judgement call the tool exists to pose.
+func renderStatusBoard() string {
+	statusPage.Lock()
+	posted := slices.Clone(statusPage.updates)
+	statusPage.Unlock()
+
+	var b strings.Builder
+	b.WriteString("Updates you have posted:\n")
+	if len(posted) == 0 {
+		b.WriteString("  (none yet)\n")
+	}
+	for i, update := range posted {
+		fmt.Fprintf(&b, "  %d. %s\n", i+1, update)
+	}
+
+	chatter := []string{
+		usefulChatter[rand.IntN(len(usefulChatter))],
+		noiseChatter[rand.IntN(len(noiseChatter))],
+	}
+	rand.Shuffle(len(chatter), func(i, j int) { chatter[i], chatter[j] = chatter[j], chatter[i] })
+	b.WriteString("\nSince you last looked:\n")
+	for _, line := range chatter {
+		fmt.Fprintf(&b, "  %s\n", line)
+	}
+	return b.String()
 }
 
 // slowBackend blocks for d, or returns early if the task is aborted. An

--- a/go/samples/basic-agents/main.go
+++ b/go/samples/basic-agents/main.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// This sample demonstrates the agent APIs by defining six agents in different
+// This sample demonstrates the agent APIs by defining seven agents in different
 // styles, one per file, behind a single CLI:
 //
 //   - pirate (pirate.go): DefineAgent with the prompt declared inline.
@@ -27,11 +27,16 @@
 //     reads it back, so each turn knows what earlier ones established.
 //   - orchestrator (orchestrator.go): delegates to sub-agents through
 //     per-agent tools, merging their artifacts into its own session.
+//   - commander (commander.go): the same middleware with Async set, so an
+//     incident commander starts its investigators in the background, keeps
+//     posting status updates while they work, and collects the results after.
 //
 // cli.go holds the CLI: it lists the agents, streams each turn, renders tool
 // calls as they happen, and routes interrupts. Conversation state persists to a
 // per-agent FileSessionStore under ./.genkit/snapshots/<agent>/, except for the
-// orchestrator's sub-agents, which run statelessly per delegation.
+// orchestrator's sub-agents, which run statelessly per delegation. The
+// commander's investigators do keep stores, which is what lets them run in the
+// background.
 //
 // Run it:
 //
@@ -54,11 +59,13 @@
 //	/back              return to the agent list
 //	/quit              exit
 //
-// Three worth trying: "/detach write me a long pirate story", then re-pick
+// Four worth trying: "/detach write me a long pirate story", then re-pick
 // pirate to wait on it; banker with "send $200 to alice" (over the $150
-// balance) or "send $120 to bob" (large enough to need approval); and barista,
+// balance) or "send $120 to bob" (large enough to need approval); barista,
 // where ordering a drink and later asking "what have I ordered?" is answered
-// from session state rather than from the transcript.
+// from session state rather than from the transcript; and commander with
+// "checkout-api is throwing 500s and customers can't pay", which posts its
+// first status update while its investigators are still running.
 package main
 
 import (
@@ -105,6 +112,7 @@ func main() {
 		newEntry(defineBankerAgent(g), handleTransferInterrupt),
 		newEntry(defineBaristaAgent(g), nil),
 		newEntry(defineOrchestratorAgent(g), nil),
+		newEntry(defineCommanderAgent(g), nil),
 	}
 
 	if err := runCLI(ctx, agents); err != nil {

--- a/go/samples/basic-agents/main.go
+++ b/go/samples/basic-agents/main.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// This sample demonstrates the agent APIs by defining six agents in different
+// This sample demonstrates the agent APIs by defining seven agents in different
 // styles, one per file, behind a single CLI:
 //
 //   - pirate (pirate.go): DefineAgent with the prompt declared inline.
@@ -27,11 +27,16 @@
 //     reads it back, so each turn knows what earlier ones established.
 //   - orchestrator (orchestrator.go): delegates to sub-agents through
 //     per-agent tools, merging their artifacts into its own session.
+//   - commander (commander.go): the same middleware with Async set, so an
+//     incident commander starts its investigators in the background, keeps
+//     posting status updates while they work, and collects the results after.
 //
 // cli.go holds the CLI: it lists the agents, streams each turn, renders tool
 // calls as they happen, and routes interrupts. Conversation state persists to a
 // per-agent FileSessionStore under ./.genkit/snapshots/<agent>/, except for the
-// orchestrator's sub-agents, which run statelessly per delegation.
+// orchestrator's sub-agents, which run statelessly per delegation. The
+// commander's investigators do keep stores, which is what lets them run in the
+// background.
 //
 // Run it:
 //
@@ -53,11 +58,13 @@
 //	/back              return to the agent list
 //	/quit              exit
 //
-// Three worth trying: "/detach write me a long pirate story", then re-pick
+// Four worth trying: "/detach write me a long pirate story", then re-pick
 // pirate to wait on it; banker with "send $200 to alice" (over the $150
-// balance) or "send $120 to bob" (large enough to need approval); and barista,
+// balance) or "send $120 to bob" (large enough to need approval); barista,
 // where ordering a drink and later asking "what have I ordered?" is answered
-// from session state rather than from the transcript.
+// from session state rather than from the transcript; and commander with
+// "checkout-api is throwing 500s and customers can't pay", which posts its
+// first status update while its investigators are still running.
 package main
 
 import (
@@ -104,6 +111,7 @@ func main() {
 		newEntry(defineBankerAgent(g), handleTransferInterrupt),
 		newEntry(defineBaristaAgent(g), nil),
 		newEntry(defineOrchestratorAgent(g), nil),
+		newEntry(defineCommanderAgent(g), nil),
 	}
 
 	if err := runCLI(ctx, agents); err != nil {


### PR DESCRIPTION
Second PR of the train, on #6118 (`AgentHandle`, `waitForSnapshot`). Adds background delegation to the `Agents` middleware: with `Async` set, every delegation tool takes a `background` flag that launches the sub-agent through its detach support and returns a task ID at once, and three shared tools let the orchestrator check, join, and stop what it launched. `Agents.Async` is the only new exported symbol.

## One control per thing the orchestrator can do with a task

```go
ai.WithUse(&middlewarex.Agents{
    Agents: []aix.AgentRef{{Name: "researcher"}},
    Async:  true,
})
```

```
delegate_to_researcher    {task, background: true}
                          -> {response, taskId: "researcher:<snapshotId>", status: "pending"}
check_background_tasks    {taskIds}
                          -> {tasks: [{taskId, agent, status, response?, artifacts?, error?}]}
wait_for_background_tasks {taskIds, timeoutSeconds?, waitFor?: "all" | "first"}
                          -> the same, plus timedOut
abort_background_tasks    {taskIds}
                          -> the same, each task reported where the stop left it
```

The async delegation input is a distinct Go type, since tool schemas are inferred statically from the struct; `ToolPrefix` namespaces the shared tools as it does the delegation tools. A launch spends a `MaxDelegations` slot, and a launch the runtime rejects before any work ran refunds it, so the hinted synchronous retry is not refused by a cap the refusal consumed. History is never forwarded to a background launch: detach requires a server-managed sub-agent, and server-managed init rejects seeded state.

## The sub-agent's snapshot is the whole record

The middleware keeps no task registry. The task ID rides in the tool result, so the orchestrator's history is the registry, and a re-instantiated orchestrator collects with nothing but the IDs it finds there. Reports key on the row: `pending` is status only; `completed` carries the last model message and the artifacts, merged under the deterministic `<agent>_<snapshotId[:8]>` namespace so a re-check after a restart overwrites rather than duplicates; a completed row whose finish reason carries no answer (`failed`, `interrupted`) reports as `failed` with the reason in `error`, because a model told `completed` moves on without reading `error`; `failed`, `aborted`, and `expired` carry an explanatory error. A completed run with no model text says so and names its artifact count, so silence is not read as failure. NOT_FOUND means "delegate again", FAILED_PRECONDITION and INVALID_ARGUMENT are reported verbatim as dead ends, and any other read error is "check again later". Settled reports are cached for the rest of the generate call.

## Wait follows tasks instead of polling them

The wait tool dispatches each task's `waitForSnapshot` companion action once, concurrently, so a trace carries one span per task per call and a task is reported the moment it settles. An elapsed `timeoutSeconds` returns the current statuses with `timedOut`; zero waits until settled, negative reports immediately. `waitFor: "first"` returns as soon as any listed task settles (`unknown` counts, since an unresolvable handle is an answer to act on), and a won race is not a timeout. Abort flips the pending row, then reads and reports the settled row through the check path, because the abort action's bare status would answer `completed` for a task that had already finished and strand its response.

## Middleware build errors keep their own status

Both wrap sites in `ai` classified every `Middleware.New` failure as INVALID_ARGUMENT, so an UNAVAILABLE from a network-backed `New` or a cancelled context reached the caller as a caller mistake. A classified error now keeps its status; only unclassified errors default to INVALID_ARGUMENT.

## What was deliberately deferred

- **No interrupt resume for background tasks.** Same report-as-text policy as synchronous delegation.
- **Task handles are not access-scoped**, mirroring the sub-agent's own unscoped companion actions; the config doc tells multi-tenant deployments to treat snapshot IDs as capability-like secrets.
- **No operator cap on the wait.** `timeoutSeconds` is the model's to choose, bounded in practice by the calling context.
