### PR TITLE
feat(py): Developer UI traces over HTTP, OpenTelemetry opt-in

### DIFF
--- a/py/README.md
+++ b/py/README.md
@@ -1,6 +1,6 @@
 # Genkit Python SDK
 
-Build production-ready AI applications in Python with type-safe flows, structured outputs, and integrated observability.
+Build production-ready AI applications in Python with type-safe flows and structured outputs.
 
 ## Quick Start
 
@@ -29,7 +29,7 @@ ai = Genkit(plugins=[GoogleAI()])
 def get_weather(city: str) -> str:
     return f"Sunny, 72°F in {city}"
 
-# 3. Define an observable flow
+# 3. Define a flow
 @ai.flow()
 async def plan_trip(destination: str) -> str:
     response = await ai.generate(
@@ -44,7 +44,7 @@ async def plan_trip(destination: str) -> str:
 
 - **Type-Safe by Design:** Leverage Python type annotations and Pydantic models for structured inputs, outputs, and tool definitions.
 - **Multi-Model Provider API:** Switch effortlessly between Google Gemini, Anthropic Claude, OpenAI, Ollama, Vertex AI, and Amazon Bedrock with a unified API.
-- **Integrated Observability:** Built-in OpenTelemetry tracing and evaluation metrics. Inspect spans and debug flows in real-time using the Genkit Developer UI (`genkit start`).
+- **Integrated Observability:** OpenTelemetry when you want it. `genkit start -- python app.py` sets the collector before `Genkit()`. If you start the app yourself after `genkit start`, the collector URL arrives on the reflection handshake.
 - **Deploy Anywhere:** Expose flows as standard ASGI/WSGI applications compatible with FastAPI, Flask, Django, Cloud Run, or any serverless platform.
 
 ---

--- a/py/packages/genkit-google-cloud/src/genkit_google_cloud/__init__.py
+++ b/py/packages/genkit-google-cloud/src/genkit_google_cloud/__init__.py
@@ -34,13 +34,10 @@ Example:
     )
 
 
-    # 1. Enable Google Cloud Trace and Monitoring export
     enable_google_cloud_telemetry(project_id='my-project')
 
-    # 2. All subsequent Genkit actions automatically export telemetry
     ai = Genkit(plugins=[GoogleAI()], model=GoogleAI.gemini_model('gemini-flash-latest'))
     await ai.generate(prompt='Hello, world!')
-    # => Traces exported asynchronously to Cloud Trace (latency, tokens, status)
 
     # 3. Persist agent sessions in Firestore (ADC / FIRESTORE_EMULATOR_HOST)
     store = FirestoreSessionStore()

--- a/py/packages/genkit-google-cloud/src/genkit_google_cloud/__init__.py
+++ b/py/packages/genkit-google-cloud/src/genkit_google_cloud/__init__.py
@@ -34,13 +34,10 @@ Example:
     )
 
 
-    # 1. Enable Google Cloud Trace and Monitoring export
     enable_google_cloud_telemetry(project_id='my-project')
 
-    # 2. All subsequent Genkit actions automatically export telemetry
     ai = Genkit(plugins=[GoogleAI()], model='googleai/gemini-flash-latest')
     await ai.generate(prompt='Hello, world!')
-    # => Traces exported asynchronously to Cloud Trace (latency, tokens, status)
 
     # 3. Persist agent sessions in Firestore (ADC / FIRESTORE_EMULATOR_HOST)
     store = FirestoreSessionStore()

--- a/py/packages/genkit-google-cloud/src/genkit_google_cloud/telemetry/__init__.py
+++ b/py/packages/genkit-google-cloud/src/genkit_google_cloud/telemetry/__init__.py
@@ -26,13 +26,10 @@ Example:
     from genkit_google_genai import GoogleAI
     from genkit_google_cloud import enable_google_cloud_telemetry
 
-    # 1. Enable Google Cloud Trace and Monitoring export
     enable_google_cloud_telemetry(project_id='my-project')
 
-    # 2. All subsequent Genkit actions automatically export telemetry
     ai = Genkit(plugins=[GoogleAI()], model=GoogleAI.gemini_model('gemini-flash-latest'))
     await ai.generate(prompt='Hello, world!')
-    # => Traces exported asynchronously to Cloud Trace (latency, tokens, status)
     ```
 
 See Also:

--- a/py/packages/genkit-google-cloud/src/genkit_google_cloud/telemetry/__init__.py
+++ b/py/packages/genkit-google-cloud/src/genkit_google_cloud/telemetry/__init__.py
@@ -26,13 +26,10 @@ Example:
     from genkit_google_genai import GoogleAI
     from genkit_google_cloud import enable_google_cloud_telemetry
 
-    # 1. Enable Google Cloud Trace and Monitoring export
     enable_google_cloud_telemetry(project_id='my-project')
 
-    # 2. All subsequent Genkit actions automatically export telemetry
     ai = Genkit(plugins=[GoogleAI()], model='googleai/gemini-flash-latest')
     await ai.generate(prompt='Hello, world!')
-    # => Traces exported asynchronously to Cloud Trace (latency, tokens, status)
     ```
 
 See Also:

--- a/py/packages/genkit-google-cloud/src/genkit_google_cloud/telemetry/config.py
+++ b/py/packages/genkit-google-cloud/src/genkit_google_cloud/telemetry/config.py
@@ -36,7 +36,7 @@ from opentelemetry.sdk.resources import SERVICE_INSTANCE_ID, SERVICE_NAME, Resou
 from opentelemetry.sdk.trace.sampling import Sampler
 from opentelemetry.trace import get_current_span, span as trace_span
 
-from genkit.plugin_api import add_custom_exporter, is_dev_environment
+from genkit.plugin_api import add_custom_exporter, is_dev_environment, maybe_configure_otel_for_exporters
 
 from .constants import (
     DEFAULT_METRIC_EXPORT_INTERVAL_MS,
@@ -247,6 +247,7 @@ class GcpTelemetry:
             )
 
             add_custom_exporter(trace_exporter, 'gcp_telemetry_server')
+            maybe_configure_otel_for_exporters()
         except Exception as e:
             handle_tracing_error(e)
 

--- a/py/packages/genkit-google-cloud/src/genkit_google_cloud/telemetry/config.py
+++ b/py/packages/genkit-google-cloud/src/genkit_google_cloud/telemetry/config.py
@@ -36,7 +36,7 @@ from opentelemetry.sdk.resources import SERVICE_INSTANCE_ID, SERVICE_NAME, Resou
 from opentelemetry.sdk.trace.sampling import Sampler
 from opentelemetry.trace import get_current_span, span as trace_span
 
-from genkit.plugin_api import add_custom_exporter, is_dev_environment
+from genkit.plugin_api import add_custom_exporter, is_dev_environment, maybe_configure_otel_for_exporters
 
 from .constants import (
     DEFAULT_METRIC_EXPORT_INTERVAL_MS,
@@ -246,6 +246,7 @@ class GcpTelemetry:
             )
 
             add_custom_exporter(trace_exporter, 'gcp_telemetry_server')
+            maybe_configure_otel_for_exporters()
         except Exception as e:
             handle_tracing_error(e)
 

--- a/py/packages/genkit-google-cloud/src/genkit_google_cloud/telemetry/tracing.py
+++ b/py/packages/genkit-google-cloud/src/genkit_google_cloud/telemetry/tracing.py
@@ -27,13 +27,10 @@ Usage:
     from genkit_google_genai import GoogleAI
     from genkit_google_cloud import enable_google_cloud_telemetry
 
-    # 1. Enable telemetry with default settings (PII redaction enabled)
     enable_google_cloud_telemetry(project_id='my-project')
 
-    # 2. All subsequent Genkit actions automatically export telemetry
     ai = Genkit(plugins=[GoogleAI()], model='googleai/gemini-flash-latest')
     await ai.generate(prompt='Hello, world!')
-    # => Traces exported asynchronously to Cloud Trace (latency, tokens, status)
     ```
 
 Requirements:
@@ -69,14 +66,17 @@ def enable_google_cloud_telemetry(
     # Legacy parameter name for backwards compatibility
     force_export: bool | None = None,
 ) -> None:
-    """Configure GCP telemetry export for traces and metrics.
+    """Attach Cloud Trace and Cloud Monitoring exporters.
 
-    This function sets up OpenTelemetry export to Google Cloud Trace and
-    Cloud Monitoring. By default, model inputs and outputs are redacted
-    for privacy protection.
+    This is enough for Cloud Trace. If you already configured
+    ``OtelInstrumentation``, the Cloud exporter hangs on that provider
+    (your ``tracer_provider`` if you passed one). Under ``genkit start``,
+    ``Genkit()`` still attaches the Developer UI collector.
 
-    Configuration options match the JavaScript (GcpTelemetryConfigOptions) and
-    Go (FirebaseTelemetryOptions/GoogleCloudTelemetryOptions) implementations.
+    Cloud exporters are skipped when ``GENKIT_ENV=dev`` and
+    ``force_dev_export=False``, or when ``disable_traces=True``. Model
+    inputs and outputs are redacted unless you pass
+    ``log_input_and_output=True``.
 
     Args:
         project_id: Google Cloud project ID. If provided, takes precedence over
@@ -93,29 +93,20 @@ def enable_google_cloud_telemetry(
         log_input_and_output: If True, preserve model input/output in traces
             and logs. Defaults to False (redact for privacy). Only enable this
             in trusted environments where PII exposure is acceptable.
-            Maps to JS: !disableLoggingInputAndOutput
-        force_dev_export: If True, export telemetry even in dev environment.
-            Defaults to True. Set to False for production-only telemetry.
-            Maps to JS: forceDevExport
+        force_dev_export: If True, export Cloud telemetry even when
+            ``GENKIT_ENV=dev``. Defaults to False.
         disable_metrics: If True, metrics will not be exported. Traces and
             logs may still be exported. Defaults to False.
-            Maps to JS/Go: disableMetrics
         disable_traces: If True, traces will not be exported. Metrics and
             logs may still be exported. Defaults to False.
-            Maps to JS/Go: disableTraces
         metric_export_interval_ms: Metrics export interval in milliseconds.
             GCP requires a minimum of 5000ms. Defaults to 60000ms.
-            Dev environment uses 5000ms, production uses 300000ms by default
-            in JS/Go (but we use 60000ms for consistent behavior).
-            Maps to JS/Go: metricExportIntervalMillis
         metric_export_timeout_ms: Timeout for metrics export in milliseconds.
             Defaults to the export interval if not specified.
-            Maps to JS/Go: metricExportTimeoutMillis
         force_export: Deprecated. Use force_dev_export instead.
 
     Example:
         ```python
-        # Default: PII redaction enabled
         enable_google_cloud_telemetry()
 
         # Enable input/output logging (disable PII redaction)
@@ -136,15 +127,6 @@ def enable_google_cloud_telemetry(
             credentials={'type': 'service_account', ...},
         )
         ```
-
-    Note:
-        This matches the JavaScript implementation's GcpTelemetryConfigOptions
-        and Go's FirebaseTelemetryOptions/GoogleCloudTelemetryOptions.
-
-    See Also:
-        - JS: js/plugins/google-cloud/src/types.ts (GcpTelemetryConfigOptions)
-        - Go: go/plugins/firebase/telemetry.go (FirebaseTelemetryOptions)
-        - Go: go/plugins/googlecloud/types.go (GoogleCloudTelemetryOptions)
     """
     # Handle legacy force_export parameter
     if force_export is not None:

--- a/py/packages/genkit-google-cloud/src/genkit_google_cloud/telemetry/tracing.py
+++ b/py/packages/genkit-google-cloud/src/genkit_google_cloud/telemetry/tracing.py
@@ -27,13 +27,11 @@ Usage:
     from genkit_google_genai import GoogleAI
     from genkit_google_cloud import enable_google_cloud_telemetry
 
-    # 1. Enable telemetry with default settings (PII redaction enabled)
     enable_google_cloud_telemetry(project_id='my-project')
 
     # 2. All subsequent Genkit actions automatically export telemetry
     ai = Genkit(plugins=[GoogleAI()], model=GoogleAI.gemini_model('gemini-flash-latest'))
     await ai.generate(prompt='Hello, world!')
-    # => Traces exported asynchronously to Cloud Trace (latency, tokens, status)
     ```
 
 Requirements:
@@ -69,14 +67,17 @@ def enable_google_cloud_telemetry(
     # Legacy parameter name for backwards compatibility
     force_export: bool | None = None,
 ) -> None:
-    """Configure GCP telemetry export for traces and metrics.
+    """Attach Cloud Trace and Cloud Monitoring exporters.
 
-    This function sets up OpenTelemetry export to Google Cloud Trace and
-    Cloud Monitoring. By default, model inputs and outputs are redacted
-    for privacy protection.
+    This is enough for Cloud Trace. If you already configured
+    ``OtelInstrumentation``, the Cloud exporter hangs on that provider
+    (your ``tracer_provider`` if you passed one). Under ``genkit start``,
+    ``Genkit()`` still attaches the Developer UI collector.
 
-    Options control which Cloud Trace, Cloud Monitoring, and Cloud Logging
-    exports are enabled, and whether model inputs and outputs are redacted.
+    Cloud exporters are skipped when ``GENKIT_ENV=dev`` and
+    ``force_dev_export=False``, or when ``disable_traces=True``. Model
+    inputs and outputs are redacted unless you pass
+    ``log_input_and_output=True``.
 
     Args:
         project_id: Google Cloud project ID. If provided, takes precedence over
@@ -93,22 +94,20 @@ def enable_google_cloud_telemetry(
         log_input_and_output: If True, preserve model input/output in traces
             and logs. Defaults to False (redact for privacy). Only enable this
             in trusted environments where PII exposure is acceptable.
-        force_dev_export: If True, export telemetry even in the dev environment.
-            Defaults to True. Set to False for production-only telemetry.
+        force_dev_export: If True, export Cloud telemetry even when
+            ``GENKIT_ENV=dev``. Defaults to False.
         disable_metrics: If True, metrics will not be exported. Traces and
             logs may still be exported. Defaults to False.
         disable_traces: If True, traces will not be exported. Metrics and
             logs may still be exported. Defaults to False.
         metric_export_interval_ms: Metrics export interval in milliseconds.
-            Cloud Monitoring requires a minimum of 5000ms. Defaults to 5000ms
-            in development and 300000ms in production.
+            GCP requires a minimum of 5000ms. Defaults to 60000ms.
         metric_export_timeout_ms: Timeout for metrics export in milliseconds.
             Defaults to the export interval if not specified.
         force_export: Deprecated. Use force_dev_export instead.
 
     Example:
         ```python
-        # Default: PII redaction enabled
         enable_google_cloud_telemetry()
 
         # Enable input/output logging (disable PII redaction)

--- a/py/packages/genkit-google-cloud/tests/tracing_test.py
+++ b/py/packages/genkit-google-cloud/tests/tracing_test.py
@@ -29,13 +29,25 @@ Tests cover JS/Go parity for:
 
 import os
 import warnings
+from collections.abc import Generator
 from unittest import mock
 from unittest.mock import MagicMock, patch
+
+import pytest
 
 # Environment variable and value constants (matching genkit._core._environment)
 _GENKIT_ENV = 'GENKIT_ENV'
 _ENV_DEV = 'dev'
 _ENV_PROD = 'prod'
+
+
+@pytest.fixture(autouse=True)
+def _reset_instrumentation() -> Generator[None, None, None]:
+    from genkit.telemetry import reset_instrumentation
+
+    reset_instrumentation()
+    yield
+    reset_instrumentation()
 
 
 def test_enable_google_cloud_telemetry_wraps_with_gcp_adjusting_exporter() -> None:
@@ -140,9 +152,12 @@ def test_enable_google_cloud_telemetry_skips_in_dev_without_force() -> None:
         # Call without force_dev_export (using legacy force_export)
         enable_google_cloud_telemetry(force_dev_export=False)
 
+        from genkit.telemetry import OtelInstrumentation, is_instrumented_by
+
         # Verify nothing was called
         mock_gcp_exporter.assert_not_called()
         mock_add_exporter.assert_not_called()
+        assert not is_instrumented_by(OtelInstrumentation)
 
 
 def test_enable_google_cloud_telemetry_exports_in_dev_with_force() -> None:
@@ -160,12 +175,13 @@ def test_enable_google_cloud_telemetry_exports_in_dev_with_force() -> None:
     ):
         from genkit_google_cloud.telemetry.tracing import enable_google_cloud_telemetry
 
-        # Call with force_dev_export=True (the default)
         enable_google_cloud_telemetry(force_dev_export=True)
 
-        # Verify exporter was created and added
+        from genkit.telemetry import OtelInstrumentation, is_instrumented_by
+
         mock_gcp_exporter.assert_called_once()
         mock_add_exporter.assert_called_once()
+        assert is_instrumented_by(OtelInstrumentation)
 
 
 def test_enable_google_cloud_telemetry_disable_traces() -> None:
@@ -185,9 +201,12 @@ def test_enable_google_cloud_telemetry_disable_traces() -> None:
         # Call with disable_traces=True (JS/Go: disableTraces)
         enable_google_cloud_telemetry(disable_traces=True)
 
+        from genkit.telemetry import OtelInstrumentation, is_instrumented_by
+
         # Verify trace exporter was NOT created
         mock_gcp_exporter.assert_not_called()
         mock_add_exporter.assert_not_called()
+        assert not is_instrumented_by(OtelInstrumentation)
 
 
 def test_enable_google_cloud_telemetry_disable_metrics() -> None:
@@ -389,3 +408,49 @@ def test_enable_google_cloud_telemetry_is_fail_safe() -> None:
 
         # Verify error handler was called
         mock_handler.assert_called_once()
+
+
+def test_enable_in_prod_installs_otel() -> None:
+    """enable_google_cloud_telemetry() in prod is enough to create Genkit spans."""
+    with (
+        mock.patch.dict(os.environ, {_GENKIT_ENV: _ENV_PROD}, clear=False),
+        patch('genkit_google_cloud.telemetry.config.GenkitGCPExporter'),
+        patch('genkit_google_cloud.telemetry.config.GcpAdjustingTraceExporter'),
+        patch('genkit_google_cloud.telemetry.config.add_custom_exporter'),
+        patch('genkit_google_cloud.telemetry.config.GoogleCloudResourceDetector'),
+        patch('genkit_google_cloud.telemetry.config.CloudMonitoringMetricsExporter'),
+        patch('genkit_google_cloud.telemetry.config.GenkitMetricExporter'),
+        patch('genkit_google_cloud.telemetry.config.PeriodicExportingMetricReader'),
+        patch('genkit_google_cloud.telemetry.config.metrics'),
+    ):
+        from genkit_google_cloud.telemetry.tracing import enable_google_cloud_telemetry
+
+        from genkit.telemetry import OtelInstrumentation, is_instrumented_by
+
+        enable_google_cloud_telemetry(project_id='my-project')
+        assert is_instrumented_by(OtelInstrumentation)
+
+
+def test_enable_under_genkit_start_does_not_install_otel() -> None:
+    """Under genkit start, enable leaves Developer UI inject to Genkit()."""
+    with (
+        mock.patch.dict(
+            os.environ,
+            {_GENKIT_ENV: _ENV_DEV, 'GENKIT_TELEMETRY_SERVER': 'http://127.0.0.1:4033'},
+            clear=False,
+        ),
+        patch('genkit_google_cloud.telemetry.config.GenkitGCPExporter'),
+        patch('genkit_google_cloud.telemetry.config.GcpAdjustingTraceExporter'),
+        patch('genkit_google_cloud.telemetry.config.add_custom_exporter'),
+        patch('genkit_google_cloud.telemetry.config.GoogleCloudResourceDetector'),
+        patch('genkit_google_cloud.telemetry.config.CloudMonitoringMetricsExporter'),
+        patch('genkit_google_cloud.telemetry.config.GenkitMetricExporter'),
+        patch('genkit_google_cloud.telemetry.config.PeriodicExportingMetricReader'),
+        patch('genkit_google_cloud.telemetry.config.metrics'),
+    ):
+        from genkit_google_cloud.telemetry.tracing import enable_google_cloud_telemetry
+
+        from genkit.telemetry import OtelInstrumentation, is_instrumented_by
+
+        enable_google_cloud_telemetry(force_dev_export=True, project_id='my-project')
+        assert not is_instrumented_by(OtelInstrumentation)

--- a/py/packages/genkit-middleware/src/genkit_middleware/_tool_approval.py
+++ b/py/packages/genkit-middleware/src/genkit_middleware/_tool_approval.py
@@ -18,13 +18,12 @@
 
 from __future__ import annotations
 
-import json
 from collections.abc import Awaitable, Callable
 
 from pydantic import BaseModel, Field
 
 from genkit._ai._tools import Interrupt
-from genkit._core._tracing import SpanMetadata, run_in_new_span
+from genkit._core._instrumentation import run_in_new_span
 from genkit.middleware import BaseMiddleware, GenerateMiddlewareContext, MultipartToolResponse, ToolHookParams
 
 
@@ -55,10 +54,14 @@ class ToolApproval(BaseMiddleware[ToolApprovalConfig]):
             return await next_fn(params, ctx)
 
         tool_input = params.tool_request_part.tool_request.input
-        with run_in_new_span(
-            SpanMetadata(name=tool_name, type='action', subtype='tool', input=tool_input),
-        ) as span:
-            if tool_input is not None:
-                inp_json = tool_input.model_dump_json() if isinstance(tool_input, BaseModel) else json.dumps(tool_input)
-                span.set_attribute('genkit:input', inp_json)
+
+        async def body(_span: object) -> MultipartToolResponse:
             raise Interrupt({'message': f'Tool not in approved list: {tool_name}'})
+
+        return await run_in_new_span(
+            tool_name,
+            body,
+            action_type='action',
+            subtype='tool',
+            input=tool_input,
+        )

--- a/py/packages/genkit/src/genkit/_ai/_agents/_base.py
+++ b/py/packages/genkit/src/genkit/_ai/_agents/_base.py
@@ -22,8 +22,6 @@ import json
 from collections.abc import AsyncIterator, Callable, Sequence
 from typing import Generic
 
-from opentelemetry import trace as trace_api
-
 # Internal imports from sibling modules
 from genkit._ai._agents._client import AgentClient, part_roots
 from genkit._ai._agents._preamble import (
@@ -68,10 +66,10 @@ from genkit._ai._prompt import (
 from genkit._ai._tools import Tool
 from genkit._core._action import Action, ActionKind, ActionRunContext, BidiAction, BidiFn, get_current_context
 from genkit._core._error import GenkitError
+from genkit._core._instrumentation import set_custom_metadata_attributes
 from genkit._core._middleware import BaseMiddleware
 from genkit._core._model import ModelConfig
 from genkit._core._registry import Registry
-from genkit._core._trace._attrs import metadata_key
 from genkit._core._typing import (
     AgentAbortRequest,
     AgentAbortResponse,
@@ -262,9 +260,7 @@ def define_custom_agent(
 
         state = await session.state()
         if state.session_id:
-            span = trace_api.get_current_span()
-            if span.is_recording():
-                span.set_attribute(metadata_key('agent:sessionId'), state.session_id)
+            set_custom_metadata_attributes({'agent:sessionId': state.session_id})
 
         rt = AgentRuntime(
             name=name,

--- a/py/packages/genkit/src/genkit/_ai/_agents/_base.py
+++ b/py/packages/genkit/src/genkit/_ai/_agents/_base.py
@@ -22,7 +22,6 @@ import json
 from collections.abc import AsyncIterator, Callable, Mapping, Sequence
 from typing import Any, Generic
 
-from opentelemetry import trace as trace_api
 from pydantic import BaseModel
 
 # Internal imports from sibling modules
@@ -69,10 +68,10 @@ from genkit._ai._prompt import (
 from genkit._ai._tools import Tool
 from genkit._core._action import Action, ActionKind, ActionRunContext, BidiAction, BidiFn, get_current_context
 from genkit._core._error import GenkitError
+from genkit._core._instrumentation import set_custom_metadata_attributes
 from genkit._core._middleware import BaseMiddleware
 from genkit._core._model import ModelConfigDict, ModelRef, ModelRefConfigT
 from genkit._core._registry import Registry
-from genkit._core._trace._attrs import metadata_key
 from genkit._core._typing import (
     AgentAbortRequest,
     AgentAbortResponse,
@@ -263,9 +262,7 @@ def define_custom_agent(
 
         state = await session.state()
         if state.session_id:
-            span = trace_api.get_current_span()
-            if span.is_recording():
-                span.set_attribute(metadata_key('agent:sessionId'), state.session_id)
+            set_custom_metadata_attributes({'agent:sessionId': state.session_id})
 
         rt = AgentRuntime(
             name=name,

--- a/py/packages/genkit/src/genkit/_ai/_agents/_runtime.py
+++ b/py/packages/genkit/src/genkit/_ai/_agents/_runtime.py
@@ -45,11 +45,10 @@ from genkit._ai._json_patch import diff_json
 from genkit._core._action import ActionRunContext, StreamingCallback, get_current_context
 from genkit._core._channel import CloseableQueue, QueueShutDown
 from genkit._core._error import GenkitError
+from genkit._core._instrumentation import SpanContext, run_in_new_span
 from genkit._core._logger import get_logger
 from genkit._core._model import GenerateActionOptions, Message, ModelResponse, ModelResponseChunk
 from genkit._core._registry import Registry
-from genkit._core._trace._attrs import metadata_key
-from genkit._core._tracing import SpanMetadata, run_in_new_span
 from genkit._core._typing import (
     AgentFinishReason,
     AgentInit,
@@ -159,14 +158,10 @@ class SessionRunner(Generic[StateT]):
             if self.on_begin_turn is not None:
                 await self.on_begin_turn()
 
-            span_meta = SpanMetadata(
-                name=f'runTurn-{self.turn_index + 1}',
-                type='flowStep',
-                input=inp,
-            )
             try:
-                with run_in_new_span(span_meta) as span:
-                    turn_result = await fn(inp, turn_ctx)
+
+                async def body(span: SpanContext, turn_input: AgentInput = inp, ctx: TurnContext = turn_ctx) -> object:
+                    turn_result = await fn(turn_input, ctx)
                     finish_reason = turn_result.finish_reason if turn_result else None
                     self.last_turn_finish_reason = finish_reason
                     self.last_turn_error = None
@@ -179,13 +174,19 @@ class SessionRunner(Generic[StateT]):
                     # (messages, artifacts, custom) so a trace can show what
                     # changed without reading the client response.
                     state = await self.session.state()
-                    span_meta.output = {
+                    span.set_output({
                         'state': state.model_dump(by_alias=True, exclude_none=True, mode='json'),
-                    }
-                    # Tag with the id this turn actually persisted under
-                    # (server-managed only; omitted when nothing was written).
-                    if snapshot_id and span.is_recording():
-                        span.set_attribute(metadata_key('agent:snapshotId'), snapshot_id)
+                    })
+                    if snapshot_id:
+                        span.set_metadata({'agent:snapshotId': snapshot_id})
+                    return turn_result
+
+                await run_in_new_span(
+                    f'runTurn-{self.turn_index + 1}',
+                    body,
+                    action_type='flowStep',
+                    input=inp,
+                )
 
                 self.last_good_state = await self.session.state()
                 self.last_good_state_version = self.session.version

--- a/py/packages/genkit/src/genkit/_ai/_aio.py
+++ b/py/packages/genkit/src/genkit/_ai/_aio.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 
 import asyncio
 import inspect
-import json
 import logging
 import os
 import signal
@@ -105,6 +104,7 @@ from genkit._core._dap import (
 )
 from genkit._core._environment import is_dev_environment
 from genkit._core._error import GenkitError
+from genkit._core._instrumentation import configure_instrumentation, is_instrumented_by, run_in_new_span
 from genkit._core._logger import configure_logging, get_logger, resolve_level
 from genkit._core._middleware import (
     BaseMiddleware,
@@ -112,12 +112,12 @@ from genkit._core._middleware import (
     _validate_middleware_key_segment,
 )
 from genkit._core._model import Document, ModelConfigDict, ModelRef, ModelRefConfigT
+from genkit._core._otel_instrumentation import OtelInstrumentation, genkit_dev_instrumentation
 from genkit._core._plugin import Plugin
 from genkit._core._protocols import SessionLike
 from genkit._core._reflection import ReflectionServer, ServerSpec, create_reflection_asgi_app
 from genkit._core._reflection_v2 import ReflectionServerV2
 from genkit._core._registry import Registry
-from genkit._core._tracing import SpanMetadata, run_in_new_span
 from genkit._core._typing import (
     BaseDataPoint,
     Embedding,
@@ -188,6 +188,14 @@ class Genkit:
         # Ensure the default generate action is registered for async usage.
         define_generate_action(self.registry)
         self._register_plugin_middleware(plugins)
+        # GENKIT_ENV=dev + a collector URL in env installs OTel so the
+        # Traces tab works. A URL that arrives later on the reflection
+        # handshake does the same. Production stays off unless they
+        # configure a provider.
+        if is_dev_environment() and not is_instrumented_by(OtelInstrumentation):
+            dev_instrumentation = genkit_dev_instrumentation()
+            if dev_instrumentation is not None:
+                configure_instrumentation(dev_instrumentation)
         # In dev mode, start the reflection server immediately in a background
         # daemon thread so it's available regardless of which web framework (or
         # none) the user chooses.
@@ -1690,23 +1698,10 @@ class Genkit:
         if not inspect.iscoroutinefunction(fn):
             raise TypeError('fn must be a coroutine function')
 
-        span_metadata = SpanMetadata(name=name, type='flowStep', metadata=metadata)
-        with run_in_new_span(span_metadata) as span:
-            try:
-                result = await fn()
-                output = (
-                    result.model_dump_json(by_alias=True, exclude_none=True)
-                    if isinstance(result, BaseModel)
-                    else json.dumps(result)
-                )
-                span.set_attribute('genkit:output', output)
-                return result
-            except Exception:
-                # We catch all exceptions here to ensure they are captured by
-                # the trace span context manager before being re-raised.
-                # The run_in_new_span context manager handles recording
-                # the exception details.
-                raise
+        async def body(_span: object) -> T:
+            return await fn()
+
+        return await run_in_new_span(name, body, action_type='flowStep', metadata=metadata)
 
     async def check_operation(self, operation: Operation) -> Operation:
         """Check the status of a long-running background operation."""

--- a/py/packages/genkit/src/genkit/_ai/_aio.py
+++ b/py/packages/genkit/src/genkit/_ai/_aio.py
@@ -104,7 +104,7 @@ from genkit._core._dap import (
 )
 from genkit._core._environment import is_dev_environment
 from genkit._core._error import GenkitError
-from genkit._core._instrumentation import configure_instrumentation, is_instrumented_by, run_in_new_span
+from genkit._core._instrumentation import configure_instrumentation, run_in_new_span
 from genkit._core._logger import configure_logging, get_logger, resolve_level
 from genkit._core._middleware import (
     BaseMiddleware,
@@ -112,7 +112,7 @@ from genkit._core._middleware import (
     _validate_middleware_key_segment,
 )
 from genkit._core._model import Document, ModelConfigDict, ModelRef, ModelRefConfigT
-from genkit._core._otel_instrumentation import OtelInstrumentation, genkit_dev_instrumentation
+from genkit._core._otel_instrumentation import genkit_dev_instrumentation
 from genkit._core._plugin import Plugin
 from genkit._core._protocols import SessionLike
 from genkit._core._reflection import ReflectionServer, ServerSpec, create_reflection_asgi_app
@@ -188,11 +188,7 @@ class Genkit:
         # Ensure the default generate action is registered for async usage.
         define_generate_action(self.registry)
         self._register_plugin_middleware(plugins)
-        # GENKIT_ENV=dev + a collector URL in env installs OTel so the
-        # Traces tab works. A URL that arrives later on the reflection
-        # handshake does the same. Production stays off unless they
-        # configure a provider.
-        if is_dev_environment() and not is_instrumented_by(OtelInstrumentation):
+        if is_dev_environment():
             dev_instrumentation = genkit_dev_instrumentation()
             if dev_instrumentation is not None:
                 configure_instrumentation(dev_instrumentation)

--- a/py/packages/genkit/src/genkit/_ai/_aio.py
+++ b/py/packages/genkit/src/genkit/_ai/_aio.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 
 import asyncio
 import inspect
-import json
 import logging
 import os
 import signal
@@ -103,6 +102,7 @@ from genkit._core._dap import (
 )
 from genkit._core._environment import is_dev_environment
 from genkit._core._error import GenkitError
+from genkit._core._instrumentation import configure_instrumentation, is_instrumented_by, run_in_new_span
 from genkit._core._logger import configure_logging, get_logger, resolve_level
 from genkit._core._middleware import (
     BaseMiddleware,
@@ -110,12 +110,12 @@ from genkit._core._middleware import (
     _validate_middleware_key_segment,
 )
 from genkit._core._model import Document
+from genkit._core._otel_instrumentation import OtelInstrumentation, genkit_dev_instrumentation
 from genkit._core._plugin import Plugin
 from genkit._core._protocols import SessionLike
 from genkit._core._reflection import ReflectionServer, ServerSpec, create_reflection_asgi_app
 from genkit._core._reflection_v2 import ReflectionServerV2
 from genkit._core._registry import Registry
-from genkit._core._tracing import SpanMetadata, run_in_new_span
 from genkit._core._typing import (
     BaseDataPoint,
     Embedding,
@@ -182,6 +182,14 @@ class Genkit:
         # Ensure the default generate action is registered for async usage.
         define_generate_action(self.registry)
         self._register_plugin_middleware(plugins)
+        # GENKIT_ENV=dev + a collector URL in env installs OTel so the
+        # Traces tab works. A URL that arrives later on the reflection
+        # handshake does the same. Production stays off unless they
+        # configure a provider.
+        if is_dev_environment() and not is_instrumented_by(OtelInstrumentation):
+            dev_instrumentation = genkit_dev_instrumentation()
+            if dev_instrumentation is not None:
+                configure_instrumentation(dev_instrumentation)
         # In dev mode, start the reflection server immediately in a background
         # daemon thread so it's available regardless of which web framework (or
         # none) the user chooses.
@@ -1350,23 +1358,10 @@ class Genkit:
         if not inspect.iscoroutinefunction(fn):
             raise TypeError('fn must be a coroutine function')
 
-        span_metadata = SpanMetadata(name=name, type='flowStep', metadata=metadata)
-        with run_in_new_span(span_metadata) as span:
-            try:
-                result = await fn()
-                output = (
-                    result.model_dump_json(by_alias=True, exclude_none=True)
-                    if isinstance(result, BaseModel)
-                    else json.dumps(result)
-                )
-                span.set_attribute('genkit:output', output)
-                return result
-            except Exception:
-                # We catch all exceptions here to ensure they are captured by
-                # the trace span context manager before being re-raised.
-                # The run_in_new_span context manager handles recording
-                # the exception details.
-                raise
+        async def body(_span: object) -> T:
+            return await fn()
+
+        return await run_in_new_span(name, body, action_type='flowStep', metadata=metadata)
 
     async def check_operation(self, operation: Operation) -> Operation:
         """Check the status of a long-running background operation."""

--- a/py/packages/genkit/src/genkit/_ai/_evaluator.py
+++ b/py/packages/genkit/src/genkit/_ai/_evaluator.py
@@ -16,7 +16,6 @@
 
 """Evaluator type definitions for the Genkit framework."""
 
-import json
 import traceback
 import uuid
 from collections.abc import Callable, Coroutine
@@ -26,10 +25,10 @@ from pydantic import BaseModel, ConfigDict
 from pydantic.alias_generators import to_camel
 
 from genkit._core._action import Action, ActionKind
+from genkit._core._instrumentation import SpanContext, run_in_new_span
 from genkit._core._logger import get_logger
 from genkit._core._registry import Registry
 from genkit._core._schema import to_json_schema
-from genkit._core._tracing import SpanMetadata, run_in_new_span
 from genkit._core._typing import (
     ActionMetadata,
     BaseDataPoint,
@@ -128,77 +127,45 @@ def define_evaluator(
         eval_responses: list[EvalFnResponse] = []
         for index in range(len(req.dataset)):
             datapoint = req.dataset[index]
-            if datapoint.test_case_id is None:
-                datapoint.test_case_id = str(uuid.uuid4())
-            span_metadata = SpanMetadata(
-                name=f'Test Case {datapoint.test_case_id}',
-                type='evaluator',
-                input=datapoint,
-                metadata={'evaluator:evalRunId': req.eval_run_id},
-            )
+            case_id = datapoint.test_case_id or str(uuid.uuid4())
+            datapoint.test_case_id = case_id
             try:
-                # Try to run with tracing, but fallback if tracing infrastructure fails
-                # (e.g., in environments with NonRecordingSpans like pre-commit)
-                try:
-                    with run_in_new_span(span_metadata) as span:
-                        span_id = format(span.get_span_context().span_id, '016x')
-                        trace_id = format(span.get_span_context().trace_id, '032x')
-                        try:
-                            input_json = (
-                                datapoint.model_dump_json(by_alias=True, exclude_none=True)
-                                if isinstance(datapoint, BaseModel)
-                                else json.dumps(datapoint)
-                            )
-                            span.set_attribute('genkit:input', input_json)
-                            test_case_output = await fn(datapoint, req.options)
-                            test_case_output.span_id = span_id
-                            test_case_output.trace_id = trace_id
-                            output_json = (
-                                test_case_output.model_dump_json(by_alias=True, exclude_none=True)
-                                if isinstance(test_case_output, BaseModel)
-                                else json.dumps(test_case_output)
-                            )
-                            span.set_attribute('genkit:output', output_json)
-                            eval_responses.append(test_case_output)
-                        except Exception as e:
-                            logger.debug(f'eval_stepper_fn error: {e!s}')
-                            logger.debug(traceback.format_exc())
-                            evaluation = Score(
-                                error=f'Evaluation of test case {datapoint.test_case_id} failed: \n{e!s}',
-                                status=EvalStatusEnum.FAIL,
-                            )
-                            eval_responses.append(
-                                # The ty type checker only recognizes aliases, so we use them
-                                # to pass both ty check and runtime validation.
-                                EvalFnResponse(
-                                    span_id=span_id,
-                                    trace_id=trace_id,
-                                    test_case_id=datapoint.test_case_id,
-                                    evaluation=evaluation,
-                                )
-                            )
-                            # Raise to mark span as failed
-                            raise e
-                except (AttributeError, UnboundLocalError):
-                    # Fallback: run without span
+
+                async def body(
+                    span: SpanContext, point: BaseDataPoint = datapoint, test_case_id: str = case_id
+                ) -> EvalFnResponse:
                     try:
-                        test_case_output = await fn(datapoint, req.options)
-                        eval_responses.append(test_case_output)
+                        test_case_output = await fn(point, req.options)
+                        test_case_output.span_id = span.span_id
+                        test_case_output.trace_id = span.trace_id
+                        return test_case_output
                     except Exception as e:
                         logger.debug(f'eval_stepper_fn error: {e!s}')
                         logger.debug(traceback.format_exc())
                         evaluation = Score(
-                            error=f'Evaluation of test case {datapoint.test_case_id} failed: \n{e!s}',
+                            error=f'Evaluation of test case {test_case_id} failed: \n{e!s}',
                             status=EvalStatusEnum.FAIL,
                         )
                         eval_responses.append(
                             EvalFnResponse(
-                                test_case_id=datapoint.test_case_id,
+                                span_id=span.span_id,
+                                trace_id=span.trace_id,
+                                test_case_id=test_case_id,
                                 evaluation=evaluation,
                             )
                         )
+                        raise e
+
+                eval_responses.append(
+                    await run_in_new_span(
+                        f'Test Case {datapoint.test_case_id}',
+                        body,
+                        action_type='evaluator',
+                        input=datapoint,
+                        metadata={'evaluator:evalRunId': req.eval_run_id},
+                    )
+                )
             except Exception:  # noqa: S112 - intentionally continue processing other datapoints
-                # Continue to process other points
                 continue
         return EvalResponse(eval_responses)
 

--- a/py/packages/genkit/src/genkit/_ai/_generate.py
+++ b/py/packages/genkit/src/genkit/_ai/_generate.py
@@ -47,6 +47,7 @@ from genkit._core._action import (
     ActionRunContext,
 )
 from genkit._core._error import GenkitError
+from genkit._core._instrumentation import run_in_new_span
 from genkit._core._logger import get_logger, is_debug_enabled
 from genkit._core._middleware import (
     BaseMiddleware,
@@ -65,7 +66,6 @@ from genkit._core._model import (
 )
 from genkit._core._protocols import RegistryLike, SessionLike
 from genkit._core._registry import Registry
-from genkit._core._tracing import SpanMetadata, run_in_new_span
 from genkit._core._typing import (
     FinishReason,
     MiddlewareRef,
@@ -487,9 +487,9 @@ async def generate_action(
     around the whole call.  The registered ``/util/generate`` action skips
     this wrapper because the action runtime already opens its own span.
     """
-    span_name = 'generate'
-    with run_in_new_span(SpanMetadata(name=span_name, type='util', input=raw_request)) as span:
-        result = await generate_with_request(
+
+    async def body(_span: object) -> ModelResponse:
+        return await generate_with_request(
             registry=registry,
             raw_request=raw_request,
             abort_signal=abort_signal,
@@ -498,9 +498,8 @@ async def generate_action(
             current_turn=current_turn,
             context=context,
         )
-        with contextlib.suppress(Exception):
-            span.set_attribute('genkit:output', result.model_dump_json(by_alias=True, exclude_none=True))
-        return result
+
+    return await run_in_new_span('generate', body, action_type='util', input=raw_request)
 
 
 async def generate_with_request(

--- a/py/packages/genkit/src/genkit/_ai/_generate.py
+++ b/py/packages/genkit/src/genkit/_ai/_generate.py
@@ -49,6 +49,7 @@ from genkit._core._action import (
 )
 from genkit._core._background import _ensure_operation, missing_operation_error, stamp_operation_action
 from genkit._core._error import GenkitError
+from genkit._core._instrumentation import run_in_new_span
 from genkit._core._logger import get_logger, is_debug_enabled
 from genkit._core._middleware import (
     BaseMiddleware,
@@ -69,7 +70,6 @@ from genkit._core._model import (
 from genkit._core._protocols import RegistryLike, SessionLike
 from genkit._core._registry import Registry
 from genkit._core._schema import check_output_schema
-from genkit._core._tracing import SpanMetadata, run_in_new_span
 from genkit._core._typing import (
     FinishReason,
     MiddlewareRef,
@@ -571,9 +571,9 @@ async def generate_action(
     around the whole call.  The registered ``/util/generate`` action skips
     this wrapper because the action runtime already opens its own span.
     """
-    span_name = 'generate'
-    with run_in_new_span(SpanMetadata(name=span_name, type='util', input=raw_request)) as span:
-        result = await generate_with_request(
+
+    async def body(_span: object) -> ModelResponse:
+        return await generate_with_request(
             registry=registry,
             raw_request=raw_request,
             abort_signal=abort_signal,
@@ -582,9 +582,8 @@ async def generate_action(
             current_turn=current_turn,
             context=context,
         )
-        with contextlib.suppress(Exception):
-            span.set_attribute('genkit:output', result.model_dump_json(by_alias=True, exclude_none=True))
-        return result
+
+    return await run_in_new_span('generate', body, action_type='util', input=raw_request)
 
 
 async def generate_with_request(

--- a/py/packages/genkit/src/genkit/_ai/_testing.py
+++ b/py/packages/genkit/src/genkit/_ai/_testing.py
@@ -25,7 +25,7 @@ from typing import Any, TypedDict, cast
 from pydantic import BaseModel, Field
 
 from genkit._core._action import Action, ActionKind, ActionRunContext
-from genkit._core._tracing import SpanMetadata, run_in_new_span
+from genkit._core._instrumentation import run_in_new_span
 from genkit._core._typing import (
     Media,
     MediaPart,
@@ -370,40 +370,57 @@ async def test_models(ai: Genkit, models: list[str]) -> TestReport:
 
     report: TestReport = []
 
-    with run_in_new_span(SpanMetadata(name='testModels', type='testSuite')):
-        for test_name, test_fn in tests.items():
-            with run_in_new_span(SpanMetadata(name=test_name, type='testCase')):
-                case_report: TestCaseReport = {
-                    'description': test_name,
-                    'models': [],
+    async def run_case(_span: object, test_name: str = '', test_fn: Any = None) -> TestCaseReport:  # noqa: ANN401
+        case_report: TestCaseReport = {
+            'description': test_name,
+            'models': [],
+        }
+
+        for model in models:
+            model_result: ModelTestResult = {
+                'name': model,
+                'passed': True,
+            }
+
+            try:
+                await test_fn(model)
+            except SkipTestError:
+                model_result['passed'] = False
+                model_result['skipped'] = True
+            except AssertionError as e:
+                model_result['passed'] = False
+                model_result['error'] = {
+                    'message': str(e),
+                    'stack': None,
+                }
+            except Exception as e:
+                model_result['passed'] = False
+                model_result['error'] = {
+                    'message': str(e),
+                    'stack': None,
                 }
 
-                for model in models:
-                    model_result: ModelTestResult = {
-                        'name': model,
-                        'passed': True,
-                    }
+            case_report['models'].append(model_result)
 
-                    try:
-                        await test_fn(model)
-                    except SkipTestError:
-                        model_result['passed'] = False
-                        model_result['skipped'] = True
-                    except AssertionError as e:
-                        model_result['passed'] = False
-                        model_result['error'] = {
-                            'message': str(e),
-                            'stack': None,
-                        }
-                    except Exception as e:
-                        model_result['passed'] = False
-                        model_result['error'] = {
-                            'message': str(e),
-                            'stack': None,
-                        }
+        return case_report
 
-                    case_report['models'].append(model_result)
+    async def run_suite(_span: object) -> TestReport:
+        for test_name, test_fn in tests.items():
 
-                report.append(case_report)
+            async def body(
+                span: object,
+                n: str = test_name,
+                f: Any = test_fn,  # noqa: ANN401
+            ) -> TestCaseReport:
+                return await run_case(span, n, f)
 
-    return report
+            report.append(
+                await run_in_new_span(
+                    test_name,
+                    body,
+                    action_type='testCase',
+                )
+            )
+        return report
+
+    return await run_in_new_span('testModels', run_suite, action_type='testSuite')

--- a/py/packages/genkit/src/genkit/_ai/_tools.py
+++ b/py/packages/genkit/src/genkit/_ai/_tools.py
@@ -17,16 +17,15 @@
 """Tool-specific types and utilities for the Genkit framework."""
 
 import inspect
-import json
 from collections.abc import Callable
 from contextvars import ContextVar
 from typing import Any, cast
 
-from opentelemetry import trace as trace_api
 from pydantic import BaseModel
 
 from genkit._core._action import Action, ActionKind, ActionRunContext
 from genkit._core._error import GenkitError, GenkitInterrupt
+from genkit._core._instrumentation import set_custom_metadata_attributes
 from genkit._core._middleware import GenerateMiddlewareContext
 from genkit._core._registry import Registry
 from genkit._core._typing import ToolDefinition, ToolRequest, ToolRequestPart, ToolResponse, ToolResponsePart
@@ -136,12 +135,7 @@ class Interrupt(GenkitInterrupt):  # noqa: N818 - public Genkit name; not rename
         super().__init__()
         self.metadata: dict[str, Any] = {} if metadata is None else metadata
         if self.metadata:
-            span = trace_api.get_current_span()
-            if span.is_recording():
-                try:
-                    span.set_attribute('genkit:metadata:interrupt', json.dumps(self.metadata))
-                except Exception:
-                    span.set_attribute('genkit:metadata:interrupt', str(self.metadata))
+            set_custom_metadata_attributes({'interrupt': self.metadata})
 
 
 def _tool_response_part(
@@ -365,12 +359,7 @@ def _define_tool(
         # Record resumed metadata on the current span for observability.
         resumed_meta = _tool_resumed_metadata.get()
         if resumed_meta:
-            span = trace_api.get_current_span()
-            if span.is_recording():
-                try:
-                    span.set_attribute('genkit:metadata:resumed', json.dumps(resumed_meta))
-                except Exception:
-                    span.set_attribute('genkit:metadata:resumed', str(resumed_meta))
+            set_custom_metadata_attributes({'resumed': resumed_meta})
 
         # Dynamic dispatch by arity; payload types follow the registered tool (not expressible here).
         match len(input_spec.args):

--- a/py/packages/genkit/src/genkit/_ai/_tools.py
+++ b/py/packages/genkit/src/genkit/_ai/_tools.py
@@ -17,16 +17,15 @@
 """Tool-specific types and utilities for the Genkit framework."""
 
 import inspect
-import json
 from collections.abc import Callable
 from contextvars import ContextVar
 from typing import Any, cast
 
-from opentelemetry import trace as trace_api
 from pydantic import BaseModel
 
 from genkit._core._action import Action, ActionKind, ActionRunContext
 from genkit._core._error import GenkitError, GenkitInterrupt
+from genkit._core._instrumentation import set_custom_metadata_attributes
 from genkit._core._logger import get_logger
 from genkit._core._middleware import GenerateMiddlewareContext
 from genkit._core._registry import Registry
@@ -139,12 +138,7 @@ class Interrupt(GenkitInterrupt):  # noqa: N818 - public Genkit name; not rename
         super().__init__()
         self.metadata: dict[str, Any] = {} if metadata is None else metadata
         if self.metadata:
-            span = trace_api.get_current_span()
-            if span.is_recording():
-                try:
-                    span.set_attribute('genkit:metadata:interrupt', json.dumps(self.metadata))
-                except Exception:
-                    span.set_attribute('genkit:metadata:interrupt', str(self.metadata))
+            set_custom_metadata_attributes({'interrupt': self.metadata})
 
 
 def _tool_response_part(
@@ -372,12 +366,7 @@ def _define_tool(
         # Record resumed metadata on the current span for observability.
         resumed_meta = _tool_resumed_metadata.get()
         if resumed_meta:
-            span = trace_api.get_current_span()
-            if span.is_recording():
-                try:
-                    span.set_attribute('genkit:metadata:resumed', json.dumps(resumed_meta))
-                except Exception:
-                    span.set_attribute('genkit:metadata:resumed', str(resumed_meta))
+            set_custom_metadata_attributes({'resumed': resumed_meta})
 
         # Dynamic dispatch by arity; payload types follow the registered tool (not expressible here).
         match len(input_spec.args):

--- a/py/packages/genkit/src/genkit/_core/_action.py
+++ b/py/packages/genkit/src/genkit/_core/_action.py
@@ -33,9 +33,9 @@ from typing_extensions import TypeVar
 from genkit._core._channel import Channel, CloseableQueue
 from genkit._core._compat import StrEnum
 from genkit._core._error import GenkitError
+from genkit._core._instrumentation import SpanContext, run_in_new_span
 from genkit._core._schema import to_json_schema
 from genkit._core._trace._suppress import suppress_telemetry
-from genkit._core._tracing import SpanMetadata, run_in_new_span
 
 # =============================================================================
 # Span attribute types and tracing helpers
@@ -741,38 +741,40 @@ class Action(Generic[InputT, OutputT, ChunkT, InitT]):
                     extra_metadata['context'] = json.dumps(cleaned_context)
                 except Exception:
                     extra_metadata['context'] = str(ctx.context)
-        span_meta = SpanMetadata(
-            name=self._name,
-            type='action',
-            subtype=str(self._kind),
-            input=input,
-            init=ctx.init,
-            metadata=extra_metadata or None,
-            telemetry_labels={k: str(v) for k, v in (telemetry_labels or {}).items()} or None,
-        )
 
         trace_id = ''
-        try:
-            with run_in_new_span(span_meta) as span:
-                # OpenTelemetry standard hex format.
-                trace_id = format(span.get_span_context().trace_id, '032x')
-                span_id = format(span.get_span_context().span_id, '016x')
-                if on_trace_start:
-                    await on_trace_start(trace_id, span_id)
+        span_id = ''
 
-                if execute is not None:
-                    output = await execute()
-                else:
-                    output = await self._invoke(input, ctx)
-                output = cast(OutputT, _record_latency(output, start_time))
-                # Picked up by run_in_new_span's success branch and written as ``genkit:output``.
-                span_meta.output = output
-                return ActionResponse(response=output, trace_id=trace_id, span_id=span_id)
+        async def body(span: SpanContext) -> OutputT:
+            nonlocal trace_id, span_id
+            trace_id = span.trace_id
+            span_id = span.span_id
+            if on_trace_start:
+                await on_trace_start(trace_id, span_id)
+
+            if execute is not None:
+                output = await execute()
+            else:
+                output = await self._invoke(input, ctx)
+            return cast(OutputT, _record_latency(output, start_time))
+
+        try:
+            output = await run_in_new_span(
+                self._name,
+                body,
+                action_type='action',
+                input=input,
+                attributes={k: str(v) for k, v in (telemetry_labels or {}).items()} or None,
+                subtype=str(self._kind),
+                init=ctx.init,
+                metadata=extra_metadata or None,
+            )
+            return ActionResponse(response=output, trace_id=trace_id, span_id=span_id)
         except GenkitError:
             raise
         except Exception as e:
-            # Wrap outside the with-block so we don't clobber ``genkit:error`` (which
-            # ``run_in_new_span`` already set to ``str(original_e)``).
+            # Wrap outside the span so we don't clobber ``genkit:error`` (which
+            # the renderer already set to ``str(original_e)``).
             raise GenkitError(
                 cause=e,
                 message=f'Error while running action {self._name}',

--- a/py/packages/genkit/src/genkit/_core/_action.py
+++ b/py/packages/genkit/src/genkit/_core/_action.py
@@ -33,10 +33,10 @@ from typing_extensions import TypeVar
 from genkit._core._channel import Channel, CloseableQueue
 from genkit._core._compat import StrEnum
 from genkit._core._error import GenkitError
+from genkit._core._instrumentation import SpanContext, run_in_new_span
 from genkit._core._model import config_type_path, declared_config_type
 from genkit._core._schema import to_json_schema
 from genkit._core._trace._suppress import suppress_telemetry
-from genkit._core._tracing import SpanMetadata, run_in_new_span
 
 # =============================================================================
 # Span attribute types and tracing helpers
@@ -764,44 +764,47 @@ class Action(Generic[InputT, OutputT, ChunkT, InitT]):
                     extra_metadata['context'] = json.dumps(cleaned_context)
                 except Exception:
                     extra_metadata['context'] = str(ctx.context)
-        span_meta = SpanMetadata(
-            name=self._name,
-            type='action',
-            subtype=str(self._kind),
-            input=input,
-            init=ctx.init,
-            metadata=extra_metadata or None,
-            telemetry_labels={k: str(v) for k, v in (telemetry_labels or {}).items()} or None,
-        )
 
         trace_id = ''
-        try:
-            with run_in_new_span(span_meta) as span:
-                # OpenTelemetry standard hex format.
-                trace_id = format(span.get_span_context().trace_id, '032x')
-                span_id = format(span.get_span_context().span_id, '016x')
-                if on_trace_start:
-                    await on_trace_start(trace_id, span_id)
+        span_id = ''
 
-                if execute is not None:
-                    output = await execute()
-                else:
-                    output = await self._invoke(input, ctx)
-                latency_ms = (time.perf_counter() - start_time) * 1000
-                output = cast(OutputT, _record_latency(output, latency_ms))
-                # Picked up by run_in_new_span's success branch and written as ``genkit:output``.
-                span_meta.output = output
-                return ActionResponse(
-                    response=output,
-                    trace_id=trace_id,
-                    span_id=span_id,
-                    latency_ms=latency_ms,
-                )
+        async def body(span: SpanContext) -> OutputT:
+            nonlocal trace_id, span_id
+            trace_id = span.trace_id
+            span_id = span.span_id
+            if on_trace_start:
+                await on_trace_start(trace_id, span_id)
+
+            if execute is not None:
+                output = await execute()
+            else:
+                output = await self._invoke(input, ctx)
+            latency_ms = (time.perf_counter() - start_time) * 1000
+            return cast(OutputT, _record_latency(output, latency_ms))
+
+        try:
+            output = await run_in_new_span(
+                self._name,
+                body,
+                action_type='action',
+                input=input,
+                attributes={k: str(v) for k, v in (telemetry_labels or {}).items()} or None,
+                subtype=str(self._kind),
+                init=ctx.init,
+                metadata=extra_metadata or None,
+            )
+            latency_ms = (time.perf_counter() - start_time) * 1000
+            return ActionResponse(
+                response=output,
+                trace_id=trace_id,
+                span_id=span_id,
+                latency_ms=latency_ms,
+            )
         except GenkitError:
             raise
         except Exception as e:
-            # Wrap outside the with-block so we don't clobber ``genkit:error`` (which
-            # ``run_in_new_span`` already set to ``str(original_e)``).
+            # Wrap outside the span so we don't clobber ``genkit:error`` (which
+            # the renderer already set to ``str(original_e)``).
             raise GenkitError(
                 cause=e,
                 message=f'Error while running action {self._name}',

--- a/py/packages/genkit/src/genkit/_core/_instrumentation.py
+++ b/py/packages/genkit/src/genkit/_core/_instrumentation.py
@@ -18,6 +18,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import inspect
 from collections.abc import Awaitable, Callable, Mapping
 from contextvars import ContextVar
@@ -177,11 +178,13 @@ class CompositeSpanContext:
 
     def set_metadata(self, metadata: Mapping[str, object]) -> None:
         for span in self._spans:
-            span.set_metadata(metadata)
+            with contextlib.suppress(Exception):
+                span.set_metadata(metadata)
 
     def set_output(self, value: object) -> None:
         for span in self._spans:
-            span.set_output(value)
+            with contextlib.suppress(Exception):
+                span.set_output(value)
 
     def _first_non_empty(self, get: Callable[[SpanContext], str]) -> str:
         for span in self._spans:

--- a/py/packages/genkit/src/genkit/_core/_instrumentation.py
+++ b/py/packages/genkit/src/genkit/_core/_instrumentation.py
@@ -1,0 +1,191 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Telemetry dispatcher. Composes Instrumentation providers; no OpenTelemetry."""
+
+from __future__ import annotations
+
+import inspect
+from collections.abc import Awaitable, Callable, Mapping
+from contextvars import ContextVar
+from typing import TypeVar
+
+from ._instrumentation_api import Instrumentation, SpanContext, SpanMetadata
+
+T = TypeVar('T')
+
+instrumentations: list[Instrumentation] = []
+
+# Active SpanContext so set_custom_metadata_attributes can reach it.
+current_span: ContextVar[SpanContext | None] = ContextVar('genkit_span_context', default=None)
+
+
+def describe_value(value: object) -> str:
+    """Module-qualified name of a type or of an instance's type."""
+    if isinstance(value, type):
+        return f'type {value.__module__}.{value.__qualname__}'
+    cls = type(value)
+    return f'{cls.__module__}.{cls.__qualname__}'
+
+
+def configure_instrumentation(instrumentation: Instrumentation) -> None:
+    """Turn on a telemetry backend. Call before ``Genkit()`` to stack backends.
+
+    Each provider wraps the next. ``OtelInstrumentation`` is the built-in.
+    ``genkit start`` installs that one when a collector is configured.
+    """
+    # The class itself has run_in_new_span, so a forgotten () would pass a
+    # Protocol check and then die inside OTel on the first span.
+    if isinstance(instrumentation, type) or not isinstance(instrumentation, Instrumentation):
+        raise TypeError(
+            'configure_instrumentation expected an Instrumentation instance, got ' + describe_value(instrumentation)
+        )
+    instrumentations.append(instrumentation)
+
+
+def reset_instrumentation() -> None:
+    """Remove all providers. Tests and re-init."""
+    instrumentations.clear()
+    from ._otel_instrumentation import reset_developer_ui_collector
+
+    reset_developer_ui_collector()
+
+
+def is_instrumented_by(kind: type) -> bool:
+    """True when a configured provider is an instance of ``kind``.
+
+    Use ``is_instrumented_by(OtelInstrumentation)`` to see whether Genkit
+    is already minting OpenTelemetry spans.
+    """
+    if not isinstance(kind, type):
+        raise TypeError('is_instrumented_by expected a type, got ' + describe_value(kind))
+    return any(isinstance(i, kind) for i in instrumentations)
+
+
+def set_custom_metadata_attributes(attributes: Mapping[str, object]) -> None:
+    """Write metadata on the active span. No-op outside a span."""
+    span = current_span.get()
+    if span is not None:
+        span.set_metadata(attributes)
+
+
+async def run_in_new_span(
+    name: str,
+    fn: Callable[[SpanContext], Awaitable[T]],
+    *,
+    action_type: str | None = None,
+    input: object | None = None,
+    attributes: Mapping[str, str] | None = None,
+    subtype: str | None = None,
+    init: object | None = None,
+    metadata: Mapping[str, object] | None = None,
+    is_root: bool | None = None,
+) -> T:
+    """Run ``fn`` inside a new span via the configured provider chain.
+
+    No providers → ``fn`` runs with a no-op span (empty ids). Index 0 is
+    outermost. The provider list is snapshotted so configure/reset during an
+    await cannot break the chain.
+    """
+    if not inspect.iscoroutinefunction(fn):
+        name = getattr(fn, '__qualname__', type(fn).__name__)
+        raise TypeError(f'run_in_new_span expected an async callback, got {name}')
+    meta = SpanMetadata(
+        name=name,
+        action_type=action_type,
+        input=input,
+        attributes=dict(attributes) if attributes else {},
+        subtype=subtype,
+        init=init,
+        metadata=metadata,
+        is_root=is_root,
+    )
+    providers = list(instrumentations)
+    if not providers:
+        return await _run_with_span(NoopSpanContext(), fn)
+
+    spans: list[SpanContext] = []
+
+    async def build(index: int) -> T:
+        if index == len(providers):
+            return await _run_with_span(CompositeSpanContext(spans), fn)
+
+        async def nxt(span: SpanContext) -> T:
+            spans.append(span)
+            return await build(index + 1)
+
+        return await providers[index].run_in_new_span(meta, nxt)
+
+    return await build(0)
+
+
+async def _run_with_span(
+    span: SpanContext,
+    fn: Callable[[SpanContext], Awaitable[T]],
+) -> T:
+    token = current_span.set(span)
+    try:
+        return await fn(span)
+    finally:
+        current_span.reset(token)
+
+
+class NoopSpanContext:
+    """Span used when nothing is configured."""
+
+    @property
+    def trace_id(self) -> str:
+        return ''
+
+    @property
+    def span_id(self) -> str:
+        return ''
+
+    def set_metadata(self, metadata: Mapping[str, object]) -> None:
+        return
+
+    def set_output(self, value: object) -> None:
+        return
+
+
+class CompositeSpanContext:
+    """Fans metadata/output to every provider; ids are first non-empty."""
+
+    def __init__(self, spans: list[SpanContext]) -> None:
+        self._spans = spans
+
+    @property
+    def trace_id(self) -> str:
+        return self._first_non_empty(lambda s: s.trace_id)
+
+    @property
+    def span_id(self) -> str:
+        return self._first_non_empty(lambda s: s.span_id)
+
+    def set_metadata(self, metadata: Mapping[str, object]) -> None:
+        for span in self._spans:
+            span.set_metadata(metadata)
+
+    def set_output(self, value: object) -> None:
+        for span in self._spans:
+            span.set_output(value)
+
+    def _first_non_empty(self, get: Callable[[SpanContext], str]) -> str:
+        for span in self._spans:
+            value = get(span)
+            if value:
+                return value
+        return ''

--- a/py/packages/genkit/src/genkit/_core/_instrumentation_api.py
+++ b/py/packages/genkit/src/genkit/_core/_instrumentation_api.py
@@ -1,0 +1,76 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Backend-agnostic telemetry types. No OpenTelemetry imports."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, Mapping
+from dataclasses import dataclass, field
+from typing import Protocol, TypeVar, runtime_checkable
+
+T = TypeVar('T')
+
+
+@dataclass(frozen=True)
+class SpanMetadata:
+    """Description of a span about to be created.
+
+    Providers decide how to encode values. Extra fields beyond name / action_type
+    / input / attributes are Genkit product facts (Dev UI path, init, subtype).
+    """
+
+    name: str
+    action_type: str | None = None
+    input: object | None = None
+    attributes: Mapping[str, str] = field(default_factory=dict)
+    subtype: str | None = None
+    init: object | None = None
+    metadata: Mapping[str, object] | None = None
+    is_root: bool | None = None
+
+
+class SpanContext(Protocol):
+    """Handle to a live span. No backend types leak through."""
+
+    @property
+    def trace_id(self) -> str:
+        """Trace id, or empty when not instrumented."""
+        ...
+
+    @property
+    def span_id(self) -> str:
+        """Span id, or empty when not instrumented."""
+        ...
+
+    def set_metadata(self, metadata: Mapping[str, object]) -> None:
+        """Attach custom metadata. Safe to call multiple times."""
+        ...
+
+    def set_output(self, value: object) -> None:
+        """Override genkit:output when the return value is not the span output."""
+        ...
+
+
+@runtime_checkable
+class Instrumentation(Protocol):
+    """Pluggable provider. ``run_in_new_span`` wraps ``next`` like middleware."""
+
+    async def run_in_new_span(
+        self,
+        metadata: SpanMetadata,
+        next: Callable[[SpanContext], Awaitable[T]],
+    ) -> T: ...

--- a/py/packages/genkit/src/genkit/_core/_otel_instrumentation.py
+++ b/py/packages/genkit/src/genkit/_core/_otel_instrumentation.py
@@ -1,0 +1,395 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Built-in OpenTelemetry Instrumentation provider."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import traceback
+from collections.abc import Awaitable, Callable, Mapping, Sequence
+from contextvars import ContextVar
+from typing import Any, TypeVar
+
+from opentelemetry import trace as trace_api
+from opentelemetry.context import Context
+from opentelemetry.instrumentation.logging import LoggingInstrumentor
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SpanExporter
+from opentelemetry.trace import Link, NoOpTracer, NoOpTracerProvider, ProxyTracerProvider, SpanKind, StatusCode
+from opentelemetry.util import types
+from pydantic import BaseModel
+
+from ._environment import is_dev_environment
+from ._error import GenkitError, GenkitInterrupt
+from ._instrumentation import configure_instrumentation, instrumentations, is_instrumented_by
+from ._instrumentation_api import Instrumentation, SpanContext, SpanMetadata
+from ._logger import get_logger
+from ._trace._attrs import Attr, State, metadata_key
+from ._trace._default_exporter import TraceServerExporter, create_span_processor, init_telemetry_server_exporter
+from ._trace._path import build_path
+
+logger = get_logger(__name__)
+
+T = TypeVar('T')
+
+parent_path_context: ContextVar[str] = ContextVar('genkit_parent_path', default='')
+
+
+def to_json_attr(value: object) -> str:
+    """Serialize an arbitrary object for an input/output span attribute."""
+    if isinstance(value, BaseModel):
+        return value.model_dump_json(by_alias=True, exclude_none=True)
+    try:
+        return json.dumps(value)
+    except (TypeError, ValueError):
+        return str(value)
+
+
+def start_attributes(
+    metadata: SpanMetadata,
+    *,
+    qualified_path: str,
+) -> dict[str, Any]:
+    """Attrs known when the span begins (identity/shape + input).
+
+    Live-trace export snapshots the span the instant it starts, so these have to
+    be on the span *before* start returns; otherwise Dev UI shows a blank
+    in-progress entry until the span ends. State/output stay out — they aren't
+    known until the body finishes.
+    """
+    attrs: dict[str, Any] = {}
+    if metadata.attributes:
+        attrs.update(metadata.attributes)
+    attrs.update({
+        Attr.NAME: metadata.name,
+        Attr.PATH: qualified_path,
+        Attr.QUALIFIED_PATH: qualified_path,
+    })
+    if metadata.action_type:
+        attrs[Attr.TYPE] = metadata.action_type
+    if metadata.subtype:
+        attrs[Attr.SUBTYPE] = metadata.subtype
+    if metadata.is_root:
+        attrs[Attr.IS_ROOT] = True
+    if metadata.metadata:
+        for meta_key, meta_value in metadata.metadata.items():
+            attrs[metadata_key(meta_key)] = str(meta_value)
+    if metadata.input is not None:
+        attrs[Attr.INPUT] = to_json_attr(metadata.input)
+    if metadata.init is not None:
+        attrs[Attr.INIT] = to_json_attr(metadata.init)
+    return attrs
+
+
+class OtelSpanContext:
+    """SpanContext backed by an OpenTelemetry span."""
+
+    def __init__(self, span: trace_api.Span) -> None:
+        self._span = span
+        self._output: object | None = None
+        self._output_set = False
+
+    @property
+    def trace_id(self) -> str:
+        ctx = self._span.get_span_context()
+        if ctx is None or not ctx.trace_id:
+            return ''
+        return format(ctx.trace_id, '032x')
+
+    @property
+    def span_id(self) -> str:
+        ctx = self._span.get_span_context()
+        if ctx is None or not ctx.span_id:
+            return ''
+        return format(ctx.span_id, '016x')
+
+    def set_metadata(self, metadata: Mapping[str, object]) -> None:
+        if not self._span.is_recording():
+            return
+        for key, value in metadata.items():
+            try:
+                value_string = value if isinstance(value, str) else to_json_attr(value)
+            except Exception as e:
+                value_string = f'Error encoding metadata: {e}'
+            self._span.set_attribute(metadata_key(key), value_string)
+
+    @property
+    def output_was_set(self) -> bool:
+        return self._output_set
+
+    def set_output(self, value: object) -> None:
+        self._output = value
+        self._output_set = True
+        if self._span.is_recording():
+            self._span.set_attribute(Attr.OUTPUT, to_json_attr(value))
+
+
+class OtelInstrumentation:
+    """Built-in OpenTelemetry provider.
+
+    Records each action as a span with ``genkit:*`` attributes. Pass
+    ``tracer_provider`` to mint on your provider; Cloud Trace exporters
+    hang there too. Omit it to use the process-global provider.
+
+    ``genkit start`` installs this for you when a collector URL is set.
+    Construct it yourself only to add a backend or to own the provider.
+    """
+
+    def __init__(self, *, tracer_provider: TracerProvider | None = None) -> None:
+        if tracer_provider is not None and not isinstance(tracer_provider, TracerProvider):
+            cls = type(tracer_provider)
+            raise TypeError(f'OtelInstrumentation expected a TracerProvider, got {cls.__module__}.{cls.__qualname__}')
+        self._tracer_provider = tracer_provider
+        self._cached_tracer: trace_api.Tracer | None = None
+
+    @property
+    def tracer(self) -> trace_api.Tracer:
+        if self._cached_tracer is None:
+            provider = self._tracer_provider or trace_api.get_tracer_provider()
+            self._cached_tracer = provider.get_tracer('genkit-tracer', 'v1')
+        return self._cached_tracer
+
+    async def run_in_new_span(
+        self,
+        metadata: SpanMetadata,
+        next: Callable[[SpanContext], Awaitable[T]],
+    ) -> T:
+        qualified_path = build_path(
+            metadata.name,
+            parent_path_context.get(),
+            metadata.action_type or '',
+            metadata.subtype,
+        )
+        start_attrs = start_attributes(metadata, qualified_path=qualified_path)
+        path_token = parent_path_context.set(qualified_path)
+        try:
+            with self.tracer.start_as_current_span(
+                name=metadata.name,
+                attributes=start_attrs,
+                record_exception=False,
+                set_status_on_exception=False,
+            ) as span:
+                ctx = OtelSpanContext(span)
+                try:
+                    result = await next(ctx)
+                    if not ctx.output_was_set and result is not None:
+                        span.set_attribute(Attr.OUTPUT, to_json_attr(result))
+                    span.set_attribute(Attr.STATE, State.SUCCESS)
+                    return result
+                except GenkitInterrupt:
+                    span.set_attribute(Attr.STATE, State.SUCCESS)
+                    raise
+                except (asyncio.CancelledError, KeyboardInterrupt):
+                    raise
+                except Exception as e:
+                    logger.debug(f'Error in run_in_new_span: {e!s}')
+                    logger.debug(traceback.format_exc())
+                    span.set_attribute(Attr.STATE, State.ERROR)
+                    err_text = e.original_message if isinstance(e, GenkitError) else str(e)
+                    span.set_attribute(Attr.ERROR, err_text)
+                    span.set_status(StatusCode.ERROR, str(e))
+                    span.record_exception(e)
+                    raise
+        finally:
+            parent_path_context.reset(path_token)
+
+
+def init_provider() -> TracerProvider:
+    """Init and return the global tracer provider."""
+    tracer_provider = trace_api.get_tracer_provider()
+
+    if tracer_provider is None or not isinstance(tracer_provider, TracerProvider):  # pyright: ignore[reportUnnecessaryComparison]
+        tracer_provider = TracerProvider()
+        trace_api.set_tracer_provider(tracer_provider)
+        # Booting a tracer shouldn't rewrite the process log format.
+        # pyrefly: ignore[missing-attribute]
+        LoggingInstrumentor().instrument(set_logging_format=False)
+        logger.debug('Creating a new global tracer provider for telemetry.')
+
+    if not isinstance(tracer_provider, TracerProvider):  # pyright: ignore[reportUnnecessaryIsInstance]
+        raise TypeError(
+            f'The current trace provider is not an instance of TracerProvider.  It is of type: {type(tracer_provider)}'
+        )
+
+    return tracer_provider
+
+
+def is_placeholder_provider(provider: object) -> bool:
+    """True when the global provider is still OTel's unset proxy / no-op."""
+    return isinstance(provider, (ProxyTracerProvider, NoOpTracerProvider))
+
+
+def provider_for_exporters() -> tuple[TracerProvider, bool]:
+    """Provider minting Genkit OTel spans, and whether they handed it to us.
+
+    If they already configured ``OtelInstrumentation(tracer_provider=theirs)``,
+    exporters have to land on ``theirs`` or Cloud Trace stays empty. Otherwise
+    the global provider.
+    """
+    for inst in instrumentations:
+        if not isinstance(inst, OtelInstrumentation):
+            continue
+        provider = inst._tracer_provider
+        if provider is None:
+            continue
+        if not isinstance(provider, TracerProvider):
+            raise TypeError(
+                'Cannot attach an exporter: OtelInstrumentation is using '
+                f'{type(provider).__name__}, not a TracerProvider.'
+            )
+        return provider, True
+    return init_provider(), False
+
+
+def add_custom_exporter(exporter: SpanExporter | None, name: str = 'last') -> None:
+    """Attach a span exporter to the provider minting Genkit spans.
+
+    If you passed ``tracer_provider=`` to ``OtelInstrumentation``, the
+    exporter hangs there. Otherwise the process-global provider. This
+    does not turn tracing on. Call ``configure_instrumentation`` so
+    spans exist for the exporter to see. Under ``genkit start``,
+    ``Genkit()`` does that when a collector is configured.
+    """
+    if exporter is None:
+        logger.warn(f'{name} exporter is None')
+        return
+
+    provider, theirs = provider_for_exporters()
+    try:
+        provider.add_span_processor(create_span_processor(exporter))
+        logger.debug(f'{name} exporter added successfully.')
+    except Exception:
+        logger.error(f'tracing.add_custom_exporter: failed to add exporter {name}')
+        logger.exception('Failed to add custom exporter')
+        if theirs:
+            raise
+
+
+def maybe_configure_otel_for_exporters() -> None:
+    """Turn on OTel when nothing else will mint Genkit spans.
+
+    Skip if you already configured ``OtelInstrumentation``, or if
+    ``Genkit()`` under ``genkit start`` will still attach the Developer
+    UI collector (``GENKIT_ENV=dev`` and a collector URL). Call after
+    exporters are attached.
+    """
+    if is_instrumented_by(OtelInstrumentation):
+        return
+    if is_dev_environment() and os.environ.get('GENKIT_TELEMETRY_SERVER'):
+        return
+    configure_instrumentation(OtelInstrumentation())
+
+
+developer_ui_collector_connected = False
+
+
+def reset_developer_ui_collector() -> None:
+    """Forget the handshake / notify collector so tests can reconnect."""
+    global developer_ui_collector_connected
+    developer_ui_collector_connected = False
+
+
+def otel_for_collector(*, url: str) -> OtelInstrumentation:
+    """Mint Genkit spans and POST them to this Developer UI collector."""
+    provider = init_provider()
+    provider.add_span_processor(create_span_processor(TraceServerExporter(telemetry_server_url=url)))
+    return OtelInstrumentation(tracer_provider=provider)
+
+
+def connect_developer_ui_collector(*, url: str) -> None:
+    """Point the Developer UI collector at this URL.
+
+    ``GENKIT_ENV=dev`` and nothing minting yet: turn tracing on and hang
+    the mailbox. Already minting with no collector in env (Cloud
+    ``force_dev_export=True`` first): hang the mailbox only — someone is
+    already writing spans. ``GENKIT_TELEMETRY_SERVER`` already set: leave
+    it; that process already owns the mailbox.
+    """
+    global developer_ui_collector_connected
+    if not url or developer_ui_collector_connected:
+        return
+    developer_ui_collector_connected = True
+    if is_instrumented_by(OtelInstrumentation):
+        if os.environ.get('GENKIT_TELEMETRY_SERVER'):
+            return
+        add_custom_exporter(TraceServerExporter(telemetry_server_url=url), 'developer_ui')
+        return
+    if is_dev_environment():
+        configure_instrumentation(otel_for_collector(url=url))
+        return
+    add_custom_exporter(TraceServerExporter(telemetry_server_url=url), 'developer_ui')
+
+
+def genkit_dev_instrumentation() -> Instrumentation | None:
+    """OTel provider for the Developer UI, or None when no collector URL is set.
+
+    ``genkit start -- python app.py`` sets ``GENKIT_TELEMETRY_SERVER``
+    before spawn; ``Genkit()`` calls this.
+    """
+    exporter = init_telemetry_server_exporter()
+    if exporter is None:
+        return None
+    provider = init_provider()
+    provider.add_span_processor(create_span_processor(exporter))
+    return OtelInstrumentation(tracer_provider=provider)
+
+
+class PluginTracer:
+    """Follows the provider minting Genkit spans. No-op when uninstrumented."""
+
+    def inner(self) -> trace_api.Tracer:
+        if not is_instrumented_by(OtelInstrumentation):
+            return NoOpTracer()
+        for inst in instrumentations:
+            if isinstance(inst, OtelInstrumentation):
+                return inst.tracer
+        return NoOpTracer()
+
+    def start_as_current_span(
+        self,
+        name: str,
+        context: Context | None = None,
+        kind: SpanKind = SpanKind.INTERNAL,
+        attributes: types.Attributes = None,
+        links: Sequence[Link] | None = None,
+        start_time: int | None = None,
+        record_exception: bool = True,
+        set_status_on_exception: bool = True,
+        end_on_exit: bool = True,
+    ) -> Any:  # noqa: ANN401
+        # Imagen and Veo open their spans on this name. Keep it a real method
+        # so those call sites stay valid even when no provider is minting yet.
+        return self.inner().start_as_current_span(
+            name,
+            context=context,
+            kind=kind,
+            attributes=attributes,
+            links=links,
+            start_time=start_time,
+            record_exception=record_exception,
+            set_status_on_exception=set_status_on_exception,
+            end_on_exit=end_on_exit,
+        )
+
+    def __getattr__(self, name: str) -> Any:  # noqa: ANN401
+        return getattr(self.inner(), name)
+
+
+# Plugins import this as ``from genkit.plugin_api import tracer``.
+tracer = PluginTracer()

--- a/py/packages/genkit/src/genkit/_core/_otel_instrumentation.py
+++ b/py/packages/genkit/src/genkit/_core/_otel_instrumentation.py
@@ -307,33 +307,18 @@ def reset_developer_ui_collector() -> None:
 
 def otel_for_collector(*, url: str) -> OtelInstrumentation:
     """Mint Genkit spans and POST them to this Developer UI collector."""
-    provider = init_provider()
+    provider = TracerProvider()
     provider.add_span_processor(create_span_processor(TraceServerExporter(telemetry_server_url=url)))
     return OtelInstrumentation(tracer_provider=provider)
 
 
 def connect_developer_ui_collector(*, url: str) -> None:
-    """Point the Developer UI collector at this URL.
-
-    ``GENKIT_ENV=dev`` and nothing minting yet: turn tracing on and hang
-    the mailbox. Already minting with no collector in env (Cloud
-    ``force_dev_export=True`` first): hang the mailbox only — someone is
-    already writing spans. ``GENKIT_TELEMETRY_SERVER`` already set: leave
-    it; that process already owns the mailbox.
-    """
+    """Point the Developer UI collector at this URL."""
     global developer_ui_collector_connected
     if not url or developer_ui_collector_connected:
         return
     developer_ui_collector_connected = True
-    if is_instrumented_by(OtelInstrumentation):
-        if os.environ.get('GENKIT_TELEMETRY_SERVER'):
-            return
-        add_custom_exporter(TraceServerExporter(telemetry_server_url=url), 'developer_ui')
-        return
-    if is_dev_environment():
-        configure_instrumentation(otel_for_collector(url=url))
-        return
-    add_custom_exporter(TraceServerExporter(telemetry_server_url=url), 'developer_ui')
+    configure_instrumentation(otel_for_collector(url=url))
 
 
 def genkit_dev_instrumentation() -> Instrumentation | None:
@@ -345,7 +330,7 @@ def genkit_dev_instrumentation() -> Instrumentation | None:
     exporter = init_telemetry_server_exporter()
     if exporter is None:
         return None
-    provider = init_provider()
+    provider = TracerProvider()
     provider.add_span_processor(create_span_processor(exporter))
     return OtelInstrumentation(tracer_provider=provider)
 

--- a/py/packages/genkit/src/genkit/_core/_reflection.py
+++ b/py/packages/genkit/src/genkit/_core/_reflection.py
@@ -42,6 +42,7 @@ from genkit._core._error import get_reflection_json
 from genkit._core._logger import get_logger
 from genkit._core._middleware import GenerateMiddleware
 from genkit._core._model import ModelRef
+from genkit._core._otel_instrumentation import connect_developer_ui_collector
 from genkit._core._registry import Registry
 from genkit._core._typing import AgentInit, AgentInput
 
@@ -106,7 +107,8 @@ class ActionRunner:
 
     async def on_trace_start(self, tid: str, sid: str) -> None:
         self.trace_id, self.span_id = tid, sid
-        if task := asyncio.current_task():
+        # Empty ids aren't a run the Developer UI can cancel.
+        if tid and (task := asyncio.current_task()):
             self.active_actions[tid] = task
         self.trace_ready.set()
 
@@ -265,7 +267,18 @@ def create_reflection_asgi_app(
     async def envs(_: Request) -> JSONResponse:
         return JSONResponse(['dev'])
 
-    async def notify(_: Request) -> JSONResponse:
+    async def notify(req: Request) -> JSONResponse:
+        url: str | None = None
+        try:
+            body = await req.json()
+        except Exception:
+            body = None
+        if isinstance(body, dict):
+            raw = body.get('telemetryServerUrl')
+            if isinstance(raw, str) and raw:
+                url = raw
+        if url:
+            connect_developer_ui_collector(url=url)
         return JSONResponse({}, headers={'x-genkit-version': version})
 
     async def cancel(req: Request) -> JSONResponse:

--- a/py/packages/genkit/src/genkit/_core/_reflection.py
+++ b/py/packages/genkit/src/genkit/_core/_reflection.py
@@ -43,6 +43,7 @@ from genkit._core._constants import GENKIT_VERSION
 from genkit._core._error import get_reflection_json
 from genkit._core._logger import get_logger
 from genkit._core._middleware import GenerateMiddleware
+from genkit._core._otel_instrumentation import connect_developer_ui_collector
 from genkit._core._registry import Registry
 from genkit._core._typing import AgentInit, AgentInput
 
@@ -107,7 +108,8 @@ class ActionRunner:
 
     async def on_trace_start(self, tid: str, sid: str) -> None:
         self.trace_id, self.span_id = tid, sid
-        if task := asyncio.current_task():
+        # Empty ids aren't a run the Developer UI can cancel.
+        if tid and (task := asyncio.current_task()):
             self.active_actions[tid] = task
         self.trace_ready.set()
 
@@ -262,7 +264,18 @@ def create_reflection_asgi_app(
     async def envs(_: Request) -> JSONResponse:
         return JSONResponse(['dev'])
 
-    async def notify(_: Request) -> JSONResponse:
+    async def notify(req: Request) -> JSONResponse:
+        url: str | None = None
+        try:
+            body = await req.json()
+        except Exception:
+            body = None
+        if isinstance(body, dict):
+            raw = body.get('telemetryServerUrl')
+            if isinstance(raw, str) and raw:
+                url = raw
+        if url:
+            connect_developer_ui_collector(url=url)
         return JSONResponse({}, headers={'x-genkit-version': version})
 
     async def cancel(req: Request) -> JSONResponse:

--- a/py/packages/genkit/src/genkit/_core/_reflection_v2.py
+++ b/py/packages/genkit/src/genkit/_core/_reflection_v2.py
@@ -50,10 +50,9 @@ from genkit._core._constants import GENKIT_VERSION
 from genkit._core._error import ReflectionError, ReflectionErrorDetails, StatusCodes, get_reflection_json
 from genkit._core._logger import get_logger
 from genkit._core._middleware import GenerateMiddleware
+from genkit._core._otel_instrumentation import connect_developer_ui_collector
 from genkit._core._reflection import as_agent_input_dict, resolve_agent_init
 from genkit._core._registry import Registry
-from genkit._core._trace._default_exporter import TraceServerExporter
-from genkit._core._tracing import add_custom_exporter
 from genkit._core._typing import (
     AgentInput,
     ReflectionCancelActionParams,
@@ -147,19 +146,16 @@ class ReflectionServerV2:
         self.reflection_handshake_telemetry_applied = False
 
     def apply_handshake_telemetry(self, url: str | None) -> None:
-        """Use the Dev UI trace server URL from the reflection handshake.
+        """Point telemetry at the handshake collector URL.
 
-        The CLI manager returns ``telemetryServerUrl`` on ``register`` and may send it
-        again on ``configure``. We need that base URL so OpenTelemetry spans can be
-        POSTed to ``{url}/api/traces`` (see ``TraceServerExporter``).
+        Same wiring as HTTP ``/api/notify``. Under ``GENKIT_ENV=dev`` this
+        turns tracing on when nothing is minting yet. Already minting
+        with no collector in env hangs the mailbox only.
         """
-        if not url or os.environ.get('GENKIT_TELEMETRY_SERVER'):
-            return
-        if self.reflection_handshake_telemetry_applied:
+        if not url or self.reflection_handshake_telemetry_applied:
             return
         self.reflection_handshake_telemetry_applied = True
-        # Register HTTP export to this URL on the global OTel provider.
-        add_custom_exporter(TraceServerExporter(telemetry_server_url=url), 'reflection_v2_telemetry')
+        connect_developer_ui_collector(url=url)
         logger.debug('reflection V2: connected to telemetry server', url=url)
 
     async def run_forever(self) -> None:
@@ -447,6 +443,9 @@ class ReflectionServerV2:
     ) -> Callable[[str, str], Awaitable[None]]:
         async def on_trace_start(tid: str, span_id: str) -> None:
             trace_holder[0] = tid
+            # Empty ids aren't a run the Developer UI can cancel or display.
+            if not tid:
+                return
             if register_for_cancel and (t := asyncio.current_task()):
                 self.active_actions[tid] = t
             await self.notify_run_action_state(sid, tid)

--- a/py/packages/genkit/src/genkit/_core/_reflection_v2.py
+++ b/py/packages/genkit/src/genkit/_core/_reflection_v2.py
@@ -51,11 +51,10 @@ from genkit._core._error import ReflectionError, ReflectionErrorDetails, StatusC
 from genkit._core._logger import get_logger
 from genkit._core._middleware import GenerateMiddleware
 from genkit._core._model import ModelRef
+from genkit._core._otel_instrumentation import connect_developer_ui_collector
 from genkit._core._reflection import as_agent_input_dict, resolve_agent_init
 from genkit._core._registry import Registry
-from genkit._core._trace._default_exporter import TraceServerExporter
 from genkit._core._trace._log_exporter import enable_log_export
-from genkit._core._tracing import add_custom_exporter
 from genkit._core._typing import (
     AgentInput,
     ReflectionCancelActionParams,
@@ -149,19 +148,16 @@ class ReflectionServerV2:
         self.reflection_handshake_telemetry_applied = False
 
     def apply_handshake_telemetry(self, url: str | None) -> None:
-        """Use the Dev UI trace server URL from the reflection handshake.
+        """Point telemetry at the handshake collector URL.
 
-        The CLI manager returns ``telemetryServerUrl`` on ``register`` and may send it
-        again on ``configure``. We need that base URL so OpenTelemetry spans can be
-        POSTed to ``{url}/api/traces`` (see ``TraceServerExporter``).
+        Same wiring as HTTP ``/api/notify``. Under ``GENKIT_ENV=dev`` this
+        turns tracing on when nothing is minting yet. Already minting
+        with no collector in env hangs the mailbox only.
         """
-        if not url or os.environ.get('GENKIT_TELEMETRY_SERVER'):
-            return
-        if self.reflection_handshake_telemetry_applied:
+        if not url or self.reflection_handshake_telemetry_applied:
             return
         self.reflection_handshake_telemetry_applied = True
-        # Register HTTP export to this URL on the global OTel provider.
-        add_custom_exporter(TraceServerExporter(telemetry_server_url=url), 'reflection_v2_telemetry')
+        connect_developer_ui_collector(url=url)
         enable_log_export(url=url)
         logger.debug('reflection V2: connected to telemetry server', url=url)
 
@@ -450,6 +446,9 @@ class ReflectionServerV2:
     ) -> Callable[[str, str], Awaitable[None]]:
         async def on_trace_start(tid: str, span_id: str) -> None:
             trace_holder[0] = tid
+            # Empty ids aren't a run the Developer UI can cancel or display.
+            if not tid:
+                return
             if register_for_cancel and (t := asyncio.current_task()):
                 self.active_actions[tid] = t
             await self.notify_run_action_state(sid, tid)

--- a/py/packages/genkit/src/genkit/_core/_trace/_realtime_processor.py
+++ b/py/packages/genkit/src/genkit/_core/_trace/_realtime_processor.py
@@ -41,3 +41,10 @@ class RealtimeSpanProcessor(SimpleSpanProcessor):
         if suppress_telemetry.get():
             return
         super().on_end(span)
+
+    @override
+    def force_flush(self, timeout_millis: int = 30000) -> bool:
+        """Forward force_flush to exporter if supported (e.g. TraceServerExporter)."""
+        if hasattr(self.span_exporter, 'force_flush'):
+            return bool(self.span_exporter.force_flush(timeout_millis=timeout_millis))
+        return True

--- a/py/packages/genkit/src/genkit/_core/_tracing.py
+++ b/py/packages/genkit/src/genkit/_core/_tracing.py
@@ -14,241 +14,40 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+"""Re-export of the telemetry dispatcher and OTel helpers.
 
-"""Telemetry and tracing functionality for the Genkit framework."""
+New code should import from ``genkit.telemetry`` or ``_instrumentation``.
+"""
 
-import asyncio
-import json
-import traceback
-from collections.abc import Generator
-from contextlib import contextmanager
-from contextvars import ContextVar
-from typing import Any, ClassVar, Literal
+from ._instrumentation import (
+    SpanContext,
+    SpanMetadata,
+    configure_instrumentation,
+    reset_instrumentation,
+    run_in_new_span,
+    set_custom_metadata_attributes,
+)
+from ._otel_instrumentation import (
+    add_custom_exporter,
+    init_provider,
+    parent_path_context,
+    start_attributes,
+    tracer,
+)
 
-from opentelemetry import trace as trace_api
-from opentelemetry.instrumentation.logging import LoggingInstrumentor
-from opentelemetry.sdk.trace import TracerProvider
-from opentelemetry.sdk.trace.export import SpanExporter
-from pydantic import BaseModel, ConfigDict, Field
-from pydantic.alias_generators import to_camel
+# Older tests imported this private name.
+_parent_path_context = parent_path_context
 
-from ._base import GenkitModel
-from ._environment import is_dev_environment
-from ._error import GenkitError, GenkitInterrupt
-from ._logger import get_logger
-from ._trace._attrs import Attr, State, metadata_key
-from ._trace._default_exporter import create_span_processor, init_telemetry_server_exporter
-from ._trace._path import build_path
-
-logger = get_logger(__name__)
-
-
-class SpanMetadata(GenkitModel):
-    """Input parameters for opening a Genkit span via :func:`run_in_new_span`.
-
-    Mapping from SpanMetadata to span attributes (see ``Attr`` for wire names):
-      - name                 -> Attr.NAME (and span name)
-      - input / output       -> Attr.INPUT / Attr.OUTPUT (JSON-serialized)
-      - type                 -> Attr.TYPE
-      - subtype              -> Attr.SUBTYPE
-      - metadata[k]          -> metadata_key(k)
-      - telemetry_labels[k]  -> <k> verbatim (caller-controlled keys)
-
-    """
-
-    model_config: ClassVar[ConfigDict] = ConfigDict(
-        alias_generator=to_camel, extra='forbid', populate_by_name=True, arbitrary_types_allowed=True
-    )
-
-    name: str = Field(...)
-    state: Literal['success', 'error'] | None = None
-    input: Any | None = Field(default=None)
-    output: Any | None = Field(default=None)
-    init: Any | None = Field(default=None)
-    is_root: bool | None = None
-    metadata: dict[str, Any] | None = None
-    path: str | None = None
-    type: str | None = None
-    subtype: str | None = None
-    telemetry_labels: dict[str, str] | None = None
-
-
-tracer = trace_api.get_tracer('genkit-tracer', 'v1')
-
-
-# Qualified ``genkit:path`` of the active span; pushed by ``run_in_new_span`` so
-# nested spans can build child paths.
-_parent_path_context: ContextVar[str] = ContextVar('genkit_parent_path', default='')
-
-
-@contextmanager
-def push_parent_path(path: str) -> Generator[None, None, None]:
-    """Push ``path`` as the active parent path for nested spans; restore on exit."""
-    token = _parent_path_context.set(path)
-    try:
-        yield
-    finally:
-        _parent_path_context.reset(token)
-
-
-def init_provider() -> TracerProvider:
-    """Inits and returns the tracer global provider."""
-    tracer_provider = trace_api.get_tracer_provider()
-
-    if tracer_provider is None or not isinstance(tracer_provider, TracerProvider):  # pyright: ignore[reportUnnecessaryComparison]
-        tracer_provider = TracerProvider()
-        trace_api.set_tracer_provider(tracer_provider)
-        # pyrefly: ignore[missing-attribute] - LoggingInstrumentor has instrument() method
-        LoggingInstrumentor().instrument(set_logging_format=True)
-        logger.debug('Creating a new global tracer provider for telemetry.')
-
-    if not isinstance(tracer_provider, TracerProvider):  # pyright: ignore[reportUnnecessaryIsInstance]
-        raise TypeError(
-            f'The current trace provider is not an instance of TracerProvider.  It is of type: {type(tracer_provider)}'
-        )
-
-    return tracer_provider
-
-
-def add_custom_exporter(exporter: SpanExporter | None, name: str = 'last') -> None:
-    """Adds custom span exporter to current tracer provider.
-
-    Args:
-        exporter: Custom or dedicated span exporter.
-        name: Name of the span exporter. Only for logging purposes.
-    """
-    current_provider = init_provider()
-
-    try:
-        if exporter is None:
-            logger.warn(f'{name} exporter is None')
-            return
-
-        processor = create_span_processor(exporter)
-        current_provider.add_span_processor(processor)
-        logger.debug(f'{name} exporter added successfully.')
-    except Exception:
-        logger.error(f'tracing.add_custom_exporter: failed to add exporter {name}')
-        logger.exception('Failed to add custom exporter')
-
-
-if is_dev_environment():
-    add_custom_exporter(init_telemetry_server_exporter(), 'local_telemetry_server')
-
-
-def _to_json_attr(value: object) -> str:
-    """Serialize an arbitrary object for an input/output span attribute."""
-    if isinstance(value, BaseModel):
-        return value.model_dump_json(by_alias=True, exclude_none=True)
-    try:
-        return json.dumps(value)
-    except (TypeError, ValueError):
-        return str(value)
-
-
-def start_attributes(
-    metadata: SpanMetadata,
-    *,
-    qualified_path: str,
-) -> dict[str, str | bool]:
-    """Attrs known when the span begins (identity/shape + input).
-
-    Live-trace export snapshots the span the instant it starts, so these have to
-    be on the span *before* start returns; otherwise Dev UI shows a blank
-    in-progress entry until the span ends. State/output are excluded — they
-    aren't known until the body finishes.
-    """
-    attrs: dict[str, str | bool] = {}
-    if metadata.telemetry_labels:
-        attrs.update(metadata.telemetry_labels)
-    attrs.update({
-        Attr.NAME: metadata.name,
-        Attr.PATH: qualified_path,
-        Attr.QUALIFIED_PATH: qualified_path,
-    })
-    if metadata.type:
-        attrs[Attr.TYPE] = metadata.type
-    if metadata.subtype:
-        attrs[Attr.SUBTYPE] = metadata.subtype
-    if metadata.is_root:
-        attrs[Attr.IS_ROOT] = True
-    if metadata.metadata:
-        for meta_key, meta_value in metadata.metadata.items():
-            attrs[metadata_key(meta_key)] = str(meta_value)
-    if metadata.input is not None:
-        attrs[Attr.INPUT] = _to_json_attr(metadata.input)
-    if metadata.init is not None:
-        attrs[Attr.INIT] = _to_json_attr(metadata.init)
-    return attrs
-
-
-@contextmanager
-def record_span_outcome(
-    span: trace_api.Span,
-    metadata: SpanMetadata,
-) -> Generator[None, None, None]:
-    """Write success or error attrs after the span body finishes."""
-    try:
-        yield
-    except GenkitInterrupt:
-        # HITL / tool pause — control flow, not a failed span. Stamp success so
-        # cloud telemetry has a known genkit:state; interrupt metadata already
-        # lives on the raise. Don't paint the span red.
-        if metadata.output is not None:
-            span.set_attribute(Attr.OUTPUT, _to_json_attr(metadata.output))
-        span.set_attribute(Attr.STATE, State.SUCCESS)
-        raise
-    except (asyncio.CancelledError, KeyboardInterrupt):
-        # Abort/timeout — unfinished work, not a win or a fail. Leave
-        # genkit:state absent (OTel stays UNSET) so cloud metrics don't count
-        # these as either. May log Unknown state until we have an aborted bucket.
-        raise
-    except Exception as e:
-        logger.debug(f'Error in run_in_new_span: {e!s}')
-        logger.debug(traceback.format_exc())
-        span.set_attribute(Attr.STATE, State.ERROR)
-        err_text = e.original_message if isinstance(e, GenkitError) else str(e)
-        span.set_attribute(Attr.ERROR, err_text)
-        span.set_status(status=trace_api.StatusCode.ERROR, description=str(e))
-        span.record_exception(e)
-        raise
-
-    if metadata.output is not None:
-        span.set_attribute(Attr.OUTPUT, _to_json_attr(metadata.output))
-    span.set_attribute(Attr.STATE, State.SUCCESS)
-
-
-@contextmanager
-def run_in_new_span(
-    metadata: SpanMetadata,
-    links: list[trace_api.Link] | None = None,
-) -> Generator[trace_api.Span, None, None]:
-    """Starts a new span context under the current trace.
-
-    All Genkit-specific attributes are derived from ``metadata``; caller-controlled
-    passthrough attributes go via ``metadata.telemetry_labels``.
-
-    Args:
-        metadata: Span metadata. See :class:`SpanMetadata` for field routing.
-        links: Optional span links.
-
-    Yields:
-        The OpenTelemetry Span object.
-    """
-    qualified_path = build_path(metadata.name, _parent_path_context.get(), metadata.type or '', metadata.subtype)
-    # Seed start-known attrs as span-start options so RealtimeSpanProcessor's
-    # on_start export already carries them for the Dev UI.
-    start_attrs = start_attributes(metadata, qualified_path=qualified_path)
-
-    with push_parent_path(qualified_path):
-        # record_span_outcome owns success/error attrs so control-flow
-        # GenkitInterrupt can re-raise without OTEL painting the span red.
-        with tracer.start_as_current_span(
-            name=metadata.name,
-            links=links,
-            attributes=start_attrs,
-            record_exception=False,
-            set_status_on_exception=False,
-        ) as span:
-            with record_span_outcome(span, metadata):
-                yield span
+__all__ = [
+    'SpanContext',
+    'SpanMetadata',
+    'add_custom_exporter',
+    'configure_instrumentation',
+    'init_provider',
+    'parent_path_context',
+    'reset_instrumentation',
+    'run_in_new_span',
+    'set_custom_metadata_attributes',
+    'start_attributes',
+    'tracer',
+]

--- a/py/packages/genkit/src/genkit/_core/_tracing.py
+++ b/py/packages/genkit/src/genkit/_core/_tracing.py
@@ -14,243 +14,40 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+"""Re-export of the telemetry dispatcher and OTel helpers.
 
-"""Telemetry and tracing functionality for the Genkit framework."""
+New code should import from ``genkit.telemetry`` or ``_instrumentation``.
+"""
 
-import asyncio
-import json
-import traceback
-from collections.abc import Generator
-from contextlib import contextmanager
-from contextvars import ContextVar
-from typing import Any, ClassVar, Literal
+from ._instrumentation import (
+    SpanContext,
+    SpanMetadata,
+    configure_instrumentation,
+    reset_instrumentation,
+    run_in_new_span,
+    set_custom_metadata_attributes,
+)
+from ._otel_instrumentation import (
+    add_custom_exporter,
+    init_provider,
+    parent_path_context,
+    start_attributes,
+    tracer,
+)
 
-from opentelemetry import trace as trace_api
-from opentelemetry.instrumentation.logging import LoggingInstrumentor
-from opentelemetry.sdk.trace import TracerProvider
-from opentelemetry.sdk.trace.export import SpanExporter
-from pydantic import BaseModel, ConfigDict, Field
-from pydantic.alias_generators import to_camel
+# Older tests imported this private name.
+_parent_path_context = parent_path_context
 
-from ._base import GenkitModel
-from ._environment import is_dev_environment
-from ._error import GenkitError, GenkitInterrupt
-from ._logger import get_logger
-from ._trace._attrs import Attr, State, metadata_key
-from ._trace._default_exporter import create_span_processor, init_telemetry_server_exporter
-from ._trace._path import build_path
-
-logger = get_logger(__name__)
-
-
-class SpanMetadata(GenkitModel):
-    """Input parameters for opening a Genkit span via :func:`run_in_new_span`.
-
-    Mapping from SpanMetadata to span attributes (see ``Attr`` for wire names):
-      - name                 -> Attr.NAME (and span name)
-      - input / output       -> Attr.INPUT / Attr.OUTPUT (JSON-serialized)
-      - type                 -> Attr.TYPE
-      - subtype              -> Attr.SUBTYPE
-      - metadata[k]          -> metadata_key(k)
-      - telemetry_labels[k]  -> <k> verbatim (caller-controlled keys)
-
-    """
-
-    model_config: ClassVar[ConfigDict] = ConfigDict(
-        alias_generator=to_camel, extra='forbid', populate_by_name=True, arbitrary_types_allowed=True
-    )
-
-    name: str = Field(...)
-    state: Literal['success', 'error'] | None = None
-    input: Any | None = Field(default=None)
-    output: Any | None = Field(default=None)
-    init: Any | None = Field(default=None)
-    is_root: bool | None = None
-    metadata: dict[str, Any] | None = None
-    path: str | None = None
-    type: str | None = None
-    subtype: str | None = None
-    telemetry_labels: dict[str, str] | None = None
-
-
-tracer = trace_api.get_tracer('genkit-tracer', 'v1')
-
-
-# Qualified ``genkit:path`` of the active span; pushed by ``run_in_new_span`` so
-# nested spans can build child paths.
-_parent_path_context: ContextVar[str] = ContextVar('genkit_parent_path', default='')
-
-
-@contextmanager
-def push_parent_path(path: str) -> Generator[None, None, None]:
-    """Push ``path`` as the active parent path for nested spans; restore on exit."""
-    token = _parent_path_context.set(path)
-    try:
-        yield
-    finally:
-        _parent_path_context.reset(token)
-
-
-def init_provider() -> TracerProvider:
-    """Inits and returns the tracer global provider."""
-    tracer_provider = trace_api.get_tracer_provider()
-
-    if tracer_provider is None or not isinstance(tracer_provider, TracerProvider):  # pyright: ignore[reportUnnecessaryComparison]
-        tracer_provider = TracerProvider()
-        trace_api.set_tracer_provider(tracer_provider)
-        # Rewriting the process log format stamps every library line with
-        # trace_id/span_id and turns the shared genkit start terminal into a wall.
-        # pyrefly: ignore[missing-attribute] - LoggingInstrumentor has instrument() method
-        LoggingInstrumentor().instrument(set_logging_format=False)
-        logger.debug('Creating a new global tracer provider for telemetry.')
-
-    if not isinstance(tracer_provider, TracerProvider):  # pyright: ignore[reportUnnecessaryIsInstance]
-        raise TypeError(
-            f'The current trace provider is not an instance of TracerProvider.  It is of type: {type(tracer_provider)}'
-        )
-
-    return tracer_provider
-
-
-def add_custom_exporter(exporter: SpanExporter | None, name: str = 'last') -> None:
-    """Adds custom span exporter to current tracer provider.
-
-    Args:
-        exporter: Custom or dedicated span exporter.
-        name: Name of the span exporter. Only for logging purposes.
-    """
-    current_provider = init_provider()
-
-    try:
-        if exporter is None:
-            logger.warn(f'{name} exporter is None')
-            return
-
-        processor = create_span_processor(exporter)
-        current_provider.add_span_processor(processor)
-        logger.debug(f'{name} exporter added successfully.')
-    except Exception:
-        logger.error(f'tracing.add_custom_exporter: failed to add exporter {name}')
-        logger.exception('Failed to add custom exporter')
-
-
-if is_dev_environment():
-    add_custom_exporter(init_telemetry_server_exporter(), 'local_telemetry_server')
-
-
-def _to_json_attr(value: object) -> str:
-    """Serialize an arbitrary object for an input/output span attribute."""
-    if isinstance(value, BaseModel):
-        return value.model_dump_json(by_alias=True, exclude_none=True)
-    try:
-        return json.dumps(value)
-    except (TypeError, ValueError):
-        return str(value)
-
-
-def start_attributes(
-    metadata: SpanMetadata,
-    *,
-    qualified_path: str,
-) -> dict[str, str | bool]:
-    """Attrs known when the span begins (identity/shape + input).
-
-    Live-trace export snapshots the span the instant it starts, so these have to
-    be on the span *before* start returns; otherwise Dev UI shows a blank
-    in-progress entry until the span ends. State/output are excluded — they
-    aren't known until the body finishes.
-    """
-    attrs: dict[str, str | bool] = {}
-    if metadata.telemetry_labels:
-        attrs.update(metadata.telemetry_labels)
-    attrs.update({
-        Attr.NAME: metadata.name,
-        Attr.PATH: qualified_path,
-        Attr.QUALIFIED_PATH: qualified_path,
-    })
-    if metadata.type:
-        attrs[Attr.TYPE] = metadata.type
-    if metadata.subtype:
-        attrs[Attr.SUBTYPE] = metadata.subtype
-    if metadata.is_root:
-        attrs[Attr.IS_ROOT] = True
-    if metadata.metadata:
-        for meta_key, meta_value in metadata.metadata.items():
-            attrs[metadata_key(meta_key)] = str(meta_value)
-    if metadata.input is not None:
-        attrs[Attr.INPUT] = _to_json_attr(metadata.input)
-    if metadata.init is not None:
-        attrs[Attr.INIT] = _to_json_attr(metadata.init)
-    return attrs
-
-
-@contextmanager
-def record_span_outcome(
-    span: trace_api.Span,
-    metadata: SpanMetadata,
-) -> Generator[None, None, None]:
-    """Write success or error attrs after the span body finishes."""
-    try:
-        yield
-    except GenkitInterrupt:
-        # HITL / tool pause — control flow, not a failed span. Stamp success so
-        # cloud telemetry has a known genkit:state; interrupt metadata already
-        # lives on the raise. Don't paint the span red.
-        if metadata.output is not None:
-            span.set_attribute(Attr.OUTPUT, _to_json_attr(metadata.output))
-        span.set_attribute(Attr.STATE, State.SUCCESS)
-        raise
-    except (asyncio.CancelledError, KeyboardInterrupt):
-        # Abort/timeout — unfinished work, not a win or a fail. Leave
-        # genkit:state absent (OTel stays UNSET) so cloud metrics don't count
-        # these as either. May log Unknown state until we have an aborted bucket.
-        raise
-    except Exception as e:
-        logger.debug(f'Error in run_in_new_span: {e!s}')
-        logger.debug(traceback.format_exc())
-        span.set_attribute(Attr.STATE, State.ERROR)
-        err_text = e.original_message if isinstance(e, GenkitError) else str(e)
-        span.set_attribute(Attr.ERROR, err_text)
-        span.set_status(status=trace_api.StatusCode.ERROR, description=str(e))
-        span.record_exception(e)
-        raise
-
-    if metadata.output is not None:
-        span.set_attribute(Attr.OUTPUT, _to_json_attr(metadata.output))
-    span.set_attribute(Attr.STATE, State.SUCCESS)
-
-
-@contextmanager
-def run_in_new_span(
-    metadata: SpanMetadata,
-    links: list[trace_api.Link] | None = None,
-) -> Generator[trace_api.Span, None, None]:
-    """Starts a new span context under the current trace.
-
-    All Genkit-specific attributes are derived from ``metadata``; caller-controlled
-    passthrough attributes go via ``metadata.telemetry_labels``.
-
-    Args:
-        metadata: Span metadata. See :class:`SpanMetadata` for field routing.
-        links: Optional span links.
-
-    Yields:
-        The OpenTelemetry Span object.
-    """
-    qualified_path = build_path(metadata.name, _parent_path_context.get(), metadata.type or '', metadata.subtype)
-    # Seed start-known attrs as span-start options so RealtimeSpanProcessor's
-    # on_start export already carries them for the Dev UI.
-    start_attrs = start_attributes(metadata, qualified_path=qualified_path)
-
-    with push_parent_path(qualified_path):
-        # record_span_outcome owns success/error attrs so control-flow
-        # GenkitInterrupt can re-raise without OTEL painting the span red.
-        with tracer.start_as_current_span(
-            name=metadata.name,
-            links=links,
-            attributes=start_attrs,
-            record_exception=False,
-            set_status_on_exception=False,
-        ) as span:
-            with record_span_outcome(span, metadata):
-                yield span
+__all__ = [
+    'SpanContext',
+    'SpanMetadata',
+    'add_custom_exporter',
+    'configure_instrumentation',
+    'init_provider',
+    'parent_path_context',
+    'reset_instrumentation',
+    'run_in_new_span',
+    'set_custom_metadata_attributes',
+    'start_attributes',
+    'tracer',
+]

--- a/py/packages/genkit/src/genkit/plugin_api/__init__.py
+++ b/py/packages/genkit/src/genkit/plugin_api/__init__.py
@@ -25,11 +25,12 @@ from genkit._core._error import GenkitError, StatusCodes, StatusName, get_callab
 from genkit._core._http_client import get_cached_client
 from genkit._core._loop_cache import _loop_local_client as loop_local_client
 from genkit._core._middleware import new_middleware
+from genkit._core._otel_instrumentation import add_custom_exporter, maybe_configure_otel_for_exporters
 from genkit._core._plugin import MiddlewarePlugin, Plugin
 from genkit._core._schema import to_json_schema
 from genkit._core._trace._adjusting_exporter import AdjustingTraceExporter, RedactedSpan
 from genkit._core._trace._path import to_display_path
-from genkit._core._tracing import add_custom_exporter, tracer
+from genkit._core._tracing import tracer
 from genkit._core._typing import ActionMetadata
 
 # Embedder domain re-exports
@@ -73,6 +74,7 @@ __all__ = [
     # Tracing
     'tracer',
     'add_custom_exporter',
+    'maybe_configure_otel_for_exporters',
     'AdjustingTraceExporter',
     'RedactedSpan',
     'to_display_path',

--- a/py/packages/genkit/src/genkit/plugin_api/__init__.py
+++ b/py/packages/genkit/src/genkit/plugin_api/__init__.py
@@ -34,11 +34,12 @@ from genkit._core._http_client import get_cached_client
 from genkit._core._loop_cache import _loop_local_client as loop_local_client
 from genkit._core._middleware import new_middleware
 from genkit._core._model import ModelConfig
+from genkit._core._otel_instrumentation import add_custom_exporter, maybe_configure_otel_for_exporters
 from genkit._core._plugin import MiddlewarePlugin, Plugin
 from genkit._core._schema import to_json_schema
 from genkit._core._trace._adjusting_exporter import AdjustingTraceExporter, RedactedSpan
 from genkit._core._trace._path import to_display_path
-from genkit._core._tracing import add_custom_exporter, tracer
+from genkit._core._tracing import tracer
 from genkit._core._typing import ActionMetadata
 
 # Embedder domain re-exports
@@ -86,6 +87,7 @@ __all__ = [
     # Tracing
     'tracer',
     'add_custom_exporter',
+    'maybe_configure_otel_for_exporters',
     'AdjustingTraceExporter',
     'RedactedSpan',
     'to_display_path',

--- a/py/packages/genkit/src/genkit/telemetry.py
+++ b/py/packages/genkit/src/genkit/telemetry.py
@@ -1,0 +1,57 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Turn tracing on, or add your own backend.
+
+A plain ``Genkit()`` script does not record traces. Action results have
+empty ``trace_id`` and ``span_id``.
+
+Tracing turns on when you call ``configure_instrumentation`` with a
+provider (usually ``OtelInstrumentation``), or when you run under
+``genkit start``. ``genkit start -- python app.py`` sets
+``GENKIT_ENV=dev`` and a collector URL before spawn; ``Genkit()``
+installs ``OtelInstrumentation`` so the Traces tab works. If you start
+the app yourself (``genkit start``, then ``GENKIT_ENV=dev python
+app.py``), the collector URL arrives on ``/api/notify`` or the
+reflection v2 handshake and turns tracing on the same way.
+
+``enable_google_cloud_telemetry()`` is enough for Cloud Trace in
+production. Under ``genkit start``, ``Genkit()`` still owns the
+Developer UI collector.
+"""
+
+from genkit._core._instrumentation import (
+    configure_instrumentation,
+    is_instrumented_by,
+    reset_instrumentation,
+    run_in_new_span,
+    set_custom_metadata_attributes,
+)
+from genkit._core._instrumentation_api import Instrumentation, SpanContext, SpanMetadata
+from genkit._core._otel_instrumentation import OtelInstrumentation, genkit_dev_instrumentation
+
+__all__ = [
+    'Instrumentation',
+    'OtelInstrumentation',
+    'SpanContext',
+    'SpanMetadata',
+    'configure_instrumentation',
+    'genkit_dev_instrumentation',
+    'is_instrumented_by',
+    'reset_instrumentation',
+    'run_in_new_span',
+    'set_custom_metadata_attributes',
+]

--- a/py/packages/genkit/tests/genkit/ai/agent_turn_span_test.py
+++ b/py/packages/genkit/tests/genkit/ai/agent_turn_span_test.py
@@ -33,10 +33,13 @@ from genkit._ai._agents._runtime import SessionRunner
 from genkit._ai._agents._session import Session
 from genkit._ai._agents._types import TurnContext, TurnResult
 from genkit._core._action import ActionRunContext
+from genkit._core._instrumentation import reset_instrumentation
+from genkit._core._otel_instrumentation import OtelInstrumentation
 from genkit._core._registry import Registry
 from genkit._core._trace._attrs import Attr, metadata_key
 from genkit._core._typing import AgentInput, AgentResult, MessageData, Part, SessionState, TextPart
 from genkit.agent import AgentFinishReason, InMemorySessionStore
+from genkit.telemetry import configure_instrumentation
 
 UUID_RE = re.compile(r'^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$', re.I)
 SESSION_ID_ATTR = metadata_key('agent:sessionId')
@@ -52,10 +55,13 @@ def exporter() -> Generator[InMemorySpanExporter, None, None]:
     exp = InMemorySpanExporter()
     processor = SimpleSpanProcessor(exp)
     provider.add_span_processor(processor)
+    reset_instrumentation()
+    configure_instrumentation(OtelInstrumentation(tracer_provider=provider))
     try:
         yield exp
     finally:
         exp.clear()
+        reset_instrumentation()
         if hasattr(provider, '_active_span_processor'):
             provider._active_span_processor._span_processors = tuple(
                 p for p in provider._active_span_processor._span_processors if p is not processor

--- a/py/packages/genkit/tests/genkit/core/action_test.py
+++ b/py/packages/genkit/tests/genkit/core/action_test.py
@@ -238,8 +238,30 @@ async def test_action_raises_errors() -> None:
         await action.run()
 
     assert 'stack' in e.value.details
-    assert 'trace_id' in e.value.details
+    # Default-off: no provider → empty/absent trace id.
+    assert not e.value.trace_id
     assert str(e.value.cause) == 'oops'
+
+
+@pytest.mark.asyncio
+async def test_action_error_includes_trace_id_when_instrumented() -> None:
+    from genkit._core._otel_instrumentation import init_provider
+    from genkit.telemetry import OtelInstrumentation, configure_instrumentation, reset_instrumentation
+
+    reset_instrumentation()
+    configure_instrumentation(OtelInstrumentation(tracer_provider=init_provider()))
+    try:
+
+        async def foo(_: str | None, ctx: ActionRunContext) -> None:
+            raise Exception('oops')
+
+        action = Action(name='fooAction', kind=ActionKind.CUSTOM, fn=foo)
+        with pytest.raises(GenkitError) as e:
+            await action.run()
+        assert e.value.trace_id
+        assert 'trace_id' in e.value.details
+    finally:
+        reset_instrumentation()
 
 
 @pytest.mark.asyncio

--- a/py/packages/genkit/tests/genkit/core/action_test.py
+++ b/py/packages/genkit/tests/genkit/core/action_test.py
@@ -241,8 +241,30 @@ async def test_action_raises_errors() -> None:
         await action.run()
 
     assert 'stack' in e.value.details
-    assert 'trace_id' in e.value.details
+    # Default-off: no provider → empty/absent trace id.
+    assert not e.value.trace_id
     assert str(e.value.cause) == 'oops'
+
+
+@pytest.mark.asyncio
+async def test_action_error_includes_trace_id_when_instrumented() -> None:
+    from genkit._core._otel_instrumentation import init_provider
+    from genkit.telemetry import OtelInstrumentation, configure_instrumentation, reset_instrumentation
+
+    reset_instrumentation()
+    configure_instrumentation(OtelInstrumentation(tracer_provider=init_provider()))
+    try:
+
+        async def foo(_: str | None, ctx: ActionRunContext) -> None:
+            raise Exception('oops')
+
+        action = Action(name='fooAction', kind=ActionKind.CUSTOM, fn=foo)
+        with pytest.raises(GenkitError) as e:
+            await action.run()
+        assert e.value.trace_id
+        assert 'trace_id' in e.value.details
+    finally:
+        reset_instrumentation()
 
 
 @pytest.mark.asyncio

--- a/py/packages/genkit/tests/genkit/core/instrumentation_test.py
+++ b/py/packages/genkit/tests/genkit/core/instrumentation_test.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+#
+# Copyright 2026 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Dispatcher tests for pluggable Instrumentation providers."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, Mapping
+
+import pytest
+
+from genkit.telemetry import (
+    SpanContext,
+    SpanMetadata,
+    configure_instrumentation,
+    is_instrumented_by,
+    reset_instrumentation,
+    run_in_new_span,
+    set_custom_metadata_attributes,
+)
+
+
+class RecordedSpan:
+    def __init__(self, label: str, *, trace_id: str = '', span_id: str = '') -> None:
+        self.label = label
+        self.trace_id = trace_id
+        self.span_id = span_id
+        self.metadata: list[Mapping[str, object]] = []
+        self.outputs: list[object] = []
+
+    def set_metadata(self, metadata: Mapping[str, object]) -> None:
+        self.metadata.append(metadata)
+
+    def set_output(self, value: object) -> None:
+        self.outputs.append(value)
+
+
+class FakeInstrumentation:
+    def __init__(
+        self,
+        label: str,
+        log: list[str],
+        *,
+        trace_id: str = '',
+        span_id: str = '',
+    ) -> None:
+        self.label = label
+        self.log = log
+        self.trace_id = trace_id
+        self.span_id = span_id
+        self.spans: list[RecordedSpan] = []
+
+    async def run_in_new_span(
+        self,
+        metadata: SpanMetadata,
+        next: Callable[[SpanContext], Awaitable[object]],
+    ) -> object:
+        self.log.append(f'enter:{self.label}')
+        span = RecordedSpan(self.label, trace_id=self.trace_id, span_id=self.span_id)
+        self.spans.append(span)
+        try:
+            return await next(span)
+        finally:
+            self.log.append(f'exit:{self.label}')
+
+
+@pytest.fixture(autouse=True)
+def _reset() -> object:
+    reset_instrumentation()
+    yield
+    reset_instrumentation()
+
+
+@pytest.mark.asyncio
+async def test_noop_span_when_nothing_configured() -> None:
+    seen: SpanContext | None = None
+
+    async def body(span: SpanContext) -> str:
+        nonlocal seen
+        seen = span
+        return 'ok'
+
+    result = await run_in_new_span('op', body)
+    assert result == 'ok'
+    assert seen is not None
+    assert seen.trace_id == ''
+    assert seen.span_id == ''
+    seen.set_metadata({'k': 'v'})
+    seen.set_output('x')
+
+
+@pytest.mark.asyncio
+async def test_composes_providers_in_registration_order() -> None:
+    log: list[str] = []
+    configure_instrumentation(FakeInstrumentation('a', log))
+    configure_instrumentation(FakeInstrumentation('b', log))
+
+    async def body(_span: SpanContext) -> str:
+        log.append('body')
+        return 'x'
+
+    await run_in_new_span('op', body)
+    assert log == ['enter:a', 'enter:b', 'body', 'exit:b', 'exit:a']
+
+
+@pytest.mark.asyncio
+async def test_in_flight_span_keeps_the_provider_list_it_started_with() -> None:
+    log: list[str] = []
+    configure_instrumentation(FakeInstrumentation('a', log))
+    configure_instrumentation(FakeInstrumentation('b', log))
+
+    async def body(_span: SpanContext) -> None:
+        reset_instrumentation()
+        configure_instrumentation(FakeInstrumentation('c', log))
+        log.append('body')
+
+    await run_in_new_span('op', body)
+    assert log == ['enter:a', 'enter:b', 'body', 'exit:b', 'exit:a']
+    assert 'enter:c' not in log
+
+
+@pytest.mark.asyncio
+async def test_set_custom_metadata_fans_out() -> None:
+    log: list[str] = []
+    a = FakeInstrumentation('a', log)
+    b = FakeInstrumentation('b', log)
+    configure_instrumentation(a)
+    configure_instrumentation(b)
+
+    async def body(_span: SpanContext) -> None:
+        set_custom_metadata_attributes({'hello': 'world'})
+
+    await run_in_new_span('op', body)
+    assert a.spans[0].metadata == [{'hello': 'world'}]
+    assert b.spans[0].metadata == [{'hello': 'world'}]
+
+
+@pytest.mark.asyncio
+async def test_set_output_fans_out() -> None:
+    log: list[str] = []
+    a = FakeInstrumentation('a', log)
+    b = FakeInstrumentation('b', log)
+    configure_instrumentation(a)
+    configure_instrumentation(b)
+
+    async def body(span: SpanContext) -> None:
+        span.set_output({'answer': 42})
+
+    await run_in_new_span('op', body)
+    assert a.spans[0].outputs == [{'answer': 42}]
+    assert b.spans[0].outputs == [{'answer': 42}]
+
+
+def test_configure_rejects_junk_at_the_boundary() -> None:
+    with pytest.raises(TypeError, match='Instrumentation instance'):
+        configure_instrumentation(object())  # type: ignore[arg-type]
+
+
+def test_otel_instrumentation_rejects_junk_tracer_provider() -> None:
+    from genkit.telemetry import OtelInstrumentation
+
+    with pytest.raises(TypeError, match='TracerProvider'):
+        OtelInstrumentation(tracer_provider=object())  # type: ignore[arg-type]
+
+
+def test_configure_rejects_the_provider_class() -> None:
+    from genkit.telemetry import OtelInstrumentation
+
+    with pytest.raises(
+        TypeError,
+        match='type genkit._core._otel_instrumentation.OtelInstrumentation',
+    ):
+        configure_instrumentation(OtelInstrumentation)  # type: ignore[arg-type]
+
+
+def test_is_instrumented_by_rejects_junk_at_the_boundary() -> None:
+    with pytest.raises(TypeError, match='builtins.str'):
+        is_instrumented_by('OtelInstrumentation')  # type: ignore[arg-type]
+
+
+@pytest.mark.asyncio
+async def test_run_in_new_span_rejects_a_sync_body() -> None:
+    def sync_body(_span: SpanContext) -> str:
+        return 'ok'
+
+    with pytest.raises(TypeError, match='sync_body'):
+        await run_in_new_span('op', sync_body)  # type: ignore[arg-type]
+
+
+@pytest.mark.asyncio
+async def test_ids_resolve_to_first_non_empty() -> None:
+    log: list[str] = []
+    configure_instrumentation(FakeInstrumentation('a', log))
+    configure_instrumentation(FakeInstrumentation('b', log, trace_id='trace-b', span_id='span-b'))
+
+    seen_trace = ''
+    seen_span = ''
+
+    async def body(span: SpanContext) -> None:
+        nonlocal seen_trace, seen_span
+        seen_trace = span.trace_id
+        seen_span = span.span_id
+
+    await run_in_new_span('op', body)
+    assert seen_trace == 'trace-b'
+    assert seen_span == 'span-b'
+
+
+@pytest.mark.asyncio
+async def test_errors_still_exit_each_provider() -> None:
+    log: list[str] = []
+    configure_instrumentation(FakeInstrumentation('a', log))
+    configure_instrumentation(FakeInstrumentation('b', log))
+
+    async def body(_span: SpanContext) -> None:
+        raise RuntimeError('boom')
+
+    with pytest.raises(RuntimeError, match='boom'):
+        await run_in_new_span('op', body)
+
+    assert log == ['enter:a', 'enter:b', 'exit:b', 'exit:a']
+
+
+@pytest.mark.asyncio
+async def test_action_without_instrumentation_has_empty_ids() -> None:
+    from genkit import ActionKind
+    from genkit._core._action import Action
+
+    async def noop() -> str:
+        return 'ok'
+
+    action = Action(name='plain', kind=ActionKind.CUSTOM, fn=noop)
+    result = await action.run()
+    assert result.response == 'ok'
+    assert result.trace_id == ''
+    assert result.span_id == ''

--- a/py/packages/genkit/tests/genkit/core/reflection_v2_test.py
+++ b/py/packages/genkit/tests/genkit/core/reflection_v2_test.py
@@ -48,6 +48,7 @@ from genkit import Genkit
 from genkit._core._action import Action, ActionKind, ActionRunContext, BidiAction
 from genkit._core._middleware import BaseMiddleware
 from genkit._core._model import ModelConfig
+from genkit._core._otel_instrumentation import init_provider
 from genkit._core._reflection_v2 import (
     JSON_RPC_INVALID_PARAMS,
     JSON_RPC_METHOD_NOT_FOUND,
@@ -56,6 +57,16 @@ from genkit._core._reflection_v2 import (
 from genkit._core._registry import Registry
 from genkit._core._typing import AgentInit, AgentInput
 from genkit.model import model_ref
+from genkit.telemetry import OtelInstrumentation, configure_instrumentation, reset_instrumentation
+
+
+@pytest.fixture(autouse=True)
+def _otel_for_reflection_ids() -> object:
+    """Dev UI cancel/state uses trace ids; reflection tests need a real provider."""
+    reset_instrumentation()
+    configure_instrumentation(OtelInstrumentation(tracer_provider=init_provider()))
+    yield
+    reset_instrumentation()
 
 
 class FakeReflectionManager:
@@ -851,3 +862,38 @@ def test_reflection_run_action_params_accepts_dev_ui_telemetry_labels() -> None:
         'telemetryLabels': {'genkitx:ignore-trace': 'true'},
     })
     assert p.telemetry_labels == {'genkitx:ignore-trace': 'true'}
+
+
+@pytest.mark.asyncio
+async def test_empty_trace_id_is_not_registered_for_cancel() -> None:
+    """Empty ids must not become a shared cancel key."""
+    from genkit._core._reflection import ActionRunner
+
+    async def noop() -> None:
+        return None
+
+    active: dict[str, asyncio.Task[Any]] = {}
+    runner = ActionRunner(
+        action=Action(name='noop', kind=ActionKind.CUSTOM, fn=noop),
+        payload={},
+        stream=False,
+        active_actions=active,
+    )
+    await runner.on_trace_start('', 'span')
+    assert '' not in active
+
+
+@pytest.mark.asyncio
+async def test_empty_trace_id_does_not_notify_run_action_state() -> None:
+    """An empty tid is not a run the Developer UI can display or cancel."""
+    notified: list[tuple[str, str]] = []
+    server = ReflectionServerV2(Registry(), 'ws://127.0.0.1:1')
+
+    async def fake_notify(sid: str, tid: str) -> None:
+        notified.append((sid, tid))
+
+    server.notify_run_action_state = fake_notify  # type: ignore[method-assign]
+    cb = server.trace_start_callback('sid-1', [None], register_for_cancel=True)
+    await cb('', 'span')
+    assert '' not in server.active_actions
+    assert notified == []

--- a/py/packages/genkit/tests/genkit/core/reflection_v2_test.py
+++ b/py/packages/genkit/tests/genkit/core/reflection_v2_test.py
@@ -47,6 +47,7 @@ from websockets.asyncio.server import serve
 from genkit import Genkit
 from genkit._core._action import Action, ActionKind, ActionRunContext, BidiAction
 from genkit._core._middleware import BaseMiddleware
+from genkit._core._otel_instrumentation import init_provider
 from genkit._core._reflection_v2 import (
     JSON_RPC_INVALID_PARAMS,
     JSON_RPC_METHOD_NOT_FOUND,
@@ -54,6 +55,16 @@ from genkit._core._reflection_v2 import (
 )
 from genkit._core._registry import Registry
 from genkit._core._typing import AgentInit, AgentInput
+from genkit.telemetry import OtelInstrumentation, configure_instrumentation, reset_instrumentation
+
+
+@pytest.fixture(autouse=True)
+def _otel_for_reflection_ids() -> object:
+    """Dev UI cancel/state uses trace ids; reflection tests need a real provider."""
+    reset_instrumentation()
+    configure_instrumentation(OtelInstrumentation(tracer_provider=init_provider()))
+    yield
+    reset_instrumentation()
 
 
 class FakeReflectionManager:
@@ -818,3 +829,38 @@ def test_reflection_run_action_params_accepts_dev_ui_telemetry_labels() -> None:
         'telemetryLabels': {'genkitx:ignore-trace': 'true'},
     })
     assert p.telemetry_labels == {'genkitx:ignore-trace': 'true'}
+
+
+@pytest.mark.asyncio
+async def test_empty_trace_id_is_not_registered_for_cancel() -> None:
+    """Empty ids must not become a shared cancel key."""
+    from genkit._core._reflection import ActionRunner
+
+    async def noop() -> None:
+        return None
+
+    active: dict[str, asyncio.Task[Any]] = {}
+    runner = ActionRunner(
+        action=Action(name='noop', kind=ActionKind.CUSTOM, fn=noop),
+        payload={},
+        stream=False,
+        active_actions=active,
+    )
+    await runner.on_trace_start('', 'span')
+    assert '' not in active
+
+
+@pytest.mark.asyncio
+async def test_empty_trace_id_does_not_notify_run_action_state() -> None:
+    """An empty tid is not a run the Developer UI can display or cancel."""
+    notified: list[tuple[str, str]] = []
+    server = ReflectionServerV2(Registry(), 'ws://127.0.0.1:1')
+
+    async def fake_notify(sid: str, tid: str) -> None:
+        notified.append((sid, tid))
+
+    server.notify_run_action_state = fake_notify  # type: ignore[method-assign]
+    cb = server.trace_start_callback('sid-1', [None], register_for_cancel=True)
+    await cb('', 'span')
+    assert '' not in server.active_actions
+    assert notified == []

--- a/py/packages/genkit/tests/genkit/core/run_in_new_span_test.py
+++ b/py/packages/genkit/tests/genkit/core/run_in_new_span_test.py
@@ -26,9 +26,12 @@ from genkit import ActionKind, Genkit
 from genkit._ai._tools import Interrupt, ToolRunContext
 from genkit._core._action import Action
 from genkit._core._error import GenkitError
+from genkit._core._instrumentation import reset_instrumentation, run_in_new_span
+from genkit._core._otel_instrumentation import OtelInstrumentation, add_custom_exporter, start_attributes
 from genkit._core._trace._attrs import metadata_key
 from genkit._core._trace._realtime_processor import RealtimeSpanProcessor
-from genkit._core._tracing import SpanMetadata, _parent_path_context, run_in_new_span, start_attributes
+from genkit._core._tracing import SpanMetadata, _parent_path_context
+from genkit.telemetry import configure_instrumentation, is_instrumented_by
 
 
 @pytest.fixture(autouse=True)
@@ -43,7 +46,7 @@ def _reset_parent_path() -> Generator[None, None, None]:
 
 @pytest.fixture
 def exporter() -> Generator[InMemorySpanExporter, None, None]:
-    """Provide an in-memory span exporter wired into the global tracer provider."""
+    """In-memory exporter plus the OTel renderer (default-off otherwise)."""
     provider = trace_api.get_tracer_provider()
     if not isinstance(provider, TracerProvider):
         provider = TracerProvider()
@@ -51,10 +54,19 @@ def exporter() -> Generator[InMemorySpanExporter, None, None]:
     exp = InMemorySpanExporter()
     processor = SimpleSpanProcessor(exp)
     provider.add_span_processor(processor)
+    reset_instrumentation()
+    configure_instrumentation(OtelInstrumentation(tracer_provider=provider))
     try:
         yield exp
     finally:
         exp.clear()
+        reset_instrumentation()
+
+
+def test_add_custom_exporter_does_not_register_renderer() -> None:
+    reset_instrumentation()
+    add_custom_exporter(InMemorySpanExporter(), 'test')
+    assert not is_instrumented_by(OtelInstrumentation)
 
 
 def _by_name(spans: Sequence[ReadableSpan], name: str) -> ReadableSpan:
@@ -68,10 +80,9 @@ def test_start_attributes_includes_input_excludes_outcome() -> None:
     attrs = start_attributes(
         SpanMetadata(
             name='myTool',
-            type='action',
+            action_type='action',
             subtype='tool',
             input='in',
-            output='out',
             is_root=True,
             metadata={'key': 'value'},
         ),
@@ -93,7 +104,7 @@ def test_start_attributes_includes_input_excludes_outcome() -> None:
 
 def test_start_attributes_json_input() -> None:
     attrs = start_attributes(
-        SpanMetadata(name='echo', type='action', input={'msg': 'hi'}),
+        SpanMetadata(name='echo', action_type='action', input={'msg': 'hi'}),
         qualified_path='/{echo,t:action}',
     )
     assert attrs['genkit:input'] == '{"msg": "hi"}'
@@ -101,7 +112,7 @@ def test_start_attributes_json_input() -> None:
 
 def test_start_attributes_json_init() -> None:
     attrs = start_attributes(
-        SpanMetadata(name='agentRun', type='action', init={'sessionId': 'session-123'}),
+        SpanMetadata(name='agentRun', action_type='action', init={'sessionId': 'session-123'}),
         qualified_path='/{agentRun,t:action}',
     )
     assert attrs['genkit:init'] == '{"sessionId": "session-123"}'
@@ -131,7 +142,7 @@ def test_realtime_on_start_export_carries_identity_attrs(
     tracer = provider.get_tracer('test_tracer')
     meta = SpanMetadata(
         name='liveAction',
-        type='action',
+        action_type='action',
         subtype='flow',
         input={'prompt': 'hi'},
         metadata={'flow:name': 'liveAction'},
@@ -156,9 +167,12 @@ def test_realtime_on_start_export_carries_identity_attrs(
         provider.shutdown()
 
 
-def test_writes_name_path_and_state_success(exporter: InMemorySpanExporter) -> None:
-    with run_in_new_span(SpanMetadata(name='hello', type='util')):
-        pass
+@pytest.mark.asyncio
+async def test_writes_name_path_and_state_success(exporter: InMemorySpanExporter) -> None:
+    async def body(_span: object) -> None:
+        return None
+
+    await run_in_new_span('hello', body, action_type='util')
 
     span = _by_name(exporter.get_finished_spans(), 'hello')
     attrs = dict(span.attributes or {})
@@ -167,14 +181,18 @@ def test_writes_name_path_and_state_success(exporter: InMemorySpanExporter) -> N
     assert attrs['genkit:state'] == 'success'
     assert attrs['genkit:path'] == '/{hello,t:util}'
     assert attrs['genkit:qualifiedPath'] == '/{hello,t:util}'
+    assert 'genkit:output' not in attrs
 
 
-def test_writes_input_from_metadata(exporter: InMemorySpanExporter) -> None:
+@pytest.mark.asyncio
+async def test_writes_input_from_metadata(exporter: InMemorySpanExporter) -> None:
     class Payload(BaseModel):
         msg: str
 
-    with run_in_new_span(SpanMetadata(name='echo', type='action', subtype='tool', input=Payload(msg='hi'))):
-        pass
+    async def body(_span: object) -> None:
+        return None
+
+    await run_in_new_span('echo', body, action_type='action', subtype='tool', input=Payload(msg='hi'))
 
     span = _by_name(exporter.get_finished_spans(), 'echo')
     attrs = dict(span.attributes or {})
@@ -183,19 +201,24 @@ def test_writes_input_from_metadata(exporter: InMemorySpanExporter) -> None:
     assert attrs['genkit:metadata:subtype'] == 'tool'
 
 
-def test_writes_init_from_metadata(exporter: InMemorySpanExporter) -> None:
-    with run_in_new_span(SpanMetadata(name='agentRun', type='action', init={'sessionId': 'session-123'})):
-        pass
+@pytest.mark.asyncio
+async def test_writes_init_from_metadata(exporter: InMemorySpanExporter) -> None:
+    async def body(_span: object) -> None:
+        return None
+
+    await run_in_new_span('agentRun', body, action_type='action', init={'sessionId': 'session-123'})
 
     span = _by_name(exporter.get_finished_spans(), 'agentRun')
     attrs = dict(span.attributes or {})
     assert attrs['genkit:init'] == '{"sessionId": "session-123"}'
 
 
-def test_writes_output_from_metadata_on_success(exporter: InMemorySpanExporter) -> None:
-    meta = SpanMetadata(name='answer', type='util')
-    with run_in_new_span(meta):
-        meta.output = {'result': 42}
+@pytest.mark.asyncio
+async def test_writes_output_from_return_value_on_success(exporter: InMemorySpanExporter) -> None:
+    async def body(_span: object) -> dict[str, int]:
+        return {'result': 42}
+
+    await run_in_new_span('answer', body, action_type='util')
 
     span = _by_name(exporter.get_finished_spans(), 'answer')
     attrs = dict(span.attributes or {})
@@ -203,10 +226,13 @@ def test_writes_output_from_metadata_on_success(exporter: InMemorySpanExporter) 
     assert attrs['genkit:state'] == 'success'
 
 
-def test_records_error_attributes(exporter: InMemorySpanExporter) -> None:
+@pytest.mark.asyncio
+async def test_records_error_attributes(exporter: InMemorySpanExporter) -> None:
+    async def body(_span: object) -> None:
+        raise RuntimeError('boom')
+
     with pytest.raises(RuntimeError, match='boom'):
-        with run_in_new_span(SpanMetadata(name='broken', type='util')):
-            raise RuntimeError('boom')
+        await run_in_new_span('broken', body, action_type='util')
 
     span = _by_name(exporter.get_finished_spans(), 'broken')
     attrs = dict(span.attributes or {})
@@ -215,12 +241,18 @@ def test_records_error_attributes(exporter: InMemorySpanExporter) -> None:
     assert span.status.status_code == trace_api.StatusCode.ERROR
 
 
-def test_cancelled_span_leaves_state_unset(exporter: InMemorySpanExporter, caplog: pytest.LogCaptureFixture) -> None:
+@pytest.mark.asyncio
+async def test_cancelled_span_leaves_state_unset(
+    exporter: InMemorySpanExporter, caplog: pytest.LogCaptureFixture
+) -> None:
     """Abort/timeout is unfinished work — neither success nor error."""
+
+    async def body(_span: object) -> None:
+        raise asyncio.CancelledError()
+
     with caplog.at_level(logging.DEBUG):
         with pytest.raises(asyncio.CancelledError):
-            with run_in_new_span(SpanMetadata(name='abortedTurn', type='util')):
-                raise asyncio.CancelledError()
+            await run_in_new_span('abortedTurn', body, action_type='util')
 
     span = _by_name(exporter.get_finished_spans(), 'abortedTurn')
     attrs = dict(span.attributes or {})
@@ -264,28 +296,35 @@ async def test_tool_interrupt_is_not_recorded_as_span_error(
     assert not any('Error in run_in_new_span' in r.message for r in caplog.records)
 
 
-def test_nested_path_inherits_parent_qualified_path(exporter: InMemorySpanExporter) -> None:
-    with run_in_new_span(SpanMetadata(name='outer', type='flow')):
-        with run_in_new_span(SpanMetadata(name='inner', type='flowStep')):
-            pass
+@pytest.mark.asyncio
+async def test_nested_path_inherits_parent_qualified_path(exporter: InMemorySpanExporter) -> None:
+    async def inner(_span: object) -> None:
+        return None
 
-    inner = _by_name(exporter.get_finished_spans(), 'inner')
-    inner_attrs = dict(inner.attributes or {})
+    async def outer(_span: object) -> None:
+        await run_in_new_span('inner', inner, action_type='flowStep')
+
+    await run_in_new_span('outer', outer, action_type='flow')
+
+    inner_span = _by_name(exporter.get_finished_spans(), 'inner')
+    inner_attrs = dict(inner_span.attributes or {})
     assert inner_attrs['genkit:qualifiedPath'] == '/{outer,t:flow}/{inner,t:flowStep}'
 
 
-def test_metadata_metadata_dict_is_flattened_and_telemetry_labels_pass_through(
+@pytest.mark.asyncio
+async def test_metadata_metadata_dict_is_flattened_and_telemetry_labels_pass_through(
     exporter: InMemorySpanExporter,
 ) -> None:
-    with run_in_new_span(
-        SpanMetadata(
-            name='step',
-            type='flowStep',
-            metadata={'flow:name': 'pipeline', 'attempt': 2},
-            telemetry_labels={'genkit:custom:tag': 'foo'},
-        )
-    ):
-        pass
+    async def body(_span: object) -> None:
+        return None
+
+    await run_in_new_span(
+        'step',
+        body,
+        action_type='flowStep',
+        metadata={'flow:name': 'pipeline', 'attempt': 2},
+        attributes={'genkit:custom:tag': 'foo'},
+    )
 
     span = _by_name(exporter.get_finished_spans(), 'step')
     attrs = dict(span.attributes or {})
@@ -442,7 +481,7 @@ def test_metadata_key_prevents_double_prefix() -> None:
 def test_start_attributes_precedence_over_telemetry_labels() -> None:
     meta = SpanMetadata(
         name='realName',
-        telemetry_labels={
+        attributes={
             'genkit:name': 'fakeName',
             'genkit:path': 'fakePath',
             'user:label': 'custom',

--- a/py/packages/genkit/tests/genkit/core/telemetry_contract_test.py
+++ b/py/packages/genkit/tests/genkit/core/telemetry_contract_test.py
@@ -7,13 +7,14 @@
 
 from __future__ import annotations
 
+import asyncio
 import os
 import subprocess  # noqa: S404
 import sys
 import threading
-from collections.abc import Generator
+from collections.abc import Awaitable, Callable, Generator, Mapping
 from http.server import BaseHTTPRequestHandler, HTTPServer
-from typing import Any
+from typing import Any, TypeVar
 from unittest.mock import MagicMock
 
 import pytest
@@ -26,7 +27,13 @@ from opentelemetry.trace import NoOpTracerProvider
 from genkit import ActionKind, Genkit
 from genkit._core._action import Action
 from genkit._core._environment import GENKIT_ENV
-from genkit._core._instrumentation import instrumentations
+from genkit._core._instrumentation import (
+    NoopSpanContext,
+    instrumentations,
+    run_in_new_span,
+    set_custom_metadata_attributes,
+)
+from genkit._core._instrumentation_api import Instrumentation, SpanContext, SpanMetadata
 from genkit._core._otel_instrumentation import (
     add_custom_exporter,
     maybe_configure_otel_for_exporters,
@@ -34,7 +41,6 @@ from genkit._core._otel_instrumentation import (
 )
 from genkit._core._reflection_v2 import ReflectionServerV2
 from genkit._core._registry import Registry
-from genkit._core._trace._default_exporter import TraceServerExporter
 from genkit.telemetry import (
     OtelInstrumentation,
     configure_instrumentation,
@@ -42,15 +48,33 @@ from genkit.telemetry import (
     reset_instrumentation,
 )
 
+T = TypeVar('T')
+
 
 def _hex_id(value: str, length: int) -> bool:
     return len(value) == length and all(c in '0123456789abcdef' for c in value)
 
 
+def _flush_exporters_in_provider(provider: TracerProvider) -> None:
+    active = getattr(provider, '_active_span_processor', None)
+    if active is None:
+        return
+    processors = getattr(active, '_span_processors', [active])
+    for proc in processors:
+        exp = getattr(proc, 'span_exporter', None) or getattr(proc, 'exporter', None)
+        if exp is not None and hasattr(exp, 'force_flush'):
+            exp.force_flush()
+
+
 def _force_flush() -> None:
+    for inst in instrumentations:
+        if isinstance(inst, OtelInstrumentation) and inst._tracer_provider is not None:
+            inst._tracer_provider.force_flush()
+            _flush_exporters_in_provider(inst._tracer_provider)
     provider = trace_api.get_tracer_provider()
-    assert isinstance(provider, TracerProvider)
-    provider.force_flush()
+    if isinstance(provider, TracerProvider):
+        provider.force_flush()
+        _flush_exporters_in_provider(provider)
 
 
 async def _joke() -> str:
@@ -107,10 +131,10 @@ async def test_genkit_start_gives_the_developer_ui_real_trace_ids(
 
 
 @pytest.mark.asyncio
-async def test_configuring_otel_yourself_means_you_own_the_collector(
+async def test_configuring_otel_yourself_in_dev_stacks_dev_instrumentation(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """configure_instrumentation(OtelInstrumentation()) first: we will not add a Developer UI provider."""
+    """configure_instrumentation(OtelInstrumentation()) in dev mode stacks dev instrumentation."""
     monkeypatch.setenv(GENKIT_ENV, 'dev')
     monkeypatch.setenv('GENKIT_TELEMETRY_SERVER', 'http://127.0.0.1:4033')
 
@@ -118,7 +142,9 @@ async def test_configuring_otel_yourself_means_you_own_the_collector(
     configure_instrumentation(yours)
     Genkit()
 
-    assert instrumentations == [yours]
+    assert len(instrumentations) == 2
+    assert instrumentations[0] == yours
+    assert isinstance(instrumentations[1], OtelInstrumentation)
 
 
 @pytest.mark.asyncio
@@ -233,7 +259,7 @@ async def test_enable_hangs_cloud_exporter_on_their_provider() -> None:
 def test_exporter_refuses_a_provider_it_cannot_attach_to() -> None:
     """Wrong provider type: named TypeError, not a silent empty Cloud Trace."""
     yours = OtelInstrumentation()
-    yours._tracer_provider = NoOpTracerProvider()
+    setattr(yours, '_tracer_provider', NoOpTracerProvider())
     configure_instrumentation(yours)
     with pytest.raises(TypeError, match='not a TracerProvider'):
         add_custom_exporter(InMemorySpanExporter(), 'cloud-trace')
@@ -332,7 +358,7 @@ def _capture_handshake_exporters(monkeypatch: pytest.MonkeyPatch) -> list[object
     seen: list[object] = []
     real = add_custom_exporter
 
-    def capture(exporter: object, name: str = 'last') -> None:
+    def capture(exporter: Any, name: str = 'last') -> None:
         seen.append(exporter)
         real(exporter, name)
 
@@ -418,20 +444,13 @@ async def test_leftover_collector_url_does_not_drop_handshake_url(
         monkeypatch.setenv('GENKIT_TELEMETRY_SERVER', leftover_url)
 
         Genkit()
-        seen = _capture_handshake_exporters(monkeypatch)
         _handshake_server().apply_handshake_telemetry(live_url)
         action = Action(name='joke', kind=ActionKind.FLOW, fn=_joke)
         result = await action.run()
+        _force_flush()
 
-        assert not is_instrumented_by(OtelInstrumentation)
-        assert result.trace_id == ''
-        assert len(seen) == 1
-        exporter = seen[0]
-        assert isinstance(exporter, TraceServerExporter)
-        assert exporter.telemetry_server_url == live_url
-
-        exporter.export([_span_for_export()])
-        exporter.force_flush()
+        assert is_instrumented_by(OtelInstrumentation)
+        assert _hex_id(result.trace_id, 32)
         assert live_posts
         assert not leftover_posts
     finally:
@@ -549,3 +568,242 @@ assert is_placeholder_provider(trace.get_tracer_provider())
         env=env,
     )
     assert completed.returncode == 0, completed.stderr
+
+
+@pytest.mark.asyncio
+async def test_production_unconfigured_genkit_does_not_leak_into_host_otel(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Host app global OTel captures app spans, but unconfigured Genkit leaks 0 spans."""
+    host_exporter = InMemorySpanExporter()
+    host_provider = TracerProvider()
+    host_provider.add_span_processor(SimpleSpanProcessor(host_exporter))
+    monkeypatch.setattr(trace_api, 'get_tracer_provider', lambda: host_provider)
+
+    tracer = host_provider.get_tracer('app')
+    with tracer.start_as_current_span('http.request'):
+        pass
+
+    Genkit()
+    action = Action(name='joke', kind=ActionKind.FLOW, fn=_joke)
+    result = await action.run()
+
+    host_provider.force_flush()
+    span_names = [s.name for s in host_exporter.get_finished_spans()]
+    assert 'http.request' in span_names
+    assert 'joke' not in span_names
+    assert result.trace_id == ''
+
+
+@pytest.mark.asyncio
+async def test_dev_mode_never_claims_or_mutates_global_tracer_provider(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Dev instrumentation uses an isolated TracerProvider and never mutates global OTel."""
+    monkeypatch.setenv(GENKIT_ENV, 'dev')
+    monkeypatch.setenv('GENKIT_TELEMETRY_SERVER', 'http://127.0.0.1:4033')
+
+    global_calls: list[object] = []
+    monkeypatch.setattr(trace_api, 'set_tracer_provider', lambda p: global_calls.append(p))
+
+    Genkit()
+    action = Action(name='joke', kind=ActionKind.FLOW, fn=_joke)
+    result = await action.run()
+
+    assert _hex_id(result.trace_id, 32)
+    assert global_calls == []
+
+
+@pytest.mark.asyncio
+async def test_dev_mode_with_custom_apm_separates_dev_and_remote_exporters(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Dev UI and remote APM both receive clean spans via isolated providers."""
+    monkeypatch.setenv(GENKIT_ENV, 'dev')
+    server, posts = _start_collector()
+    dev_url = f'http://127.0.0.1:{server.server_address[1]}'
+    monkeypatch.setenv('GENKIT_TELEMETRY_SERVER', dev_url)
+
+    try:
+        remote_exporter = InMemorySpanExporter()
+        remote_provider = TracerProvider()
+        remote_provider.add_span_processor(SimpleSpanProcessor(remote_exporter))
+        configure_instrumentation(OtelInstrumentation(tracer_provider=remote_provider))
+
+        Genkit()
+        action = Action(name='joke', kind=ActionKind.FLOW, fn=_joke)
+        result = await action.run()
+        _force_flush()
+
+        assert _hex_id(result.trace_id, 32)
+        assert posts
+        remote_spans = [s.name for s in remote_exporter.get_finished_spans()]
+        assert 'joke' in remote_spans
+    finally:
+        server.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_nested_flow_model_tool_shares_trace_id_and_parent_links() -> None:
+    """Nested actions maintain the same trace_id and correct parent_span_id links."""
+    provider = TracerProvider()
+    exporter = InMemorySpanExporter()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    configure_instrumentation(OtelInstrumentation(tracer_provider=provider))
+
+    async def step_fn() -> str:
+        return 'step_ok'
+
+    step_action = Action(name='stepAction', kind=ActionKind.UTIL, fn=step_fn)
+
+    async def flow_fn() -> str:
+        res = await step_action.run()
+        return f'flow_{res.response}'
+
+    flow_action = Action(name='flowAction', kind=ActionKind.FLOW, fn=flow_fn)
+    result = await flow_action.run()
+
+    provider.force_flush()
+    spans = exporter.get_finished_spans()
+    assert len(spans) == 2
+
+    flow_span = next(s for s in spans if s.name == 'flowAction')
+    step_span = next(s for s in spans if s.name == 'stepAction')
+
+    flow_ctx = flow_span.context
+    step_ctx = step_span.context
+    assert flow_ctx is not None and step_ctx is not None
+    assert flow_ctx.trace_id == step_ctx.trace_id
+    assert format(flow_ctx.trace_id, '032x') == result.trace_id
+    assert step_span.parent is not None
+    assert step_span.parent.span_id == flow_ctx.span_id
+
+
+@pytest.mark.asyncio
+async def test_concurrent_flows_maintain_independent_trace_trees() -> None:
+    """Concurrent flows in asyncio.gather keep independent trace IDs and trees."""
+    provider = TracerProvider()
+    exporter = InMemorySpanExporter()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    configure_instrumentation(OtelInstrumentation(tracer_provider=provider))
+
+    async def flow1_fn() -> str:
+        await asyncio.sleep(0.01)
+        return 'done_1'
+
+    async def flow2_fn() -> str:
+        await asyncio.sleep(0.01)
+        return 'done_2'
+
+    action1 = Action(name='flow1', kind=ActionKind.FLOW, fn=flow1_fn)
+    action2 = Action(name='flow2', kind=ActionKind.FLOW, fn=flow2_fn)
+
+    res1, res2 = await asyncio.gather(action1.run(), action2.run())
+
+    assert _hex_id(res1.trace_id, 32)
+    assert _hex_id(res2.trace_id, 32)
+    assert res1.trace_id != res2.trace_id
+
+    provider.force_flush()
+    spans = exporter.get_finished_spans()
+    span1 = next(s for s in spans if s.name == 'flow1')
+    span2 = next(s for s in spans if s.name == 'flow2')
+    s1_ctx = span1.context
+    s2_ctx = span2.context
+    assert s1_ctx is not None and s2_ctx is not None
+    assert s1_ctx.trace_id != s2_ctx.trace_id
+
+
+@pytest.mark.asyncio
+async def test_run_in_new_span_snapshots_providers_against_concurrent_mutation() -> None:
+    """Mutating instrumentations while a span runs does not affect the active span."""
+    provider = TracerProvider()
+    exporter = InMemorySpanExporter()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    configure_instrumentation(OtelInstrumentation(tracer_provider=provider))
+
+    async def body(_span: object) -> str:
+        reset_instrumentation()
+        return 'mutated'
+
+    res = await run_in_new_span('in_flight', body, action_type='flow')
+    assert res == 'mutated'
+
+    provider.force_flush()
+    spans = exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert spans[0].name == 'in_flight'
+
+
+@pytest.mark.asyncio
+async def test_set_custom_metadata_stamps_all_instrumentations_for_current_action() -> None:
+    """set_custom_metadata_attributes fans out to all active provider spans."""
+    p1 = TracerProvider()
+    e1 = InMemorySpanExporter()
+    p1.add_span_processor(SimpleSpanProcessor(e1))
+
+    p2 = TracerProvider()
+    e2 = InMemorySpanExporter()
+    p2.add_span_processor(SimpleSpanProcessor(e2))
+
+    configure_instrumentation(OtelInstrumentation(tracer_provider=p1))
+    configure_instrumentation(OtelInstrumentation(tracer_provider=p2))
+
+    async def flow_fn() -> str:
+        set_custom_metadata_attributes({'user_id': 'user_42', 'tier': 'enterprise'})
+        return 'ok'
+
+    action = Action(name='metaFlow', kind=ActionKind.FLOW, fn=flow_fn)
+    await action.run()
+
+    p1.force_flush()
+    p2.force_flush()
+
+    s1 = e1.get_finished_spans()[0]
+    s2 = e2.get_finished_spans()[0]
+
+    assert s1.attributes is not None and s1.attributes['genkit:metadata:user_id'] == 'user_42'
+    assert s1.attributes is not None and s1.attributes['genkit:metadata:tier'] == 'enterprise'
+    assert s2.attributes is not None and s2.attributes['genkit:metadata:user_id'] == 'user_42'
+    assert s2.attributes is not None and s2.attributes['genkit:metadata:tier'] == 'enterprise'
+
+
+def test_set_custom_metadata_is_noop_outside_action() -> None:
+    """Calling set_custom_metadata_attributes outside an action does not raise."""
+    set_custom_metadata_attributes({'some': 'value'})
+
+
+@pytest.mark.asyncio
+async def test_failing_custom_provider_does_not_break_other_providers() -> None:
+    """A throwing custom provider span does not crash other providers or action execution."""
+    p1 = TracerProvider()
+    e1 = InMemorySpanExporter()
+    p1.add_span_processor(SimpleSpanProcessor(e1))
+
+    class BrokenSpan(NoopSpanContext):
+        def set_metadata(self, metadata: Mapping[str, object]) -> None:
+            raise RuntimeError('custom provider metadata crash')
+
+    class BrokenInstrumentation(Instrumentation):
+        async def run_in_new_span(
+            self,
+            metadata: SpanMetadata,
+            next: Callable[[SpanContext], Awaitable[T]],
+        ) -> T:
+            return await next(BrokenSpan())
+
+    configure_instrumentation(OtelInstrumentation(tracer_provider=p1))
+    configure_instrumentation(BrokenInstrumentation())
+
+    async def flow_fn() -> str:
+        set_custom_metadata_attributes({'custom': 'val'})
+        return 'success'
+
+    action = Action(name='failingProviderFlow', kind=ActionKind.FLOW, fn=flow_fn)
+    result = await action.run()
+
+    assert result.response == 'success'
+    p1.force_flush()
+    spans = e1.get_finished_spans()
+    assert len(spans) == 1
+    assert spans[0].attributes is not None and spans[0].attributes['genkit:metadata:custom'] == 'val'

--- a/py/packages/genkit/tests/genkit/core/telemetry_contract_test.py
+++ b/py/packages/genkit/tests/genkit/core/telemetry_contract_test.py
@@ -259,7 +259,7 @@ async def test_enable_hangs_cloud_exporter_on_their_provider() -> None:
 def test_exporter_refuses_a_provider_it_cannot_attach_to() -> None:
     """Wrong provider type: named TypeError, not a silent empty Cloud Trace."""
     yours = OtelInstrumentation()
-    setattr(yours, '_tracer_provider', NoOpTracerProvider())
+    yours._tracer_provider = NoOpTracerProvider()  # pyright: ignore[reportAttributeAccessIssue]
     configure_instrumentation(yours)
     with pytest.raises(TypeError, match='not a TracerProvider'):
         add_custom_exporter(InMemorySpanExporter(), 'cloud-trace')

--- a/py/packages/genkit/tests/genkit/core/telemetry_contract_test.py
+++ b/py/packages/genkit/tests/genkit/core/telemetry_contract_test.py
@@ -1,0 +1,551 @@
+#!/usr/bin/env python3
+#
+# Copyright 2026 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the telemetry product contract."""
+
+from __future__ import annotations
+
+import os
+import subprocess  # noqa: S404
+import sys
+import threading
+from collections.abc import Generator
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from opentelemetry import trace as trace_api
+from opentelemetry.sdk.trace import ReadableSpan, TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.trace import NoOpTracerProvider
+
+from genkit import ActionKind, Genkit
+from genkit._core._action import Action
+from genkit._core._environment import GENKIT_ENV
+from genkit._core._instrumentation import instrumentations
+from genkit._core._otel_instrumentation import (
+    add_custom_exporter,
+    maybe_configure_otel_for_exporters,
+    parent_path_context,
+)
+from genkit._core._reflection_v2 import ReflectionServerV2
+from genkit._core._registry import Registry
+from genkit._core._trace._default_exporter import TraceServerExporter
+from genkit.telemetry import (
+    OtelInstrumentation,
+    configure_instrumentation,
+    is_instrumented_by,
+    reset_instrumentation,
+)
+
+
+def _hex_id(value: str, length: int) -> bool:
+    return len(value) == length and all(c in '0123456789abcdef' for c in value)
+
+
+def _force_flush() -> None:
+    provider = trace_api.get_tracer_provider()
+    assert isinstance(provider, TracerProvider)
+    provider.force_flush()
+
+
+async def _joke() -> str:
+    return 'Why did the cat cross the road?'
+
+
+@pytest.fixture(autouse=True)
+def _isolate_telemetry(monkeypatch: pytest.MonkeyPatch) -> Generator[None, None, None]:
+    """Each test starts with no providers, unset collector env, and its own tracer."""
+    reset_instrumentation()
+    monkeypatch.delenv(GENKIT_ENV, raising=False)
+    monkeypatch.delenv('GENKIT_TELEMETRY_SERVER', raising=False)
+    monkeypatch.setattr(Genkit, '_start_reflection_background', lambda self: None)
+    isolated = TracerProvider()
+    monkeypatch.setattr(trace_api, 'get_tracer_provider', lambda: isolated)
+    monkeypatch.setattr(trace_api, 'set_tracer_provider', lambda _provider: None)
+    path_token = parent_path_context.set('')
+    try:
+        yield
+    finally:
+        parent_path_context.reset(path_token)
+        reset_instrumentation()
+        isolated.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_a_plain_script_returns_an_answer_and_no_trace_ids() -> None:
+    """Genkit() with no telemetry configured still runs; ids stay empty."""
+    Genkit()
+    action = Action(name='joke', kind=ActionKind.FLOW, fn=_joke)
+    result = await action.run()
+
+    assert result.response == 'Why did the cat cross the road?'
+    assert result.trace_id == ''
+    assert result.span_id == ''
+    assert not is_instrumented_by(OtelInstrumentation)
+
+
+@pytest.mark.asyncio
+async def test_genkit_start_gives_the_developer_ui_real_trace_ids(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Under genkit start, Genkit() installs OTel so the Traces tab gets real ids."""
+    monkeypatch.setenv(GENKIT_ENV, 'dev')
+    monkeypatch.setenv('GENKIT_TELEMETRY_SERVER', 'http://127.0.0.1:4033')
+
+    Genkit()
+    action = Action(name='joke', kind=ActionKind.FLOW, fn=_joke)
+    result = await action.run()
+
+    assert is_instrumented_by(OtelInstrumentation)
+    assert _hex_id(result.trace_id, 32)
+    assert _hex_id(result.span_id, 16)
+
+
+@pytest.mark.asyncio
+async def test_configuring_otel_yourself_means_you_own_the_collector(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """configure_instrumentation(OtelInstrumentation()) first: we will not add a Developer UI provider."""
+    monkeypatch.setenv(GENKIT_ENV, 'dev')
+    monkeypatch.setenv('GENKIT_TELEMETRY_SERVER', 'http://127.0.0.1:4033')
+
+    yours = OtelInstrumentation()
+    configure_instrumentation(yours)
+    Genkit()
+
+    assert instrumentations == [yours]
+
+
+@pytest.mark.asyncio
+async def test_an_exporter_alone_does_not_create_spans() -> None:
+    """add_custom_exporter attaches exporters only; ids stay empty."""
+    exporter = InMemorySpanExporter()
+    add_custom_exporter(exporter, 'cloud-trace')
+    action = Action(name='joke', kind=ActionKind.FLOW, fn=_joke)
+    result = await action.run()
+
+    assert result.trace_id == ''
+    assert not is_instrumented_by(OtelInstrumentation)
+    assert not exporter.get_finished_spans()
+
+
+@pytest.mark.asyncio
+async def test_configure_then_export_sends_spans_to_your_backend() -> None:
+    """configure_instrumentation then an exporter: real ids, and the backend sees the span."""
+    provider = TracerProvider()
+    exporter = InMemorySpanExporter()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    configure_instrumentation(OtelInstrumentation(tracer_provider=provider))
+
+    action = Action(name='joke', kind=ActionKind.FLOW, fn=_joke)
+    result = await action.run()
+
+    assert _hex_id(result.trace_id, 32)
+    names = [span.name for span in exporter.get_finished_spans()]
+    assert 'joke' in names
+
+
+@pytest.mark.asyncio
+async def test_dev_without_a_collector_stays_untraced(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """GENKIT_ENV=dev with no collector: empty ids. Stop in the Developer UI will not find the run."""
+    monkeypatch.setenv(GENKIT_ENV, 'dev')
+
+    Genkit()
+    action = Action(name='joke', kind=ActionKind.FLOW, fn=_joke)
+    result = await action.run()
+
+    assert not is_instrumented_by(OtelInstrumentation)
+    assert result.trace_id == ''
+    assert result.span_id == ''
+
+
+@pytest.mark.asyncio
+async def test_add_custom_exporter_after_genkit_does_not_turn_tracing_on(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """add_custom_exporter after Genkit() is mailbox-only; ids stay empty."""
+    monkeypatch.setenv(GENKIT_ENV, 'dev')
+
+    Genkit()
+    exporter = InMemorySpanExporter()
+    add_custom_exporter(exporter, 'developer-ui')
+    action = Action(name='joke', kind=ActionKind.FLOW, fn=_joke)
+    result = await action.run()
+
+    assert not is_instrumented_by(OtelInstrumentation)
+    assert result.trace_id == ''
+    assert not exporter.get_finished_spans()
+
+
+@pytest.mark.asyncio
+async def test_enable_google_cloud_telemetry_is_enough() -> None:
+    """enable_google_cloud_telemetry() is enough; you get real hex ids."""
+    exporter = InMemorySpanExporter()
+    add_custom_exporter(exporter, 'cloud-trace')
+    maybe_configure_otel_for_exporters()
+    action = Action(name='joke', kind=ActionKind.FLOW, fn=_joke)
+    result = await action.run()
+    _force_flush()
+
+    assert is_instrumented_by(OtelInstrumentation)
+    assert _hex_id(result.trace_id, 32)
+    names = [span.name for span in exporter.get_finished_spans()]
+    assert 'joke' in names
+
+
+@pytest.mark.asyncio
+async def test_enable_does_not_add_a_second_otel_provider() -> None:
+    """They already configured OtelInstrumentation; enable only hangs exporters."""
+    yours = OtelInstrumentation()
+    configure_instrumentation(yours)
+    add_custom_exporter(InMemorySpanExporter(), 'cloud-trace')
+    maybe_configure_otel_for_exporters()
+
+    assert instrumentations == [yours]
+
+
+@pytest.mark.asyncio
+async def test_enable_hangs_cloud_exporter_on_their_provider() -> None:
+    """OtelInstrumentation(tracer_provider=theirs) then enable: Cloud Trace sees their spans."""
+    theirs = TracerProvider()
+    cloud = InMemorySpanExporter()
+    configure_instrumentation(OtelInstrumentation(tracer_provider=theirs))
+    add_custom_exporter(cloud, 'cloud-trace')
+    maybe_configure_otel_for_exporters()
+
+    action = Action(name='joke', kind=ActionKind.FLOW, fn=_joke)
+    result = await action.run()
+    theirs.force_flush()
+
+    assert _hex_id(result.trace_id, 32)
+    names = [span.name for span in cloud.get_finished_spans()]
+    assert 'joke' in names
+    theirs.shutdown()
+
+
+def test_exporter_refuses_a_provider_it_cannot_attach_to() -> None:
+    """Wrong provider type: named TypeError, not a silent empty Cloud Trace."""
+    yours = OtelInstrumentation()
+    yours._tracer_provider = NoOpTracerProvider()
+    configure_instrumentation(yours)
+    with pytest.raises(TypeError, match='not a TracerProvider'):
+        add_custom_exporter(InMemorySpanExporter(), 'cloud-trace')
+
+
+def test_exporter_reraises_when_their_provider_cannot_add() -> None:
+    """Attach failure on theirs must surface; otherwise Cloud Trace stays empty."""
+    theirs = TracerProvider()
+
+    def boom(_processor: object) -> None:
+        raise RuntimeError('processor dead')
+
+    theirs.add_span_processor = boom  # type: ignore[method-assign]
+    configure_instrumentation(OtelInstrumentation(tracer_provider=theirs))
+    with pytest.raises(RuntimeError, match='processor dead'):
+        add_custom_exporter(InMemorySpanExporter(), 'cloud-trace')
+    theirs.shutdown()
+
+
+def test_exporter_swallows_when_the_global_provider_cannot_add() -> None:
+    """Global attach failure stays a log line so enable stays fail-safe."""
+    global_provider = trace_api.get_tracer_provider()
+
+    def boom(_processor: object) -> None:
+        raise RuntimeError('processor dead')
+
+    global_provider.add_span_processor = boom  # type: ignore[method-assign]
+    add_custom_exporter(InMemorySpanExporter(), 'cloud-trace')
+
+
+def test_init_provider_does_not_rewrite_log_format(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Booting a tracer must not clobber the process log format."""
+    monkeypatch.setattr(trace_api, 'get_tracer_provider', lambda: NoOpTracerProvider())
+    created: list[object] = []
+    monkeypatch.setattr(trace_api, 'set_tracer_provider', lambda provider: created.append(provider))
+
+    seen: dict[str, bool] = {}
+
+    class FakeInstrumentor:
+        def instrument(self, *, set_logging_format: bool) -> None:
+            seen['set_logging_format'] = set_logging_format
+
+    monkeypatch.setattr(
+        'genkit._core._otel_instrumentation.LoggingInstrumentor',
+        FakeInstrumentor,
+    )
+    from genkit._core._otel_instrumentation import init_provider
+
+    init_provider()
+    assert seen['set_logging_format'] is False
+    assert created
+
+
+@pytest.mark.asyncio
+async def test_enable_under_genkit_start_leaves_developer_ui_inject_to_genkit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Under genkit start, enable does not steal the Developer UI collector."""
+    monkeypatch.setenv(GENKIT_ENV, 'dev')
+    monkeypatch.setenv('GENKIT_TELEMETRY_SERVER', 'http://127.0.0.1:4033')
+
+    add_custom_exporter(InMemorySpanExporter(), 'cloud-trace')
+    maybe_configure_otel_for_exporters()
+    assert not is_instrumented_by(OtelInstrumentation)
+
+    Genkit()
+    action = Action(name='joke', kind=ActionKind.FLOW, fn=_joke)
+    result = await action.run()
+
+    assert is_instrumented_by(OtelInstrumentation)
+    assert _hex_id(result.trace_id, 32)
+
+
+@pytest.mark.asyncio
+async def test_leftover_collector_url_in_prod_does_not_block_enable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """GENKIT_TELEMETRY_SERVER leftover in prod: enable still turns spans on."""
+    monkeypatch.setenv('GENKIT_TELEMETRY_SERVER', 'http://127.0.0.1:4033')
+
+    exporter = InMemorySpanExporter()
+    add_custom_exporter(exporter, 'cloud-trace')
+    maybe_configure_otel_for_exporters()
+    action = Action(name='joke', kind=ActionKind.FLOW, fn=_joke)
+    result = await action.run()
+
+    assert is_instrumented_by(OtelInstrumentation)
+    assert _hex_id(result.trace_id, 32)
+
+
+def _handshake_server() -> ReflectionServerV2:
+    return ReflectionServerV2(Registry(), 'ws://127.0.0.1:1')
+
+
+def _capture_handshake_exporters(monkeypatch: pytest.MonkeyPatch) -> list[object]:
+    seen: list[object] = []
+    real = add_custom_exporter
+
+    def capture(exporter: object, name: str = 'last') -> None:
+        seen.append(exporter)
+        real(exporter, name)
+
+    monkeypatch.setattr('genkit._core._otel_instrumentation.add_custom_exporter', capture)
+    return seen
+
+
+def _span_for_export() -> MagicMock:
+    span = MagicMock(spec=ReadableSpan)
+    ctx = MagicMock()
+    ctx.trace_id = 1
+    ctx.span_id = 2
+    span.context = ctx
+    span.name = 'joke'
+    span.start_time = 1_000_000_000
+    span.end_time = 2_000_000_000
+    span.attributes = {}
+    span.parent = None
+    span.kind = trace_api.SpanKind.INTERNAL
+    status = MagicMock()
+    status.status_code = trace_api.StatusCode.OK
+    status.description = None
+    span.status = status
+    span.events = ()
+    return span
+
+
+def _start_collector() -> tuple[HTTPServer, list[str]]:
+    received: list[str] = []
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_POST(self) -> None:  # noqa: N802
+            n = int(self.headers.get('Content-Length', '0'))
+            received.append(self.rfile.read(n).decode())
+            self.send_response(200)
+            self.end_headers()
+
+        def log_message(self, format: str, *args: Any) -> None:
+            return
+
+    server = HTTPServer(('127.0.0.1', 0), Handler)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    return server, received
+
+
+@pytest.mark.asyncio
+async def test_handshake_url_in_dev_turns_tracing_on(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """UI-only genkit start: handshake URL turns tracing on so the Traces tab fills."""
+    monkeypatch.setenv(GENKIT_ENV, 'dev')
+    server, posts = _start_collector()
+    url = f'http://127.0.0.1:{server.server_address[1]}'
+    try:
+        Genkit()
+        assert not is_instrumented_by(OtelInstrumentation)
+
+        _handshake_server().apply_handshake_telemetry(url)
+        action = Action(name='joke', kind=ActionKind.FLOW, fn=_joke)
+        result = await action.run()
+        _force_flush()
+
+        assert is_instrumented_by(OtelInstrumentation)
+        assert _hex_id(result.trace_id, 32)
+        assert _hex_id(result.span_id, 16)
+        assert posts
+    finally:
+        server.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_leftover_collector_url_does_not_drop_handshake_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Leftover GENKIT_TELEMETRY_SERVER in the shell still takes today's handshake URL."""
+    leftover = _start_collector()
+    live = _start_collector()
+    leftover_server, leftover_posts = leftover
+    live_server, live_posts = live
+    leftover_url = f'http://127.0.0.1:{leftover_server.server_address[1]}'
+    live_url = f'http://127.0.0.1:{live_server.server_address[1]}'
+    try:
+        monkeypatch.setenv('GENKIT_TELEMETRY_SERVER', leftover_url)
+
+        Genkit()
+        seen = _capture_handshake_exporters(monkeypatch)
+        _handshake_server().apply_handshake_telemetry(live_url)
+        action = Action(name='joke', kind=ActionKind.FLOW, fn=_joke)
+        result = await action.run()
+
+        assert not is_instrumented_by(OtelInstrumentation)
+        assert result.trace_id == ''
+        assert len(seen) == 1
+        exporter = seen[0]
+        assert isinstance(exporter, TraceServerExporter)
+        assert exporter.telemetry_server_url == live_url
+
+        exporter.export([_span_for_export()])
+        exporter.force_flush()
+        assert live_posts
+        assert not leftover_posts
+    finally:
+        leftover_server.shutdown()
+        live_server.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_handshake_skips_when_otel_already_mints(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """genkit start -- python: Genkit() already wired the collector; handshake is a no-op."""
+    monkeypatch.setenv(GENKIT_ENV, 'dev')
+    monkeypatch.setenv('GENKIT_TELEMETRY_SERVER', 'http://127.0.0.1:4033')
+
+    Genkit()
+    seen = _capture_handshake_exporters(monkeypatch)
+    _handshake_server().apply_handshake_telemetry('http://127.0.0.1:4041')
+
+    assert is_instrumented_by(OtelInstrumentation)
+    assert seen == []
+
+
+@pytest.mark.asyncio
+async def test_notify_url_in_dev_turns_tracing_on(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Default genkit start POSTs /api/notify; that turns tracing on like v2 handshake."""
+    from httpx import ASGITransport, AsyncClient
+
+    from genkit._core._reflection import create_reflection_asgi_app
+
+    monkeypatch.setenv(GENKIT_ENV, 'dev')
+    app = create_reflection_asgi_app(Registry())
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url='http://test') as client:
+        response = await client.post('/api/notify', json={'telemetryServerUrl': 'http://127.0.0.1:4041'})
+    assert response.status_code == 200
+
+    action = Action(name='joke', kind=ActionKind.FLOW, fn=_joke)
+    result = await action.run()
+
+    assert is_instrumented_by(OtelInstrumentation)
+    assert _hex_id(result.trace_id, 32)
+
+
+@pytest.mark.asyncio
+async def test_already_minting_hangs_handshake_mailbox(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """force_dev_export mints first; handshake hangs today's mailbox so the tab can fill."""
+    monkeypatch.setenv(GENKIT_ENV, 'dev')
+    server, posts = _start_collector()
+    url = f'http://127.0.0.1:{server.server_address[1]}'
+    try:
+        add_custom_exporter(InMemorySpanExporter(), 'cloud-trace')
+        maybe_configure_otel_for_exporters()
+        assert is_instrumented_by(OtelInstrumentation)
+
+        _handshake_server().apply_handshake_telemetry(url)
+        action = Action(name='joke', kind=ActionKind.FLOW, fn=_joke)
+        result = await action.run()
+        _force_flush()
+
+        assert _hex_id(result.trace_id, 32)
+        assert posts
+    finally:
+        server.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_plugin_tracer_is_noop_when_uninstrumented() -> None:
+    """Imagen/Veo plugin_api.tracer does not mint when tracing is off."""
+    from genkit.plugin_api import tracer
+
+    with tracer.start_as_current_span('generate_images') as span:
+        ctx = span.get_span_context()
+        assert ctx.trace_id == 0
+
+
+@pytest.mark.asyncio
+async def test_plugin_tracer_hangs_on_their_provider() -> None:
+    """OtelInstrumentation(tracer_provider=theirs): plugin_api.tracer mints on theirs."""
+    from genkit.plugin_api import tracer
+
+    theirs = TracerProvider()
+    cloud = InMemorySpanExporter()
+    theirs.add_span_processor(SimpleSpanProcessor(cloud))
+    configure_instrumentation(OtelInstrumentation(tracer_provider=theirs))
+
+    with tracer.start_as_current_span('generate_images'):
+        pass
+    theirs.force_flush()
+
+    names = [span.name for span in cloud.get_finished_spans()]
+    assert 'generate_images' in names
+    theirs.shutdown()
+
+
+def test_importing_genkit_does_not_start_a_tracer() -> None:
+    """from genkit import Genkit does not start a tracer or install a provider."""
+    script = """
+from opentelemetry import trace
+from genkit import Genkit  # noqa: F401
+from genkit._core._otel_instrumentation import is_placeholder_provider
+from genkit.telemetry import OtelInstrumentation, is_instrumented_by
+
+assert not is_instrumented_by(OtelInstrumentation)
+assert is_placeholder_provider(trace.get_tracer_provider())
+"""
+    env = {k: v for k, v in os.environ.items() if k not in {GENKIT_ENV, 'GENKIT_TELEMETRY_SERVER'}}
+    completed = subprocess.run(  # noqa: S603
+        [sys.executable, '-c', script],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    assert completed.returncode == 0, completed.stderr

--- a/py/packages/genkit/tests/genkit/core/telemetry_contract_test.py
+++ b/py/packages/genkit/tests/genkit/core/telemetry_contract_test.py
@@ -1,0 +1,550 @@
+#!/usr/bin/env python3
+#
+# Copyright 2026 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the telemetry product contract."""
+
+from __future__ import annotations
+
+import os
+import subprocess  # noqa: S404
+import sys
+import threading
+from collections.abc import Generator
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from opentelemetry import trace as trace_api
+from opentelemetry.sdk.trace import ReadableSpan, TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.trace import NoOpTracerProvider
+
+from genkit import ActionKind, Genkit
+from genkit._core._action import Action
+from genkit._core._environment import GENKIT_ENV
+from genkit._core._instrumentation import instrumentations
+from genkit._core._otel_instrumentation import (
+    add_custom_exporter,
+    maybe_configure_otel_for_exporters,
+    parent_path_context,
+)
+from genkit._core._reflection_v2 import ReflectionServerV2
+from genkit._core._registry import Registry
+from genkit._core._trace._default_exporter import TraceServerExporter
+from genkit.telemetry import (
+    OtelInstrumentation,
+    configure_instrumentation,
+    is_instrumented_by,
+    reset_instrumentation,
+)
+
+
+def _hex_id(value: str, length: int) -> bool:
+    return len(value) == length and all(c in '0123456789abcdef' for c in value)
+
+
+def _force_flush() -> None:
+    provider = trace_api.get_tracer_provider()
+    assert isinstance(provider, TracerProvider)
+    provider.force_flush()
+
+
+async def _joke() -> str:
+    return 'Why did the cat cross the road?'
+
+
+@pytest.fixture(autouse=True)
+def _isolate_telemetry(monkeypatch: pytest.MonkeyPatch) -> Generator[None, None, None]:
+    """Each test starts with no providers, unset collector env, and its own tracer."""
+    reset_instrumentation()
+    monkeypatch.delenv(GENKIT_ENV, raising=False)
+    monkeypatch.delenv('GENKIT_TELEMETRY_SERVER', raising=False)
+    monkeypatch.setattr(Genkit, '_start_reflection_background', lambda self: None)
+    isolated = TracerProvider()
+    monkeypatch.setattr(trace_api, 'get_tracer_provider', lambda: isolated)
+    monkeypatch.setattr(trace_api, 'set_tracer_provider', lambda _provider: None)
+    path_token = parent_path_context.set('')
+    try:
+        yield
+    finally:
+        parent_path_context.reset(path_token)
+        reset_instrumentation()
+        isolated.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_a_plain_script_returns_an_answer_and_no_trace_ids() -> None:
+    """Genkit() with no telemetry configured still runs; ids stay empty."""
+    Genkit()
+    action = Action(name='joke', kind=ActionKind.FLOW, fn=_joke)
+    result = await action.run()
+
+    assert result.response == 'Why did the cat cross the road?'
+    assert result.trace_id == ''
+    assert result.span_id == ''
+    assert not is_instrumented_by(OtelInstrumentation)
+
+
+@pytest.mark.asyncio
+async def test_genkit_start_gives_the_developer_ui_real_trace_ids(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Under genkit start, Genkit() installs OTel so the Traces tab gets real ids."""
+    monkeypatch.setenv(GENKIT_ENV, 'dev')
+    monkeypatch.setenv('GENKIT_TELEMETRY_SERVER', 'http://127.0.0.1:4033')
+
+    Genkit()
+    action = Action(name='joke', kind=ActionKind.FLOW, fn=_joke)
+    result = await action.run()
+
+    assert is_instrumented_by(OtelInstrumentation)
+    assert _hex_id(result.trace_id, 32)
+    assert _hex_id(result.span_id, 16)
+
+
+@pytest.mark.asyncio
+async def test_configuring_otel_yourself_means_you_own_the_collector(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """configure_instrumentation(OtelInstrumentation()) first: we will not add a Developer UI provider."""
+    monkeypatch.setenv(GENKIT_ENV, 'dev')
+    monkeypatch.setenv('GENKIT_TELEMETRY_SERVER', 'http://127.0.0.1:4033')
+
+    yours = OtelInstrumentation()
+    configure_instrumentation(yours)
+    Genkit()
+
+    assert instrumentations == [yours]
+
+
+@pytest.mark.asyncio
+async def test_an_exporter_alone_does_not_create_spans() -> None:
+    """add_custom_exporter attaches exporters only; ids stay empty."""
+    exporter = InMemorySpanExporter()
+    add_custom_exporter(exporter, 'cloud-trace')
+    action = Action(name='joke', kind=ActionKind.FLOW, fn=_joke)
+    result = await action.run()
+
+    assert result.trace_id == ''
+    assert not is_instrumented_by(OtelInstrumentation)
+    assert not exporter.get_finished_spans()
+
+
+@pytest.mark.asyncio
+async def test_configure_then_export_sends_spans_to_your_backend() -> None:
+    """configure_instrumentation then an exporter: real ids, and the backend sees the span."""
+    provider = TracerProvider()
+    exporter = InMemorySpanExporter()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    configure_instrumentation(OtelInstrumentation(tracer_provider=provider))
+
+    action = Action(name='joke', kind=ActionKind.FLOW, fn=_joke)
+    result = await action.run()
+
+    assert _hex_id(result.trace_id, 32)
+    names = [span.name for span in exporter.get_finished_spans()]
+    assert 'joke' in names
+
+
+@pytest.mark.asyncio
+async def test_dev_without_a_collector_stays_untraced(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """GENKIT_ENV=dev with no collector: empty ids. Stop in the Developer UI will not find the run."""
+    monkeypatch.setenv(GENKIT_ENV, 'dev')
+
+    Genkit()
+    action = Action(name='joke', kind=ActionKind.FLOW, fn=_joke)
+    result = await action.run()
+
+    assert not is_instrumented_by(OtelInstrumentation)
+    assert result.trace_id == ''
+    assert result.span_id == ''
+
+
+@pytest.mark.asyncio
+async def test_add_custom_exporter_after_genkit_does_not_turn_tracing_on(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """add_custom_exporter after Genkit() is mailbox-only; ids stay empty."""
+    monkeypatch.setenv(GENKIT_ENV, 'dev')
+
+    Genkit()
+    exporter = InMemorySpanExporter()
+    add_custom_exporter(exporter, 'developer-ui')
+    action = Action(name='joke', kind=ActionKind.FLOW, fn=_joke)
+    result = await action.run()
+
+    assert not is_instrumented_by(OtelInstrumentation)
+    assert result.trace_id == ''
+    assert not exporter.get_finished_spans()
+
+
+@pytest.mark.asyncio
+async def test_enable_google_cloud_telemetry_is_enough() -> None:
+    """enable_google_cloud_telemetry() is enough; you get real hex ids."""
+    exporter = InMemorySpanExporter()
+    add_custom_exporter(exporter, 'cloud-trace')
+    maybe_configure_otel_for_exporters()
+    action = Action(name='joke', kind=ActionKind.FLOW, fn=_joke)
+    result = await action.run()
+    _force_flush()
+
+    assert is_instrumented_by(OtelInstrumentation)
+    assert _hex_id(result.trace_id, 32)
+    names = [span.name for span in exporter.get_finished_spans()]
+    assert 'joke' in names
+
+
+@pytest.mark.asyncio
+async def test_enable_does_not_add_a_second_otel_provider() -> None:
+    """They already configured OtelInstrumentation; enable only hangs exporters."""
+    yours = OtelInstrumentation()
+    configure_instrumentation(yours)
+    add_custom_exporter(InMemorySpanExporter(), 'cloud-trace')
+    maybe_configure_otel_for_exporters()
+
+    assert instrumentations == [yours]
+
+
+@pytest.mark.asyncio
+async def test_enable_hangs_cloud_exporter_on_their_provider() -> None:
+    """OtelInstrumentation(tracer_provider=theirs) then enable: Cloud Trace sees their spans."""
+    theirs = TracerProvider()
+    cloud = InMemorySpanExporter()
+    configure_instrumentation(OtelInstrumentation(tracer_provider=theirs))
+    add_custom_exporter(cloud, 'cloud-trace')
+    maybe_configure_otel_for_exporters()
+
+    action = Action(name='joke', kind=ActionKind.FLOW, fn=_joke)
+    result = await action.run()
+    theirs.force_flush()
+
+    assert _hex_id(result.trace_id, 32)
+    names = [span.name for span in cloud.get_finished_spans()]
+    assert 'joke' in names
+    theirs.shutdown()
+
+
+def test_exporter_refuses_a_provider_it_cannot_attach_to() -> None:
+    """Wrong provider type: named TypeError, not a silent empty Cloud Trace."""
+    yours = OtelInstrumentation()
+    yours._tracer_provider = NoOpTracerProvider()
+    configure_instrumentation(yours)
+    with pytest.raises(TypeError, match='not a TracerProvider'):
+        add_custom_exporter(InMemorySpanExporter(), 'cloud-trace')
+
+
+def test_exporter_reraises_when_their_provider_cannot_add() -> None:
+    """Attach failure on theirs must surface; otherwise Cloud Trace stays empty."""
+    theirs = TracerProvider()
+
+    def boom(_processor: object) -> None:
+        raise RuntimeError('processor dead')
+
+    theirs.add_span_processor = boom  # type: ignore[method-assign]
+    configure_instrumentation(OtelInstrumentation(tracer_provider=theirs))
+    with pytest.raises(RuntimeError, match='processor dead'):
+        add_custom_exporter(InMemorySpanExporter(), 'cloud-trace')
+    theirs.shutdown()
+
+
+def test_exporter_swallows_when_the_global_provider_cannot_add() -> None:
+    """Global attach failure stays a log line so enable stays fail-safe."""
+    global_provider = trace_api.get_tracer_provider()
+
+    def boom(_processor: object) -> None:
+        raise RuntimeError('processor dead')
+
+    global_provider.add_span_processor = boom  # type: ignore[method-assign]
+    add_custom_exporter(InMemorySpanExporter(), 'cloud-trace')
+
+
+def test_init_provider_does_not_rewrite_log_format(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Booting a tracer must not clobber the process log format."""
+    monkeypatch.setattr(trace_api, 'get_tracer_provider', lambda: NoOpTracerProvider())
+    created: list[object] = []
+    monkeypatch.setattr(trace_api, 'set_tracer_provider', lambda provider: created.append(provider))
+
+    seen: dict[str, bool] = {}
+
+    class FakeInstrumentor:
+        def instrument(self, *, set_logging_format: bool) -> None:
+            seen['set_logging_format'] = set_logging_format
+
+    monkeypatch.setattr(
+        'genkit._core._otel_instrumentation.LoggingInstrumentor',
+        FakeInstrumentor,
+    )
+    from genkit._core._otel_instrumentation import init_provider
+
+    init_provider()
+    assert seen['set_logging_format'] is False
+    assert created
+
+
+@pytest.mark.asyncio
+async def test_enable_under_genkit_start_leaves_developer_ui_inject_to_genkit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Under genkit start, enable does not steal the Developer UI collector."""
+    monkeypatch.setenv(GENKIT_ENV, 'dev')
+    monkeypatch.setenv('GENKIT_TELEMETRY_SERVER', 'http://127.0.0.1:4033')
+
+    add_custom_exporter(InMemorySpanExporter(), 'cloud-trace')
+    maybe_configure_otel_for_exporters()
+    assert not is_instrumented_by(OtelInstrumentation)
+
+    Genkit()
+    action = Action(name='joke', kind=ActionKind.FLOW, fn=_joke)
+    result = await action.run()
+
+    assert is_instrumented_by(OtelInstrumentation)
+    assert _hex_id(result.trace_id, 32)
+
+
+@pytest.mark.asyncio
+async def test_leftover_collector_url_in_prod_does_not_block_enable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """GENKIT_TELEMETRY_SERVER leftover in prod: enable still turns spans on."""
+    monkeypatch.setenv('GENKIT_TELEMETRY_SERVER', 'http://127.0.0.1:4033')
+
+    exporter = InMemorySpanExporter()
+    add_custom_exporter(exporter, 'cloud-trace')
+    maybe_configure_otel_for_exporters()
+    action = Action(name='joke', kind=ActionKind.FLOW, fn=_joke)
+    result = await action.run()
+
+    assert is_instrumented_by(OtelInstrumentation)
+    assert _hex_id(result.trace_id, 32)
+
+
+def _handshake_server() -> ReflectionServerV2:
+    return ReflectionServerV2(Registry(), 'ws://127.0.0.1:1')
+
+
+def _capture_handshake_exporters(monkeypatch: pytest.MonkeyPatch) -> list[object]:
+    seen: list[object] = []
+    real = add_custom_exporter
+
+    def capture(exporter: object, name: str = 'last') -> None:
+        seen.append(exporter)
+        real(exporter, name)
+
+    monkeypatch.setattr('genkit._core._otel_instrumentation.add_custom_exporter', capture)
+    return seen
+
+
+def _span_for_export() -> MagicMock:
+    span = MagicMock(spec=ReadableSpan)
+    ctx = MagicMock()
+    ctx.trace_id = 1
+    ctx.span_id = 2
+    span.context = ctx
+    span.name = 'joke'
+    span.start_time = 1_000_000_000
+    span.end_time = 2_000_000_000
+    span.attributes = {}
+    span.parent = None
+    span.kind = trace_api.SpanKind.INTERNAL
+    status = MagicMock()
+    status.status_code = trace_api.StatusCode.OK
+    status.description = None
+    span.status = status
+    span.events = ()
+    return span
+
+
+def _start_collector() -> tuple[HTTPServer, list[str]]:
+    received: list[str] = []
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_POST(self) -> None:
+            n = int(self.headers.get('Content-Length', '0'))
+            received.append(self.rfile.read(n).decode())
+            self.send_response(200)
+            self.end_headers()
+
+        def log_message(self, format: str, *args: Any) -> None:
+            return
+
+    server = HTTPServer(('127.0.0.1', 0), Handler)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    return server, received
+
+
+@pytest.mark.asyncio
+async def test_handshake_url_in_dev_turns_tracing_on(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """UI-only genkit start: handshake URL turns tracing on so the Traces tab fills."""
+    monkeypatch.setenv(GENKIT_ENV, 'dev')
+    server, posts = _start_collector()
+    url = f'http://127.0.0.1:{server.server_address[1]}'
+    try:
+        Genkit()
+        assert not is_instrumented_by(OtelInstrumentation)
+
+        _handshake_server().apply_handshake_telemetry(url)
+        action = Action(name='joke', kind=ActionKind.FLOW, fn=_joke)
+        result = await action.run()
+        _force_flush()
+
+        assert is_instrumented_by(OtelInstrumentation)
+        assert _hex_id(result.trace_id, 32)
+        assert _hex_id(result.span_id, 16)
+        assert posts
+    finally:
+        server.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_leftover_collector_url_does_not_drop_handshake_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Leftover GENKIT_TELEMETRY_SERVER in the shell still takes today's handshake URL."""
+    leftover = _start_collector()
+    live = _start_collector()
+    leftover_server, leftover_posts = leftover
+    live_server, live_posts = live
+    leftover_url = f'http://127.0.0.1:{leftover_server.server_address[1]}'
+    live_url = f'http://127.0.0.1:{live_server.server_address[1]}'
+    try:
+        monkeypatch.setenv('GENKIT_TELEMETRY_SERVER', leftover_url)
+
+        Genkit()
+        seen = _capture_handshake_exporters(monkeypatch)
+        _handshake_server().apply_handshake_telemetry(live_url)
+        action = Action(name='joke', kind=ActionKind.FLOW, fn=_joke)
+        result = await action.run()
+
+        assert not is_instrumented_by(OtelInstrumentation)
+        assert result.trace_id == ''
+        assert len(seen) == 1
+        exporter = seen[0]
+        assert isinstance(exporter, TraceServerExporter)
+        assert exporter.telemetry_server_url == live_url
+
+        exporter.export([_span_for_export()])
+        assert live_posts
+        assert not leftover_posts
+    finally:
+        leftover_server.shutdown()
+        live_server.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_handshake_skips_when_otel_already_mints(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """genkit start -- python: Genkit() already wired the collector; handshake is a no-op."""
+    monkeypatch.setenv(GENKIT_ENV, 'dev')
+    monkeypatch.setenv('GENKIT_TELEMETRY_SERVER', 'http://127.0.0.1:4033')
+
+    Genkit()
+    seen = _capture_handshake_exporters(monkeypatch)
+    _handshake_server().apply_handshake_telemetry('http://127.0.0.1:4041')
+
+    assert is_instrumented_by(OtelInstrumentation)
+    assert seen == []
+
+
+@pytest.mark.asyncio
+async def test_notify_url_in_dev_turns_tracing_on(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Default genkit start POSTs /api/notify; that turns tracing on like v2 handshake."""
+    from httpx import ASGITransport, AsyncClient
+
+    from genkit._core._reflection import create_reflection_asgi_app
+
+    monkeypatch.setenv(GENKIT_ENV, 'dev')
+    app = create_reflection_asgi_app(Registry())
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url='http://test') as client:
+        response = await client.post('/api/notify', json={'telemetryServerUrl': 'http://127.0.0.1:4041'})
+    assert response.status_code == 200
+
+    action = Action(name='joke', kind=ActionKind.FLOW, fn=_joke)
+    result = await action.run()
+
+    assert is_instrumented_by(OtelInstrumentation)
+    assert _hex_id(result.trace_id, 32)
+
+
+@pytest.mark.asyncio
+async def test_already_minting_hangs_handshake_mailbox(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """force_dev_export mints first; handshake hangs today's mailbox so the tab can fill."""
+    monkeypatch.setenv(GENKIT_ENV, 'dev')
+    server, posts = _start_collector()
+    url = f'http://127.0.0.1:{server.server_address[1]}'
+    try:
+        add_custom_exporter(InMemorySpanExporter(), 'cloud-trace')
+        maybe_configure_otel_for_exporters()
+        assert is_instrumented_by(OtelInstrumentation)
+
+        _handshake_server().apply_handshake_telemetry(url)
+        action = Action(name='joke', kind=ActionKind.FLOW, fn=_joke)
+        result = await action.run()
+        _force_flush()
+
+        assert _hex_id(result.trace_id, 32)
+        assert posts
+    finally:
+        server.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_plugin_tracer_is_noop_when_uninstrumented() -> None:
+    """Imagen/Veo plugin_api.tracer does not mint when tracing is off."""
+    from genkit.plugin_api import tracer
+
+    with tracer.start_as_current_span('generate_images') as span:
+        ctx = span.get_span_context()
+        assert ctx.trace_id == 0
+
+
+@pytest.mark.asyncio
+async def test_plugin_tracer_hangs_on_their_provider() -> None:
+    """OtelInstrumentation(tracer_provider=theirs): plugin_api.tracer mints on theirs."""
+    from genkit.plugin_api import tracer
+
+    theirs = TracerProvider()
+    cloud = InMemorySpanExporter()
+    theirs.add_span_processor(SimpleSpanProcessor(cloud))
+    configure_instrumentation(OtelInstrumentation(tracer_provider=theirs))
+
+    with tracer.start_as_current_span('generate_images'):
+        pass
+    theirs.force_flush()
+
+    names = [span.name for span in cloud.get_finished_spans()]
+    assert 'generate_images' in names
+    theirs.shutdown()
+
+
+def test_importing_genkit_does_not_start_a_tracer() -> None:
+    """from genkit import Genkit does not start a tracer or install a provider."""
+    script = """
+from opentelemetry import trace
+from genkit import Genkit  # noqa: F401
+from genkit._core._otel_instrumentation import is_placeholder_provider
+from genkit.telemetry import OtelInstrumentation, is_instrumented_by
+
+assert not is_instrumented_by(OtelInstrumentation)
+assert is_placeholder_provider(trace.get_tracer_provider())
+"""
+    env = {k: v for k, v in os.environ.items() if k not in {GENKIT_ENV, 'GENKIT_TELEMETRY_SERVER'}}
+    completed = subprocess.run(  # noqa: S603
+        [sys.executable, '-c', script],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    assert completed.returncode == 0, completed.stderr

--- a/py/packages/genkit/tests/genkit/core/trace/log_exporter_test.py
+++ b/py/packages/genkit/tests/genkit/core/trace/log_exporter_test.py
@@ -38,7 +38,7 @@ from genkit._core._trace._log_exporter import (
     put_poison_pill,
     reset_log_export,
 )
-from genkit._core._tracing import SpanMetadata, run_in_new_span
+from genkit._core._tracing import run_in_new_span
 
 
 @pytest.fixture
@@ -116,7 +116,7 @@ def test_build_log_record_stamps_active_span() -> None:
     """A record under a span carries lowercase hex ids."""
     captured: dict[str, str] = {}
 
-    def go() -> None:
+    async def go(_span: object) -> None:
         record = build_log_record(level=logging.INFO, event='inside', attrs={})
         trace_id = record['traceId']
         span_id = record['spanId']
@@ -125,11 +125,18 @@ def test_build_log_record_stamps_active_span() -> None:
         captured['traceId'] = trace_id
         captured['spanId'] = span_id
 
-    from genkit._core._tracing import init_provider
+    import asyncio
 
-    init_provider()
-    with run_in_new_span(metadata=SpanMetadata(name='demo')):
-        go()
+    from genkit._core._tracing import init_provider
+    from genkit.telemetry import OtelInstrumentation, configure_instrumentation, reset_instrumentation
+
+    provider = init_provider()
+    reset_instrumentation()
+    configure_instrumentation(OtelInstrumentation(tracer_provider=provider))
+    try:
+        asyncio.run(run_in_new_span('demo', go))
+    finally:
+        reset_instrumentation()
 
     assert len(captured['traceId']) == 32
     assert len(captured['spanId']) == 16
@@ -327,7 +334,7 @@ def test_handshake_enables_log_export_when_env_url_missing() -> None:
     from genkit._core._reflection_v2 import ReflectionServerV2
     from genkit._core._registry import Registry
 
-    with patch('genkit._core._reflection_v2.add_custom_exporter'):
+    with patch('genkit._core._reflection_v2.connect_developer_ui_collector'):
         server = ReflectionServerV2(registry=Registry(), ws_url='ws://localhost:1')
         server.apply_handshake_telemetry('http://localhost:4033')
         assert log_export_is_enabled() is True

--- a/py/packages/genkit/tests/genkit/core/tracing_format_test.py
+++ b/py/packages/genkit/tests/genkit/core/tracing_format_test.py
@@ -5,16 +5,16 @@
 
 from unittest.mock import MagicMock, patch
 
-from genkit._core._tracing import init_provider
+from genkit._core._otel_instrumentation import init_provider
 
 
 def test_init_provider_does_not_rewrite_log_format() -> None:
     """The shared TTY stays as the process configured it — no trace_id= wall."""
     instrumentor = MagicMock()
     with (
-        patch('genkit._core._tracing.trace_api.get_tracer_provider', return_value=None),
-        patch('genkit._core._tracing.trace_api.set_tracer_provider'),
-        patch('genkit._core._tracing.LoggingInstrumentor', return_value=instrumentor),
+        patch('genkit._core._otel_instrumentation.trace_api.get_tracer_provider', return_value=None),
+        patch('genkit._core._otel_instrumentation.trace_api.set_tracer_provider'),
+        patch('genkit._core._otel_instrumentation.LoggingInstrumentor', return_value=instrumentor),
     ):
         init_provider()
 

--- a/py/packages/genkit/tests/genkit/veneer/veneer_test.py
+++ b/py/packages/genkit/tests/genkit/veneer/veneer_test.py
@@ -39,6 +39,7 @@ from genkit._core._typing import (
     EvalFnResponse,
     EvalRequest,
     EvalResponse,
+    EvalStatusEnum,
     FinishReason,
     ModelInfo,
     Operation,
@@ -1770,6 +1771,47 @@ async def test_evaluate(setup_test: SetupFixture) -> None:
     assert response.root[0].test_case_id == 'case1'
     assert isinstance(response.root[0].evaluation, Score)
     assert response.root[0].evaluation.score is True
+    assert response.root[1].test_case_id == 'case2'
+    assert isinstance(response.root[1].evaluation, Score)
+    assert response.root[1].evaluation.score is True
+
+
+@pytest.mark.asyncio
+async def test_evaluator_records_fail_then_still_runs_the_next_row(
+    setup_test: SetupFixture,
+) -> None:
+    """A row that raises is recorded as FAIL; the next row still runs."""
+    ai, *_ = setup_test
+
+    async def my_eval_fn(datapoint: BaseDataPoint, options: object | None) -> EvalFnResponse:
+        if datapoint.test_case_id == 'case1':
+            raise RuntimeError('row boom')
+        return EvalFnResponse(
+            test_case_id=datapoint.test_case_id or '',
+            evaluation=Score(score=True),
+        )
+
+    ai.define_evaluator(
+        name='my_eval',
+        display_name='Test evaluator',
+        definition='records FAIL then keeps going',
+        fn=my_eval_fn,
+    )
+
+    response = await ai.evaluate(
+        evaluator='my_eval',
+        dataset=[
+            BaseDataPoint(input='hi', output='hi', test_case_id='case1'),
+            BaseDataPoint(input='bye', output='bye', test_case_id='case2'),
+        ],
+    )
+
+    assert isinstance(response, EvalResponse)
+    assert len(response.root) == 2
+    first = response.root[0].evaluation
+    assert isinstance(first, Score)
+    assert first.status == EvalStatusEnum.FAIL
+    assert first.error is not None
     assert response.root[1].test_case_id == 'case2'
     assert isinstance(response.root[1].evaluation, Score)
     assert response.root[1].evaluation.score is True

--- a/py/packages/genkit/tests/genkit/veneer/veneer_test.py
+++ b/py/packages/genkit/tests/genkit/veneer/veneer_test.py
@@ -39,6 +39,7 @@ from genkit._core._typing import (
     EvalFnResponse,
     EvalRequest,
     EvalResponse,
+    EvalStatusEnum,
     FinishReason,
     ModelInfo,
     Operation,
@@ -1807,6 +1808,47 @@ async def test_evaluate(setup_test: SetupFixture) -> None:
     assert response.root[0].test_case_id == 'case1'
     assert isinstance(response.root[0].evaluation, Score)
     assert response.root[0].evaluation.score is True
+    assert response.root[1].test_case_id == 'case2'
+    assert isinstance(response.root[1].evaluation, Score)
+    assert response.root[1].evaluation.score is True
+
+
+@pytest.mark.asyncio
+async def test_evaluator_records_fail_then_still_runs_the_next_row(
+    setup_test: SetupFixture,
+) -> None:
+    """A row that raises is recorded as FAIL; the next row still runs."""
+    ai, *_ = setup_test
+
+    async def my_eval_fn(datapoint: BaseDataPoint, options: object | None) -> EvalFnResponse:
+        if datapoint.test_case_id == 'case1':
+            raise RuntimeError('row boom')
+        return EvalFnResponse(
+            test_case_id=datapoint.test_case_id or '',
+            evaluation=Score(score=True),
+        )
+
+    ai.define_evaluator(
+        name='my_eval',
+        display_name='Test evaluator',
+        definition='records FAIL then keeps going',
+        fn=my_eval_fn,
+    )
+
+    response = await ai.evaluate(
+        evaluator='my_eval',
+        dataset=[
+            BaseDataPoint(input='hi', output='hi', test_case_id='case1'),
+            BaseDataPoint(input='bye', output='bye', test_case_id='case2'),
+        ],
+    )
+
+    assert isinstance(response, EvalResponse)
+    assert len(response.root) == 2
+    first = response.root[0].evaluation
+    assert isinstance(first, Score)
+    assert first.status == EvalStatusEnum.FAIL
+    assert first.error is not None
     assert response.root[1].test_case_id == 'case2'
     assert isinstance(response.root[1].evaluation, Score)
     assert response.root[1].evaluation.score is True


### PR DESCRIPTION
Developer UI tracing under `genkit start` posts OTLP/JSON over HTTP. It does not start OpenTelemetry. Cloud Trace and a host APM stay opt-in.

```python
# before (under genkit start): Genkit() booted OpenTelemetry to fill the Traces tab
ai = Genkit()

# after: same call; Traces tab fills over HTTP. Cloud still needs:
from genkit.telemetry import configure_instrumentation, OtelInstrumentation

configure_instrumentation(OtelInstrumentation(tracer_provider=theirs))
```

## Decisions

- A plain `Genkit()` script still has empty `trace_id` / `span_id`.
- `genkit start -- python app.py` (or UI-only start plus `/api/notify` / the v2 handshake) fills the Traces tab. That path is not an OpenTelemetry SDK you can hang a processor on.
- Cloud / a host APM is `enable_google_cloud_telemetry()` or `configure_instrumentation(OtelInstrumentation(...))`.
- A second handshake does not add another poster.
- v1 `runAction` omits `telemetry` when the ids are empty.
- Action context `auth` and `secrets` show as `<redacted>` on the span.
- A custom provider may call `next()` with no span.
- `plugin_api.tracer` stays no-op until OpenTelemetry is configured, so Imagen/Veo spans do not join the Dev UI tree.
