### PR TITLE
feat(py): box background operation before wrap_model

### DIFF
--- a/py/packages/genkit-google-genai/tests/google_genai_plugin_test.py
+++ b/py/packages/genkit-google-genai/tests/google_genai_plugin_test.py
@@ -50,7 +50,7 @@ from genkit_google_genai.models.gemini import (
 from genkit_google_genai.models.imagen import ImagenConfigSchema
 from genkit_google_genai.models.veo import VeoConfigSchema, VeoModel
 
-from genkit import ActionKind, GenkitError, Message, ModelRequest, Part, Role, TextPart
+from genkit import ActionKind, Genkit, GenkitError, Message, ModelRequest, Part, Role, TextPart
 from genkit.model import Operation
 from genkit.plugin_api import Action, to_json_schema
 
@@ -561,6 +561,21 @@ async def test_vertexai_resolve_veo_as_model_returns_none(mock_list_models: Magi
     action = await plugin.resolve(ActionKind.MODEL, 'vertexai/veo-3.0-generate-001')
 
     assert action is None
+
+
+@patch('genkit_google_genai.google.genai.client.Client')
+@patch('genkit_google_genai.google._list_genai_models')
+@pytest.mark.asyncio
+async def test_resolve_model_finds_veo_as_background(mock_list_models: MagicMock, mock_client: MagicMock) -> None:
+    """resolve(MODEL, veo) is None so resolve_model can see the background start action."""
+    mock_list_models.return_value = GenaiModels()
+
+    ai = Genkit(plugins=[GoogleAI(api_key='test-key')])
+    action = await ai.registry.resolve_model('googleai/veo-3.0-generate-001')
+
+    assert action is not None
+    assert action.kind == ActionKind.BACKGROUND_MODEL
+    assert action.name == 'googleai/veo-3.0-generate-001'
 
 
 @patch('genkit_google_genai.google.genai.client.Client')

--- a/py/packages/genkit/src/genkit/_ai/_aio.py
+++ b/py/packages/genkit/src/genkit/_ai/_aio.py
@@ -95,6 +95,7 @@ from genkit._core._background import (
     check_operation,
     define_background_model,
     lookup_background_action,
+    missing_operation_error,
 )
 from genkit._core._channel import Channel, run_loop
 from genkit._core._dap import (
@@ -1754,9 +1755,6 @@ class Genkit:
 
         # Extract operation from response
         if not hasattr(response, 'operation') or not response.operation:
-            raise GenkitError(
-                status='FAILED_PRECONDITION',
-                message=f"Model '{model_action.name}' did not return an operation.",
-            )
+            raise missing_operation_error(name=model_action.name)
 
         return response.operation

--- a/py/packages/genkit/src/genkit/_ai/_aio.py
+++ b/py/packages/genkit/src/genkit/_ai/_aio.py
@@ -29,7 +29,7 @@ import threading
 import uuid
 from collections.abc import Awaitable, Callable, Coroutine, Mapping, Sequence
 from pathlib import Path
-from typing import Any, TypeVar, cast, overload
+from typing import Any, TypeVar, overload
 
 import anyio
 import uvicorn
@@ -146,23 +146,6 @@ ChunkT = TypeVar('ChunkT')
 R = TypeVar('R')
 T = TypeVar('T')
 MiddlewareT = TypeVar('MiddlewareT', bound=BaseMiddleware)
-
-
-def _model_supports_long_running(model_action: Action) -> bool:
-    """Check if a model action supports long-running operations."""
-    model_info = model_action.metadata.get('model') if model_action.metadata else None
-    if not model_info:
-        return False
-    # Handle ModelInfo object
-    if hasattr(model_info, 'supports'):
-        supports = getattr(model_info, 'supports', None)
-        return bool(getattr(supports, 'long_running', False)) if supports else False
-    # Handle dict (cast needed because isinstance narrows too much for type checkers)
-    if isinstance(model_info, dict):
-        model_dict = cast(dict[str, Any], model_info)
-        supports = model_dict.get('supports')
-        return bool(supports.get('longRunning', False)) if isinstance(supports, dict) else False
-    return False
 
 
 class Genkit:
@@ -1725,8 +1708,7 @@ class Genkit:
                 message=f"Model '{resolved.name}' not found.",
             )
 
-        # Check if model supports long-running operations
-        if not _model_supports_long_running(model_action):
+        if model_action.kind != ActionKind.BACKGROUND_MODEL:
             raise GenkitError(
                 status='INVALID_ARGUMENT',
                 message=f"Model '{model_action.name}' does not support long running operations.",

--- a/py/packages/genkit/src/genkit/_ai/_generate.py
+++ b/py/packages/genkit/src/genkit/_ai/_generate.py
@@ -47,7 +47,7 @@ from genkit._core._action import (
     ActionKind,
     ActionRunContext,
 )
-from genkit._core._background import _ensure_operation
+from genkit._core._background import _ensure_operation, missing_operation_error
 from genkit._core._error import GenkitError
 from genkit._core._logger import get_logger, is_debug_enabled
 from genkit._core._middleware import (
@@ -657,10 +657,7 @@ def box_background_start(*, raw: object, request: ModelRequest, name: str) -> Mo
     """
     if isinstance(raw, ModelResponse):
         if raw.operation is None:
-            raise GenkitError(
-                status='FAILED_PRECONDITION',
-                message=f"Background model '{name}' did not return an operation",
-            )
+            raise missing_operation_error(name=name)
         if raw.latency_ms is None:
             raw.latency_ms = _latency_ms_from_operation(raw.operation)
         return raw

--- a/py/packages/genkit/src/genkit/_ai/_generate.py
+++ b/py/packages/genkit/src/genkit/_ai/_generate.py
@@ -793,9 +793,6 @@ async def _generate_action_turn(
         # through persist and the tool loop.
         if model.kind == ActionKind.BACKGROUND_MODEL:
             if model_response.operation is None:
-                # wrap_model may read .message. The job id lives on
-                # .operation; a rebuild that only copies message /
-                # finish_reason drops it.
                 raise GenkitError(
                     status='FAILED_PRECONDITION',
                     message=(
@@ -915,7 +912,13 @@ async def _generate_action_turn(
         iteration=current_turn,
         message_index=chunks.message_index,
     )
-    return await dispatch_generate(generate_params, run_ctx, run_one_iteration)
+    response = await dispatch_generate(generate_params, run_ctx, run_one_iteration)
+    if model.kind == ActionKind.BACKGROUND_MODEL and response.operation is None:
+        raise GenkitError(
+            status='FAILED_PRECONDITION',
+            message=('wrap_generate returned no operation for a background model; pass through response.operation'),
+        )
+    return response
 
 
 def apply_format(

--- a/py/packages/genkit/src/genkit/_ai/_generate.py
+++ b/py/packages/genkit/src/genkit/_ai/_generate.py
@@ -648,6 +648,43 @@ def _latency_ms_from_operation(operation: Operation) -> float | None:
     return None
 
 
+def box_background_start(*, raw: object, request: ModelRequest, name: str) -> ModelResponse:
+    """Turn a background start into the ModelResponse wrap_model reads.
+
+    start() is a poll handle. Already-boxed responses pass through; a chat
+    turn with no handle is a model-author mistake.
+    """
+    if isinstance(raw, ModelResponse):
+        if raw.operation is None:
+            raise GenkitError(
+                status='FAILED_PRECONDITION',
+                message=f"Background model '{name}' did not return an operation",
+            )
+        if raw.latency_ms is None:
+            raw.latency_ms = _latency_ms_from_operation(raw.operation)
+        return raw
+    if not isinstance(raw, Operation):
+        raise GenkitError(
+            status='FAILED_PRECONDITION',
+            message=f"Background model '{name}' did not return an operation",
+        )
+    return ModelResponse(
+        operation=raw,
+        request=request,
+        latency_ms=_latency_ms_from_operation(raw),
+    )
+
+
+def reject_foreground_operation(*, raw: object, name: str) -> ModelResponse:
+    """A chat model returns a message, not a job handle."""
+    if isinstance(raw, Operation) or (isinstance(raw, ModelResponse) and raw.operation is not None):
+        raise GenkitError(
+            status='FAILED_PRECONDITION',
+            message=f"Model '{name}' is a define_model and returned an operation; use define_background_model",
+        )
+    return cast(ModelResponse, raw)
+
+
 def _persist_threaded_conversation(response: ModelResponse, messages: list[Message]) -> ModelResponse:
     """Persist the threaded conversation onto the response's request.
 
@@ -795,37 +832,9 @@ async def _generate_action_turn(
                     abort_signal=c.abort_signal,
                 )
             ).response
-            # wrap_model reads .message. A background start is a poll handle,
-            # so box it before the hook. A chat model that returns a handle
-            # is registered on the wrong kind.
             if model.kind == ActionKind.BACKGROUND_MODEL:
-                if isinstance(raw, ModelResponse):
-                    if raw.operation is None:
-                        raise GenkitError(
-                            status='FAILED_PRECONDITION',
-                            message=f"Background model '{model.name}' did not return an operation",
-                        )
-                    if raw.latency_ms is None:
-                        raw.latency_ms = _latency_ms_from_operation(raw.operation)
-                    return raw
-                if not isinstance(raw, Operation):
-                    raise GenkitError(
-                        status='FAILED_PRECONDITION',
-                        message=f"Background model '{model.name}' did not return an operation",
-                    )
-                return ModelResponse(
-                    operation=raw,
-                    request=params.request,
-                    latency_ms=_latency_ms_from_operation(raw),
-                )
-            if isinstance(raw, Operation) or (isinstance(raw, ModelResponse) and raw.operation is not None):
-                raise GenkitError(
-                    status='FAILED_PRECONDITION',
-                    message=(
-                        f"Model '{model.name}' is a define_model and returned an operation; use define_background_model"
-                    ),
-                )
-            return raw
+                return box_background_start(raw=raw, request=params.request, name=model.name)
+            return reject_foreground_operation(raw=raw, name=model.name)
 
         with chunks.intercept_model_stream(ctx, role=Role.MODEL):
             model_response = await dispatch_model(

--- a/py/packages/genkit/src/genkit/_ai/_generate.py
+++ b/py/packages/genkit/src/genkit/_ai/_generate.py
@@ -72,6 +72,7 @@ from genkit._core._typing import (
     FinishReason,
     MiddlewareRef,
     MultipartToolResponse,
+    Operation,
     Part,
     Role,
     TextPart,
@@ -766,7 +767,7 @@ async def _generate_action_turn(
             request = _augment_with_context(request)
 
         async def next_fn(params: ModelHookParams, c: GenerateMiddlewareContext) -> ModelResponse:
-            return (
+            raw = (
                 await model.run(
                     input=params.request,
                     context=c.custom_context,
@@ -774,6 +775,11 @@ async def _generate_action_turn(
                     abort_signal=c.abort_signal,
                 )
             ).response
+            # start() returns a poll handle. wrap_model is documented as
+            # seeing a ModelResponse, so wrap before the hook runs.
+            if isinstance(raw, Operation):
+                return ModelResponse(operation=raw, request=params.request)
+            return raw
 
         with chunks.intercept_model_stream(ctx, role=Role.MODEL):
             model_response = await dispatch_model(
@@ -781,6 +787,11 @@ async def _generate_action_turn(
                 ctx,
                 next_fn,
             )
+
+        if model_response.operation is not None:
+            if model_response.request is None:
+                model_response.request = request
+            return model_response
 
         def message_parser(msg: Message) -> Any:  # noqa: ANN401
             if formatter is None:

--- a/py/packages/genkit/src/genkit/_ai/_generate.py
+++ b/py/packages/genkit/src/genkit/_ai/_generate.py
@@ -675,14 +675,16 @@ def box_background_start(*, raw: object, request: ModelRequest, name: str) -> Mo
     )
 
 
-def reject_foreground_operation(*, raw: object, name: str) -> ModelResponse:
+def assert_foreground_model_has_no_operation(*, raw: object, name: str) -> None:
     """A chat model returns a message, not a job handle."""
     if isinstance(raw, Operation) or (isinstance(raw, ModelResponse) and raw.operation is not None):
         raise GenkitError(
             status='FAILED_PRECONDITION',
-            message=f"Model '{name}' is a define_model and returned an operation; use define_background_model",
+            message=(
+                f"Model '{name}' is a regular model that returns a response immediately. "
+                'Use define_background_model for background models that return operations.'
+            ),
         )
-    return cast(ModelResponse, raw)
 
 
 def _persist_threaded_conversation(response: ModelResponse, messages: list[Message]) -> ModelResponse:
@@ -834,7 +836,8 @@ async def _generate_action_turn(
             ).response
             if model.kind == ActionKind.BACKGROUND_MODEL:
                 return box_background_start(raw=raw, request=params.request, name=model.name)
-            return reject_foreground_operation(raw=raw, name=model.name)
+            assert_foreground_model_has_no_operation(raw=raw, name=model.name)
+            return cast(ModelResponse, raw)
 
         with chunks.intercept_model_stream(ctx, role=Role.MODEL):
             model_response = await dispatch_model(

--- a/py/packages/genkit/src/genkit/_ai/_generate.py
+++ b/py/packages/genkit/src/genkit/_ai/_generate.py
@@ -637,6 +637,17 @@ class ChunkAccumulator:
             ctx.replace_on_chunk(previous)
 
 
+def _latency_ms_from_operation(operation: Operation) -> float | None:
+    """Copy start timing off the handle if the wrapper stamped it."""
+    meta = operation.metadata
+    if not isinstance(meta, dict):
+        return None
+    raw_ms = meta.get('latencyMs')
+    if isinstance(raw_ms, int | float):
+        return float(raw_ms)
+    return None
+
+
 def _persist_threaded_conversation(response: ModelResponse, messages: list[Message]) -> ModelResponse:
     """Persist the threaded conversation onto the response's request.
 
@@ -663,6 +674,15 @@ async def _generate_action_turn(
     raise_if_aborted(run_ctx.abort_signal)
 
     model, tools, format_def = await resolve_parameters(registry, raw_request)
+
+    if model.kind == ActionKind.BACKGROUND_MODEL and raw_request.resume is not None:
+        raise GenkitError(
+            status='FAILED_PRECONDITION',
+            message=(
+                f"Cannot resume background model '{model.name}'; "
+                'a background start cannot satisfy an interrupted tool turn'
+            ),
+        )
 
     raw_request, formatter = apply_format(raw_request, format_def)
 
@@ -775,10 +795,36 @@ async def _generate_action_turn(
                     abort_signal=c.abort_signal,
                 )
             ).response
-            # start() returns a poll handle. wrap_model is documented as
-            # seeing a ModelResponse, so wrap before the hook runs.
-            if isinstance(raw, Operation):
-                return ModelResponse(operation=raw, request=params.request)
+            # wrap_model reads .message. A background start is a poll handle,
+            # so box it before the hook. A chat model that returns a handle
+            # is registered on the wrong kind.
+            if model.kind == ActionKind.BACKGROUND_MODEL:
+                if isinstance(raw, ModelResponse):
+                    if raw.operation is None:
+                        raise GenkitError(
+                            status='FAILED_PRECONDITION',
+                            message=f"Background model '{model.name}' did not return an operation",
+                        )
+                    if raw.latency_ms is None:
+                        raw.latency_ms = _latency_ms_from_operation(raw.operation)
+                    return raw
+                if not isinstance(raw, Operation):
+                    raise GenkitError(
+                        status='FAILED_PRECONDITION',
+                        message=f"Background model '{model.name}' did not return an operation",
+                    )
+                return ModelResponse(
+                    operation=raw,
+                    request=params.request,
+                    latency_ms=_latency_ms_from_operation(raw),
+                )
+            if isinstance(raw, Operation) or (isinstance(raw, ModelResponse) and raw.operation is not None):
+                raise GenkitError(
+                    status='FAILED_PRECONDITION',
+                    message=(
+                        f"Model '{model.name}' is a define_model and returned an operation; use define_background_model"
+                    ),
+                )
             return raw
 
         with chunks.intercept_model_stream(ctx, role=Role.MODEL):
@@ -787,21 +833,6 @@ async def _generate_action_turn(
                 ctx,
                 next_fn,
             )
-
-        # A background start is a poll handle, not a conversation turn.
-        # define_model LRO replies that also carry a message still go
-        # through persist and the tool loop.
-        if model.kind == ActionKind.BACKGROUND_MODEL:
-            if model_response.operation is None:
-                raise GenkitError(
-                    status='FAILED_PRECONDITION',
-                    message=(
-                        'wrap_model returned no operation for a background model; pass through response.operation'
-                    ),
-                )
-            if model_response.request is None:
-                model_response.request = request
-            return model_response
 
         def message_parser(msg: Message) -> Any:  # noqa: ANN401
             if formatter is None:
@@ -912,13 +943,7 @@ async def _generate_action_turn(
         iteration=current_turn,
         message_index=chunks.message_index,
     )
-    response = await dispatch_generate(generate_params, run_ctx, run_one_iteration)
-    if model.kind == ActionKind.BACKGROUND_MODEL and response.operation is None:
-        raise GenkitError(
-            status='FAILED_PRECONDITION',
-            message=('wrap_generate returned no operation for a background model; pass through response.operation'),
-        )
-    return response
+    return await dispatch_generate(generate_params, run_ctx, run_one_iteration)
 
 
 def apply_format(

--- a/py/packages/genkit/src/genkit/_ai/_generate.py
+++ b/py/packages/genkit/src/genkit/_ai/_generate.py
@@ -47,6 +47,7 @@ from genkit._core._action import (
     ActionKind,
     ActionRunContext,
 )
+from genkit._core._background import _ensure_operation
 from genkit._core._error import GenkitError
 from genkit._core._logger import get_logger, is_debug_enabled
 from genkit._core._middleware import (
@@ -663,15 +664,11 @@ def box_background_start(*, raw: object, request: ModelRequest, name: str) -> Mo
         if raw.latency_ms is None:
             raw.latency_ms = _latency_ms_from_operation(raw.operation)
         return raw
-    if not isinstance(raw, Operation):
-        raise GenkitError(
-            status='FAILED_PRECONDITION',
-            message=f"Background model '{name}' did not return an operation",
-        )
+    op = _ensure_operation(response=raw, name=name)
     return ModelResponse(
-        operation=raw,
+        operation=op,
         request=request,
-        latency_ms=_latency_ms_from_operation(raw),
+        latency_ms=_latency_ms_from_operation(op),
     )
 
 

--- a/py/packages/genkit/src/genkit/_ai/_generate.py
+++ b/py/packages/genkit/src/genkit/_ai/_generate.py
@@ -47,7 +47,7 @@ from genkit._core._action import (
     ActionKind,
     ActionRunContext,
 )
-from genkit._core._background import _ensure_operation, missing_operation_error
+from genkit._core._background import _ensure_operation, missing_operation_error, stamp_operation_action
 from genkit._core._error import GenkitError
 from genkit._core._logger import get_logger, is_debug_enabled
 from genkit._core._middleware import (
@@ -638,39 +638,24 @@ class ChunkAccumulator:
             ctx.replace_on_chunk(previous)
 
 
-def _latency_ms_from_operation(operation: Operation) -> float | None:
-    """Copy start timing off the handle if the wrapper stamped it."""
-    meta = operation.metadata
-    if not isinstance(meta, dict):
-        return None
-    raw_ms = meta.get('latencyMs')
-    if isinstance(raw_ms, int | float):
-        return float(raw_ms)
-    return None
+def box_background_start(
+    *,
+    raw: object,
+    request: ModelRequest,
+    name: str,
+    latency_ms: float | None = None,
+) -> ModelResponse:
+    """Turn a start() Operation into the ModelResponse wrap_model reads.
 
-
-def box_background_start(*, raw: object, request: ModelRequest, name: str) -> ModelResponse:
-    """Turn a background start into the ModelResponse wrap_model reads.
-
-    start() is a poll handle. Already-boxed responses pass through; a chat
-    turn with no handle is a model-author mistake.
+    Timing comes from Action.run, not from the ticket.
     """
-    if isinstance(raw, ModelResponse):
-        if raw.operation is None:
-            raise missing_operation_error(name=name)
-        if raw.latency_ms is None:
-            raw.latency_ms = _latency_ms_from_operation(raw.operation)
-        return raw
     op = _ensure_operation(response=raw, name=name)
-    return ModelResponse(
-        operation=op,
-        request=request,
-        latency_ms=_latency_ms_from_operation(op),
-    )
+    stamp_operation_action(operation=op, name=name)
+    return ModelResponse(operation=op, request=request, latency_ms=latency_ms)
 
 
-def assert_foreground_model_has_no_operation(*, raw: object, name: str) -> None:
-    """A chat model returns a message, not a job handle."""
+def require_model_response(*, raw: object, name: str) -> ModelResponse:
+    """A chat model returns a ModelResponse, not a dict or a job handle."""
     if isinstance(raw, Operation) or (isinstance(raw, ModelResponse) and raw.operation is not None):
         raise GenkitError(
             status='FAILED_PRECONDITION',
@@ -679,6 +664,25 @@ def assert_foreground_model_has_no_operation(*, raw: object, name: str) -> None:
                 'Use define_background_model for background models that return operations.'
             ),
         )
+    if not isinstance(raw, ModelResponse):
+        raise GenkitError(
+            status='FAILED_PRECONDITION',
+            message=f"Model '{name}' did not return a ModelResponse.",
+        )
+    return raw
+
+
+@dataclass
+class BoxedStart:
+    """The ModelResponse start() produced, before wrap_model / wrap_generate."""
+
+    response: ModelResponse | None = None
+
+
+def assert_hook_kept_operation(*, boxed: ModelResponse | None, after_hooks: ModelResponse, name: str) -> None:
+    """A hook that called start() and then dropped the ticket orphans the job."""
+    if boxed is not None and boxed.operation is not None and after_hooks.operation is None:
+        raise missing_operation_error(name=name)
 
 
 def _persist_threaded_conversation(response: ModelResponse, messages: list[Message]) -> ModelResponse:
@@ -707,6 +711,7 @@ async def _generate_action_turn(
     raise_if_aborted(run_ctx.abort_signal)
 
     model, tools, format_def = await resolve_parameters(registry, raw_request)
+    boxed_start = BoxedStart()
 
     if model.kind == ActionKind.BACKGROUND_MODEL and raw_request.resume is not None:
         raise GenkitError(
@@ -820,18 +825,22 @@ async def _generate_action_turn(
             request = _augment_with_context(request)
 
         async def next_fn(params: ModelHookParams, c: GenerateMiddlewareContext) -> ModelResponse:
-            raw = (
-                await model.run(
-                    input=params.request,
-                    context=c.custom_context,
-                    on_chunk=c.on_chunk,
-                    abort_signal=c.abort_signal,
-                )
-            ).response
+            result = await model.run(
+                input=params.request,
+                context=c.custom_context,
+                on_chunk=c.on_chunk,
+                abort_signal=c.abort_signal,
+            )
+            raw = result.response
             if model.kind == ActionKind.BACKGROUND_MODEL:
-                return box_background_start(raw=raw, request=params.request, name=model.name)
-            assert_foreground_model_has_no_operation(raw=raw, name=model.name)
-            return cast(ModelResponse, raw)
+                boxed_start.response = box_background_start(
+                    raw=raw,
+                    request=params.request,
+                    name=model.name,
+                    latency_ms=result.latency_ms,
+                )
+                return boxed_start.response
+            return require_model_response(raw=raw, name=model.name)
 
         with chunks.intercept_model_stream(ctx, role=Role.MODEL):
             model_response = await dispatch_model(
@@ -839,6 +848,11 @@ async def _generate_action_turn(
                 ctx,
                 next_fn,
             )
+        assert_hook_kept_operation(
+            boxed=boxed_start.response,
+            after_hooks=model_response,
+            name=model.name,
+        )
 
         def message_parser(msg: Message) -> Any:  # noqa: ANN401
             if formatter is None:
@@ -863,7 +877,8 @@ async def _generate_action_turn(
         response.assert_valid()
         generated_msg = response.message
 
-        if generated_msg is None:
+        # A ticket means generate is done. Don't run tools against a start handle.
+        if generated_msg is None or response.operation is not None:
             return _persist_threaded_conversation(response, turn_options.messages)
 
         # Stamp output format metadata on message so the Dev UI can render formatted JSON vs plain text.
@@ -949,7 +964,13 @@ async def _generate_action_turn(
         iteration=current_turn,
         message_index=chunks.message_index,
     )
-    return await dispatch_generate(generate_params, run_ctx, run_one_iteration)
+    result = await dispatch_generate(generate_params, run_ctx, run_one_iteration)
+    assert_hook_kept_operation(
+        boxed=boxed_start.response,
+        after_hooks=result,
+        name=model.name,
+    )
+    return result
 
 
 def apply_format(

--- a/py/packages/genkit/src/genkit/_ai/_generate.py
+++ b/py/packages/genkit/src/genkit/_ai/_generate.py
@@ -788,7 +788,20 @@ async def _generate_action_turn(
                 next_fn,
             )
 
-        if model_response.operation is not None:
+        # A background start is a poll handle, not a conversation turn.
+        # define_model LRO replies that also carry a message still go
+        # through persist and the tool loop.
+        if model.kind == ActionKind.BACKGROUND_MODEL:
+            if model_response.operation is None:
+                # wrap_model may read .message. The job id lives on
+                # .operation; a rebuild that only copies message /
+                # finish_reason drops it.
+                raise GenkitError(
+                    status='FAILED_PRECONDITION',
+                    message=(
+                        'wrap_model returned no operation for a background model; pass through response.operation'
+                    ),
+                )
             if model_response.request is None:
                 model_response.request = request
             return model_response

--- a/py/packages/genkit/src/genkit/_ai/_model.py
+++ b/py/packages/genkit/src/genkit/_ai/_model.py
@@ -282,6 +282,15 @@ def _check_request_annotation(name: str, fn: ModelFn) -> None:
     )
 
 
+def claims_long_running(*, model_options: dict[str, object]) -> bool:
+    """True when this model metadata asked for a background job."""
+    supports = model_options.get('supports')
+    if isinstance(supports, dict):
+        supports_dict = cast(dict[str, object], supports)
+        return bool(supports_dict.get('longRunning'))
+    return False
+
+
 def define_model(
     registry: Registry,
     name: str,
@@ -312,6 +321,12 @@ def define_model(
     # Default label to name if not set
     if 'label' not in model_options or not model_options['label']:
         model_options['label'] = name
+
+    if claims_long_running(model_options=model_options):
+        raise GenkitError(
+            status='INVALID_ARGUMENT',
+            message=f"define_model '{name}' cannot set longRunning. Use define_background_model.",
+        )
 
     # Add config schema if provided
     if config_schema:

--- a/py/packages/genkit/src/genkit/_core/_action.py
+++ b/py/packages/genkit/src/genkit/_core/_action.py
@@ -46,9 +46,8 @@ from genkit._core._tracing import SpanMetadata, run_in_new_span
 SpanAttributeValue = otel_types.AttributeValue
 
 
-def _record_latency(output: object, start_time: float) -> object:
+def _record_latency(output: object, latency_ms: float) -> object:
     """Stamp ``latency_ms`` on the output if it has one (in place, or via ``model_copy`` for frozen models)."""
-    latency_ms = (time.perf_counter() - start_time) * 1000
     if hasattr(output, 'latency_ms'):
         try:
             cast(Any, output).latency_ms = latency_ms
@@ -146,6 +145,7 @@ class ActionResponse(BaseModel, Generic[ResponseT]):
     response: ResponseT
     trace_id: str
     span_id: str = ''
+    latency_ms: float | None = None
 
 
 ChunkT_co = TypeVar('ChunkT_co', covariant=True)
@@ -787,10 +787,16 @@ class Action(Generic[InputT, OutputT, ChunkT, InitT]):
                     output = await execute()
                 else:
                     output = await self._invoke(input, ctx)
-                output = cast(OutputT, _record_latency(output, start_time))
+                latency_ms = (time.perf_counter() - start_time) * 1000
+                output = cast(OutputT, _record_latency(output, latency_ms))
                 # Picked up by run_in_new_span's success branch and written as ``genkit:output``.
                 span_meta.output = output
-                return ActionResponse(response=output, trace_id=trace_id, span_id=span_id)
+                return ActionResponse(
+                    response=output,
+                    trace_id=trace_id,
+                    span_id=span_id,
+                    latency_ms=latency_ms,
+                )
         except GenkitError:
             raise
         except Exception as e:

--- a/py/packages/genkit/src/genkit/_core/_background.py
+++ b/py/packages/genkit/src/genkit/_core/_background.py
@@ -25,6 +25,7 @@ from typing import Any, Generic, TypeVar
 from pydantic import BaseModel
 
 from genkit._core._action import Action, ActionKind, ActionRunContext
+from genkit._core._error import GenkitError
 from genkit._core._model import ModelRequest, ModelResponse
 from genkit._core._registry import Registry
 from genkit._core._schema import to_json_schema
@@ -119,7 +120,7 @@ class BackgroundAction(Generic[OutputT]):
             An Operation with an ID to track the job.
         """
         result = await self.start_action.run(input)
-        return _ensure_operation(result.response)
+        return _ensure_operation(response=result.response, name=self.start_action.name)
 
     async def check(self, operation: Operation) -> Operation:
         """Check the status of a background operation.
@@ -131,7 +132,7 @@ class BackgroundAction(Generic[OutputT]):
             Updated Operation with current status.
         """
         result = await self.check_action.run(operation)
-        return _ensure_operation(result.response)
+        return _ensure_operation(response=result.response, name=self.check_action.name)
 
     async def cancel(self, operation: Operation) -> Operation:
         """Cancel a background operation.
@@ -148,16 +149,17 @@ class BackgroundAction(Generic[OutputT]):
             # Return operation unchanged if cancel not supported
             return operation
         result = await self.cancel_action.run(operation)
-        return _ensure_operation(result.response)
+        return _ensure_operation(response=result.response, name=self.cancel_action.name)
 
 
-def _ensure_operation(response: Any) -> Operation:  # noqa: ANN401
-    """Convert response to Operation type."""
+def _ensure_operation(*, response: object, name: str) -> Operation:
+    """A start/check/cancel fn returns an Operation, not a dict."""
     if isinstance(response, Operation):
         return response
-    if isinstance(response, dict):
-        return Operation.model_validate(response)
-    raise TypeError(f'Expected Operation, got {type(response)}')
+    raise GenkitError(
+        status='FAILED_PRECONDITION',
+        message=f"Background model '{name}' did not return an operation",
+    )
 
 
 class DefineBackgroundModelOptions(BaseModel):

--- a/py/packages/genkit/src/genkit/_core/_background.py
+++ b/py/packages/genkit/src/genkit/_core/_background.py
@@ -51,6 +51,13 @@ def _make_action_key(action_type: ActionKind | str, name: str) -> str:
     return f'/{action_type}/{name}'
 
 
+def stamp_operation_action(*, operation: Operation, name: str) -> None:
+    """A handle needs the start action key so check/cancel can find the job."""
+    if operation.action:
+        return
+    operation.action = _make_action_key(ActionKind.BACKGROUND_MODEL, name)
+
+
 StartModelOpFn = Callable[[ModelRequest, ActionRunContext], Awaitable[Operation]]
 CheckModelOpFn = Callable[[Operation], Awaitable[Operation]]
 CancelModelOpFn = Callable[[Operation], Awaitable[Operation]]
@@ -153,10 +160,10 @@ class BackgroundAction(Generic[OutputT]):
 
 
 def missing_operation_error(*, name: str) -> GenkitError:
-    """The caller asked for a handle and the model did not return one."""
+    """The caller asked for a handle and this action did not return one."""
     return GenkitError(
         status='FAILED_PRECONDITION',
-        message=f"Background model '{name}' did not return an operation.",
+        message=f"'{name}' did not return an operation.",
     )
 
 

--- a/py/packages/genkit/src/genkit/_core/_background.py
+++ b/py/packages/genkit/src/genkit/_core/_background.py
@@ -152,14 +152,19 @@ class BackgroundAction(Generic[OutputT]):
         return _ensure_operation(response=result.response, name=self.cancel_action.name)
 
 
+def missing_operation_error(*, name: str) -> GenkitError:
+    """The caller asked for a handle and the model did not return one."""
+    return GenkitError(
+        status='FAILED_PRECONDITION',
+        message=f"Background model '{name}' did not return an operation.",
+    )
+
+
 def _ensure_operation(*, response: object, name: str) -> Operation:
     """A start/check/cancel fn returns an Operation, not a dict."""
     if isinstance(response, Operation):
         return response
-    raise GenkitError(
-        status='FAILED_PRECONDITION',
-        message=f"Background model '{name}' did not return an operation",
-    )
+    raise missing_operation_error(name=name)
 
 
 class DefineBackgroundModelOptions(BaseModel):

--- a/py/packages/genkit/src/genkit/_core/_model.py
+++ b/py/packages/genkit/src/genkit/_core/_model.py
@@ -557,9 +557,12 @@ class ModelResponse(GenkitModel, Generic[OutputT]):
 
         return cast(OutputT, parsed)
 
-    @cached_property
+    @property
     def messages(self) -> list[Message]:
-        """All messages including request history and the response message."""
+        """All messages including request history and the response message.
+
+        Recomputed each read so attaching ``request`` later still shows up.
+        """
         if self.message is None:
             return [Message(m) for m in self.request.messages] if self.request else []
         return [

--- a/py/packages/genkit/src/genkit/_core/_model.py
+++ b/py/packages/genkit/src/genkit/_core/_model.py
@@ -519,16 +519,15 @@ class ModelResponse(GenkitModel, Generic[OutputT]):
         pass
 
     def __eq__(self, other: object) -> bool:
-        """Compare responses by message, finish_reason, and operation.
+        """Compare responses by message, finish_reason, and operation id.
 
         Two start handles with different job ids are not the same response.
+        Timing on the handle is not part of the job.
         """
         if isinstance(other, ModelResponse):
-            return (
-                self.message == other.message
-                and self.finish_reason == other.finish_reason
-                and self.operation == other.operation
-            )
+            self_op = self.operation.id if self.operation is not None else None
+            other_op = other.operation.id if other.operation is not None else None
+            return self.message == other.message and self.finish_reason == other.finish_reason and self_op == other_op
         return super().__eq__(other)
 
     def __hash__(self) -> int:

--- a/py/packages/genkit/src/genkit/_core/_model.py
+++ b/py/packages/genkit/src/genkit/_core/_model.py
@@ -519,9 +519,16 @@ class ModelResponse(GenkitModel, Generic[OutputT]):
         pass
 
     def __eq__(self, other: object) -> bool:
-        """Compare responses by message and finish_reason."""
+        """Compare responses by message, finish_reason, and operation.
+
+        Two start handles with different job ids are not the same response.
+        """
         if isinstance(other, ModelResponse):
-            return self.message == other.message and self.finish_reason == other.finish_reason
+            return (
+                self.message == other.message
+                and self.finish_reason == other.finish_reason
+                and self.operation == other.operation
+            )
         return super().__eq__(other)
 
     def __hash__(self) -> int:

--- a/py/packages/genkit/src/genkit/_core/_model.py
+++ b/py/packages/genkit/src/genkit/_core/_model.py
@@ -238,17 +238,17 @@ class Message(MessageData):
         """Return identity-based hash."""
         return hash(id(self))
 
-    @cached_property
+    @property
     def text(self) -> str:
         """All text parts concatenated into a single string."""
         return text_from_message(self)
 
-    @cached_property
+    @property
     def tool_requests(self) -> list[ToolRequestPart]:
         """All tool request parts in this message."""
         return [p.root for p in self.content if isinstance(p.root, ToolRequestPart)]
 
-    @cached_property
+    @property
     def interrupts(self) -> list[ToolRequestPart]:
         """Tool requests marked as interrupted."""
         return [p for p in self.tool_requests if p.metadata and p.metadata.get('interrupt')]
@@ -481,6 +481,13 @@ class ModelRequest(GenkitModel, Generic[ModelRequestConfigT]):
         self.output.content_type = v
 
 
+def operation_snapshot(*, operation: Operation | None) -> tuple[object, object, object, object]:
+    """Job id plus the fields that change when a check lands."""
+    if operation is None:
+        return (None, None, None, None)
+    return (operation.id, operation.done, operation.error, operation.output)
+
+
 class ModelResponse(GenkitModel, Generic[OutputT]):
     """Model response with utilities for text extraction, output parsing, and validation."""
 
@@ -519,31 +526,37 @@ class ModelResponse(GenkitModel, Generic[OutputT]):
         pass
 
     def __eq__(self, other: object) -> bool:
-        """Compare responses by message, finish_reason, and operation id.
+        """Compare responses by message, finish_reason, and poll snapshot.
 
-        Two start handles with different job ids are not the same response.
-        Timing on the handle is not part of the job.
+        Same job id with a later done/error/output is a later check, not
+        the same response. Timing on the handle is not part of the job.
         """
         if isinstance(other, ModelResponse):
-            self_op = self.operation.id if self.operation is not None else None
-            other_op = other.operation.id if other.operation is not None else None
-            return self.message == other.message and self.finish_reason == other.finish_reason and self_op == other_op
+            return (
+                self.message == other.message
+                and self.finish_reason == other.finish_reason
+                and operation_snapshot(operation=self.operation) == operation_snapshot(operation=other.operation)
+            )
         return super().__eq__(other)
 
     def __hash__(self) -> int:
         """Return identity-based hash."""
         return hash(id(self))
 
-    @cached_property
+    @property
     def text(self) -> str:
         """All text parts concatenated into a single string."""
         if self.message is None:
             return ''
         return self.message.text
 
-    @cached_property
+    @property
     def output(self) -> OutputT:
-        """Parsed JSON output from the response text, validated against schema if set."""
+        """Parsed JSON output from the response text, validated against schema if set.
+
+        Recomputed each read so attaching a schema after a first touch still
+        returns the typed model.
+        """
         if self._message_parser and self.message is not None:
             parsed = self._message_parser(self.message)
         else:
@@ -570,14 +583,17 @@ class ModelResponse(GenkitModel, Generic[OutputT]):
             self.message,
         ]
 
-    @cached_property
+    @property
     def tool_requests(self) -> list[ToolRequestPart]:
-        """All tool request parts in the response message."""
+        """All tool request parts in the response message.
+
+        Recomputed each read so a later message still shows up.
+        """
         if self.message is None:
             return []
         return self.message.tool_requests
 
-    @cached_property
+    @property
     def media(self) -> list[Media]:
         """All media parts in the response message."""
         if self.message is None:
@@ -588,7 +604,7 @@ class ModelResponse(GenkitModel, Generic[OutputT]):
             if isinstance(part.root, MediaPart) and part.root.media is not None
         ]
 
-    @cached_property
+    @property
     def interrupts(self) -> list[ToolRequestPart]:
         """Tool requests marked as interrupted."""
         if self.message is None:
@@ -637,7 +653,7 @@ class ModelResponseChunk(ModelResponseChunkSchema, Generic[OutputT]):
         """Return hash."""
         return hash(id(self))
 
-    @cached_property
+    @property
     def text(self) -> str:
         """Text content of this chunk."""
         parts: list[str] = []
@@ -651,7 +667,7 @@ class ModelResponseChunk(ModelResponseChunkSchema, Generic[OutputT]):
                     parts.append(str(text_val))
         return ''.join(parts)
 
-    @cached_property
+    @property
     def accumulated_text(self) -> str:
         """Text from all previous chunks plus this chunk."""
         parts: list[str] = []
@@ -667,7 +683,7 @@ class ModelResponseChunk(ModelResponseChunkSchema, Generic[OutputT]):
                             parts.append(str(text_val))
         return ''.join(parts) + self.text
 
-    @cached_property
+    @property
     def output(self) -> OutputT:
         """Parsed JSON output from accumulated text."""
         if self.chunk_parser:

--- a/py/packages/genkit/tests/genkit/ai/background_generate_test.py
+++ b/py/packages/genkit/tests/genkit/ai/background_generate_test.py
@@ -315,7 +315,7 @@ async def test_background_start_model_response_without_operation_raises(ai: Genk
 
     _register_raw_background(ai, name='empty-bg', start=start)
 
-    with pytest.raises(GenkitError, match='Background model') as exc_info:
+    with pytest.raises(GenkitError, match="Background model 'empty-bg' did not return an operation") as exc_info:
         await ai.generate(model='empty-bg', prompt='a cat')
 
     assert exc_info.value.status == 'FAILED_PRECONDITION'

--- a/py/packages/genkit/tests/genkit/ai/background_generate_test.py
+++ b/py/packages/genkit/tests/genkit/ai/background_generate_test.py
@@ -26,6 +26,7 @@ from genkit._core._error import GenkitError
 from genkit._core._middleware import BaseMiddleware, GenerateHookParams, GenerateMiddlewareContext, ModelHookParams
 from genkit._core._model import ModelRequest, ModelResponse
 from genkit._core._typing import (
+    Error,
     FinishReason,
     Operation,
     Part,
@@ -150,17 +151,17 @@ class DropsOperation(BaseMiddleware):
 
 
 @pytest.mark.asyncio
-async def test_generate_operation_fails_when_wrap_model_drops_operation(ai: Genkit) -> None:
-    """generate() stays quiet; generate_operation is the one missing-handle error."""
+async def test_generate_fails_when_wrap_model_drops_operation(ai: Genkit) -> None:
+    """A hook that drops a billed ticket is a missing handle on both doors."""
     register_bg_model(ai)
 
-    response = await ai.generate(model='bg-model', prompt='a cat surfing', use=[DropsOperation()])
-    assert response.operation is None
+    with pytest.raises(GenkitError, match='did not return an operation') as generate_info:
+        await ai.generate(model='bg-model', prompt='a cat surfing', use=[DropsOperation()])
+    assert generate_info.value.status == 'FAILED_PRECONDITION'
 
-    with pytest.raises(GenkitError, match='did not return an operation') as exc_info:
+    with pytest.raises(GenkitError, match='did not return an operation') as operation_info:
         await ai.generate_operation(model='bg-model', prompt='a cat surfing', use=[DropsOperation()])
-
-    assert exc_info.value.status == 'FAILED_PRECONDITION'
+    assert operation_info.value.status == 'FAILED_PRECONDITION'
 
 
 class DropsGenerate(BaseMiddleware):
@@ -175,17 +176,17 @@ class DropsGenerate(BaseMiddleware):
 
 
 @pytest.mark.asyncio
-async def test_generate_operation_fails_when_wrap_generate_drops_operation(ai: Genkit) -> None:
-    """Same one error if wrap_generate rebuilds the response without the handle."""
+async def test_generate_fails_when_wrap_generate_drops_operation(ai: Genkit) -> None:
+    """Same missing-handle error if wrap_generate rebuilds the response without the ticket."""
     register_bg_model(ai)
 
-    response = await ai.generate(model='bg-model', prompt='a cat surfing', use=[DropsGenerate()])
-    assert response.operation is None
+    with pytest.raises(GenkitError, match='did not return an operation') as generate_info:
+        await ai.generate(model='bg-model', prompt='a cat surfing', use=[DropsGenerate()])
+    assert generate_info.value.status == 'FAILED_PRECONDITION'
 
-    with pytest.raises(GenkitError, match='did not return an operation') as exc_info:
+    with pytest.raises(GenkitError, match='did not return an operation') as operation_info:
         await ai.generate_operation(model='bg-model', prompt='a cat surfing', use=[DropsGenerate()])
-
-    assert exc_info.value.status == 'FAILED_PRECONDITION'
+    assert operation_info.value.status == 'FAILED_PRECONDITION'
 
 
 class SwallowsStart(BaseMiddleware):
@@ -274,14 +275,20 @@ async def test_generate_rejects_resume_on_background_model(ai: Genkit) -> None:
 
 
 @pytest.mark.asyncio
-async def test_generate_forwards_start_latency(ai: Genkit) -> None:
-    """wrapped_start already measured the call; the boxed response should carry it."""
+async def test_generate_stamps_latency_from_action_run(ai: Genkit) -> None:
+    """Action.run's clock lands on the boxed response for both registration shapes."""
     register_bg_model(ai)
+    wrapped = await ai.generate(model='bg-model', prompt='a cat')
+    assert wrapped.latency_ms is not None
+    assert wrapped.latency_ms >= 0
 
-    response = await ai.generate(model='bg-model', prompt='a cat')
+    async def start(_request: ModelRequest, _ctx: ActionRunContext) -> Operation:
+        return Operation(id='raw-1', done=False)
 
-    assert response.latency_ms is not None
-    assert response.latency_ms >= 0
+    _register_raw_background(ai, name='raw-bg', start=start)
+    raw = await ai.generate(model='raw-bg', prompt='a cat')
+    assert raw.latency_ms is not None
+    assert raw.latency_ms >= 0
 
 
 def _register_raw_background(ai: Genkit, *, name: str, start: Callable[..., Awaitable[object]]) -> None:
@@ -289,37 +296,40 @@ def _register_raw_background(ai: Genkit, *, name: str, start: Callable[..., Awai
 
 
 @pytest.mark.asyncio
-async def test_background_start_already_boxed_model_response(ai: Genkit) -> None:
-    """start() that already returned ModelResponse(operation=...) is passed through."""
+async def test_box_stamps_operation_action_so_check_can_poll(ai: Genkit) -> None:
+    """A raw start that forgot action can still be polled after generate()."""
+
+    async def start(_request: ModelRequest, _ctx: ActionRunContext) -> Operation:
+        return Operation(id='raw-1', done=False)
+
+    async def check(op: Operation, _ctx: ActionRunContext) -> Operation:
+        return Operation(id=op.id, done=True, action=op.action)
+
+    _register_raw_background(ai, name='raw-bg', start=start)
+    ai.registry.register_action(name='raw-bg/check', kind=ActionKind.CHECK_OPERATION, fn=check)
+
+    response = await ai.generate(model='raw-bg', prompt='a cat')
+    assert response.operation is not None
+    assert response.operation.action == '/background-model/raw-bg'
+
+    updated = await ai.check_operation(response.operation)
+    assert updated.id == 'raw-1'
+    assert updated.done is True
+
+
+@pytest.mark.asyncio
+async def test_background_start_must_return_operation(ai: Genkit) -> None:
+    """start() returns an Operation. A ModelResponse is a plugin bug."""
 
     async def start(_request: ModelRequest, _ctx: ActionRunContext) -> ModelResponse:
         return ModelResponse(operation=Operation(id='boxed-1', done=False))
 
     _register_raw_background(ai, name='boxed-bg', start=start)
 
-    response = await ai.generate(model='boxed-bg', prompt='a cat')
-
-    assert response.operation is not None
-    assert response.operation.id == 'boxed-1'
-    assert response.message is None
-
-
-@pytest.mark.asyncio
-async def test_background_start_model_response_without_operation_raises(ai: Genkit) -> None:
-    """A background start that returns a chat turn has no handle to poll."""
-
-    async def start(_request: ModelRequest, _ctx: ActionRunContext) -> ModelResponse:
-        return ModelResponse(
-            message=Message(role=Role.MODEL, content=[Part(root=TextPart(text='nope'))]),
-        )
-
-    _register_raw_background(ai, name='empty-bg', start=start)
-
-    with pytest.raises(GenkitError, match="Background model 'empty-bg' did not return an operation") as exc_info:
-        await ai.generate(model='empty-bg', prompt='a cat')
+    with pytest.raises(GenkitError, match="'boxed-bg' did not return an operation") as exc_info:
+        await ai.generate(model='boxed-bg', prompt='a cat')
 
     assert exc_info.value.status == 'FAILED_PRECONDITION'
-    assert 'did not return an operation' in str(exc_info.value)
 
 
 @pytest.mark.asyncio
@@ -336,6 +346,36 @@ async def test_define_model_returning_operation_raises(ai: Genkit) -> None:
 
     assert exc_info.value.status == 'FAILED_PRECONDITION'
     assert 'plain' in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_define_model_returning_dict_raises(ai: Genkit) -> None:
+    """A chat model that returns a dict is a plugin bug, not an AttributeError."""
+
+    async def model_fn(_request: ModelRequest, _ctx: ActionRunContext) -> dict[str, object]:
+        return {'operation': {'id': 'op-1', 'done': False}}
+
+    ai.define_model(name='plain-dict', fn=model_fn)
+
+    with pytest.raises(GenkitError, match="Model 'plain-dict' did not return a ModelResponse") as exc_info:
+        await ai.generate(model='plain-dict', prompt='hi')
+
+    assert exc_info.value.status == 'FAILED_PRECONDITION'
+
+
+@pytest.mark.asyncio
+async def test_define_model_returning_none_raises(ai: Genkit) -> None:
+    """A chat model that returns None is a plugin bug, not an AttributeError."""
+
+    async def model_fn(_request: ModelRequest, _ctx: ActionRunContext) -> None:
+        return None
+
+    ai.define_model(name='plain-none', fn=model_fn)
+
+    with pytest.raises(GenkitError, match="Model 'plain-none' did not return a ModelResponse") as exc_info:
+        await ai.generate(model='plain-none', prompt='hi')
+
+    assert exc_info.value.status == 'FAILED_PRECONDITION'
 
 
 @pytest.mark.asyncio
@@ -366,10 +406,43 @@ def test_model_response_messages_sees_request_set_after_first_read() -> None:
     assert [m.text for m in resp.messages] == ['a cat']
 
 
-def test_model_response_eq_uses_operation_id() -> None:
-    """Same job id is the same response even when start timing differs."""
+def test_model_response_views_see_message_set_after_first_read() -> None:
+    """A hook that touches text/interrupts/output before message is set must not freeze empty."""
+    resp = ModelResponse()
+    assert resp.text == ''
+    assert resp.interrupts == []
+    assert resp.tool_requests == []
+    assert resp.media == []
+    assert resp.output is None
+
+    resp.message = Message(
+        role=Role.MODEL,
+        content=[
+            Part(
+                root=ToolRequestPart(
+                    tool_request=ToolRequest(name='ping', input={}),
+                    metadata={'interrupt': True},
+                )
+            ),
+            Part(root=TextPart(text='{"ok": true}')),
+        ],
+    )
+    assert resp.text == '{"ok": true}'
+    assert len(resp.interrupts) == 1
+    assert len(resp.tool_requests) == 1
+    assert resp.output == {'ok': True}
+
+
+def test_model_response_eq_uses_operation_snapshot() -> None:
+    """Same job and poll state match even when start timing differs."""
     a = ModelResponse(operation=Operation(id='unique-a', metadata={'latencyMs': 0.166}))
     b = ModelResponse(operation=Operation(id='unique-a', metadata={'latencyMs': 0.002}))
     c = ModelResponse(operation=Operation(id='unique-b'))
     assert a == b
     assert a != c
+
+    in_flight = ModelResponse(operation=Operation(id='job1', done=False))
+    finished = ModelResponse(operation=Operation(id='job1', done=True, output={'url': 'x'}))
+    failed = ModelResponse(operation=Operation(id='job1', done=True, error=Error(message='boom')))
+    assert in_flight != finished
+    assert finished != failed

--- a/py/packages/genkit/tests/genkit/ai/background_generate_test.py
+++ b/py/packages/genkit/tests/genkit/ai/background_generate_test.py
@@ -20,12 +20,23 @@ from collections.abc import Awaitable, Callable
 
 import pytest
 
-from genkit import Genkit
+from genkit import Genkit, Message
 from genkit._core._action import ActionRunContext
 from genkit._core._background import BackgroundAction
+from genkit._core._error import GenkitError
 from genkit._core._middleware import BaseMiddleware, GenerateMiddlewareContext, ModelHookParams
 from genkit._core._model import ModelRequest, ModelResponse
-from genkit._core._typing import Operation
+from genkit._core._typing import (
+    FinishReason,
+    ModelInfo,
+    Operation,
+    Part,
+    Role,
+    Supports,
+    TextPart,
+    ToolRequest,
+    ToolRequestPart,
+)
 
 
 @pytest.fixture
@@ -126,3 +137,82 @@ async def test_generate_boxes_before_wrap_model(ai: Genkit) -> None:
     assert response.operation is not None
     assert response.operation.id == 'bg-op-123'
     assert response.message is None
+
+
+class DropsOperation(BaseMiddleware):
+    async def wrap_model(
+        self,
+        params: ModelHookParams,
+        ctx: GenerateMiddlewareContext,
+        next_fn: Callable[[ModelHookParams, GenerateMiddlewareContext], Awaitable[ModelResponse]],
+    ) -> ModelResponse:
+        resp = await next_fn(params, ctx)
+        return ModelResponse(message=resp.message, finish_reason=resp.finish_reason)
+
+
+@pytest.mark.asyncio
+async def test_generate_fails_when_wrap_model_drops_operation(ai: Genkit) -> None:
+    """A hook that rebuilds ModelResponse without operation must not blame the model."""
+    await register_bg_model(ai)
+
+    with pytest.raises(GenkitError, match='wrap_model returned no operation') as exc_info:
+        await ai.generate(model='bg-model', prompt='a cat surfing', use=[DropsOperation()])
+
+    assert exc_info.value.status == 'FAILED_PRECONDITION'
+
+    with pytest.raises(GenkitError, match='wrap_model returned no operation') as op_exc:
+        await ai.generate_operation(model='bg-model', prompt='a cat surfing', use=[DropsOperation()])
+
+    assert op_exc.value.status == 'FAILED_PRECONDITION'
+    assert 'did not return an operation' not in str(op_exc.value)
+
+
+@pytest.mark.asyncio
+async def test_generate_on_lro_define_model_still_runs_tools(ai: Genkit) -> None:
+    """A define_model LRO that also returns a tool request still runs the tool loop."""
+    tool_ran = 0
+
+    @ai.tool(name='ping')
+    async def ping() -> str:
+        nonlocal tool_ran
+        tool_ran += 1
+        return 'pong'
+
+    turns = 0
+
+    async def model_fn(request: ModelRequest, ctx: ActionRunContext) -> ModelResponse:
+        nonlocal turns
+        turns += 1
+        if turns == 1:
+            return ModelResponse(
+                message=Message(
+                    role=Role.MODEL,
+                    content=[Part(root=ToolRequestPart(tool_request=ToolRequest(name='ping', input={}, ref='1')))],
+                ),
+                operation=Operation(id='lro-1', done=False),
+                finish_reason=FinishReason.STOP,
+            )
+        return ModelResponse(
+            message=Message(role=Role.MODEL, content=[Part(root=TextPart(text='done'))]),
+            finish_reason=FinishReason.STOP,
+        )
+
+    ai.define_model(
+        name='lro-model',
+        fn=model_fn,
+        info=ModelInfo(supports=Supports(long_running=True, tools=True)),
+    )
+
+    response = await ai.generate(model='lro-model', prompt='x', tools=['ping'])
+
+    assert tool_ran == 1
+    assert response.text == 'done'
+    assert response.operation is None
+
+
+def test_model_response_eq_includes_operation() -> None:
+    """Two start handles with different job ids are not the same response."""
+    a = ModelResponse(operation=Operation(id='unique-a'))
+    b = ModelResponse(operation=Operation(id='unique-b'))
+    assert a != b
+    assert a == ModelResponse(operation=Operation(id='unique-a'))

--- a/py/packages/genkit/tests/genkit/ai/background_generate_test.py
+++ b/py/packages/genkit/tests/genkit/ai/background_generate_test.py
@@ -356,6 +356,16 @@ async def test_define_model_returning_model_response_with_operation_raises(ai: G
     assert exc_info.value.status == 'FAILED_PRECONDITION'
 
 
+def test_model_response_messages_sees_request_set_after_first_read() -> None:
+    """History is request + message. A first read before request is attached must not stick."""
+    resp = ModelResponse(operation=Operation(id='x'))
+    assert resp.messages == []
+    resp.request = ModelRequest(
+        messages=[Message(role=Role.USER, content=[Part(root=TextPart(text='a cat'))])],
+    )
+    assert [m.text for m in resp.messages] == ['a cat']
+
+
 def test_model_response_eq_uses_operation_id() -> None:
     """Same job id is the same response even when start timing differs."""
     a = ModelResponse(operation=Operation(id='unique-a', metadata={'latencyMs': 0.166}))

--- a/py/packages/genkit/tests/genkit/ai/background_generate_test.py
+++ b/py/packages/genkit/tests/genkit/ai/background_generate_test.py
@@ -24,7 +24,7 @@ from genkit import Genkit, Message
 from genkit._core._action import ActionRunContext
 from genkit._core._background import BackgroundAction
 from genkit._core._error import GenkitError
-from genkit._core._middleware import BaseMiddleware, GenerateMiddlewareContext, ModelHookParams
+from genkit._core._middleware import BaseMiddleware, GenerateHookParams, GenerateMiddlewareContext, ModelHookParams
 from genkit._core._model import ModelRequest, ModelResponse
 from genkit._core._typing import (
     FinishReason,
@@ -165,6 +165,29 @@ async def test_generate_fails_when_wrap_model_drops_operation(ai: Genkit) -> Non
 
     assert op_exc.value.status == 'FAILED_PRECONDITION'
     assert 'did not return an operation' not in str(op_exc.value)
+
+
+class DropsGenerate(BaseMiddleware):
+    async def wrap_generate(
+        self,
+        params: GenerateHookParams,
+        ctx: GenerateMiddlewareContext,
+        next_fn: Callable[[GenerateHookParams, GenerateMiddlewareContext], Awaitable[ModelResponse]],
+    ) -> ModelResponse:
+        resp = await next_fn(params, ctx)
+        return ModelResponse(message=resp.message, finish_reason=resp.finish_reason)
+
+
+@pytest.mark.asyncio
+async def test_generate_fails_when_wrap_generate_drops_operation(ai: Genkit) -> None:
+    """wrap_generate can still rebuild the final response; dropping the handle must not blame the model."""
+    await register_bg_model(ai)
+
+    with pytest.raises(GenkitError, match='wrap_generate returned no operation') as exc_info:
+        await ai.generate(model='bg-model', prompt='a cat surfing', use=[DropsGenerate()])
+
+    assert exc_info.value.status == 'FAILED_PRECONDITION'
+    assert 'did not return an operation' not in str(exc_info.value)
 
 
 @pytest.mark.asyncio

--- a/py/packages/genkit/tests/genkit/ai/background_generate_test.py
+++ b/py/packages/genkit/tests/genkit/ai/background_generate_test.py
@@ -20,22 +20,21 @@ from collections.abc import Awaitable, Callable
 
 import pytest
 
-from genkit import Genkit, Message
+from genkit import ActionKind, Document, Genkit, Message
 from genkit._core._action import ActionRunContext
-from genkit._core._background import BackgroundAction
 from genkit._core._error import GenkitError
 from genkit._core._middleware import BaseMiddleware, GenerateHookParams, GenerateMiddlewareContext, ModelHookParams
 from genkit._core._model import ModelRequest, ModelResponse
 from genkit._core._typing import (
     FinishReason,
-    ModelInfo,
     Operation,
     Part,
     Role,
-    Supports,
     TextPart,
     ToolRequest,
     ToolRequestPart,
+    ToolResponse,
+    ToolResponsePart,
 )
 
 
@@ -44,14 +43,14 @@ def ai() -> Genkit:
     return Genkit()
 
 
-async def register_bg_model(ai: Genkit, *, op_id: str = 'bg-op-123') -> BackgroundAction:
+def register_bg_model(ai: Genkit, *, op_id: str = 'bg-op-123') -> None:
     async def start(_request: ModelRequest, _ctx: ActionRunContext) -> Operation:
         return Operation(id=op_id, done=False)
 
     async def check(op: Operation) -> Operation:
         return op
 
-    return ai.define_background_model(
+    ai.define_background_model(
         name='bg-model',
         start=start,
         check=check,
@@ -61,7 +60,7 @@ async def register_bg_model(ai: Genkit, *, op_id: str = 'bg-op-123') -> Backgrou
 @pytest.mark.asyncio
 async def test_generate_returns_operation_for_background_model(ai: Genkit) -> None:
     """generate() wraps the start handle. message stays empty."""
-    await register_bg_model(ai)
+    register_bg_model(ai)
 
     response = await ai.generate(model='bg-model', prompt='a cat surfing')
 
@@ -75,7 +74,7 @@ async def test_generate_returns_operation_for_background_model(ai: Genkit) -> No
 @pytest.mark.asyncio
 async def test_generate_operation_with_background_model(ai: Genkit) -> None:
     """generate_operation() returns that same handle."""
-    await register_bg_model(ai, op_id='bg-op-456')
+    register_bg_model(ai, op_id='bg-op-456')
 
     operation = await ai.generate_operation(model='bg-model', prompt='a cat surfing')
 
@@ -130,7 +129,7 @@ class ReadsMessage(BaseMiddleware):
 @pytest.mark.asyncio
 async def test_generate_boxes_before_wrap_model(ai: Genkit) -> None:
     """wrap_model sees a ModelResponse, so reading .message does not crash."""
-    await register_bg_model(ai)
+    register_bg_model(ai)
 
     response = await ai.generate(model='bg-model', prompt='a cat surfing', use=[ReadsMessage()])
 
@@ -151,20 +150,17 @@ class DropsOperation(BaseMiddleware):
 
 
 @pytest.mark.asyncio
-async def test_generate_fails_when_wrap_model_drops_operation(ai: Genkit) -> None:
-    """A hook that rebuilds ModelResponse without operation must not blame the model."""
-    await register_bg_model(ai)
+async def test_generate_operation_fails_when_wrap_model_drops_operation(ai: Genkit) -> None:
+    """generate() stays quiet; generate_operation is the one missing-handle error."""
+    register_bg_model(ai)
 
-    with pytest.raises(GenkitError, match='wrap_model returned no operation') as exc_info:
-        await ai.generate(model='bg-model', prompt='a cat surfing', use=[DropsOperation()])
+    response = await ai.generate(model='bg-model', prompt='a cat surfing', use=[DropsOperation()])
+    assert response.operation is None
 
-    assert exc_info.value.status == 'FAILED_PRECONDITION'
-
-    with pytest.raises(GenkitError, match='wrap_model returned no operation') as op_exc:
+    with pytest.raises(GenkitError, match='did not return an operation') as exc_info:
         await ai.generate_operation(model='bg-model', prompt='a cat surfing', use=[DropsOperation()])
 
-    assert op_exc.value.status == 'FAILED_PRECONDITION'
-    assert 'did not return an operation' not in str(op_exc.value)
+    assert exc_info.value.status == 'FAILED_PRECONDITION'
 
 
 class DropsGenerate(BaseMiddleware):
@@ -179,63 +175,191 @@ class DropsGenerate(BaseMiddleware):
 
 
 @pytest.mark.asyncio
-async def test_generate_fails_when_wrap_generate_drops_operation(ai: Genkit) -> None:
-    """wrap_generate can still rebuild the final response; dropping the handle must not blame the model."""
-    await register_bg_model(ai)
+async def test_generate_operation_fails_when_wrap_generate_drops_operation(ai: Genkit) -> None:
+    """Same one error if wrap_generate rebuilds the response without the handle."""
+    register_bg_model(ai)
 
-    with pytest.raises(GenkitError, match='wrap_generate returned no operation') as exc_info:
-        await ai.generate(model='bg-model', prompt='a cat surfing', use=[DropsGenerate()])
+    response = await ai.generate(model='bg-model', prompt='a cat surfing', use=[DropsGenerate()])
+    assert response.operation is None
+
+    with pytest.raises(GenkitError, match='did not return an operation') as exc_info:
+        await ai.generate_operation(model='bg-model', prompt='a cat surfing', use=[DropsGenerate()])
 
     assert exc_info.value.status == 'FAILED_PRECONDITION'
-    assert 'did not return an operation' not in str(exc_info.value)
+
+
+class SwallowsStart(BaseMiddleware):
+    async def wrap_model(
+        self,
+        params: ModelHookParams,
+        ctx: GenerateMiddlewareContext,
+        next_fn: Callable[[ModelHookParams, GenerateMiddlewareContext], Awaitable[ModelResponse]],
+    ) -> ModelResponse:
+        try:
+            return await next_fn(params, ctx)
+        except GenkitError:
+            return ModelResponse(
+                message=Message(role=Role.MODEL, content=[Part(root=TextPart(text='FLASH'))]),
+                finish_reason=FinishReason.STOP,
+            )
 
 
 @pytest.mark.asyncio
-async def test_generate_on_lro_define_model_still_runs_tools(ai: Genkit) -> None:
-    """A define_model LRO that also returns a tool request still runs the tool loop."""
-    tool_ran = 0
+async def test_generate_keeps_fallback_answer_when_start_raises(ai: Genkit) -> None:
+    """A hook that substitutes another model's answer is not a missing handle."""
 
-    @ai.tool(name='ping')
-    async def ping() -> str:
-        nonlocal tool_ran
-        tool_ran += 1
-        return 'pong'
+    async def start(_request: ModelRequest, _ctx: ActionRunContext) -> Operation:
+        raise GenkitError(status='UNAVAILABLE', message='veo capacity exhausted')
 
-    turns = 0
+    async def check(op: Operation) -> Operation:
+        return op
 
-    async def model_fn(request: ModelRequest, ctx: ActionRunContext) -> ModelResponse:
-        nonlocal turns
-        turns += 1
-        if turns == 1:
-            return ModelResponse(
-                message=Message(
-                    role=Role.MODEL,
-                    content=[Part(root=ToolRequestPart(tool_request=ToolRequest(name='ping', input={}, ref='1')))],
-                ),
-                operation=Operation(id='lro-1', done=False),
-                finish_reason=FinishReason.STOP,
-            )
-        return ModelResponse(
-            message=Message(role=Role.MODEL, content=[Part(root=TextPart(text='done'))]),
-            finish_reason=FinishReason.STOP,
-        )
+    ai.define_background_model(name='bg-model', start=start, check=check)
 
-    ai.define_model(
-        name='lro-model',
-        fn=model_fn,
-        info=ModelInfo(supports=Supports(long_running=True, tools=True)),
-    )
+    response = await ai.generate(model='bg-model', prompt='a cat', use=[SwallowsStart()])
 
-    response = await ai.generate(model='lro-model', prompt='x', tools=['ping'])
-
-    assert tool_ran == 1
-    assert response.text == 'done'
+    assert response.text == 'FLASH'
     assert response.operation is None
 
 
-def test_model_response_eq_includes_operation() -> None:
-    """Two start handles with different job ids are not the same response."""
-    a = ModelResponse(operation=Operation(id='unique-a'))
-    b = ModelResponse(operation=Operation(id='unique-b'))
-    assert a != b
-    assert a == ModelResponse(operation=Operation(id='unique-a'))
+@pytest.mark.asyncio
+async def test_generate_persists_clean_history_without_injected_docs(ai: Genkit) -> None:
+    """Injected RAG text stays off response.request.messages."""
+    register_bg_model(ai)
+
+    response = await ai.generate(
+        model='bg-model',
+        prompt='render a cat',
+        docs=[Document.from_text('SECRET-CONTEXT-DOC')],
+    )
+
+    assert response.request is not None
+    dumped = ' '.join(m.text for m in response.request.messages)
+    assert 'SECRET-CONTEXT-DOC' not in dumped
+    assert 'render a cat' in dumped
+
+
+@pytest.mark.asyncio
+async def test_generate_rejects_resume_on_background_model(ai: Genkit) -> None:
+    """A video start cannot satisfy an interrupt resume. Don't bill start()."""
+    started = 0
+
+    async def start(_request: ModelRequest, _ctx: ActionRunContext) -> Operation:
+        nonlocal started
+        started += 1
+        return Operation(id='bg-op-123', done=False)
+
+    async def check(op: Operation) -> Operation:
+        return op
+
+    ai.define_background_model(name='bg-model', start=start, check=check)
+
+    with pytest.raises(GenkitError, match='Cannot resume background model') as exc_info:
+        await ai.generate(
+            model='bg-model',
+            messages=[
+                Message(role=Role.USER, content=[Part(root=TextPart(text='hi'))]),
+                Message(
+                    role=Role.MODEL,
+                    content=[
+                        Part(root=ToolRequestPart(tool_request=ToolRequest(name='ping', input={}, ref='1'))),
+                    ],
+                ),
+            ],
+            resume_respond=[ToolResponsePart(tool_response=ToolResponse(name='ping', ref='1', output='ok'))],
+        )
+
+    assert exc_info.value.status == 'FAILED_PRECONDITION'
+    assert started == 0
+
+
+@pytest.mark.asyncio
+async def test_generate_forwards_start_latency(ai: Genkit) -> None:
+    """wrapped_start already measured the call; the boxed response should carry it."""
+    register_bg_model(ai)
+
+    response = await ai.generate(model='bg-model', prompt='a cat')
+
+    assert response.latency_ms is not None
+    assert response.latency_ms >= 0
+
+
+def _register_raw_background(ai: Genkit, *, name: str, start: Callable[..., Awaitable[object]]) -> None:
+    ai.registry.register_action(name=name, kind=ActionKind.BACKGROUND_MODEL, fn=start)
+
+
+@pytest.mark.asyncio
+async def test_background_start_already_boxed_model_response(ai: Genkit) -> None:
+    """start() that already returned ModelResponse(operation=...) is passed through."""
+
+    async def start(_request: ModelRequest, _ctx: ActionRunContext) -> ModelResponse:
+        return ModelResponse(operation=Operation(id='boxed-1', done=False))
+
+    _register_raw_background(ai, name='boxed-bg', start=start)
+
+    response = await ai.generate(model='boxed-bg', prompt='a cat')
+
+    assert response.operation is not None
+    assert response.operation.id == 'boxed-1'
+    assert response.message is None
+
+
+@pytest.mark.asyncio
+async def test_background_start_model_response_without_operation_raises(ai: Genkit) -> None:
+    """A background start that returns a chat turn has no handle to poll."""
+
+    async def start(_request: ModelRequest, _ctx: ActionRunContext) -> ModelResponse:
+        return ModelResponse(
+            message=Message(role=Role.MODEL, content=[Part(root=TextPart(text='nope'))]),
+        )
+
+    _register_raw_background(ai, name='empty-bg', start=start)
+
+    with pytest.raises(GenkitError, match='Background model') as exc_info:
+        await ai.generate(model='empty-bg', prompt='a cat')
+
+    assert exc_info.value.status == 'FAILED_PRECONDITION'
+    assert 'did not return an operation' in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_define_model_returning_operation_raises(ai: Genkit) -> None:
+    """A chat model that returns a bare Operation is registered on the wrong kind."""
+
+    async def model_fn(_request: ModelRequest, _ctx: ActionRunContext) -> Operation:
+        return Operation(id='sneaky', done=False)
+
+    ai.define_model(name='plain', fn=model_fn)
+
+    with pytest.raises(GenkitError, match='define_background_model') as exc_info:
+        await ai.generate(model='plain', prompt='hi')
+
+    assert exc_info.value.status == 'FAILED_PRECONDITION'
+    assert 'plain' in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_define_model_returning_model_response_with_operation_raises(ai: Genkit) -> None:
+    """A chat model that stuffs a handle onto ModelResponse is the same mistake."""
+
+    async def model_fn(_request: ModelRequest, _ctx: ActionRunContext) -> ModelResponse:
+        return ModelResponse(
+            message=Message(role=Role.MODEL, content=[Part(root=TextPart(text='Started'))]),
+            operation=Operation(id='lro-1', done=False),
+        )
+
+    ai.define_model(name='plain', fn=model_fn)
+
+    with pytest.raises(GenkitError, match='define_background_model') as exc_info:
+        await ai.generate(model='plain', prompt='hi')
+
+    assert exc_info.value.status == 'FAILED_PRECONDITION'
+
+
+def test_model_response_eq_uses_operation_id() -> None:
+    """Same job id is the same response even when start timing differs."""
+    a = ModelResponse(operation=Operation(id='unique-a', metadata={'latencyMs': 0.166}))
+    b = ModelResponse(operation=Operation(id='unique-a', metadata={'latencyMs': 0.002}))
+    c = ModelResponse(operation=Operation(id='unique-b'))
+    assert a == b
+    assert a != c

--- a/py/packages/genkit/tests/genkit/ai/background_generate_test.py
+++ b/py/packages/genkit/tests/genkit/ai/background_generate_test.py
@@ -73,6 +73,37 @@ async def test_generate_operation_with_background_model(ai: Genkit) -> None:
     assert operation.action == '/background-model/bg-model'
 
 
+@pytest.mark.asyncio
+async def test_generate_returns_the_job_without_polling(ai: Genkit) -> None:
+    """generate() hands back the job now. It does not wait until the job is done.
+
+    A background model (video, and anything registered with
+    ``define_background_model``) starts a job and returns a handle. You
+    poll later with ``check_operation``. ``generate()`` and
+    ``generate_operation()`` only start; they must not call ``check``
+    on the way out, or a long render would block the first call.
+    """
+    checks = 0
+
+    async def start(_request: ModelRequest, _ctx: ActionRunContext) -> Operation:
+        return Operation(id='bg-op-123', done=False)
+
+    async def check(op: Operation) -> Operation:
+        nonlocal checks
+        checks += 1
+        return Operation(id=op.id, done=True)
+
+    ai.define_background_model(name='bg-model', start=start, check=check)
+
+    response = await ai.generate(model='bg-model', prompt='a cat surfing')
+    operation = await ai.generate_operation(model='bg-model', prompt='a cat surfing')
+
+    assert response.operation is not None
+    assert response.operation.done is False
+    assert operation.done is False
+    assert checks == 0
+
+
 class ReadsMessage(BaseMiddleware):
     async def wrap_model(
         self,

--- a/py/packages/genkit/tests/genkit/ai/background_generate_test.py
+++ b/py/packages/genkit/tests/genkit/ai/background_generate_test.py
@@ -1,0 +1,97 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""generate() / generate_operation() against a define_background_model fake."""
+
+from collections.abc import Awaitable, Callable
+
+import pytest
+
+from genkit import Genkit
+from genkit._core._action import ActionRunContext
+from genkit._core._background import BackgroundAction
+from genkit._core._middleware import BaseMiddleware, GenerateMiddlewareContext, ModelHookParams
+from genkit._core._model import ModelRequest, ModelResponse
+from genkit._core._typing import Operation
+
+
+@pytest.fixture
+def ai() -> Genkit:
+    return Genkit()
+
+
+async def register_bg_model(ai: Genkit, *, op_id: str = 'bg-op-123') -> BackgroundAction:
+    async def start(_request: ModelRequest, _ctx: ActionRunContext) -> Operation:
+        return Operation(id=op_id, done=False)
+
+    async def check(op: Operation) -> Operation:
+        return op
+
+    return ai.define_background_model(
+        name='bg-model',
+        start=start,
+        check=check,
+    )
+
+
+@pytest.mark.asyncio
+async def test_generate_returns_operation_for_background_model(ai: Genkit) -> None:
+    """generate() wraps the start handle. message stays empty."""
+    await register_bg_model(ai)
+
+    response = await ai.generate(model='bg-model', prompt='a cat surfing')
+
+    assert response.operation is not None
+    assert response.operation.id == 'bg-op-123'
+    assert response.operation.done is False
+    assert response.operation.action == '/background-model/bg-model'
+    assert response.message is None
+
+
+@pytest.mark.asyncio
+async def test_generate_operation_with_background_model(ai: Genkit) -> None:
+    """generate_operation() returns that same handle."""
+    await register_bg_model(ai, op_id='bg-op-456')
+
+    operation = await ai.generate_operation(model='bg-model', prompt='a cat surfing')
+
+    assert isinstance(operation, Operation)
+    assert operation.id == 'bg-op-456'
+    assert operation.action == '/background-model/bg-model'
+
+
+class ReadsMessage(BaseMiddleware):
+    async def wrap_model(
+        self,
+        params: ModelHookParams,
+        ctx: GenerateMiddlewareContext,
+        next_fn: Callable[[ModelHookParams, GenerateMiddlewareContext], Awaitable[ModelResponse]],
+    ) -> ModelResponse:
+        response = await next_fn(params, ctx)
+        _ = response.message
+        return response
+
+
+@pytest.mark.asyncio
+async def test_generate_boxes_before_wrap_model(ai: Genkit) -> None:
+    """wrap_model sees a ModelResponse, so reading .message does not crash."""
+    await register_bg_model(ai)
+
+    response = await ai.generate(model='bg-model', prompt='a cat surfing', use=[ReadsMessage()])
+
+    assert response.operation is not None
+    assert response.operation.id == 'bg-op-123'
+    assert response.message is None

--- a/py/packages/genkit/tests/genkit/ai/generate_operation_test.py
+++ b/py/packages/genkit/tests/genkit/ai/generate_operation_test.py
@@ -141,37 +141,22 @@ async def test_generate_operation_model_no_supports_info(ai: Genkit) -> None:
     assert 'does not support long running operations' in str(exc_info.value)
 
 
-@pytest.mark.asyncio
-async def test_generate_operation_no_operation_returned(ai: Genkit) -> None:
-    """Test error when model supports LRO but doesn't return an operation.
+def test_define_model_rejects_long_running(ai: Genkit) -> None:
+    """A chat model cannot advertise a background job. Use define_background_model."""
 
-    This matches the JS FAILED_PRECONDITION error case.
-    """
-
-    # Define a model that claims to support long_running but doesn't return an operation
     async def model_fn(request: ModelRequest, ctx: ActionRunContext) -> ModelResponse:
-        # Return a normal response without an operation
         return ModelResponse(
-            message=Message(
-                role=Role.MODEL,
-                content=[Part(root=TextPart(text='Hello'))],
-            ),
+            message=Message(role=Role.MODEL, content=[Part(root=TextPart(text='Hello'))]),
         )
 
-    ai.define_model(
-        name='fake-lro-model',
-        fn=model_fn,
-        info=ModelInfo(
-            supports=Supports(
-                long_running=True,  # Claims to support LRO
-            ),
-        ),
-    )
+    with pytest.raises(GenkitError, match='define_background_model') as exc_info:
+        ai.define_model(
+            name='fake-lro-model',
+            fn=model_fn,
+            info=ModelInfo(supports=Supports(long_running=True)),
+        )
 
-    with pytest.raises(GenkitError) as exc_info:
-        await ai.generate_operation(model='fake-lro-model', prompt='Hi')
-
-    assert 'did not return an operation' in str(exc_info.value)
+    assert exc_info.value.status == 'INVALID_ARGUMENT'
 
 
 @pytest.mark.asyncio
@@ -236,4 +221,11 @@ async def test_generate_operation_passes_all_options(ai: Genkit) -> None:
     )
 
     assert captured_request is not None
-    assert captured_request.config is not None
+    config = captured_request.config
+    if isinstance(config, dict):
+        assert config.get('temperature') == 0.7
+    else:
+        assert config is not None
+        assert getattr(config, 'temperature', None) == 0.7
+    assert any(m.role == Role.SYSTEM and 'test assistant' in m.text.lower() for m in captured_request.messages)
+    assert any(m.role == Role.USER and 'Test prompt' in m.text for m in captured_request.messages)

--- a/py/packages/genkit/tests/genkit/ai/generate_operation_test.py
+++ b/py/packages/genkit/tests/genkit/ai/generate_operation_test.py
@@ -176,32 +176,15 @@ async def test_generate_operation_no_operation_returned(ai: Genkit) -> None:
 
 @pytest.mark.asyncio
 async def test_generate_operation_success_with_lro_model(ai: Genkit) -> None:
-    """Test successful generate_operation with a proper long-running model."""
-    expected_operation = Operation(
-        id='test-operation-123',
-        done=False,
-        action='/background-model/lro-model',
-    )
+    """Test successful generate_operation with a background model."""
 
-    # Define a model that supports long_running and returns an operation
-    async def model_fn(request: ModelRequest, ctx: ActionRunContext) -> ModelResponse:
-        return ModelResponse(
-            message=Message(
-                role=Role.MODEL,
-                content=[Part(root=TextPart(text='Started'))],
-            ),
-            operation=expected_operation,
-        )
+    async def start(_request: ModelRequest, _ctx: ActionRunContext) -> Operation:
+        return Operation(id='test-operation-123', done=False)
 
-    ai.define_model(
-        name='lro-model',
-        fn=model_fn,
-        info=ModelInfo(
-            supports=Supports(
-                long_running=True,
-            ),
-        ),
-    )
+    async def check(op: Operation) -> Operation:
+        return op
+
+    ai.define_background_model(name='lro-model', start=start, check=check)
 
     operation = await ai.generate_operation(model='lro-model', prompt='Generate video')
 
@@ -212,44 +195,17 @@ async def test_generate_operation_success_with_lro_model(ai: Genkit) -> None:
 
 
 @pytest.mark.asyncio
-async def test_generate_operation_with_default_model(ai: Genkit) -> None:
+async def test_generate_operation_with_default_model() -> None:
     """Test generate_operation uses default model when set."""
-    expected_operation = Operation(
-        id='default-op-456',
-        done=False,
-    )
 
-    async def model_fn(request: ModelRequest, ctx: ActionRunContext) -> ModelResponse:
-        return ModelResponse(
-            message=Message(
-                role=Role.MODEL,
-                content=[Part(root=TextPart(text='Started'))],
-            ),
-            operation=expected_operation,
-        )
+    async def start(_request: ModelRequest, _ctx: ActionRunContext) -> Operation:
+        return Operation(id='default-op-456', done=False)
 
-    ai.define_model(
-        name='default-lro-model',
-        fn=model_fn,
-        info=ModelInfo(
-            supports=Supports(
-                long_running=True,
-            ),
-        ),
-    )
+    async def check(op: Operation) -> Operation:
+        return op
 
-    # Create a new Genkit instance with the default model set
     ai_with_default = Genkit(model='default-lro-model')
-    # Re-register the model on the new instance
-    ai_with_default.define_model(
-        name='default-lro-model',
-        fn=model_fn,
-        info=ModelInfo(
-            supports=Supports(
-                long_running=True,
-            ),
-        ),
-    )
+    ai_with_default.define_background_model(name='default-lro-model', start=start, check=check)
 
     operation = await ai_with_default.generate_operation(prompt='Generate video')
 
@@ -261,28 +217,16 @@ async def test_generate_operation_with_default_model(ai: Genkit) -> None:
 async def test_generate_operation_passes_all_options(ai: Genkit) -> None:
     """Test that generate_operation passes all options to generate()."""
     captured_request: ModelRequest | None = None
-    expected_operation = Operation(id='opt-test-789', done=False)
 
-    async def model_fn(request: ModelRequest, ctx: ActionRunContext) -> ModelResponse:
+    async def start(request: ModelRequest, _ctx: ActionRunContext) -> Operation:
         nonlocal captured_request
         captured_request = request
-        return ModelResponse(
-            message=Message(
-                role=Role.MODEL,
-                content=[Part(root=TextPart(text='Started'))],
-            ),
-            operation=expected_operation,
-        )
+        return Operation(id='opt-test-789', done=False)
 
-    ai.define_model(
-        name='options-test-model',
-        fn=model_fn,
-        info=ModelInfo(
-            supports=Supports(
-                long_running=True,
-            ),
-        ),
-    )
+    async def check(op: Operation) -> Operation:
+        return op
+
+    ai.define_background_model(name='options-test-model', start=start, check=check)
 
     await ai.generate_operation(
         model='options-test-model',
@@ -292,5 +236,4 @@ async def test_generate_operation_passes_all_options(ai: Genkit) -> None:
     )
 
     assert captured_request is not None
-    # Verify config was passed
     assert captured_request.config is not None

--- a/py/packages/genkit/tests/genkit/ai/model_ref_generate_test.py
+++ b/py/packages/genkit/tests/genkit/ai/model_ref_generate_test.py
@@ -17,8 +17,8 @@ from genkit._ai._prompt import PromptConfig, to_generate_action_options
 from genkit._ai._testing import EchoModel, define_echo_model
 from genkit._core._action import ActionRunContext
 from genkit._core._error import GenkitError
-from genkit._core._model import Message, ModelRequest, ModelResponse
-from genkit._core._typing import ModelInfo, Operation, Part, Role, Supports, TextPart
+from genkit._core._model import ModelRequest
+from genkit._core._typing import Operation
 from genkit.model import model_ref
 
 
@@ -214,28 +214,16 @@ async def test_define_prompt_dict_none_clear_and_extra(
 @pytest.mark.asyncio
 async def test_generate_operation_with_model_ref(ai: Genkit) -> None:
     """generate_operation applies the ref's version and config, not just the name."""
-    expected_operation = Operation(
-        id='ref-op-123',
-        done=False,
-        action='/background-model/lro-model',
-    )
     seen: list[ModelRequest] = []
 
-    async def model_fn(request: ModelRequest, ctx: ActionRunContext) -> ModelResponse:
+    async def start(request: ModelRequest, _ctx: ActionRunContext) -> Operation:
         seen.append(request)
-        return ModelResponse(
-            message=Message(
-                role=Role.MODEL,
-                content=[Part(root=TextPart(text='Started'))],
-            ),
-            operation=expected_operation,
-        )
+        return Operation(id='ref-op-123', done=False)
 
-    ai.define_model(
-        name='lro-model',
-        fn=model_fn,
-        info=ModelInfo(supports=Supports(long_running=True)),
-    )
+    async def check(op: Operation) -> Operation:
+        return op
+
+    ai.define_background_model(name='lro-model', start=start, check=check)
     ref = model_ref(
         'lro-model',
         config_schema=ModelConfig,

--- a/py/packages/genkit/tests/genkit/veneer/veneer_test.py
+++ b/py/packages/genkit/tests/genkit/veneer/veneer_test.py
@@ -1596,7 +1596,7 @@ def test_define_model_with_info(setup_test: SetupFixture) -> None:
         fn=foo_model_fn,
         info=ModelInfo(
             label='Foo Bar',
-            supports=Supports(multiturn=True, tools=True, system_role=True, long_running=True),
+            supports=Supports(multiturn=True, tools=True, system_role=True),
         ),
     )
     assert action.metadata['model'] == {
@@ -1605,7 +1605,6 @@ def test_define_model_with_info(setup_test: SetupFixture) -> None:
             'multiturn': True,
             'tools': True,
             'systemRole': True,
-            'longRunning': True,
         },
     }
 

--- a/py/packages/genkit/tests/genkit/veneer/veneer_test.py
+++ b/py/packages/genkit/tests/genkit/veneer/veneer_test.py
@@ -1831,20 +1831,16 @@ def test_define_background_model_with_info(setup_test: SetupFixture) -> None:
 async def test_generate_operation_with_model_info_long_running(
     setup_test: SetupFixture,
 ) -> None:
-    """Verify generate_operation succeeds for a model defined with ModelInfo(supports=Supports(long_running=True))."""
+    """Verify generate_operation succeeds for a define_background_model."""
     ai, _, _, *_ = setup_test
 
-    async def my_model(request: ModelRequest) -> ModelResponse:
-        return ModelResponse(
-            message=Message(role='model', content=[TextPart(text='done')]),
-            operation=Operation(id='op123', done=False),
-        )
+    async def start(_request: ModelRequest, _ctx: ActionRunContext) -> Operation:
+        return Operation(id='op123', done=False)
 
-    ai.define_model(
-        name='lr_model',
-        fn=my_model,
-        info=ModelInfo(supports=Supports(long_running=True)),
-    )
+    async def check(op: Operation) -> Operation:
+        return op
+
+    ai.define_background_model(name='lr_model', start=start, check=check)
 
     op = await ai.generate_operation(model='lr_model', prompt='test')
     assert op is not None


### PR DESCRIPTION
## Summary
- `generate()` on a background model returns a `ModelResponse` whose `operation` is the start handle and whose `message` is `None`. It does not poll until done.
- `generate_operation()` is that same start and returns the `Operation`. If `generate()` came back without a handle, this is the missing-handle error.
- `start()` is boxed into a `ModelResponse` **before** `wrap_model`, so a hook that reads `.message` is safe. Boxing before the chain is deliberate.
- After the hook, a background start takes the same path as chat: pin `response.request` to the pre-`wrap_model` request, debug-log, `assert_valid()`, persist. `message is None` is the exit, not a kind-keyed early return.
- A hook (Fallback, cache, a drop) may replace the boxed start. `generate()` keeps that answer. It does not demand an `operation` from every post-middleware response.
- A `start()` that is not an `Operation` (or a boxed handle) raises `FAILED_PRECONDITION: Background model 'X' did not return an operation`. A dict is not coerced into a ticket.
- `define_model` that returns an `operation` raises. Use `define_background_model`. That combo is not a product.
- Resume against a background model is rejected before `start()` is billed. A start cannot finish a tool interrupt.
- `ModelResponse.__eq__` compares `message`, `finish_reason`, and `[operation.id](http://operation.id/)`. Timing on the handle is not the job.
- `.messages` is a `@property`, so attaching `request` after a first read still shows history.