### PR TITLE
fix(go/plugins/googlegenai): stop resending and re-creating the context cache

### DIFF
--- a/go/ai/request_helpers.go
+++ b/go/ai/request_helpers.go
@@ -17,8 +17,6 @@
 package ai
 
 import (
-	"maps"
-
 	"github.com/firebase/genkit/go/core"
 )
 
@@ -108,41 +106,30 @@ func NewTextMessage(role Role, text string) *Message {
 
 // WithCacheTTL adds cache TTL configuration for the desired message
 func (m *Message) WithCacheTTL(ttlSeconds int) *Message {
-	metadata := make(map[string]any)
-
-	if m.Metadata != nil {
-		metadata = m.Metadata
-	}
-
-	cache := map[string]any{
-		"cache": map[string]any{
-			"ttlSeconds": ttlSeconds,
-		},
-	}
-	maps.Copy(metadata, cache)
-
-	return &Message{
-		Content:  m.Content,
-		Role:     m.Role,
-		Metadata: metadata,
-	}
+	return m.withCacheMetadata("ttlSeconds", ttlSeconds)
 }
 
 // WithCacheName adds cache name to use in the generate request
 func (m *Message) WithCacheName(n string) *Message {
-	metadata := make(map[string]any)
+	return m.withCacheMetadata("name", n)
+}
 
+// withCacheMetadata sets one key of the message's "cache" metadata and leaves
+// the rest of that map alone, so a message can carry both the ttl that builds
+// a cache and the name of the one an earlier turn already built. Replacing the
+// whole map instead would make the two setters cancel each other out.
+func (m *Message) withCacheMetadata(key string, value any) *Message {
+	metadata := make(map[string]any)
 	if m.Metadata != nil {
 		metadata = m.Metadata
 	}
 
-	cache := map[string]any{
-		"cache": map[string]any{
-			"name": n,
-		},
+	cache, _ := metadata["cache"].(map[string]any)
+	if cache == nil {
+		cache = make(map[string]any)
 	}
-
-	maps.Copy(metadata, cache)
+	cache[key] = value
+	metadata["cache"] = cache
 
 	return &Message{
 		Content:  m.Content,

--- a/go/plugins/googlegenai/README.md
+++ b/go/plugins/googlegenai/README.md
@@ -301,27 +301,80 @@ resp, err := genkit.Generate(ctx, g,
 
 ### Context Caching
 
-Gemini 2.5 and newer models automatically cache common content prefixes. In Genkit Go, you can mark content for caching using `WithCacheTTL` or `WithCacheName`.
+There are two kinds of caching, and they bill differently. Most traffic wants
+the first one.
+
+#### Implicit caching (automatic, no code)
+
+Gemini 2.5 and newer models cache repeated prompt prefixes on their own. It is
+on by default on both the Gemini API and Vertex AI, there is no storage charge,
+and a hit bills the repeated tokens at a fraction of the normal input price.
+You do not call anything to get it.
+
+What it asks of you is only that the repeated part stays at the front of the
+prompt and stays identical between calls, and that the prompt is large enough
+to qualify (roughly a thousand tokens and up, depending on the model). Genkit
+sends messages in the order you build them, so putting the stable content in
+the first message is enough.
+
+Read the hit off the response:
 
 ```go
-// Create a message with cached content
+resp, err := genkit.Generate(ctx, g,
+    ai.WithModelName("googleai/gemini-flash-latest"),
+    ai.WithMessages(ai.NewUserTextMessage(largeStableContext)),
+    ai.WithPrompt("Task 1..."),
+)
+// Tokens billed at the cached rate, implicit or explicit.
+fmt.Println(resp.Usage.CachedContentTokens)
+```
+
+See [Gemini API context caching][gemini-caching] and
+[Vertex AI context caching][vertex-caching] for the current thresholds.
+
+#### Explicit caching (`WithCacheTTL`)
+
+`WithCacheTTL` uploads the marked message and everything before it to a cache
+resource, and later requests point at it instead of resending it. This buys a
+guaranteed hit and a lifetime you control. In exchange you pay to store the
+content for that lifetime, so it is worth it when you know you will reuse a
+large prefix and want the hit guaranteed rather than best-effort. If you are
+not sure, start with implicit caching and measure `CachedContentTokens`.
+
+```go
+// Cache this message and everything before it. The marker is inclusive, so
+// keep the question in a separate message.
 cachedMsg := ai.NewUserTextMessage(largeContent).WithCacheTTL(300)
 
-// First request - content will be cached
 resp1, err := genkit.Generate(ctx, g,
     ai.WithModelName("googleai/gemini-flash-latest"),
     ai.WithMessages(cachedMsg),
     ai.WithPrompt("Task 1..."),
 )
 
-// Second request with same prefix - eligible for cache hit
+// Later requests reuse the same cache. Replaying the history carries the
+// cache name back automatically; rebuilding the same prefix by hand also
+// finds it, because Genkit looks for a cache holding that content before it
+// creates another one.
 resp2, err := genkit.Generate(ctx, g,
     ai.WithModelName("googleai/gemini-flash-latest"),
-    // Reuse the history from previous response or construct messages with same prefix
     ai.WithMessages(resp1.History()...),
     ai.WithPrompt("Task 2..."),
 )
 ```
+
+The cached prefix travels by reference only: it is not also sent inline, so it
+is billed once. If the cache has expired or no longer matches the request,
+Genkit builds a fresh one rather than failing.
+
+`WithCacheName` points a request at a cache you already hold. Use it when you
+kept the name yourself instead of replaying the history. If that cache is gone,
+the request still goes through, uncached.
+
+Tools and system prompts are not supported with explicit caching.
+
+[gemini-caching]: https://ai.google.dev/gemini-api/docs/caching
+[vertex-caching]: https://cloud.google.com/vertex-ai/generative-ai/docs/context-cache/context-cache-overview
 
 ### Handling Errors and Blocked Content
 

--- a/go/plugins/googlegenai/cache.go
+++ b/go/plugins/googlegenai/cache.go
@@ -20,15 +20,15 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"time"
 
 	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/core/logger"
 	"github.com/firebase/genkit/go/core/status"
 	"google.golang.org/genai"
 )
-
-const cacheContentsPerPage = 5
 
 var invalidArgMessages = struct {
 	modelVersion string
@@ -39,94 +39,133 @@ var invalidArgMessages = struct {
 	systemPrompt: "system prompts are not supported with context caching",
 }
 
-// handleCache checks if caching should be used, attempts to find or create the
-// cache, and returns the cached content plus the inclusive index of the last
-// cached message (-1 when no cache is in use).
+// handleCache checks if caching should be used and attempts to find or create
+// the cache. It returns the cached content along with the messages that still
+// have to be sent inline: the cached prefix is not among them, since it reaches
+// the model through the CachedContent resource and sending it inline as well
+// would bill it twice (#6137).
 func handleCache(
 	ctx context.Context,
 	client *genai.Client,
 	request *ai.ModelRequest,
 	model string,
-) (*genai.CachedContent, int, error) {
+) (*genai.CachedContent, []*ai.Message, error) {
 	cs, err := findCacheMarker(request)
 	if err != nil {
-		return nil, -1, err
-	}
-	if cs == nil {
-		return nil, -1, nil
+		return nil, nil, err
 	}
 	// no cache mark found
-	if cs.endIndex == -1 {
-		return nil, -1, err
+	if cs == nil {
+		return nil, request.Messages, nil
 	}
 	// index out of bounds
 	if cs.endIndex < 0 || cs.endIndex >= len(request.Messages) {
-		return nil, -1, status.Errorf(status.ErrInvalidArgument, "end of cached contents, index %d is invalid", cs.endIndex)
+		return nil, nil, status.Errorf(status.ErrInvalidArgument, "end of cached contents, index %d is invalid", cs.endIndex)
 	}
 
 	// since context caching is only available for specific model versions, we
 	// must make sure the configuration has the right version
 	err = validateContextCacheRequest(request, model)
 	if err != nil {
-		return nil, -1, err
+		return nil, nil, err
 	}
 
 	messages, err := messagesToCache(request.Messages, cs.endIndex)
 	if err != nil {
-		return nil, -1, err
+		return nil, nil, err
 	}
-	hash := calculateCacheHash(messages)
+	hash, err := calculateCacheHash(messages, model)
+	if err != nil {
+		return nil, nil, err
+	}
 
+	// A name only records that an earlier turn built a cache. The resource
+	// lives no longer than its TTL, and the request it was built from may have
+	// moved on since, so a name that no longer resolves falls back to a fresh
+	// cache instead of failing. The caller cannot act on that failure anyway:
+	// the name comes from Genkit's own response metadata, not from them.
 	var cache *genai.CachedContent
 	if cs.name != "" {
 		cache, err = lookupCache(ctx, client, cs.name)
-		if err != nil {
-			// TODO: if cache expired or not found, create a fresh one
-			return nil, -1, fmt.Errorf("cache lookup error: %w", wrapAPIError(err))
+		switch {
+		case err != nil:
+			logger.Warn(ctx, "context cache lookup failed, looking for another cache with the same contents",
+				"name", cs.name, "error", wrapAPIError(err))
+			cache = nil
+		case cache.DisplayName != hash:
+			logger.Warn(ctx, "context cache no longer matches the request messages, looking for another cache with the same contents",
+				"name", cs.name)
+			cache = nil
 		}
-		// make sure the cache contents matches the request messages hash
-		if cache.DisplayName != hash {
-			return nil, -1, status.Errorf(status.ErrInvalidArgument, "invalid cache name: hash mismatch between cached content and request messages")
-		}
-
-		return cache, cs.endIndex, nil
 	}
 
-	if cs.ttl > 0 {
+	// The name only travels back to the caller through the response metadata,
+	// so a caller who rebuilds the same prefix instead of replaying
+	// resp.History() arrives here without one. Look for a cache that already
+	// holds this content before paying to store a second copy of it.
+	if cache == nil {
+		cache, err = findCacheByHash(ctx, client, hash)
+		if err != nil {
+			logger.Warn(ctx, "context cache scan failed, creating a fresh cache", "error", err)
+		}
+	}
+
+	if cache == nil {
+		if cs.ttl <= 0 {
+			// A name-only marker that resolved to nothing. There is no ttl to
+			// build a replacement with, so send the whole request: the answer
+			// is still right, it just is not cached.
+			logger.Warn(ctx, "no usable context cache and no ttlSeconds to create one, sending the full request",
+				"name", cs.name)
+			return nil, request.Messages, nil
+		}
 		cache, err = client.Caches.Create(ctx, model, &genai.CreateCachedContentConfig{
 			DisplayName: hash,
 			TTL:         time.Duration(cs.ttl) * time.Second,
 			Contents:    messages,
 		})
 		if err != nil {
-			return nil, -1, fmt.Errorf("cache creation error: %w", wrapAPIError(err))
+			return nil, nil, fmt.Errorf("cache creation error: %w", wrapAPIError(err))
 		}
 	}
 
-	if cache == nil {
-		return nil, -1, nil
-	}
-	return cache, cs.endIndex, nil
+	return cache, request.Messages[cs.endIndex+1:], nil
 }
 
-// messagesToCache collects all the messages that should be cached
-func messagesToCache(m []*ai.Message, cacheEndIdx int) ([]*genai.Content, error) {
-	var messagesToCache []*genai.Content
-	for i := 0; i <= cacheEndIdx; i++ {
-		msg := m[i]
-		if msg.Role == ai.RoleSystem {
-			continue
-		}
-		parts, err := toGeminiParts(msg.Content)
+// cacheScanLimit bounds the search for a reusable cache. The scan runs before
+// every request that asks for explicit caching, and a project can hold far
+// more cache resources than are worth paging through; giving up only costs a
+// fresh cache.
+const cacheScanLimit = 200
+
+// findCacheByHash looks for a cache resource whose DisplayName is hash, which
+// is how [calculateCacheHash] records what a cache holds. A scan failure is
+// not fatal: the caller falls back to creating a cache.
+func findCacheByHash(ctx context.Context, client *genai.Client, hash string) (*genai.CachedContent, error) {
+	scanned := 0
+	for c, err := range client.Caches.All(ctx) {
 		if err != nil {
-			return nil, err
+			return nil, wrapAPIError(err)
 		}
-		messagesToCache = append(messagesToCache, &genai.Content{
-			Parts: parts,
-			Role:  string(msg.Role),
-		})
+		if c.DisplayName == hash {
+			return c, nil
+		}
+		if scanned++; scanned >= cacheScanLimit {
+			logger.Warn(ctx, "gave up looking for a reusable context cache", "scanned", scanned)
+			return nil, nil
+		}
 	}
-	return messagesToCache, nil
+	return nil, nil
+}
+
+// messagesToCache converts the messages through cacheEndIdx (inclusive) into
+// the contents stored on the CachedContent resource. It shares toGeminiContents
+// with the inline path so that the cached prefix is encoded exactly like the
+// messages sent alongside it: same role mapping, same handling of contentless
+// turns. The order is chronological and feeds calculateCacheHash, so changing
+// it invalidates every live cache name.
+func messagesToCache(m []*ai.Message, cacheEndIdx int) ([]*genai.Content, error) {
+	return toGeminiContents(m[:cacheEndIdx+1])
 }
 
 // validateContextCacheRequest checks for supported models and checks if Tools
@@ -150,10 +189,12 @@ type cacheSettings struct {
 	endIndex int
 }
 
-// findCacheMarker finds the cache mark in the list of request messages.
-// All of the messages preceding this mark will be cached.
+// findCacheMarker finds the cache mark in the list of request messages. The
+// marked message and everything before it is cached: endIndex is inclusive.
+// The scan runs newest to oldest, so the newest cache name in the history wins
+// and only the newest ttl marker is honoured.
 func findCacheMarker(request *ai.ModelRequest) (*cacheSettings, error) {
-	var cacheName string
+	cacheName, cacheNameIdx := "", -1
 
 	for i := len(request.Messages) - 1; i >= 0; i-- {
 		m := request.Messages[i]
@@ -171,11 +212,12 @@ func findCacheMarker(request *ai.ModelRequest) (*cacheSettings, error) {
 			return nil, status.Errorf(status.ErrInvalidArgument, "cache metadata should be map but got: %T", cacheVal)
 		}
 
-		// cache name should be only used to indicate the request already
-		// generated a cache
-		if n, ok := c["name"].(string); ok {
-			cacheName = n
-			continue
+		// A message can carry the name of a cache an earlier turn built, the
+		// ttl that builds one, or both. Several turns of a replayed history
+		// carry a name, so keep the first seen: the scan runs newest to oldest.
+		name, hasName := c["name"].(string)
+		if hasName && cacheName == "" {
+			cacheName, cacheNameIdx = name, i
 		}
 
 		// ttlSeconds arrives as an int when set in Go code and as a float64 or
@@ -204,7 +246,19 @@ func findCacheMarker(request *ai.ModelRequest) (*cacheSettings, error) {
 			}, nil
 		}
 
+		if hasName {
+			continue
+		}
+
 		return nil, status.Errorf(status.ErrInvalidArgument, "invalid cache metadata, expected ttlSeconds or name, got: %v", c)
+	}
+
+	// A name with no ttl anywhere names a cache an earlier turn built. The
+	// marked message closes the cached span, the same way a ttl marker does;
+	// handleCache checks that against the cache's own contents before trusting
+	// it, and falls back to sending the whole request if it does not hold up.
+	if cacheName != "" {
+		return &cacheSettings{name: cacheName, endIndex: cacheNameIdx}, nil
 	}
 	return nil, nil
 }
@@ -218,23 +272,27 @@ func lookupCache(ctx context.Context, client *genai.Client, name string) (*genai
 	return client.Caches.Get(ctx, name, nil)
 }
 
-// calculateCacheKey generates a sha256 key for cached content used to
-// validate the proper usage of the requested cache
-func calculateCacheHash(content []*genai.Content) string {
-	hash := sha256.New()
-
-	// Incorporate content parts to ensure uniqueness
-	for _, c := range content {
-		for _, p := range c.Parts {
-			if p.Text != "" {
-				hash.Write([]byte(p.Text))
-			} else if p.InlineData != nil {
-				hash.Write([]byte(p.InlineData.MIMEType))
-				hash.Write([]byte(p.InlineData.Data))
-			}
-		}
+// calculateCacheHash generates a sha256 key over the contents of a cache. It
+// is stored as the resource's DisplayName and re-checked on every reuse, so it
+// has to cover everything that tells one cached prefix apart from another.
+// Hashing the JSON encoding does that: it reaches every part kind and keeps
+// field and message boundaries, where folding selected fields into a bare
+// digest silently collided. Two different gs:// videos both hashed to the
+// digest of no bytes at all, because URI media carries neither Text nor
+// InlineData. The model is part of the key because a cache resource belongs to
+// the model that created it, matching the JS and Python plugins.
+func calculateCacheHash(content []*genai.Content, model string) (string, error) {
+	b, err := json.Marshal(struct {
+		Model    string           `json:"model"`
+		Contents []*genai.Content `json:"contents"`
+	}{Model: model, Contents: content})
+	if err != nil {
+		// Reachable through tool inputs and outputs, which carry caller-owned
+		// map[string]any into FunctionCall.Args and FunctionResponse.Response.
+		return "", status.Errorf(status.ErrInvalidArgument, "cannot hash cache contents: %v", err)
 	}
-	return hex.EncodeToString(hash.Sum(nil))
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:]), nil
 }
 
 // cacheMetadata writes in the metadata map the cache name used in the

--- a/go/plugins/googlegenai/cache.go
+++ b/go/plugins/googlegenai/cache.go
@@ -289,7 +289,7 @@ func calculateCacheHash(content []*genai.Content, model string) (string, error) 
 	if err != nil {
 		// Reachable through tool inputs and outputs, which carry caller-owned
 		// map[string]any into FunctionCall.Args and FunctionResponse.Response.
-		return "", status.Errorf(status.ErrInvalidArgument, "cannot hash cache contents: %v", err)
+		return "", status.Errorf(status.ErrInvalidArgument, "cannot hash cache contents: %w", err)
 	}
 	sum := sha256.Sum256(b)
 	return hex.EncodeToString(sum[:]), nil

--- a/go/plugins/googlegenai/cache.go
+++ b/go/plugins/googlegenai/cache.go
@@ -46,33 +46,33 @@ func handleCache(
 	client *genai.Client,
 	request *ai.ModelRequest,
 	model string,
-) (*genai.CachedContent, error) {
+) (*genai.CachedContent, int, error) {
 	cs, err := findCacheMarker(request)
 	if err != nil {
-		return nil, err
+		return nil, -1, err
 	}
 	if cs == nil {
-		return nil, nil
+		return nil, -1, nil
 	}
 	// no cache mark found
 	if cs.endIndex == -1 {
-		return nil, err
+		return nil, -1, err
 	}
 	// index out of bounds
 	if cs.endIndex < 0 || cs.endIndex >= len(request.Messages) {
-		return nil, status.Errorf(status.ErrInvalidArgument, "end of cached contents, index %d is invalid", cs.endIndex)
+		return nil, -1, status.Errorf(status.ErrInvalidArgument, "end of cached contents, index %d is invalid", cs.endIndex)
 	}
 
 	// since context caching is only available for specific model versions, we
 	// must make sure the configuration has the right version
 	err = validateContextCacheRequest(request, model)
 	if err != nil {
-		return nil, err
+		return nil, -1, err
 	}
 
 	messages, err := messagesToCache(request.Messages, cs.endIndex)
 	if err != nil {
-		return nil, err
+		return nil, -1, err
 	}
 	hash := calculateCacheHash(messages)
 
@@ -81,14 +81,14 @@ func handleCache(
 		cache, err = lookupCache(ctx, client, cs.name)
 		if err != nil {
 			// TODO: if cache expired or not found, create a fresh one
-			return nil, fmt.Errorf("cache lookup error: %w", wrapAPIError(err))
+			return nil, -1, fmt.Errorf("cache lookup error: %w", wrapAPIError(err))
 		}
 		// make sure the cache contents matches the request messages hash
 		if cache.DisplayName != hash {
-			return nil, status.Errorf(status.ErrInvalidArgument, "invalid cache name: hash mismatch between cached content and request messages")
+			return nil, -1, status.Errorf(status.ErrInvalidArgument, "invalid cache name: hash mismatch between cached content and request messages")
 		}
 
-		return cache, nil
+		return cache, cs.endIndex, nil
 	}
 
 	if cs.ttl > 0 {
@@ -98,11 +98,14 @@ func handleCache(
 			Contents:    messages,
 		})
 		if err != nil {
-			return nil, fmt.Errorf("cache creation error: %w", wrapAPIError(err))
+			return nil, -1, fmt.Errorf("cache creation error: %w", wrapAPIError(err))
 		}
 	}
 
-	return cache, nil
+	if cache == nil {
+		return nil, -1, nil
+	}
+	return cache, cs.endIndex, nil
 }
 
 // messagesToCache collects all the messages that should be cached

--- a/go/plugins/googlegenai/cache.go
+++ b/go/plugins/googlegenai/cache.go
@@ -39,8 +39,9 @@ var invalidArgMessages = struct {
 	systemPrompt: "system prompts are not supported with context caching",
 }
 
-// handleCache checks if caching should be used, attempts to find or create the cache,
-// and returns the cached content if applicable.
+// handleCache checks if caching should be used, attempts to find or create the
+// cache, and returns the cached content plus the inclusive index of the last
+// cached message (-1 when no cache is in use).
 func handleCache(
 	ctx context.Context,
 	client *genai.Client,
@@ -111,18 +112,18 @@ func handleCache(
 // messagesToCache collects all the messages that should be cached
 func messagesToCache(m []*ai.Message, cacheEndIdx int) ([]*genai.Content, error) {
 	var messagesToCache []*genai.Content
-	for i := cacheEndIdx; i >= 0; i-- {
-		m := m[i]
-		if m.Role == ai.RoleSystem {
+	for i := 0; i <= cacheEndIdx; i++ {
+		msg := m[i]
+		if msg.Role == ai.RoleSystem {
 			continue
 		}
-		parts, err := toGeminiParts(m.Content)
+		parts, err := toGeminiParts(msg.Content)
 		if err != nil {
 			return nil, err
 		}
 		messagesToCache = append(messagesToCache, &genai.Content{
 			Parts: parts,
-			Role:  string(m.Role),
+			Role:  string(msg.Role),
 		})
 	}
 	return messagesToCache, nil

--- a/go/plugins/googlegenai/cache_test.go
+++ b/go/plugins/googlegenai/cache_test.go
@@ -249,6 +249,24 @@ func TestToGeminiContents_DropsCachedPrefix(t *testing.T) {
 	}
 }
 
+func TestMessagesToCache_PreservesChronologicalOrder(t *testing.T) {
+	req := []*ai.Message{
+		{Role: ai.RoleUser, Content: []*ai.Part{{Text: "first"}}},
+		{Role: ai.RoleModel, Content: []*ai.Part{{Text: "second"}}},
+		{Role: ai.RoleUser, Content: []*ai.Part{{Text: "third, not cached"}}},
+	}
+	got, err := messagesToCache(req, 1)
+	if err != nil {
+		t.Fatalf("messagesToCache: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("len = %d, want 2", len(got))
+	}
+	if got[0].Parts[0].Text != "first" || got[1].Parts[0].Text != "second" {
+		t.Errorf("order = %q, %q; want first, second", got[0].Parts[0].Text, got[1].Parts[0].Text)
+	}
+}
+
 func TestFindCacheMarker_NumericTTLForms(t *testing.T) {
 	// ttlSeconds is an int when set from Go code but arrives as float64 or
 	// json.Number after a JSON round-trip (dev UI, reflection server). All

--- a/go/plugins/googlegenai/cache_test.go
+++ b/go/plugins/googlegenai/cache_test.go
@@ -198,72 +198,104 @@ func TestExtractCacheConfig_InvalidCacheType(t *testing.T) {
 	}
 }
 
-func TestToGeminiContents_DropsCachedPrefix(t *testing.T) {
-	prefix := "this is a large stable prefix that should only live in the cache"
-	followUp := "what did I just say?"
-	req := &ai.ModelRequest{
-		Messages: []*ai.Message{
-			{
-				Role:    ai.RoleUser,
-				Content: []*ai.Part{{Text: prefix}},
-				Metadata: map[string]any{
-					"cache": map[string]any{"ttlSeconds": 3600},
-				},
-			},
-			{
-				Role:    ai.RoleUser,
-				Content: []*ai.Part{{Text: followUp}},
-			},
-		},
-	}
+// TestMessagesToCache pins that the cached span stops at the boundary, stays
+// in chronological order (calculateCacheHash reads it in slice order, so the
+// order is part of every live cache name), and is encoded exactly like the
+// messages sent inline. The last part matters because the cached prefix is no
+// longer sent inline as well: the copy stored on the resource is the only one
+// the model ever sees.
+func TestMessagesToCache(t *testing.T) {
+	t.Run("chronological up to the boundary", func(t *testing.T) {
+		msgs := []*ai.Message{
+			ai.NewUserTextMessage("first"),
+			ai.NewModelTextMessage("second"),
+			ai.NewUserTextMessage("third, not cached"),
+		}
+		got, err := messagesToCache(msgs, 1)
+		if err != nil {
+			t.Fatalf("messagesToCache: %v", err)
+		}
+		if len(got) != 2 {
+			t.Fatalf("len = %d, want 2", len(got))
+		}
+		if got[0].Parts[0].Text != "first" || got[1].Parts[0].Text != "second" {
+			t.Errorf("order = %q, %q; want first, second", got[0].Parts[0].Text, got[1].Parts[0].Text)
+		}
+	})
 
-	cs, err := findCacheMarker(req)
-	if err != nil {
-		t.Fatalf("findCacheMarker: %v", err)
-	}
-	if cs == nil || cs.endIndex != 0 {
-		t.Fatalf("cache marker = %#v, want endIndex=0", cs)
-	}
+	t.Run("tool turns take the gemini role", func(t *testing.T) {
+		msgs := []*ai.Message{
+			ai.NewMessage(ai.RoleTool, nil, ai.NewToolResponsePart(&ai.ToolResponse{Name: "myTool", Output: "result"})),
+			ai.NewUserTextMessage("and now?"),
+		}
+		got, err := messagesToCache(msgs, 0)
+		if err != nil {
+			t.Fatalf("messagesToCache: %v", err)
+		}
+		// The Gemini Content API takes only "user" and "model"; a raw "tool"
+		// is rejected by Caches.Create.
+		if got[0].Role != "user" {
+			t.Errorf("cached role = %q, want %q", got[0].Role, "user")
+		}
+	})
 
-	// Reproduce #6137: sending the whole request inline includes the prefix.
-	inline, err := toGeminiContents(req, -1)
-	if err != nil {
-		t.Fatalf("toGeminiContents(no skip): %v", err)
-	}
-	if len(inline) != 2 {
-		t.Fatalf("inline contents = %d, want 2 (bug: prefix sent with the follow-up)", len(inline))
-	}
-	if got := inline[0].Parts[0].Text; got != prefix {
-		t.Fatalf("inline[0] = %q, want cached prefix", got)
-	}
-
-	got, err := toGeminiContents(req, cs.endIndex)
-	if err != nil {
-		t.Fatalf("toGeminiContents(skip cached): %v", err)
-	}
-	if len(got) != 1 {
-		t.Fatalf("contents after cache boundary = %d, want 1", len(got))
-	}
-	if got[0].Parts[0].Text != followUp {
-		t.Errorf("remaining content = %q, want %q", got[0].Parts[0].Text, followUp)
-	}
+	t.Run("contentless turns are skipped", func(t *testing.T) {
+		// A blocked model turn replayed via resp.History() carries no content,
+		// and the API rejects contents with zero parts.
+		msgs := []*ai.Message{
+			{Role: ai.RoleModel},
+			ai.NewUserTextMessage("hi"),
+		}
+		got, err := messagesToCache(msgs, 1)
+		if err != nil {
+			t.Fatalf("messagesToCache: %v", err)
+		}
+		if len(got) != 1 {
+			t.Fatalf("len = %d, want 1 (the contentless turn must be dropped)", len(got))
+		}
+		if got[0].Parts[0].Text != "hi" {
+			t.Errorf("cached = %q, want %q", got[0].Parts[0].Text, "hi")
+		}
+	})
 }
 
-func TestMessagesToCache_PreservesChronologicalOrder(t *testing.T) {
-	req := []*ai.Message{
-		{Role: ai.RoleUser, Content: []*ai.Part{{Text: "first"}}},
-		{Role: ai.RoleModel, Content: []*ai.Part{{Text: "second"}}},
-		{Role: ai.RoleUser, Content: []*ai.Part{{Text: "third, not cached"}}},
+// TestCalculateCacheHash pins that the hash tells apart everything the cache
+// lookup relies on it to tell apart. It is the only check that a named cache
+// holds the request's own content, and the request no longer carries that
+// content inline, so a collision silently answers from the wrong cache.
+func TestCalculateCacheHash(t *testing.T) {
+	hashOf := func(t *testing.T, model string, msgs ...*ai.Message) string {
+		t.Helper()
+		contents, err := messagesToCache(msgs, len(msgs)-1)
+		if err != nil {
+			t.Fatalf("messagesToCache: %v", err)
+		}
+		h, err := calculateCacheHash(contents, model)
+		if err != nil {
+			t.Fatalf("calculateCacheHash: %v", err)
+		}
+		return h
 	}
-	got, err := messagesToCache(req, 1)
-	if err != nil {
-		t.Fatalf("messagesToCache: %v", err)
+	media := func(uri string) *ai.Message {
+		return ai.NewMessage(ai.RoleUser, nil, ai.NewMediaPart("video/mp4", uri))
 	}
-	if len(got) != 2 {
-		t.Fatalf("len = %d, want 2", len(got))
+
+	// URI media carries neither Text nor InlineData, the two fields the hash
+	// used to fold in, so every such cache hashed alike.
+	if a, b := hashOf(t, "m", media("gs://bucket/a.mp4")), hashOf(t, "m", media("gs://bucket/b.mp4")); a == b {
+		t.Errorf("two different gs:// videos hash alike: %s", a)
 	}
-	if got[0].Parts[0].Text != "first" || got[1].Parts[0].Text != "second" {
-		t.Errorf("order = %q, %q; want first, second", got[0].Parts[0].Text, got[1].Parts[0].Text)
+	// A cache resource belongs to the model that created it.
+	if a, b := hashOf(t, "gemini-2.5-flash", ai.NewUserTextMessage("x")), hashOf(t, "gemini-2.5-pro", ai.NewUserTextMessage("x")); a == b {
+		t.Errorf("same contents on two models hash alike: %s", a)
+	}
+	// Message boundaries have to survive: without them "ab" and "a"+"b" fold
+	// into the same digest.
+	if a, b := hashOf(t, "m", ai.NewUserTextMessage("ab")), hashOf(t, "m", ai.NewUserTextMessage("a"), ai.NewUserTextMessage("b")); a == b {
+		t.Errorf("[ab] and [a b] hash alike: %s", a)
+	}
+	if a, b := hashOf(t, "m", ai.NewUserTextMessage("x")), hashOf(t, "m", ai.NewUserTextMessage("x")); a != b {
+		t.Errorf("hash is not stable: %s != %s", a, b)
 	}
 }
 

--- a/go/plugins/googlegenai/cache_test.go
+++ b/go/plugins/googlegenai/cache_test.go
@@ -198,6 +198,57 @@ func TestExtractCacheConfig_InvalidCacheType(t *testing.T) {
 	}
 }
 
+func TestToGeminiContents_DropsCachedPrefix(t *testing.T) {
+	prefix := "this is a large stable prefix that should only live in the cache"
+	followUp := "what did I just say?"
+	req := &ai.ModelRequest{
+		Messages: []*ai.Message{
+			{
+				Role:    ai.RoleUser,
+				Content: []*ai.Part{{Text: prefix}},
+				Metadata: map[string]any{
+					"cache": map[string]any{"ttlSeconds": 3600},
+				},
+			},
+			{
+				Role:    ai.RoleUser,
+				Content: []*ai.Part{{Text: followUp}},
+			},
+		},
+	}
+
+	cs, err := findCacheMarker(req)
+	if err != nil {
+		t.Fatalf("findCacheMarker: %v", err)
+	}
+	if cs == nil || cs.endIndex != 0 {
+		t.Fatalf("cache marker = %#v, want endIndex=0", cs)
+	}
+
+	// Reproduce #6137: sending the whole request inline includes the prefix.
+	inline, err := toGeminiContents(req, -1)
+	if err != nil {
+		t.Fatalf("toGeminiContents(no skip): %v", err)
+	}
+	if len(inline) != 2 {
+		t.Fatalf("inline contents = %d, want 2 (bug: prefix sent with the follow-up)", len(inline))
+	}
+	if got := inline[0].Parts[0].Text; got != prefix {
+		t.Fatalf("inline[0] = %q, want cached prefix", got)
+	}
+
+	got, err := toGeminiContents(req, cs.endIndex)
+	if err != nil {
+		t.Fatalf("toGeminiContents(skip cached): %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("contents after cache boundary = %d, want 1", len(got))
+	}
+	if got[0].Parts[0].Text != followUp {
+		t.Errorf("remaining content = %q, want %q", got[0].Parts[0].Text, followUp)
+	}
+}
+
 func TestFindCacheMarker_NumericTTLForms(t *testing.T) {
 	// ttlSeconds is an int when set from Go code but arrives as float64 or
 	// json.Number after a JSON round-trip (dev UI, reflection server). All

--- a/go/plugins/googlegenai/gemini.go
+++ b/go/plugins/googlegenai/gemini.go
@@ -159,7 +159,7 @@ func generate(
 	}
 	model = resolveVertexModelName(client, model)
 
-	cache, cachedThrough, err := handleCache(ctx, client, input, model)
+	cache, inline, err := handleCache(ctx, client, input, model)
 	if err != nil {
 		return nil, err
 	}
@@ -169,12 +169,26 @@ func generate(
 		return nil, err
 	}
 
-	contents, err := toGeminiContents(input, cachedThrough)
+	contents, err := toGeminiContents(inline)
 	if err != nil {
 		return nil, err
 	}
 	if len(contents) == 0 {
-		return nil, status.Errorf(status.ErrInvalidArgument, "at least one message is required in generate request")
+		if cache == nil {
+			return nil, status.Errorf(status.ErrInvalidArgument, "at least one message is required in generate request")
+		}
+		// The cache boundary covers every message, e.g. a single message that
+		// carries both the document and the question. The prefix still reaches
+		// the model through the CachedContent resource, but the API rejects a
+		// request with no contents at all, so carry it with a minimal turn
+		// rather than failing a request that worked before the prefix stopped
+		// being sent inline. The Python plugin pads the same way; the JS one
+		// cannot reach this state, since its cached span is sliced out of the
+		// chat history, which excludes the current prompt.
+		contents = []*genai.Content{{
+			Role:  toGeminiRole(ai.RoleUser),
+			Parts: []*genai.Part{genai.NewPartFromText(" ")},
+		}}
 	}
 
 	// Send out the actual request.
@@ -321,20 +335,19 @@ func mergeCandidateMetadata(dst, src *genai.Candidate) {
 	}
 }
 
-// toGeminiContents converts the non-system messages of an [*ai.ModelRequest]
-// to a slice of [*genai.Content]. System messages are handled separately via
-// the request's system instruction.
+// toGeminiContents converts non-system messages to a slice of
+// [*genai.Content]. System messages are handled separately via the request's
+// system instruction.
 //
-// cachedThrough is the inclusive index of the last message stored in a
-// CachedContent resource, or -1 if no cache is in use. Messages at or before
-// that index must not be sent inline — the JS plugin slices the cached span
-// off the request, and sending it here would bill the prefix twice (#6137).
-func toGeminiContents(input *ai.ModelRequest, cachedThrough int) ([]*genai.Content, error) {
-	var contents []*genai.Content
-	for i, m := range input.Messages {
-		if cachedThrough >= 0 && i <= cachedThrough {
-			continue
-		}
+// It takes the messages rather than the request so that a caller using context
+// caching can hand it just the span it wants encoded. [handleCache] returns the
+// messages left after the cache boundary, and the cached prefix is encoded by
+// [messagesToCache] through this same function, so both halves of the
+// conversation agree on roles and on contentless turns, and the prefix is never
+// sent inline as well as by reference (#6137).
+func toGeminiContents(msgs []*ai.Message) ([]*genai.Content, error) {
+	contents := make([]*genai.Content, 0, len(msgs))
+	for _, m := range msgs {
 		// system parts are handled separately
 		if m.Role == ai.RoleSystem {
 			continue

--- a/go/plugins/googlegenai/gemini.go
+++ b/go/plugins/googlegenai/gemini.go
@@ -159,7 +159,7 @@ func generate(
 	}
 	model = resolveVertexModelName(client, model)
 
-	cache, err := handleCache(ctx, client, input, model)
+	cache, cachedThrough, err := handleCache(ctx, client, input, model)
 	if err != nil {
 		return nil, err
 	}
@@ -169,7 +169,7 @@ func generate(
 		return nil, err
 	}
 
-	contents, err := toGeminiContents(input)
+	contents, err := toGeminiContents(input, cachedThrough)
 	if err != nil {
 		return nil, err
 	}
@@ -324,9 +324,17 @@ func mergeCandidateMetadata(dst, src *genai.Candidate) {
 // toGeminiContents converts the non-system messages of an [*ai.ModelRequest]
 // to a slice of [*genai.Content]. System messages are handled separately via
 // the request's system instruction.
-func toGeminiContents(input *ai.ModelRequest) ([]*genai.Content, error) {
+//
+// cachedThrough is the inclusive index of the last message stored in a
+// CachedContent resource, or -1 if no cache is in use. Messages at or before
+// that index must not be sent inline — the JS plugin slices the cached span
+// off the request, and sending it here would bill the prefix twice (#6137).
+func toGeminiContents(input *ai.ModelRequest, cachedThrough int) ([]*genai.Content, error) {
 	var contents []*genai.Content
-	for _, m := range input.Messages {
+	for i, m := range input.Messages {
+		if cachedThrough >= 0 && i <= cachedThrough {
+			continue
+		}
 		// system parts are handled separately
 		if m.Role == ai.RoleSystem {
 			continue

--- a/go/plugins/googlegenai/gemini_test.go
+++ b/go/plugins/googlegenai/gemini_test.go
@@ -18,10 +18,12 @@ package googlegenai
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/firebase/genkit/go/ai"
@@ -1438,7 +1440,7 @@ func TestToGeminiContents(t *testing.T) {
 		},
 	}
 
-	contents, err := toGeminiContents(input, -1)
+	contents, err := toGeminiContents(input.Messages)
 	if err != nil {
 		t.Fatalf("toGeminiContents failed: %v", err)
 	}
@@ -1793,4 +1795,337 @@ func TestGenerateStreamBlockedCandidateMidStream(t *testing.T) {
 	if got := r.Text(); got != "so far" {
 		t.Errorf("Text() = %q, want %q", got, "so far")
 	}
+}
+
+// cacheServer stands in for the Gemini backend on the calls a cached request
+// makes: scanning for a reusable cache, creating one, and generating. The scan
+// comes back empty, so every test on it takes the create path. It records the
+// generateContent body so a test can assert what actually went on the wire.
+func cacheServer(t *testing.T, cacheName string, gotBody *map[string]any) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.Contains(r.URL.Path, "cachedContents") && r.Method == http.MethodGet:
+			fmt.Fprint(w, `{"cachedContents":[]}`)
+		case strings.Contains(r.URL.Path, "cachedContents"):
+			var req map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				t.Errorf("decode cachedContents body: %v", err)
+			}
+			fmt.Fprintf(w, `{"name":%q,"displayName":%q}`, cacheName, req["displayName"])
+		default:
+			if err := json.NewDecoder(r.Body).Decode(gotBody); err != nil {
+				t.Errorf("decode generateContent body: %v", err)
+			}
+			fmt.Fprint(w, `{"candidates":[{"content":{"role":"model","parts":[{"text":"ok"}]}}]}`)
+		}
+	}))
+}
+
+// contentTexts flattens the text of every content in a decoded
+// generateContent body.
+func contentTexts(t *testing.T, body map[string]any) []string {
+	t.Helper()
+	var texts []string
+	contents, _ := body["contents"].([]any)
+	for _, c := range contents {
+		parts, _ := c.(map[string]any)["parts"].([]any)
+		for _, p := range parts {
+			if s, ok := p.(map[string]any)["text"].(string); ok {
+				texts = append(texts, s)
+			}
+		}
+	}
+	return texts
+}
+
+// TestGenerateDropsCachedPrefix is the regression test for #6137: the prefix
+// folded into the cache resource must not also travel inline, or it is billed
+// twice and the model sees it twice. It drives generate end to end because the
+// bug was in the wiring, not in either helper on its own.
+func TestGenerateDropsCachedPrefix(t *testing.T) {
+	const (
+		prefix   = "a large stable prefix that should only live in the cache"
+		followUp = "what did I just say?"
+		name     = "cachedContents/abc123"
+	)
+	var body map[string]any
+	srv := cacheServer(t, name, &body)
+	defer srv.Close()
+
+	input := &ai.ModelRequest{Messages: []*ai.Message{
+		ai.NewUserTextMessage(prefix).WithCacheTTL(3600),
+		ai.NewUserTextMessage(followUp),
+	}}
+	r, err := generate(context.Background(), newTestClient(t, srv.URL), "gemini-2.5-flash", input, &genai.GenerateContentConfig{}, nil)
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+
+	if got := contentTexts(t, body); len(got) != 1 || got[0] != followUp {
+		t.Errorf("inline contents = %q, want only %q; the cached prefix was sent again", got, followUp)
+	}
+	if got := body["cachedContent"]; got != name {
+		t.Errorf("cachedContent = %v, want %q", got, name)
+	}
+	// The cache name rides back on the response so the next turn can reuse it.
+	cache, _ := r.Message.Metadata["cache"].(map[string]any)
+	if cache["name"] != name {
+		t.Errorf("response cache metadata = %v, want name %q", r.Message.Metadata["cache"], name)
+	}
+	// The full history stays on the request, so resp.History() can still find
+	// the marker on the next turn.
+	if len(r.Request.Messages) != 2 {
+		t.Errorf("r.Request.Messages = %d, want 2", len(r.Request.Messages))
+	}
+}
+
+// TestGenerateCachedPrefixCoversEveryMessage covers the boundary that leaves
+// nothing to send inline, e.g. one message carrying both a document and the
+// question. Dropping the prefix must not turn a request that worked into an
+// "at least one message is required" rejection.
+func TestGenerateCachedPrefixCoversEveryMessage(t *testing.T) {
+	var body map[string]any
+	srv := cacheServer(t, "cachedContents/only", &body)
+	defer srv.Close()
+
+	input := &ai.ModelRequest{Messages: []*ai.Message{
+		ai.NewUserTextMessage("a large document, and: summarize it").WithCacheTTL(3600),
+	}}
+	if _, err := generate(context.Background(), newTestClient(t, srv.URL), "gemini-2.5-flash", input, &genai.GenerateContentConfig{}, nil); err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+
+	if got := body["cachedContent"]; got != "cachedContents/only" {
+		t.Errorf("cachedContent = %v, want the cache to carry the prefix", got)
+	}
+	if got := contentTexts(t, body); len(got) != 1 || strings.TrimSpace(got[0]) != "" {
+		t.Errorf("inline contents = %q, want a single placeholder turn", got)
+	}
+}
+
+// TestGenerateNoMessages keeps the plain empty-request rejection, which the
+// cache placeholder above must not swallow.
+func TestGenerateNoMessages(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("generate should have failed before reaching the API")
+	}))
+	defer srv.Close()
+
+	_, err := generate(context.Background(), newTestClient(t, srv.URL), "gemini-2.5-flash", &ai.ModelRequest{}, &genai.GenerateContentConfig{}, nil)
+	if err == nil {
+		t.Fatal("generate = nil error, want an error for a request with no messages")
+	}
+}
+
+// TestGenerateRemakesUnusableCache covers the two ways a cache name carried
+// over from an earlier turn stops being usable: the resource is gone, or it no
+// longer holds what this request holds. Both build a fresh cache instead of
+// failing, because the name came from Genkit's own response metadata and the
+// caller has no way to act on the failure.
+func TestGenerateRemakesUnusableCache(t *testing.T) {
+	tests := []struct {
+		name   string
+		lookup func(w http.ResponseWriter)
+	}{
+		{
+			name: "resource expired",
+			lookup: func(w http.ResponseWriter) {
+				w.WriteHeader(http.StatusNotFound)
+				fmt.Fprint(w, `{"error":{"code":404,"message":"cache not found","status":"NOT_FOUND"}}`)
+			},
+		},
+		{
+			name: "contents no longer match",
+			lookup: func(w http.ResponseWriter) {
+				fmt.Fprint(w, `{"name":"cachedContents/stale","displayName":"the-hash-of-another-request"}`)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var created bool
+			var body map[string]any
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				switch {
+				case strings.HasSuffix(r.URL.Path, "cachedContents") && r.Method == http.MethodGet:
+					// The scan for a reusable cache finds nothing.
+					fmt.Fprint(w, `{"cachedContents":[]}`)
+				case strings.Contains(r.URL.Path, "cachedContents") && r.Method == http.MethodGet:
+					tt.lookup(w)
+				case strings.Contains(r.URL.Path, "cachedContents"):
+					created = true
+					fmt.Fprint(w, `{"name":"cachedContents/fresh","displayName":"fresh"}`)
+				default:
+					if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+						t.Errorf("decode generateContent body: %v", err)
+					}
+					fmt.Fprint(w, `{"candidates":[{"content":{"role":"model","parts":[{"text":"ok"}]}}]}`)
+				}
+			}))
+			defer srv.Close()
+
+			// The ttl marker and the name from the previous turn ride on
+			// different messages, the way resp.History() replays them.
+			input := &ai.ModelRequest{Messages: []*ai.Message{
+				ai.NewUserTextMessage("a large stable prefix").WithCacheTTL(3600),
+				ai.NewModelTextMessage("an earlier answer").WithCacheName("cachedContents/stale"),
+				ai.NewUserTextMessage("follow up"),
+			}}
+			if _, err := generate(context.Background(), newTestClient(t, srv.URL), "gemini-2.5-flash", input, &genai.GenerateContentConfig{}, nil); err != nil {
+				t.Fatalf("generate: %v", err)
+			}
+
+			if !created {
+				t.Error("no fresh cache was created for an unusable cache name")
+			}
+			if got := body["cachedContent"]; got != "cachedContents/fresh" {
+				t.Errorf("cachedContent = %v, want the fresh cache", got)
+			}
+			if got := contentTexts(t, body); len(got) != 2 {
+				t.Errorf("inline contents = %q, want the two messages after the cache boundary", got)
+			}
+		})
+	}
+}
+
+// TestGenerateReusesCacheWithSameContents covers the caller who rebuilds the
+// same prefix rather than replaying resp.History(). The cache name only ever
+// travels back through the response metadata, so that caller arrives with no
+// name and used to mint, and pay to store, a fresh copy on every single call.
+func TestGenerateReusesCacheWithSameContents(t *testing.T) {
+	var created bool
+	var body map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.HasSuffix(r.URL.Path, "cachedContents") && r.Method == http.MethodGet:
+			// A cache holding this exact prefix already exists. Its display
+			// name is the hash the plugin is about to compute.
+			contents, err := messagesToCache(cachedPrefixRequest().Messages, 0)
+			if err != nil {
+				t.Fatalf("messagesToCache: %v", err)
+			}
+			hash, err := calculateCacheHash(contents, "gemini-2.5-flash")
+			if err != nil {
+				t.Fatalf("calculateCacheHash: %v", err)
+			}
+			fmt.Fprintf(w, `{"cachedContents":[{"name":"cachedContents/other","displayName":"nope"},{"name":"cachedContents/existing","displayName":%q}]}`, hash)
+		case strings.Contains(r.URL.Path, "cachedContents"):
+			created = true
+			fmt.Fprint(w, `{"name":"cachedContents/wasteful","displayName":"x"}`)
+		default:
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Errorf("decode generateContent body: %v", err)
+			}
+			fmt.Fprint(w, `{"candidates":[{"content":{"role":"model","parts":[{"text":"ok"}]}}]}`)
+		}
+	}))
+	defer srv.Close()
+
+	if _, err := generate(context.Background(), newTestClient(t, srv.URL), "gemini-2.5-flash", cachedPrefixRequest(), &genai.GenerateContentConfig{}, nil); err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+
+	if created {
+		t.Error("a second cache was created for contents already cached")
+	}
+	if got := body["cachedContent"]; got != "cachedContents/existing" {
+		t.Errorf("cachedContent = %v, want the cache that already held the prefix", got)
+	}
+}
+
+// cachedPrefixRequest is the canonical shape from the README: a large stable
+// message marked for caching, then the question.
+func cachedPrefixRequest() *ai.ModelRequest {
+	return &ai.ModelRequest{Messages: []*ai.Message{
+		ai.NewUserTextMessage("a large stable prefix").WithCacheTTL(3600),
+		ai.NewUserTextMessage("what did I just say?"),
+	}}
+}
+
+// TestGenerateWithCacheNameOnly covers ai.Message.WithCacheName used on its
+// own, which the README offers alongside WithCacheTTL. It used to be a silent
+// no-op: the whole prefix went inline at full price with no cache and no
+// error, which is bug #6137 by another route.
+func TestGenerateWithCacheNameOnly(t *testing.T) {
+	prefix := ai.NewUserTextMessage("a large stable prefix")
+	request := func() *ai.ModelRequest {
+		return &ai.ModelRequest{Messages: []*ai.Message{
+			ai.NewUserTextMessage("a large stable prefix").WithCacheName("cachedContents/known"),
+			ai.NewUserTextMessage("what did I just say?"),
+		}}
+	}
+	contents, err := messagesToCache([]*ai.Message{prefix}, 0)
+	if err != nil {
+		t.Fatalf("messagesToCache: %v", err)
+	}
+	hash, err := calculateCacheHash(contents, "gemini-2.5-flash")
+	if err != nil {
+		t.Fatalf("calculateCacheHash: %v", err)
+	}
+
+	t.Run("named cache holds the prefix", func(t *testing.T) {
+		var body map[string]any
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			switch {
+			case strings.Contains(r.URL.Path, "cachedContents"):
+				fmt.Fprintf(w, `{"name":"cachedContents/known","displayName":%q}`, hash)
+			default:
+				if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+					t.Errorf("decode generateContent body: %v", err)
+				}
+				fmt.Fprint(w, `{"candidates":[{"content":{"role":"model","parts":[{"text":"ok"}]}}]}`)
+			}
+		}))
+		defer srv.Close()
+
+		if _, err := generate(context.Background(), newTestClient(t, srv.URL), "gemini-2.5-flash", request(), &genai.GenerateContentConfig{}, nil); err != nil {
+			t.Fatalf("generate: %v", err)
+		}
+		if got := body["cachedContent"]; got != "cachedContents/known" {
+			t.Errorf("cachedContent = %v, want the named cache to be used", got)
+		}
+		if got := contentTexts(t, body); len(got) != 1 || got[0] != "what did I just say?" {
+			t.Errorf("inline contents = %q, want only the question", got)
+		}
+	})
+
+	t.Run("named cache is gone", func(t *testing.T) {
+		// No ttl means there is nothing to build a replacement with, so the
+		// request goes out whole rather than failing or losing the prefix.
+		var body map[string]any
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			switch {
+			case strings.HasSuffix(r.URL.Path, "cachedContents") && r.Method == http.MethodGet:
+				fmt.Fprint(w, `{"cachedContents":[]}`)
+			case strings.Contains(r.URL.Path, "cachedContents") && r.Method == http.MethodGet:
+				w.WriteHeader(http.StatusNotFound)
+				fmt.Fprint(w, `{"error":{"code":404,"message":"cache not found","status":"NOT_FOUND"}}`)
+			case strings.Contains(r.URL.Path, "cachedContents"):
+				t.Error("no cache should be created without a ttl")
+			default:
+				if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+					t.Errorf("decode generateContent body: %v", err)
+				}
+				fmt.Fprint(w, `{"candidates":[{"content":{"role":"model","parts":[{"text":"ok"}]}}]}`)
+			}
+		}))
+		defer srv.Close()
+
+		if _, err := generate(context.Background(), newTestClient(t, srv.URL), "gemini-2.5-flash", request(), &genai.GenerateContentConfig{}, nil); err != nil {
+			t.Fatalf("generate: %v", err)
+		}
+		if _, ok := body["cachedContent"]; ok {
+			t.Errorf("cachedContent = %v, want no cache on the request", body["cachedContent"])
+		}
+		if got := contentTexts(t, body); len(got) != 2 {
+			t.Errorf("inline contents = %q, want the whole request", got)
+		}
+	})
 }

--- a/go/plugins/googlegenai/gemini_test.go
+++ b/go/plugins/googlegenai/gemini_test.go
@@ -1438,7 +1438,7 @@ func TestToGeminiContents(t *testing.T) {
 		},
 	}
 
-	contents, err := toGeminiContents(input)
+	contents, err := toGeminiContents(input, -1)
 	if err != nil {
 		t.Fatalf("toGeminiContents failed: %v", err)
 	}

--- a/go/plugins/googlegenai/googleai_live_test.go
+++ b/go/plugins/googlegenai/googleai_live_test.go
@@ -678,6 +678,9 @@ func TestCacheHelper(t *testing.T) {
 			t.Fatalf("expecting to be bar but got: %q", bar)
 		}
 
+		// A name and a ttl say different things: which cache an earlier turn
+		// built, and how long to keep the one this turn builds. Setting one
+		// leaves the other in place.
 		m.WithCacheName("dummy-name")
 		metadata = m.Metadata
 		cache, ok = metadata["cache"].(map[string]any)
@@ -685,12 +688,12 @@ func TestCacheHelper(t *testing.T) {
 			t.Fatalf("cache should be a map, got: %T", cache)
 		}
 		ttl, ok := cache["ttlSeconds"].(int)
-		if ok {
-			t.Fatalf("cache should have been overwriten, expecting cache name, not ttl: %d", ttl)
+		if !ok || ttl != 50 {
+			t.Fatalf("ttlSeconds should have survived setting the cache name, got: %v", cache["ttlSeconds"])
 		}
 		name, ok := cache["name"].(string)
 		if !ok {
-			t.Fatalf("cache should have been overwriten, expecting cache name, got: %v", name)
+			t.Fatalf("expecting a cache name, got: %v", cache["name"])
 		}
 		if name != "dummy-name" {
 			t.Fatalf("cache name mismatch, want dummy-name, got: %s", name)


### PR DESCRIPTION
Fixes #6137

Repairs the explicit context-caching path, which billed a caller more for turning it on than for leaving it off.

## Bugs fixed

**The cached prefix was sent inline as well.** `handleCache` stored `messages[0..endIndex]` on the `CachedContent` resource and left `request.Messages` alone, so `toGeminiContents` sent them again: billed as cached tokens and as full-price input, and seen twice by the model. `handleCache` now returns the messages that still have to go on the wire, so nothing downstream needs to know a cache exists. JS slices the same span off `chatRequest.history`.

**The cached span was encoded differently from the inline one.** It was built backwards, wrote `ai.RoleTool` through as role `"tool"`, which the Content API rejects, and kept messages whose parts converted to nothing, which it also rejects. Both spans now share one converter, so they cannot drift apart again.

**The content hash could not tell two caches apart.** Only `Text` and `InlineData` reached the digest, with no separator, so every `gs://` document hashed to the digest of no bytes at all and `[ab]` collided with `[a][b]`. That hash is the only check that a named cache holds the request's own content. Contents now hash by their JSON encoding, keyed by model.

**Every request created a new cache.** Nothing looked for a resource already holding the same content, and the name reaches the caller only through response metadata. `handleCache` now scans display names first, bounded at 200. A cache that no longer resolves or no longer matches is rebuilt, rather than returned as an error the caller cannot act on.

**The markers cancelled each other, and a name alone did nothing.** `WithCacheTTL` and `WithCacheName` each replaced the whole `cache` metadata map, and `findCacheMarker` ignored a name unless a ttl accompanied it, so caching was silently off and the prefix went inline at full price.

```go
msg := ai.NewUserTextMessage(doc).WithCacheTTL(3600).WithCacheName(known)
// cache metadata: {"ttlSeconds": 3600, "name": known}
```

## Behavior worth noting

Gemini 2.5 and newer cache repeated prefixes implicitly, on by default and with no storage charge, while `WithCacheTTL` bills a resource for its lifetime. `Usage.CachedContentTokens` reports a hit either way, so the explicit path earns its cost only when the hit has to be guaranteed. Marking the last message leaves nothing to send inline, so the request carries a minimal turn rather than failing.
