### PR TITLE
feat(cli): Add log:list CLI command

### DIFF
--- a/genkit-tools/cli/src/cli.ts
+++ b/genkit-tools/cli/src/cli.ts
@@ -33,6 +33,7 @@ import { evalRun } from './commands/eval-run';
 import { flowBatchRun } from './commands/flow-batch-run';
 import { flowRun } from './commands/flow-run';
 import { initAiTools } from './commands/init-ai-tools/index';
+import { logList } from './commands/log-list';
 import { mcp } from './commands/mcp';
 import { getPluginCommands, getPluginSubCommand } from './commands/plugins';
 import {
@@ -72,6 +73,7 @@ const commands: Command[] = [
   docsList,
   docsRead,
   docsSearch,
+  logList,
   traceGet,
   traceList,
 ];

--- a/genkit-tools/cli/src/commands/log-list.ts
+++ b/genkit-tools/cli/src/commands/log-list.ts
@@ -38,13 +38,15 @@ export interface LogListOptions {
  * chronological order.
  */
 export const logList = new Command('log:list')
-  .description('list logs')
+  .description(
+    'list logs. By default, the most recent logs are returned. Note: Filtering by trace-id is highly recommended.'
+  )
   .option('-l, --limit <number>', 'limit the number of returned logs', '15')
   .option('--trace-id <id>', 'filter by trace ID')
   .option('--span-id <id>', 'filter by span ID')
   .option(
-    '--severity <severity>',
-    'filter by severity (e.g., INFO, ERROR, WARNING)'
+    '--severity <level>',
+    'filter to logs at this severity level and higher (e.g., info, warn, error)'
   )
   .addOption(
     new Option('-f, --format <format>', 'output format')
@@ -66,7 +68,21 @@ export const logList = new Command('log:list')
           filter.spanId = options.spanId;
         }
         if (options.severity) {
-          filter.severityText = options.severity;
+          const severities: Record<string, number> = {
+            trace: 1,
+            debug: 5,
+            info: 9,
+            warn: 13,
+            error: 17,
+            fatal: 21,
+          };
+          const num = severities[options.severity.toLowerCase()];
+          if (num !== undefined) {
+            filter.severityNumber = num;
+          } else {
+            // Fallback for custom severity texts
+            filter.severityText = options.severity;
+          }
         }
 
         const limit = Number.parseInt(options.limit, 10);
@@ -102,7 +118,7 @@ export const logList = new Command('log:list')
           );
           logs.forEach((log) => {
             let time = 'unknown';
-            if (log.timestamp) {
+            if (typeof log.timestamp === 'number') {
               time = new Date(log.timestamp).toLocaleString();
             }
 

--- a/genkit-tools/cli/src/commands/log-list.ts
+++ b/genkit-tools/cli/src/commands/log-list.ts
@@ -1,0 +1,157 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { LogQueryFilter } from '@genkit-ai/tools-common';
+import type { BaseRuntimeManager } from '@genkit-ai/tools-common/manager';
+import { findProjectRoot, logger } from '@genkit-ai/tools-common/utils';
+import { Command } from 'commander';
+import { runWithManager } from '../utils/manager-utils';
+
+export interface LogListOptions {
+  limit: string;
+  traceId?: string;
+  spanId?: string;
+  severity?: string;
+  continuationToken?: string;
+  verbose?: boolean;
+}
+
+/**
+ * Command to list logs. By default, logs are returned in reverse
+ * chronological order.
+ */
+export const logList = new Command('log:list')
+  .description('list logs')
+  .option('-l, --limit <number>', 'limit the number of returned logs', '15')
+  .option('--trace-id <id>', 'filter by trace ID')
+  .option('--span-id <id>', 'filter by span ID')
+  .option(
+    '--severity <severity>',
+    'filter by severity (e.g., INFO, ERROR, WARNING)'
+  )
+  .option(
+    '-v, --verbose',
+    'display the full JSON log instead of the preview message'
+  )
+  .option('--continuation-token <token>', 'continuation token for pagination')
+  .action(async (options: LogListOptions) => {
+    const projectRoot = await findProjectRoot();
+
+    const runAction = async (manager: BaseRuntimeManager) => {
+      try {
+        const filter: LogQueryFilter = {};
+        if (options.traceId) {
+          filter.traceId = options.traceId;
+        }
+        if (options.spanId) {
+          filter.spanId = options.spanId;
+        }
+        if (options.severity) {
+          filter.severityText = options.severity;
+        }
+
+        const listRequest = {
+          limit: Number.parseInt(options.limit, 10),
+          continuationToken: options.continuationToken,
+          filter: Object.keys(filter).length > 0 ? filter : undefined,
+        };
+
+        const response = await manager.listLogs(listRequest);
+
+        if (!response || !response.logs || response.logs.length === 0) {
+          logger.info('No logs found.');
+          return;
+        }
+
+        const logs = response.logs;
+
+        if (options.verbose) {
+          logs.forEach((log) => {
+            console.log(JSON.stringify(log, null, 2));
+            console.log('---');
+          });
+        } else {
+          console.log(
+            `Found ${logs.length} log${logs.length === 1 ? '' : 's'}:\n`
+          );
+          logs.forEach((log) => {
+            let time = 'unknown';
+            if (log.timestamp) {
+              time = new Date(log.timestamp).toLocaleString();
+            }
+
+            const id = log.logId || 'unknown';
+            const severity = log.severityText || 'unknown';
+            const message = formatBody(log.body);
+            const attributes = formatAttributes(log.attributes);
+
+            console.log(`ID:       ${id}`);
+            console.log(`Severity: ${severity}`);
+            console.log(`Time:     ${time}`);
+            if (message) console.log(`Message:  ${message}`);
+            if (attributes) console.log(`Attrs:    ${attributes}`);
+
+            console.log('---');
+          });
+        }
+
+        if (response.continuationToken) {
+          console.log(
+            `\nTo get the next page, use: --continuation-token ${response.continuationToken}`
+          );
+        }
+      } catch (e) {
+        logger.error(`Error listing logs: ${e}`);
+      }
+    };
+
+    await runWithManager(projectRoot, runAction);
+  });
+
+function formatBody(value: unknown): string {
+  if (value === undefined || value === null) return '';
+  const strValue =
+    typeof value === 'object' ? JSON.stringify(value) : String(value);
+
+  // If it's a long string and doesn't match patterns, limit it
+  return strValue.length > 100 ? strValue.substring(0, 100) + '...' : strValue;
+}
+
+function formatAttributes(
+  attributes: Record<string, unknown> | undefined
+): string {
+  if (!attributes || Object.keys(attributes).length === 0) return '';
+  const pairs = Object.entries(attributes).map(([key, value]) => {
+    let strValue: string;
+    if (typeof value === 'object' && value !== null) {
+      try {
+        strValue = JSON.stringify(value);
+      } catch {
+        strValue = '[Object]';
+      }
+    } else {
+      strValue = String(value);
+    }
+    const truncated =
+      strValue.length > 50 ? strValue.substring(0, 50) + '...' : strValue;
+    return `${key}=${truncated}`;
+  });
+
+  const fullString = pairs.join(', ');
+  return fullString.length > 100
+    ? fullString.substring(0, 100) + '...'
+    : fullString;
+}

--- a/genkit-tools/cli/src/commands/log-list.ts
+++ b/genkit-tools/cli/src/commands/log-list.ts
@@ -118,8 +118,15 @@ export const logList = new Command('log:list')
           );
           logs.forEach((log) => {
             let time = 'unknown';
-            if (typeof log.timestamp === 'number') {
-              time = new Date(log.timestamp).toLocaleString();
+            if (
+              typeof log.timestamp === 'number' &&
+              Number.isFinite(log.timestamp)
+            ) {
+              try {
+                time = new Date(log.timestamp).toLocaleString();
+              } catch {
+                // Fallback to 'unknown' if timestamp is out of range
+              }
             }
 
             const id = log.logId || 'unknown';

--- a/genkit-tools/cli/src/commands/log-list.ts
+++ b/genkit-tools/cli/src/commands/log-list.ts
@@ -39,7 +39,7 @@ export interface LogListOptions {
  */
 export const logList = new Command('log:list')
   .description(
-    'list logs. By default, the most recent logs are returned. Note: Filtering by trace-id is highly recommended.'
+    'list logs, in reverse chronological order. Filtering by trace-id is highly recommended.'
   )
   .option('-l, --limit <number>', 'limit the number of returned logs', '15')
   .option('--trace-id <id>', 'filter by trace ID')

--- a/genkit-tools/cli/src/commands/log-list.ts
+++ b/genkit-tools/cli/src/commands/log-list.ts
@@ -63,8 +63,16 @@ export const logList = new Command('log:list')
           filter.severityText = options.severity;
         }
 
+        const limit = Number.parseInt(options.limit, 10);
+        if (Number.isNaN(limit) || limit <= 0) {
+          logger.error(
+            `Invalid limit: "${options.limit}". It must be a positive integer.`
+          );
+          return;
+        }
+
         const listRequest = {
-          limit: Number.parseInt(options.limit, 10),
+          limit,
           continuationToken: options.continuationToken,
           filter: Object.keys(filter).length > 0 ? filter : undefined,
         };
@@ -123,8 +131,16 @@ export const logList = new Command('log:list')
 
 function formatBody(value: unknown): string {
   if (value === undefined || value === null) return '';
-  const strValue =
-    typeof value === 'object' ? JSON.stringify(value) : String(value);
+  let strValue: string;
+  if (typeof value === 'object') {
+    try {
+      strValue = JSON.stringify(value);
+    } catch {
+      strValue = '[Object]';
+    }
+  } else {
+    strValue = String(value);
+  }
 
   // If it's a long string and doesn't match patterns, limit it
   return strValue.length > 100 ? strValue.substring(0, 100) + '...' : strValue;

--- a/genkit-tools/cli/src/commands/log-list.ts
+++ b/genkit-tools/cli/src/commands/log-list.ts
@@ -16,8 +16,12 @@
 
 import type { LogQueryFilter } from '@genkit-ai/tools-common';
 import type { BaseRuntimeManager } from '@genkit-ai/tools-common/manager';
-import { findProjectRoot, logger } from '@genkit-ai/tools-common/utils';
-import { Command } from 'commander';
+import {
+  findProjectRoot,
+  forceStderr,
+  logger,
+} from '@genkit-ai/tools-common/utils';
+import { Command, Option } from 'commander';
 import { runWithManager } from '../utils/manager-utils';
 
 export interface LogListOptions {
@@ -26,7 +30,7 @@ export interface LogListOptions {
   spanId?: string;
   severity?: string;
   continuationToken?: string;
-  verbose?: boolean;
+  format: 'text' | 'jsonl';
 }
 
 /**
@@ -42,12 +46,14 @@ export const logList = new Command('log:list')
     '--severity <severity>',
     'filter by severity (e.g., INFO, ERROR, WARNING)'
   )
-  .option(
-    '-v, --verbose',
-    'display the full JSON log instead of the preview message'
+  .addOption(
+    new Option('-f, --format <format>', 'output format')
+      .choices(['text', 'jsonl'])
+      .default('text')
   )
   .option('--continuation-token <token>', 'continuation token for pagination')
   .action(async (options: LogListOptions) => {
+    if (options.format === 'jsonl') forceStderr();
     const projectRoot = await findProjectRoot();
 
     const runAction = async (manager: BaseRuntimeManager) => {
@@ -86,10 +92,9 @@ export const logList = new Command('log:list')
 
         const logs = response.logs;
 
-        if (options.verbose) {
+        if (options.format === 'jsonl') {
           logs.forEach((log) => {
-            console.log(JSON.stringify(log, null, 2));
-            console.log('---');
+            console.log(JSON.stringify(log));
           });
         } else {
           console.log(
@@ -107,6 +112,10 @@ export const logList = new Command('log:list')
             const attributes = formatAttributes(log.attributes);
 
             console.log(`ID:       ${id}`);
+            if (!options.traceId && log.traceId)
+              console.log(`Trace ID: ${log.traceId}`);
+            if (!options.spanId && log.spanId)
+              console.log(`Span ID:  ${log.spanId}`);
             console.log(`Severity: ${severity}`);
             console.log(`Time:     ${time}`);
             if (message) console.log(`Message:  ${message}`);
@@ -117,9 +126,15 @@ export const logList = new Command('log:list')
         }
 
         if (response.continuationToken) {
-          console.log(
-            `\nTo get the next page, use: --continuation-token ${response.continuationToken}`
-          );
+          if (options.format === 'jsonl') {
+            logger.info(
+              `To get the next page, use: --continuation-token ${response.continuationToken}`
+            );
+          } else {
+            console.log(
+              `\nTo get the next page, use: --continuation-token ${response.continuationToken}`
+            );
+          }
         }
       } catch (e) {
         logger.error(`Error listing logs: ${e}`);

--- a/genkit-tools/cli/src/commands/trace-list.ts
+++ b/genkit-tools/cli/src/commands/trace-list.ts
@@ -145,6 +145,10 @@ export const traceList = new Command('trace:list')
             `\nTo get the next page, use: --continuation-token ${response.continuationToken}`
           );
         }
+
+        console.log(
+          `\nTip: Use "genkit trace:get <traceId>" to view full trace details.`
+        );
       } catch (e) {
         logger.error(`Error listing traces: ${e}`);
       }

--- a/genkit-tools/cli/src/commands/trace-list.ts
+++ b/genkit-tools/cli/src/commands/trace-list.ts
@@ -92,7 +92,9 @@ export const traceList = new Command('trace:list')
           return;
         }
 
-        console.log(`Found ${response.traces.length} traces:\n`);
+        console.log(
+          `Found ${response.traces.length} trace${response.traces.length === 1 ? '' : 's'}:\n`
+        );
 
         response.traces.forEach((trace) => {
           let duration = 'unknown';

--- a/genkit-tools/cli/tests/commands/log-list_test.ts
+++ b/genkit-tools/cli/tests/commands/log-list_test.ts
@@ -144,14 +144,14 @@ describe('log:list command', () => {
       limit: 5,
       continuationToken: '',
       filter: {
-        severityText: 'ERROR',
+        severityNumber: 17,
         traceId: 'trace-1',
         spanId: 'span-1',
       },
     });
   });
 
-  it('should output formatted  logs without verbose flag', async () => {
+  it('should output logs in text format by default', async () => {
     mockManager.listLogs.mockResolvedValue({
       logs: [
         {

--- a/genkit-tools/cli/tests/commands/log-list_test.ts
+++ b/genkit-tools/cli/tests/commands/log-list_test.ts
@@ -156,6 +156,8 @@ describe('log:list command', () => {
       logs: [
         {
           logId: 'log-123',
+          traceId: 'trace-123',
+          spanId: 'span-123',
           timestamp: 1718302195000,
           severityText: 'WARN',
           body: 'A'.repeat(110),
@@ -180,6 +182,8 @@ describe('log:list command', () => {
     ]);
 
     expect(console.log).toHaveBeenCalledWith('ID:       log-123');
+    expect(console.log).toHaveBeenCalledWith('Trace ID: trace-123');
+    expect(console.log).toHaveBeenCalledWith('Span ID:  span-123');
     expect(console.log).toHaveBeenCalledWith('Severity: WARN');
     expect(console.log).toHaveBeenCalledWith(
       `Time:     ${new Date(1718302195000).toLocaleString()}`
@@ -188,12 +192,12 @@ describe('log:list command', () => {
     expect(console.log).toHaveBeenCalledWith('Attrs:    key=value');
   });
 
-  it('should output full logs as json in verbose mode', async () => {
+  it('should output logs in jsonl format', async () => {
     mockManager.listLogs.mockResolvedValue({
       logs: [
         {
           timestamp: 1718302195000,
-          body: 'Verbose log',
+          body: 'JSONL log',
         },
       ],
     });
@@ -201,7 +205,8 @@ describe('log:list command', () => {
     await logList.parseAsync([
       'node',
       'log:list',
-      '--verbose',
+      '--format',
+      'jsonl',
       '--limit',
       '15',
       '--severity',
@@ -220,12 +225,8 @@ describe('log:list command', () => {
       filter: undefined,
     });
 
-    // In verbose mode, it dumps the full JSON using JSON.stringify(log, null, 2)
     expect(console.log).toHaveBeenCalledWith(
-      expect.stringContaining('"body": "Verbose log"')
-    );
-    expect(console.log).toHaveBeenCalledWith(
-      expect.stringContaining('"timestamp": 1718302195000')
+      JSON.stringify({ timestamp: 1718302195000, body: 'JSONL log' })
     );
   });
 

--- a/genkit-tools/cli/tests/commands/log-list_test.ts
+++ b/genkit-tools/cli/tests/commands/log-list_test.ts
@@ -1,0 +1,251 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { findProjectRoot, logger } from '@genkit-ai/tools-common/utils';
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { logList } from '../../src/commands/log-list';
+import { runWithManager } from '../../src/utils/manager-utils';
+
+jest.mock('@genkit-ai/tools-common/utils');
+jest.mock('../../src/utils/manager-utils');
+
+describe('log:list command', () => {
+  let mockManager: any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockManager = {
+      listLogs: jest.fn(),
+    };
+
+    (findProjectRoot as jest.Mock<any>).mockResolvedValue('/mock/project/root');
+
+    (runWithManager as jest.Mock<any>).mockImplementation(
+      async (projectRoot: any, action: any) => {
+        await action(mockManager);
+      }
+    );
+
+    jest.spyOn(logger, 'info').mockImplementation((() => {}) as any);
+    jest.spyOn(logger, 'error').mockImplementation((() => {}) as any);
+    jest.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  it('should list logs with default limit', async () => {
+    mockManager.listLogs.mockResolvedValue({
+      logs: [
+        {
+          timestamp: 1718302195000,
+          severityText: 'INFO',
+          body: 'Hello World',
+          attributes: {
+            'genkit:name': 'test-log',
+          },
+        },
+      ],
+    });
+
+    await logList.parseAsync(['node', 'log:list']);
+
+    expect(findProjectRoot).toHaveBeenCalled();
+    expect(runWithManager).toHaveBeenCalled();
+    expect(mockManager.listLogs).toHaveBeenCalledWith({
+      limit: 15,
+      continuationToken: undefined,
+      filter: undefined,
+    });
+    expect(console.log).toHaveBeenCalledWith('Found 1 log:\n');
+    expect(console.log).toHaveBeenCalledWith(expect.stringContaining('INFO'));
+    expect(console.log).toHaveBeenCalledWith(
+      expect.stringContaining('Hello World')
+    );
+    expect(console.log).toHaveBeenCalledWith(
+      expect.stringContaining('Attrs:    genkit:name=test-log')
+    );
+  });
+
+  it('should handle pagination with continuation token', async () => {
+    mockManager.listLogs.mockResolvedValue({
+      logs: [
+        {
+          timestamp: 1718302195000,
+          body: 'Another log',
+        },
+      ],
+      continuationToken: 'next-page-token',
+    });
+
+    await logList.parseAsync([
+      'node',
+      'log:list',
+      '--limit',
+      '15',
+      '--severity',
+      '',
+      '--trace-id',
+      '',
+      '--span-id',
+      '',
+      '--continuation-token',
+      'some-token',
+    ]);
+
+    expect(mockManager.listLogs).toHaveBeenCalledWith({
+      limit: 15,
+      continuationToken: 'some-token',
+      filter: undefined,
+    });
+    expect(console.log).toHaveBeenCalledWith(
+      '\nTo get the next page, use: --continuation-token next-page-token'
+    );
+  });
+
+  it('should list logs with filters and custom limit', async () => {
+    mockManager.listLogs.mockResolvedValue({
+      logs: [
+        {
+          timestamp: 1718302195000,
+          severityText: 'ERROR',
+          body: 'An error occurred',
+        },
+      ],
+    });
+
+    await logList.parseAsync([
+      'node',
+      'log:list',
+      '--limit',
+      '5',
+      '--severity',
+      'ERROR',
+      '--trace-id',
+      'trace-1',
+      '--span-id',
+      'span-1',
+      '--continuation-token',
+      '',
+    ]);
+
+    expect(mockManager.listLogs).toHaveBeenCalledWith({
+      limit: 5,
+      continuationToken: '',
+      filter: {
+        severityText: 'ERROR',
+        traceId: 'trace-1',
+        spanId: 'span-1',
+      },
+    });
+  });
+
+  it('should output formatted  logs without verbose flag', async () => {
+    mockManager.listLogs.mockResolvedValue({
+      logs: [
+        {
+          logId: 'log-123',
+          timestamp: 1718302195000,
+          severityText: 'WARN',
+          body: 'A'.repeat(110),
+          attributes: { key: 'value' },
+        },
+      ],
+    });
+
+    await logList.parseAsync([
+      'node',
+      'log:list',
+      '--limit',
+      '15',
+      '--severity',
+      '',
+      '--trace-id',
+      '',
+      '--span-id',
+      '',
+      '--continuation-token',
+      '',
+    ]);
+
+    expect(console.log).toHaveBeenCalledWith('ID:       log-123');
+    expect(console.log).toHaveBeenCalledWith('Severity: WARN');
+    expect(console.log).toHaveBeenCalledWith(
+      `Time:     ${new Date(1718302195000).toLocaleString()}`
+    );
+    expect(console.log).toHaveBeenCalledWith(`Message:  ${'A'.repeat(100)}...`);
+    expect(console.log).toHaveBeenCalledWith('Attrs:    key=value');
+  });
+
+  it('should output full logs as json in verbose mode', async () => {
+    mockManager.listLogs.mockResolvedValue({
+      logs: [
+        {
+          timestamp: 1718302195000,
+          body: 'Verbose log',
+        },
+      ],
+    });
+
+    await logList.parseAsync([
+      'node',
+      'log:list',
+      '--verbose',
+      '--limit',
+      '15',
+      '--severity',
+      '',
+      '--trace-id',
+      '',
+      '--span-id',
+      '',
+      '--continuation-token',
+      '',
+    ]);
+
+    expect(mockManager.listLogs).toHaveBeenCalledWith({
+      limit: 15,
+      continuationToken: '',
+      filter: undefined,
+    });
+
+    // In verbose mode, it dumps the full JSON using JSON.stringify(log, null, 2)
+    expect(console.log).toHaveBeenCalledWith(
+      expect.stringContaining('"body": "Verbose log"')
+    );
+    expect(console.log).toHaveBeenCalledWith(
+      expect.stringContaining('"timestamp": 1718302195000')
+    );
+  });
+
+  it('should log info when no logs are found', async () => {
+    mockManager.listLogs.mockResolvedValue({
+      logs: [],
+    });
+
+    await logList.parseAsync(['node', 'log:list']);
+
+    expect(logger.info).toHaveBeenCalledWith('No logs found.');
+  });
+
+  it('should handle and log errors', async () => {
+    mockManager.listLogs.mockRejectedValue(new Error('API failure'));
+
+    await logList.parseAsync(['node', 'log:list']);
+
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining('Error listing logs: Error: API failure')
+    );
+  });
+});

--- a/genkit-tools/cli/tests/commands/trace-list_test.ts
+++ b/genkit-tools/cli/tests/commands/trace-list_test.ts
@@ -81,7 +81,7 @@ describe('trace:list command', () => {
         neq: { 'genkitx:ignore-trace': ['true'] },
       },
     });
-    expect(console.log).toHaveBeenCalledWith('Found 1 traces:\n');
+    expect(console.log).toHaveBeenCalledWith('Found 1 trace:\n');
     expect(console.log).toHaveBeenCalledWith('ID:       trace-1');
     expect(console.log).toHaveBeenCalledWith('Status:   success');
     expect(console.log).toHaveBeenCalledWith('Input:    my input string');

--- a/genkit-tools/common/src/manager/manager.ts
+++ b/genkit-tools/common/src/manager/manager.ts
@@ -157,6 +157,14 @@ export abstract class BaseRuntimeManager {
       if (query !== '') query += '&';
       query += `continuationToken=${continuationToken}`;
     }
+    if (filter?.severityText) {
+      if (query !== '') query += '&';
+      query += `severityText=${filter.severityText}`;
+    }
+    if (filter?.severityNumber) {
+      if (query !== '') query += '&';
+      query += `severityNumber=${filter.severityNumber}`;
+    }
 
     const fullUrl = query !== '' ? `${url}?${query}` : url;
 

--- a/genkit-tools/common/src/manager/manager.ts
+++ b/genkit-tools/common/src/manager/manager.ts
@@ -165,6 +165,10 @@ export abstract class BaseRuntimeManager {
       if (query !== '') query += '&';
       query += `severityNumber=${filter.severityNumber}`;
     }
+    if (filter?.spanId && !filter?.traceId) {
+      if (query !== '') query += '&';
+      query += `spanId=${encodeURIComponent(filter.spanId)}`;
+    }
 
     const fullUrl = query !== '' ? `${url}?${query}` : url;
 

--- a/genkit-tools/common/src/manager/manager.ts
+++ b/genkit-tools/common/src/manager/manager.ts
@@ -159,7 +159,7 @@ export abstract class BaseRuntimeManager {
     }
     if (filter?.severityText) {
       if (query !== '') query += '&';
-      query += `severityText=${filter.severityText}`;
+      query += `severityText=${encodeURIComponent(filter.severityText)}`;
     }
     if (filter?.severityNumber) {
       if (query !== '') query += '&';

--- a/genkit-tools/common/src/types/apis.ts
+++ b/genkit-tools/common/src/types/apis.ts
@@ -68,7 +68,9 @@ export type ListTracesResponse = z.infer<typeof ListTracesResponseSchema>;
 export const LogQueryFilterSchema = z.object({
   traceId: z.string().optional(),
   spanId: z.string().optional(),
+  /** Filters logs by exact string match. Use for custom severity levels. */
   severityText: z.string().optional(),
+  /** Filters logs to this numerical severity level and higher (>=). Used for standard OpenTelemetry severities. */
   severityNumber: z.number().optional(),
 });
 

--- a/genkit-tools/common/src/types/apis.ts
+++ b/genkit-tools/common/src/types/apis.ts
@@ -68,6 +68,8 @@ export type ListTracesResponse = z.infer<typeof ListTracesResponseSchema>;
 export const LogQueryFilterSchema = z.object({
   traceId: z.string().optional(),
   spanId: z.string().optional(),
+  severityText: z.string().optional(),
+  severityNumber: z.number().optional(),
 });
 
 export type LogQueryFilter = z.infer<typeof LogQueryFilterSchema>;

--- a/genkit-tools/common/src/types/log.ts
+++ b/genkit-tools/common/src/types/log.ts
@@ -50,6 +50,8 @@ export const LogQuerySchema = z.object({
   continuationToken: z.string().optional(),
   traceId: z.string().optional(),
   spanId: z.string().optional(),
+  severityText: z.string().optional(),
+  severityNumber: z.number().optional(),
 });
 
 export type LogQuery = z.infer<typeof LogQuerySchema>;

--- a/genkit-tools/common/src/types/log.ts
+++ b/genkit-tools/common/src/types/log.ts
@@ -50,7 +50,9 @@ export const LogQuerySchema = z.object({
   continuationToken: z.string().optional(),
   traceId: z.string().optional(),
   spanId: z.string().optional(),
+  /** Filters logs by exact string match. Use for custom severity levels. */
   severityText: z.string().optional(),
+  /** Filters logs to this numerical severity level and higher (>=). Used for standard OpenTelemetry severities. */
   severityNumber: z.number().optional(),
 });
 

--- a/genkit-tools/telemetry-server/src/file-log-store.ts
+++ b/genkit-tools/telemetry-server/src/file-log-store.ts
@@ -114,6 +114,8 @@ export class LocalFileLogStore implements LogStore {
       startFromIndex,
       traceId: query?.traceId,
       spanId: query?.spanId,
+      severityText: query?.severityText,
+      severityNumber: query?.severityNumber,
     });
 
     const logs: LogRecordData[] = [];
@@ -235,6 +237,8 @@ export class LogIndex {
     startFromIndex: number;
     traceId?: string;
     spanId?: string;
+    severityText?: string;
+    severityNumber?: number;
   }): LogIndexSearchResult {
     const indexFiles = this.listIndexFiles().sort().reverse();
 
@@ -263,6 +267,13 @@ export class LogIndex {
           if (!d) return false;
           if (query.traceId && d.traceId !== query.traceId) return false;
           if (query.spanId && d.spanId !== query.spanId) return false;
+          if (
+            query.severityText &&
+            d.severityText?.toLowerCase() !== query.severityText.toLowerCase()
+          )
+            return false;
+          if (query.severityNumber && d.severityNumber !== query.severityNumber)
+            return false;
           return true;
         });
 

--- a/genkit-tools/telemetry-server/src/file-log-store.ts
+++ b/genkit-tools/telemetry-server/src/file-log-store.ts
@@ -272,7 +272,11 @@ export class LogIndex {
             d.severityText?.toLowerCase() !== query.severityText.toLowerCase()
           )
             return false;
-          if (query.severityNumber && d.severityNumber !== query.severityNumber)
+          if (
+            query.severityNumber !== undefined &&
+            (d.severityNumber === undefined ||
+              d.severityNumber < query.severityNumber)
+          )
             return false;
           return true;
         });

--- a/genkit-tools/telemetry-server/src/index.ts
+++ b/genkit-tools/telemetry-server/src/index.ts
@@ -228,13 +228,13 @@ export async function startTelemetryServer(params: {
       } = request.query;
       response.json(
         await params.logStore.list({
-          limit: limit ? Number.parseInt(limit.toString()) : 100,
+          limit: limit ? Number.parseInt(limit.toString(), 10) || 100 : 100,
           continuationToken: continuationToken
             ? continuationToken.toString()
             : undefined,
           severityText: severityText ? severityText.toString() : undefined,
           severityNumber: severityNumber
-            ? Number.parseInt(severityNumber.toString())
+            ? Number.parseInt(severityNumber.toString(), 10) || undefined
             : undefined,
           traceId: traceId ? traceId.toString() : undefined,
           spanId: spanId ? spanId.toString() : undefined,
@@ -252,14 +252,14 @@ export async function startTelemetryServer(params: {
       const { traceId } = request.params;
       response.json(
         await params.logStore.list({
-          limit: limit ? Number.parseInt(limit.toString()) : 100,
+          limit: limit ? Number.parseInt(limit.toString(), 10) || 100 : 100,
           continuationToken: continuationToken
             ? continuationToken.toString()
             : undefined,
           traceId,
           severityText: severityText ? severityText.toString() : undefined,
           severityNumber: severityNumber
-            ? Number.parseInt(severityNumber.toString())
+            ? Number.parseInt(severityNumber.toString(), 10) || undefined
             : undefined,
         })
       );
@@ -277,7 +277,7 @@ export async function startTelemetryServer(params: {
         const { traceId, spanId } = request.params;
         response.json(
           await params.logStore.list({
-            limit: limit ? Number.parseInt(limit.toString()) : 100,
+            limit: limit ? Number.parseInt(limit.toString(), 10) || 100 : 100,
             continuationToken: continuationToken
               ? continuationToken.toString()
               : undefined,
@@ -285,7 +285,7 @@ export async function startTelemetryServer(params: {
             spanId,
             severityText: severityText ? severityText.toString() : undefined,
             severityNumber: severityNumber
-              ? Number.parseInt(severityNumber.toString())
+              ? Number.parseInt(severityNumber.toString(), 10) || undefined
               : undefined,
           })
         );

--- a/genkit-tools/telemetry-server/src/index.ts
+++ b/genkit-tools/telemetry-server/src/index.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { LogStore } from '@genkit-ai/tools-common';
+import type { LogQuery, LogStore } from '@genkit-ai/tools-common';
 import {
   TraceDataSchema,
   TraceQueryFilterSchema,
@@ -40,6 +40,44 @@ export interface SpanBroadcastEvent {
   type: 'span_start' | 'span_end';
   traceId: string;
   span: SpanData;
+}
+
+/**
+ * Parses an integer parameter from query parameters with an optional fallback/default value.
+ */
+export function parseIntParam(value: unknown): number | undefined;
+export function parseIntParam(value: unknown, defaultValue: number): number;
+export function parseIntParam(
+  value: unknown,
+  defaultValue?: number
+): number | undefined {
+  if (value === undefined || value === null || value === '')
+    return defaultValue;
+  const parsed = Number.parseInt(String(value), 10);
+  return Number.isNaN(parsed) ? defaultValue : parsed;
+}
+
+/**
+ * Extracts and normalizes LogQuery parameters from request query and route path params.
+ */
+export function parseLogQuery(
+  query: express.Request['query'],
+  params?: { traceId?: string; spanId?: string }
+): LogQuery {
+  return {
+    limit: parseIntParam(query.limit, 100),
+    continuationToken: query.continuationToken
+      ? query.continuationToken.toString()
+      : undefined,
+    severityText: query.severityText
+      ? query.severityText.toString()
+      : undefined,
+    severityNumber: parseIntParam(query.severityNumber),
+    traceId:
+      params?.traceId ?? (query.traceId ? query.traceId.toString() : undefined),
+    spanId:
+      params?.spanId ?? (query.spanId ? query.spanId.toString() : undefined),
+  };
 }
 
 /**
@@ -202,7 +240,7 @@ export async function startTelemetryServer(params: {
       const { limit, continuationToken, filter } = request.query;
       response.json(
         await params.traceStore.list({
-          limit: limit ? Number.parseInt(limit.toString()) : 10,
+          limit: parseIntParam(limit, 10),
           continuationToken: continuationToken
             ? continuationToken.toString()
             : undefined,
@@ -218,28 +256,7 @@ export async function startTelemetryServer(params: {
 
   api.get('/api/logs', async (request, response, next) => {
     try {
-      const {
-        limit,
-        continuationToken,
-        severityText,
-        severityNumber,
-        traceId,
-        spanId,
-      } = request.query;
-      response.json(
-        await params.logStore.list({
-          limit: limit ? Number.parseInt(limit.toString(), 10) || 100 : 100,
-          continuationToken: continuationToken
-            ? continuationToken.toString()
-            : undefined,
-          severityText: severityText ? severityText.toString() : undefined,
-          severityNumber: severityNumber
-            ? Number.parseInt(severityNumber.toString(), 10) || undefined
-            : undefined,
-          traceId: traceId ? traceId.toString() : undefined,
-          spanId: spanId ? spanId.toString() : undefined,
-        })
-      );
+      response.json(await params.logStore.list(parseLogQuery(request.query)));
     } catch (e) {
       next(e);
     }
@@ -247,21 +264,8 @@ export async function startTelemetryServer(params: {
 
   api.get('/api/traces/:traceId/logs', async (request, response, next) => {
     try {
-      const { limit, continuationToken, severityText, severityNumber } =
-        request.query;
-      const { traceId } = request.params;
       response.json(
-        await params.logStore.list({
-          limit: limit ? Number.parseInt(limit.toString(), 10) || 100 : 100,
-          continuationToken: continuationToken
-            ? continuationToken.toString()
-            : undefined,
-          traceId,
-          severityText: severityText ? severityText.toString() : undefined,
-          severityNumber: severityNumber
-            ? Number.parseInt(severityNumber.toString(), 10) || undefined
-            : undefined,
-        })
+        await params.logStore.list(parseLogQuery(request.query, request.params))
       );
     } catch (e) {
       next(e);
@@ -272,22 +276,10 @@ export async function startTelemetryServer(params: {
     '/api/traces/:traceId/spans/:spanId/logs',
     async (request, response, next) => {
       try {
-        const { limit, continuationToken, severityText, severityNumber } =
-          request.query;
-        const { traceId, spanId } = request.params;
         response.json(
-          await params.logStore.list({
-            limit: limit ? Number.parseInt(limit.toString(), 10) || 100 : 100,
-            continuationToken: continuationToken
-              ? continuationToken.toString()
-              : undefined,
-            traceId,
-            spanId,
-            severityText: severityText ? severityText.toString() : undefined,
-            severityNumber: severityNumber
-              ? Number.parseInt(severityNumber.toString(), 10) || undefined
-              : undefined,
-          })
+          await params.logStore.list(
+            parseLogQuery(request.query, request.params)
+          )
         );
       } catch (e) {
         next(e);

--- a/genkit-tools/telemetry-server/src/index.ts
+++ b/genkit-tools/telemetry-server/src/index.ts
@@ -218,8 +218,14 @@ export async function startTelemetryServer(params: {
 
   api.get('/api/logs', async (request, response, next) => {
     try {
-      const { limit, continuationToken, severityText, severityNumber } =
-        request.query;
+      const {
+        limit,
+        continuationToken,
+        severityText,
+        severityNumber,
+        traceId,
+        spanId,
+      } = request.query;
       response.json(
         await params.logStore.list({
           limit: limit ? Number.parseInt(limit.toString()) : 100,
@@ -230,6 +236,8 @@ export async function startTelemetryServer(params: {
           severityNumber: severityNumber
             ? Number.parseInt(severityNumber.toString())
             : undefined,
+          traceId: traceId ? traceId.toString() : undefined,
+          spanId: spanId ? spanId.toString() : undefined,
         })
       );
     } catch (e) {

--- a/genkit-tools/telemetry-server/src/index.ts
+++ b/genkit-tools/telemetry-server/src/index.ts
@@ -218,12 +218,17 @@ export async function startTelemetryServer(params: {
 
   api.get('/api/logs', async (request, response, next) => {
     try {
-      const { limit, continuationToken } = request.query;
+      const { limit, continuationToken, severityText, severityNumber } =
+        request.query;
       response.json(
         await params.logStore.list({
           limit: limit ? Number.parseInt(limit.toString()) : 100,
           continuationToken: continuationToken
             ? continuationToken.toString()
+            : undefined,
+          severityText: severityText ? severityText.toString() : undefined,
+          severityNumber: severityNumber
+            ? Number.parseInt(severityNumber.toString())
             : undefined,
         })
       );
@@ -234,7 +239,8 @@ export async function startTelemetryServer(params: {
 
   api.get('/api/traces/:traceId/logs', async (request, response, next) => {
     try {
-      const { limit, continuationToken } = request.query;
+      const { limit, continuationToken, severityText, severityNumber } =
+        request.query;
       const { traceId } = request.params;
       response.json(
         await params.logStore.list({
@@ -243,6 +249,10 @@ export async function startTelemetryServer(params: {
             ? continuationToken.toString()
             : undefined,
           traceId,
+          severityText: severityText ? severityText.toString() : undefined,
+          severityNumber: severityNumber
+            ? Number.parseInt(severityNumber.toString())
+            : undefined,
         })
       );
     } catch (e) {
@@ -254,7 +264,8 @@ export async function startTelemetryServer(params: {
     '/api/traces/:traceId/spans/:spanId/logs',
     async (request, response, next) => {
       try {
-        const { limit, continuationToken } = request.query;
+        const { limit, continuationToken, severityText, severityNumber } =
+          request.query;
         const { traceId, spanId } = request.params;
         response.json(
           await params.logStore.list({
@@ -264,6 +275,10 @@ export async function startTelemetryServer(params: {
               : undefined,
             traceId,
             spanId,
+            severityText: severityText ? severityText.toString() : undefined,
+            severityNumber: severityNumber
+              ? Number.parseInt(severityNumber.toString())
+              : undefined,
           })
         );
       } catch (e) {


### PR DESCRIPTION
Add a log:list command similar to trace:list command for listing logs. Allows filtering on the following args:

```
bash-3.2$ genkit log:list --help
Usage: genkit log:list [options]

list logs

Options:
  -l, --limit <number>          limit the number of returned logs (default: "15")
  --trace-id <id>               filter by trace ID
  --span-id <id>                filter by span ID
  --severity <severity>         filter by severity (e.g., INFO, ERROR, WARNING)
  -f, --format <format>         output format (choices: "text", "jsonl", default: "text")
  --continuation-token <token>  continuation token for pagination
  -h, --help                    display help for command
```

Sample output:
```
bash-3.2$ genkit log:list
Error: listen EADDRINUSE: address already in use 127.0.0.1:4033
Found 15 logs:

ID:       cce5e07e-c686-4069-95da-efb18265f796
Severity: INFO
Time:     8/20/2026, 3:52:34 PM
Message:  Input[blockingMiddleware > generate, blockingMiddleware]
Attrs:    logging.googleapis.com/spanId=7f0e86e2c5652248, logging.googleapis.com/trace=projects/shruti-genkit-...
---
ID:       7956edb0-15ac-4a78-a419-fcf698326392
Severity: ERROR
Time:     8/20/2026, 3:52:34 PM
```

Checklist:
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] PR description contains enough context, bug link, code samples for new APIs
- [x] Tested (manually, unit tested, etc.)
- [ ] Docs/readmes updated

