### PR TITLE
fix(py): redact auth and secrets on action spans

### DIFF
--- a/py/packages/genkit/src/genkit/_core/_action.py
+++ b/py/packages/genkit/src/genkit/_core/_action.py
@@ -59,6 +59,21 @@ def _record_latency(output: object, start_time: float) -> object:
     return output
 
 
+REDACTED_CONTEXT_KEYS = frozenset({'auth', 'secrets'})
+
+
+def context_for_telemetry(*, context: dict[str, Any]) -> dict[str, Any]:
+    # The Dev UI Context panel dumps this object. Tokens and API keys
+    # live under auth/secrets, so those keys stay off the span.
+    if not (REDACTED_CONTEXT_KEYS & context.keys()):
+        return context
+    traced = dict(context)
+    for key in REDACTED_CONTEXT_KEYS:
+        if key in traced:
+            traced[key] = '<redacted>'
+    return traced
+
+
 def _sanitize_value(val: object, seen: set[int] | None = None) -> object:
     """Recursively filter out dictionary keys or list items that cannot be serialized to JSON."""
     if seen is None:
@@ -756,14 +771,15 @@ class Action(Generic[InputT, OutputT, ChunkT, InitT]):
         # Surface action context (auth, headers, etc.) on the span so the Dev UI
         # trace inspector can render the "Context" panel for a flow run.
         if ctx.context:
+            traced_context = context_for_telemetry(context=ctx.context)
             try:
-                extra_metadata['context'] = json.dumps(ctx.context)
+                extra_metadata['context'] = json.dumps(traced_context)
             except Exception:
                 try:
-                    cleaned_context = _sanitize_value(ctx.context)
+                    cleaned_context = _sanitize_value(traced_context)
                     extra_metadata['context'] = json.dumps(cleaned_context)
                 except Exception:
-                    extra_metadata['context'] = str(ctx.context)
+                    extra_metadata['context'] = str(traced_context)
         span_meta = SpanMetadata(
             name=self._name,
             type='action',

--- a/py/packages/genkit/tests/genkit/core/run_in_new_span_test.py
+++ b/py/packages/genkit/tests/genkit/core/run_in_new_span_test.py
@@ -370,7 +370,7 @@ async def test_action_context_telemetry_sanitizes_unserializable(exporter: InMem
     # We pass a context dictionary with both serializable and unserializable values,
     # including nested dictionaries and lists.
     complex_context: dict[str, object] = {
-        'auth': {
+        'session': {
             'user_id': 123,
             'token': 'secret_token',
             'raw_connection': UnserializableObject(),  # should be dropped
@@ -392,9 +392,9 @@ async def test_action_context_telemetry_sanitizes_unserializable(exporter: InMem
     context_json = json.loads(context_attr)
 
     # Assertions
-    assert context_json['auth']['user_id'] == 123
-    assert context_json['auth']['token'] == 'secret_token'
-    assert context_json['auth']['raw_connection'] == 'Unserializable'
+    assert context_json['session']['user_id'] == 123
+    assert context_json['session']['token'] == 'secret_token'
+    assert context_json['session']['raw_connection'] == 'Unserializable'
 
     assert context_json['serializable_list'] == [1, 'two', {'nested_key': 'nested_val'}]
     assert context_json['unserializable_list'] == [1, 'Unserializable', 3]
@@ -432,6 +432,31 @@ async def test_action_context_telemetry_circular_references(exporter: InMemorySp
 
     # 'key' is serializable, and 'self' circular reference should be safely cut off with '[Circular]'
     assert context_json == {'key': 'val', 'self': '[Circular]'}
+
+
+@pytest.mark.asyncio
+async def test_action_context_telemetry_redacts_auth_and_secrets(exporter: InMemorySpanExporter) -> None:
+    """Top-level auth/secrets are redacted on the span so the Context panel is safe."""
+
+    async def noop() -> str:
+        return 'ok'
+
+    action = Action(name='scrubTest', kind=ActionKind.FLOW, fn=noop)
+    await action.run(
+        context={
+            'auth': {'token': 'super-secret'},
+            'secrets': {'apiKey': 'SUPER-SECRET'},
+            'safeField': 'hello',
+            'nestedField': {'auth': 'this stays'},
+        }
+    )
+
+    span = _by_name(exporter.get_finished_spans(), 'scrubTest')
+    context_json = json.loads(dict(span.attributes or {})['genkit:metadata:context'])
+    assert context_json['auth'] == '<redacted>'
+    assert context_json['secrets'] == '<redacted>'
+    assert context_json['safeField'] == 'hello'
+    assert context_json['nestedField'] == {'auth': 'this stays'}
 
 
 def test_metadata_key_prevents_double_prefix() -> None:


### PR DESCRIPTION
## What this fixes

When an action runs, its run context gets dumped onto the trace span as genkit:metadata:context so the Dev UI can render the "Context" panel. Before this change, that dump was verbatim - so auth tokens and API keys passed via context ended up stored in traces (and forwarded to whatever telemetry exporter is configured).

```python
@ai.flow()
async def greet(name: str) -> str:
    ...

await greet(
    'Alice',
    context={
        'auth': {'token': 'ya29.secret-token'},
        'secrets': {'api_key': 'sk-live-abc123'},
        'locale': 'en-US',
    },
)
```

**Before** - the span attribute genkit:metadata:context contained:

```json
{"auth": {"token": "ya29.secret-token"}, "secrets": {"api_key": "sk-live-abc123"}, "locale": "en-US"}
```

**After** - top-level auth and secrets are replaced before the dump:

```json
{"auth": "<redacted>", "secrets": "<redacted>", "locale": "en-US"}
```

## What is deliberately unchanged

- **The live context the action sees.** Redaction happens on a copy written to the span; ctx.context['auth'] still holds the real token inside the flow and its tools.
- **Nested keys named auth.** Only the well-known top-level auth / secrets slots are scrubbed - {'session': {'auth': ...}} passes through untouched, since we can't guess the semantics of arbitrary nested shapes.

## Out of scope

Does not add check_operation(..., context=) or teach Veo to read a poll-time key.