### PR TITLE
feat(js/plugins/compat-oai): add Responses streaming, tool calling, and reasoning round-trip

### DIFF
--- a/js/plugins/compat-oai/src/openai/index.ts
+++ b/js/plugins/compat-oai/src/openai/index.ts
@@ -57,6 +57,7 @@ import {
   SUPPORTED_GPT_MODELS,
 } from './gpt.js';
 import {
+  isNonStreamingResponsesModelName,
   isResponsesOnlyModelName,
   OpenAIResponsesConfigSchema,
   openAIResponsesModelRef,
@@ -138,6 +139,9 @@ function createResolver(pluginOptions: PluginOptions) {
         client,
         pluginOptions,
         modelRef,
+        streaming: !isNonStreamingResponsesModelName(
+          toModelName(actionName, pluginOptions.name)
+        ),
       });
     } else {
       const modelRef = openAIModelRef({ name: actionName });
@@ -249,6 +253,9 @@ export function openAIPlugin(options?: OpenAIPluginOptions): GenkitPluginV2 {
             client,
             pluginOptions,
             modelRef,
+            streaming: !isNonStreamingResponsesModelName(
+              toModelName(modelRef.name, pluginOptions.name)
+            ),
           })
         )
       );

--- a/js/plugins/compat-oai/src/openai/responses.ts
+++ b/js/plugins/compat-oai/src/openai/responses.ts
@@ -84,7 +84,8 @@ export const OpenAIResponsesConfigSchema = ResponsesCommonConfigSchema.extend({
 const RESPONSES_MODEL_INFO: ModelInfo = {
   supports: {
     multiturn: true,
-    tools: false,
+    tools: true,
+    toolChoice: true,
     media: true,
     systemRole: true,
     output: ['text', 'json'],

--- a/js/plugins/compat-oai/src/openai/responses.ts
+++ b/js/plugins/compat-oai/src/openai/responses.ts
@@ -75,6 +75,25 @@ export function isResponsesOnlyModelName(
   );
 }
 
+/**
+ * Responses-only models that reject `stream: true`. A streaming caller gets
+ * the completed response delivered as a single chunk instead. Hand-curated
+ * like {@link RESPONSES_ONLY_MODELS}, from the per-model feature tables.
+ */
+export const NON_STREAMING_RESPONSES_MODELS = ['o1-pro', 'o3-pro'] as const;
+
+/**
+ * Checks whether a Responses model name must not be streamed, with the same
+ * suffix bias as {@link isResponsesOnlyModelName}.
+ * @param name The bare model name, without the plugin namespace.
+ */
+export function isNonStreamingResponsesModelName(name?: string): boolean {
+  if (!name) return false;
+  return NON_STREAMING_RESPONSES_MODELS.some(
+    (base) => name === base || name.startsWith(`${base}-`)
+  );
+}
+
 /** OpenAI Responses API custom configuration schema. */
 export const OpenAIResponsesConfigSchema = ResponsesCommonConfigSchema.extend({
   store: z.boolean().optional(),

--- a/js/plugins/compat-oai/src/responses.ts
+++ b/js/plugins/compat-oai/src/responses.ts
@@ -294,6 +294,22 @@ export function toOpenAIResponsesInput(
   };
 }
 
+/**
+ * Checks whether a model belongs to a reasoning family, i.e. can return
+ * reasoning items with encrypted content.
+ *
+ * Hand-curated by family like the transport lists in openai/responses.ts:
+ * requesting `reasoning.encrypted_content` from a non-reasoning model is a
+ * 400, not a no-op. Chat-tuned variants (`gpt-5-chat-latest`) are the
+ * non-reasoning exceptions inside a reasoning family.
+ * @param name The bare model name, without the plugin namespace.
+ */
+export function isReasoningModelName(name?: string): boolean {
+  if (!name) return false;
+  if (name.includes('chat')) return false;
+  return /^o\d|^gpt-5|^codex/.test(name);
+}
+
 /** Drops keys whose value is `undefined` so they never show up in traces. */
 function stripUndefined<T extends object>(value: T): T {
   return Object.fromEntries(
@@ -378,15 +394,18 @@ export function toOpenAIResponsesRequestBody(
       ? [includeFromConfig as ResponseIncludable]
       : (includeFromConfig as ResponseIncludable[] | undefined);
   // Under the stateless default the encrypted reasoning payload is the only
-  // context a reasoning model can resume from, so it is always requested.
-  const include: ResponseIncludable[] | undefined = storeValue
-    ? callerInclude
-    : [
-        ...new Set<ResponseIncludable>([
-          ...(callerInclude ?? []),
-          'reasoning.encrypted_content',
-        ]),
-      ];
+  // context a reasoning model can resume from, so it is requested for every
+  // model that can return one; asking a non-reasoning model for it is a 400,
+  // not a no-op, so the gate matters for dual-transport models.
+  const include: ResponseIncludable[] | undefined =
+    !storeValue && isReasoningModelName((modelVersion as string) ?? modelName)
+      ? [
+          ...new Set<ResponseIncludable>([
+            ...(callerInclude ?? []),
+            'reasoning.encrypted_content',
+          ]),
+        ]
+      : callerInclude;
 
   const body: ResponseCreateParamsNonStreaming = {
     model: modelVersion ?? modelName,

--- a/js/plugins/compat-oai/src/responses.ts
+++ b/js/plugins/compat-oai/src/responses.ts
@@ -622,6 +622,10 @@ export interface ResponsesToolCallAccumulator {
  * `output_index`. Mutated in place as fragments arrive.
  * @returns The chunk to emit, or `undefined` for events with no chunk-visible
  * payload.
+ *
+ * Chunks carry no `index`: that field is the position of the message in the
+ * conversation, not the response's `output_index`, and core fills it with the
+ * tool-loop message index when omitted.
  */
 export function fromOpenAIResponsesStreamEvent(
   event: ResponseStreamEvent,
@@ -629,14 +633,11 @@ export function fromOpenAIResponsesStreamEvent(
 ): GenerateResponseChunkData | undefined {
   switch (event.type) {
     case 'response.output_text.delta':
-      return { index: event.output_index, content: [{ text: event.delta }] };
+      return { content: [{ text: event.delta }] };
     case 'response.refusal.delta':
-      return { index: event.output_index, content: [{ text: event.delta }] };
+      return { content: [{ text: event.delta }] };
     case 'response.reasoning_summary_text.delta':
-      return {
-        index: event.output_index,
-        content: [{ reasoning: event.delta }],
-      };
+      return { content: [{ reasoning: event.delta }] };
     case 'response.output_item.added': {
       if (event.item.type !== 'function_call') return undefined;
       const acc: ResponsesToolCallAccumulator = {
@@ -646,7 +647,6 @@ export function fromOpenAIResponsesStreamEvent(
       };
       toolCalls.set(event.output_index, acc);
       return {
-        index: event.output_index,
         content: [
           {
             toolRequest: {
@@ -670,7 +670,6 @@ export function fromOpenAIResponsesStreamEvent(
         input = {};
       }
       return {
-        index: event.output_index,
         content: [
           {
             toolRequest: { name: acc.name, ref: acc.ref, input, partial: true },
@@ -751,7 +750,6 @@ export function openAIResponsesModelRunner(
       );
       if (options?.streamingRequested && !canStream && options.sendChunk) {
         options.sendChunk({
-          index: 0,
           content: converted.message?.content ?? [],
         });
       }

--- a/js/plugins/compat-oai/src/responses.ts
+++ b/js/plugins/compat-oai/src/responses.ts
@@ -272,10 +272,12 @@ export function toOpenAIResponsesInput(
           input.push({
             type: 'function_call_output',
             call_id: part.toolResponse.ref ?? '',
+            // `output` is required on the wire; a void tool's undefined would
+            // vanish from the serialized JSON entirely.
             output:
               typeof part.toolResponse.output === 'string'
                 ? part.toolResponse.output
-                : JSON.stringify(part.toolResponse.output),
+                : JSON.stringify(part.toolResponse.output ?? null),
           });
         }
         break;
@@ -369,13 +371,19 @@ export function toOpenAIResponsesRequestBody(
   }
 
   const storeValue = store ?? false;
+  // A bare-string `include` from the passthrough config would otherwise be
+  // spread into single characters below.
+  const callerInclude =
+    typeof includeFromConfig === 'string'
+      ? [includeFromConfig as ResponseIncludable]
+      : (includeFromConfig as ResponseIncludable[] | undefined);
   // Under the stateless default the encrypted reasoning payload is the only
   // context a reasoning model can resume from, so it is always requested.
   const include: ResponseIncludable[] | undefined = storeValue
-    ? (includeFromConfig as ResponseIncludable[] | undefined)
+    ? callerInclude
     : [
         ...new Set<ResponseIncludable>([
-          ...((includeFromConfig as ResponseIncludable[] | undefined) ?? []),
+          ...(callerInclude ?? []),
           'reasoning.encrypted_content',
         ]),
       ];

--- a/js/plugins/compat-oai/src/responses.ts
+++ b/js/plugins/compat-oai/src/responses.ts
@@ -31,14 +31,20 @@ import {
   z,
 } from 'genkit';
 import { parsePartialJson } from 'genkit/extract';
-import type { ModelAction, ModelInfo } from 'genkit/model';
+import type { ModelAction, ModelInfo, ToolDefinition } from 'genkit/model';
 import { model } from 'genkit/plugin';
 import type OpenAI from 'openai';
 import type {
+  FunctionTool,
   Response as OpenAIResponse,
   ResponseCreateParamsNonStreaming,
+  ResponseIncludable,
   ResponseInput,
   ResponseInputContent,
+  ResponseInputItem,
+  ResponseReasoningItem,
+  ResponseStreamEvent,
+  Tool,
 } from 'openai/resources/responses/responses.mjs';
 import { PluginOptions } from './index.js';
 import {
@@ -125,27 +131,92 @@ export function toOpenAIResponsesContent(
 }
 
 /**
- * Serializes a prior model turn into the text of an assistant input message.
+ * Converts a Genkit ToolDefinition into a Responses API function tool.
+ *
+ * The Responses `FunctionTool` shape is flat and requires `strict`, so the Chat
+ * Completions converter cannot be reused. `strict` stays null: genkit tool
+ * schemas are not authored for OpenAI strict mode, which rejects any schema
+ * missing `additionalProperties: false`.
+ * @param tool The Genkit ToolDefinition to convert.
+ * @returns The corresponding Responses API function tool.
+ */
+export function toOpenAIResponsesTool(tool: ToolDefinition): FunctionTool {
+  return {
+    type: 'function',
+    name: tool.name,
+    description: tool.description,
+    parameters: (tool.inputSchema ?? null) as Record<string, unknown> | null,
+    strict: null,
+  };
+}
+
+/**
+ * Serializes a prior model turn into Responses API input items, preserving the
+ * order of text, tool-call and reasoning parts.
  *
  * Structured output comes back as a `data` part carrying no text, so replaying
  * only the turn's text would send an empty assistant message and lose the
- * model's own previous answer.
+ * model's own previous answer. Reasoning parts replay only through the
+ * encrypted round-trip: the item id and encrypted payload ride `part.metadata`,
+ * and a summary-only reasoning part carries nothing the API can resume from.
  * @param parts The content of the model message.
- * @returns The assistant message text, empty when the turn carries nothing
- * this transport can replay.
+ * @returns The input items, empty when the turn carries nothing this transport
+ * can replay.
  * @throws GenkitError if a part cannot be represented in assistant history.
  */
-function fromModelTurn(parts: Part[]): string {
+function toModelTurnItems(parts: Part[]): ResponseInputItem[] {
+  const items: ResponseInputItem[] = [];
   let text = '';
-  for (const part of parts) {
+  const flushText = () => {
+    if (text) {
+      items.push({ role: 'assistant', content: text });
+      text = '';
+    }
+  };
+  for (let i = 0; i < parts.length; i++) {
+    const part = parts[i];
     if (part.text !== undefined) {
       text += part.text;
     } else if (part.data !== undefined) {
       text += JSON.stringify(part.data);
+    } else if (part.toolRequest !== undefined) {
+      flushText();
+      const itemId = part.metadata?.itemId as string | undefined;
+      items.push({
+        type: 'function_call',
+        call_id: part.toolRequest.ref ?? '',
+        name: part.toolRequest.name,
+        arguments: JSON.stringify(part.toolRequest.input ?? {}),
+        ...(itemId ? { id: itemId } : {}),
+      });
     } else if (part.reasoning !== undefined) {
-      // Reasoning is replayed through the encrypted round-trip, which this
-      // slice does not implement; the plain summary adds nothing on its own.
-      continue;
+      const itemId = part.metadata?.itemId as string | undefined;
+      if (!itemId) continue;
+      flushText();
+      // One Responses reasoning item was fanned out into one part per summary;
+      // fold consecutive parts with the same item id back into a single item.
+      const summary: ResponseReasoningItem['summary'] = [];
+      let encrypted: string | undefined;
+      let j = i;
+      for (
+        ;
+        j < parts.length &&
+        parts[j].reasoning !== undefined &&
+        parts[j].metadata?.itemId === itemId;
+        j++
+      ) {
+        if (parts[j].reasoning) {
+          summary.push({ type: 'summary_text', text: parts[j].reasoning! });
+        }
+        encrypted ??= parts[j].metadata?.encryptedContent as string | undefined;
+      }
+      i = j - 1;
+      items.push({
+        type: 'reasoning',
+        id: itemId,
+        summary,
+        ...(encrypted ? { encrypted_content: encrypted } : {}),
+      });
     } else {
       throw new GenkitError({
         status: 'INVALID_ARGUMENT',
@@ -153,7 +224,8 @@ function fromModelTurn(parts: Part[]): string {
       });
     }
   }
-  return text;
+  flushText();
+  return items;
 }
 
 /**
@@ -186,13 +258,27 @@ export function toOpenAIResponsesInput(
           ),
         });
         break;
-      case 'model': {
-        // An assistant message with no content carries nothing and OpenAI
-        // rejects it, so a turn that reduces to nothing is left out entirely.
-        const content = fromModelTurn(msg.content);
-        if (content) input.push({ role: 'assistant', content });
+      case 'model':
+        input.push(...toModelTurnItems(msg.content));
         break;
-      }
+      case 'tool':
+        for (const part of msg.content) {
+          if (part.toolResponse === undefined) {
+            throw new GenkitError({
+              status: 'INVALID_ARGUMENT',
+              message: `Unsupported genkit part fields encountered for current message role: ${JSON.stringify(part)}.`,
+            });
+          }
+          input.push({
+            type: 'function_call_output',
+            call_id: part.toolResponse.ref ?? '',
+            output:
+              typeof part.toolResponse.output === 'string'
+                ? part.toolResponse.output
+                : JSON.stringify(part.toolResponse.output),
+          });
+        }
+        break;
       default:
         throw new GenkitError({
           status: 'UNIMPLEMENTED',
@@ -223,16 +309,6 @@ export function toOpenAIResponsesRequestBody(
   modelName: string,
   request: GenerateRequest
 ): ResponseCreateParamsNonStreaming {
-  // Genkit only warns when a model declares `supports.tools: false`, so without
-  // this the tools would be dropped and the model would answer as if none had
-  // been offered.
-  if (request.tools?.length) {
-    throw new GenkitError({
-      status: 'INVALID_ARGUMENT',
-      message: `Tool calling is not yet supported on the OpenAI Responses API transport (model ${modelName}).`,
-    });
-  }
-
   const { input, instructions } = toOpenAIResponsesInput(
     request.messages,
     request.config?.visualDetailLevel
@@ -247,6 +323,8 @@ export function toOpenAIResponsesRequestBody(
     version: modelVersion,
     store,
     instructions: instructionsFromConfig,
+    tools: toolsFromConfig,
+    include: includeFromConfig,
     // Selects the OpenAI transport; it is a plugin concept, not a wire field.
     transport,
     stream,
@@ -285,6 +363,23 @@ export function toOpenAIResponsesRequestBody(
       .filter(Boolean)
       .join('\n\n') || undefined;
 
+  const tools: Tool[] = request.tools?.map(toOpenAIResponsesTool) ?? [];
+  if (toolsFromConfig) {
+    tools.push(...(toolsFromConfig as Tool[]));
+  }
+
+  const storeValue = store ?? false;
+  // Under the stateless default the encrypted reasoning payload is the only
+  // context a reasoning model can resume from, so it is always requested.
+  const include: ResponseIncludable[] | undefined = storeValue
+    ? (includeFromConfig as ResponseIncludable[] | undefined)
+    : [
+        ...new Set<ResponseIncludable>([
+          ...((includeFromConfig as ResponseIncludable[] | undefined) ?? []),
+          'reasoning.encrypted_content',
+        ]),
+      ];
+
   const body: ResponseCreateParamsNonStreaming = {
     model: modelVersion ?? modelName,
     input,
@@ -292,9 +387,12 @@ export function toOpenAIResponsesRequestBody(
     max_output_tokens,
     temperature,
     top_p,
+    tools: tools.length ? tools : undefined,
+    tool_choice: request.toolChoice,
+    include,
     // The Responses API retains requests and responses server-side by default;
     // pinning it off matches the Chat Completions retention posture.
-    store: store ?? false,
+    store: storeValue,
     ...restOfConfig,
   };
 
@@ -352,13 +450,6 @@ function toFinishInfo(response: OpenAIResponse): {
 }
 
 /**
- * Output items asking the caller to run a tool. Genkit has no way to answer one
- * on this transport yet, and dropping it would leave the caller with an empty
- * response instead of an error.
- */
-const TOOL_CALL_ITEM_TYPES = new Set(['function_call', 'custom_tool_call']);
-
-/**
  * Best-effort conversion of json-mode output text into a data part. A response
  * truncated by `max_output_tokens` or a content filter can end with partial
  * JSON, which must surface through the finish reason rather than as a
@@ -381,7 +472,7 @@ function toJsonData(text: string): Part {
  * @param response The Response to convert.
  * @param jsonMode Whether the response text is expected to be JSON.
  * @returns The converted Genkit GenerateResponseData object.
- * @throws GenkitError if the response failed or asks for a tool call.
+ * @throws GenkitError if the response failed or asks for a custom tool call.
  */
 export function fromOpenAIResponse(
   response: OpenAIResponse,
@@ -402,24 +493,58 @@ export function fromOpenAIResponse(
   let refused = false;
   for (const item of response.output ?? []) {
     if (item.type === 'reasoning') {
-      for (const summary of item.summary ?? []) {
-        if (summary.text) content.push({ reasoning: summary.text });
+      // The item id and encrypted payload ride part metadata so the item can
+      // be reassembled and replayed on the next stateless turn. The payload
+      // rides only the item's first part; the id marks the rest as one item.
+      const meta: Record<string, unknown> = { itemId: item.id };
+      if (item.encrypted_content) {
+        meta.encryptedContent = item.encrypted_content;
+      }
+      const summaries = (item.summary ?? []).filter((s) => s.text);
+      if (summaries.length === 0) {
+        // A reasoning model asked for no summary still returns the item; the
+        // empty part exists purely to carry the payload through history.
+        if (item.encrypted_content) {
+          content.push({ reasoning: '', metadata: meta });
+        }
+      } else {
+        summaries.forEach((summary, index) => {
+          content.push({
+            reasoning: summary.text,
+            metadata: index === 0 ? meta : { itemId: item.id },
+          });
+        });
       }
     } else if (item.type === 'message') {
       for (const contentItem of item.content ?? []) {
         if (contentItem.type === 'output_text') {
-          content.push(
-            jsonMode ? toJsonData(contentItem.text) : { text: contentItem.text }
-          );
+          const part: Part = jsonMode
+            ? toJsonData(contentItem.text)
+            : { text: contentItem.text };
+          if (contentItem.annotations?.length) {
+            part.metadata = { annotations: contentItem.annotations };
+          }
+          content.push(part);
         } else if (contentItem.type === 'refusal') {
           refused = true;
           content.push({ text: contentItem.refusal });
         }
       }
-    } else if (TOOL_CALL_ITEM_TYPES.has(item.type)) {
+    } else if (item.type === 'function_call') {
+      content.push({
+        toolRequest: {
+          name: item.name,
+          ref: item.call_id,
+          input: item.arguments ? JSON.parse(item.arguments) : {},
+        },
+        ...(item.id ? { metadata: { itemId: item.id } } : {}),
+      });
+    } else if ((item.type as string) === 'custom_tool_call') {
+      // The pinned SDK's output-item union predates custom tools, but the live
+      // API can still return one.
       throw new GenkitError({
         status: 'UNIMPLEMENTED',
-        message: `Tool calling is not yet supported on the OpenAI Responses API transport; the model returned a '${item.type}' item.`,
+        message: `Custom tool calls are not supported on the OpenAI Responses API transport; the model returned a 'custom_tool_call' item.`,
       });
     }
     // Records of tools OpenAI ran itself (`web_search_call`, `mcp_call`, ...);
@@ -445,6 +570,91 @@ export function fromOpenAIResponse(
     },
     raw: response,
   };
+}
+
+/**
+ * Accumulates the streamed argument fragments of one function call. The
+ * `response.output_item.added` event carries the call's `name` and `call_id`;
+ * subsequent `response.function_call_arguments.delta` events carry only
+ * fragments of the `arguments` JSON string, keyed by `output_index`.
+ */
+export interface ResponsesToolCallAccumulator {
+  name: string;
+  ref: string;
+  /** Concatenated `arguments` JSON string fragments received so far. */
+  args: string;
+}
+
+/**
+ * Converts one Responses API stream event into a Genkit response chunk.
+ *
+ * Annotation events are deliberately ignored: annotations attach to the final
+ * text part's metadata in {@link fromOpenAIResponse}, which every streamed
+ * request still runs through.
+ * @param event The stream event to convert.
+ * @param toolCalls Per-request function-call accumulators, keyed by
+ * `output_index`. Mutated in place as fragments arrive.
+ * @returns The chunk to emit, or `undefined` for events with no chunk-visible
+ * payload.
+ */
+export function fromOpenAIResponsesStreamEvent(
+  event: ResponseStreamEvent,
+  toolCalls: Map<number, ResponsesToolCallAccumulator>
+): GenerateResponseChunkData | undefined {
+  switch (event.type) {
+    case 'response.output_text.delta':
+      return { index: event.output_index, content: [{ text: event.delta }] };
+    case 'response.refusal.delta':
+      return { index: event.output_index, content: [{ text: event.delta }] };
+    case 'response.reasoning_summary_text.delta':
+      return {
+        index: event.output_index,
+        content: [{ reasoning: event.delta }],
+      };
+    case 'response.output_item.added': {
+      if (event.item.type !== 'function_call') return undefined;
+      const acc: ResponsesToolCallAccumulator = {
+        name: event.item.name,
+        ref: event.item.call_id,
+        args: event.item.arguments ?? '',
+      };
+      toolCalls.set(event.output_index, acc);
+      return {
+        index: event.output_index,
+        content: [
+          {
+            toolRequest: {
+              name: acc.name,
+              ref: acc.ref,
+              input: {},
+              partial: true,
+            },
+          },
+        ],
+      };
+    }
+    case 'response.function_call_arguments.delta': {
+      const acc = toolCalls.get(event.output_index);
+      if (!acc) return undefined;
+      acc.args += event.delta;
+      let input: unknown = {};
+      try {
+        input = acc.args ? parsePartialJson(acc.args) : {};
+      } catch {
+        input = {};
+      }
+      return {
+        index: event.output_index,
+        content: [
+          {
+            toolRequest: { name: acc.name, ref: acc.ref, input, partial: true },
+          },
+        ],
+      };
+    }
+    default:
+      return undefined;
+  }
 }
 
 /**
@@ -474,24 +684,25 @@ export function openAIResponsesModelRunner(
       defaultClient
     );
     try {
-      const response = await client.responses.create(
-        toOpenAIResponsesRequestBody(name, request),
-        { signal: options?.abortSignal }
-      );
-      const converted = fromOpenAIResponse(
-        response,
-        request.output?.format === 'json'
-      );
-      // The Responses event protocol is not mapped yet, so a streaming caller
-      // gets the completed response delivered as a single chunk rather than
-      // nothing at all.
-      if (options?.streamingRequested && options.sendChunk) {
-        options.sendChunk({
-          index: 0,
-          content: converted.message?.content ?? [],
+      const body = toOpenAIResponsesRequestBody(name, request);
+      let response: OpenAIResponse;
+      if (options?.streamingRequested) {
+        const stream = client.responses.stream(
+          { ...body, stream: true },
+          { signal: options?.abortSignal }
+        );
+        const toolCalls = new Map<number, ResponsesToolCallAccumulator>();
+        for await (const event of stream) {
+          const chunk = fromOpenAIResponsesStreamEvent(event, toolCalls);
+          if (chunk) options.sendChunk!(chunk);
+        }
+        response = await stream.finalResponse();
+      } else {
+        response = await client.responses.create(body, {
+          signal: options?.abortSignal,
         });
       }
-      return converted;
+      return fromOpenAIResponse(response, request.output?.format === 'json');
     } catch (e) {
       rethrowOpenAIError(e);
     }
@@ -537,7 +748,8 @@ const GENERIC_RESPONSES_MODEL_INFO: ModelInfo = {
   supports: {
     multiturn: true,
     media: true,
-    tools: false,
+    tools: true,
+    toolChoice: true,
     systemRole: true,
     output: ['text', 'json'],
     // Without this genkit wraps the model in simulateConstrainedGeneration,

--- a/js/plugins/compat-oai/src/responses.ts
+++ b/js/plugins/compat-oai/src/responses.ts
@@ -476,6 +476,24 @@ function toJsonData(text: string): Part {
 }
 
 /**
+ * Best-effort parse of a function call's `arguments` string. A response
+ * truncated by `max_output_tokens` can end with partial JSON, which must
+ * surface as a `length` finish reason rather than a SyntaxError.
+ */
+function parseFunctionCallArguments(args: string): unknown {
+  if (!args) return {};
+  try {
+    return JSON.parse(args);
+  } catch {
+    try {
+      return parsePartialJson(args);
+    } catch {
+      return args;
+    }
+  }
+}
+
+/**
  * Converts an OpenAI Response into Genkit response data.
  * @param response The Response to convert.
  * @param jsonMode Whether the response text is expected to be JSON.
@@ -543,7 +561,7 @@ export function fromOpenAIResponse(
         toolRequest: {
           name: item.name,
           ref: item.call_id,
-          input: item.arguments ? JSON.parse(item.arguments) : {},
+          input: parseFunctionCallArguments(item.arguments),
         },
         ...(item.id ? { metadata: { itemId: item.id } } : {}),
       });
@@ -700,11 +718,23 @@ export function openAIResponsesModelRunner(
           { signal: options?.abortSignal }
         );
         const toolCalls = new Map<number, ResponsesToolCallAccumulator>();
+        // The SDK's finalResponse() snapshot only folds in `response.completed`,
+        // so a stream ending in `response.incomplete` or `response.failed`
+        // would come back as a stale in-progress response with the truncation
+        // or failure erased. Capture the terminal event's response instead.
+        let terminalResponse: OpenAIResponse | undefined;
         for await (const event of stream) {
+          if (
+            event.type === 'response.completed' ||
+            event.type === 'response.incomplete' ||
+            event.type === 'response.failed'
+          ) {
+            terminalResponse = event.response;
+          }
           const chunk = fromOpenAIResponsesStreamEvent(event, toolCalls);
           if (chunk) options.sendChunk!(chunk);
         }
-        response = await stream.finalResponse();
+        response = terminalResponse ?? (await stream.finalResponse());
       } else {
         response = await client.responses.create(body, {
           signal: options?.abortSignal,

--- a/js/plugins/compat-oai/src/responses.ts
+++ b/js/plugins/compat-oai/src/responses.ts
@@ -694,7 +694,8 @@ export function fromOpenAIResponsesStreamEvent(
 export function openAIResponsesModelRunner(
   name: string,
   defaultClient: OpenAI,
-  pluginOptions?: Omit<PluginOptions, 'apiKey'>
+  pluginOptions?: Omit<PluginOptions, 'apiKey'>,
+  modelOptions?: { streaming?: boolean }
 ) {
   return async (
     request: GenerateRequest,
@@ -709,10 +710,14 @@ export function openAIResponsesModelRunner(
       request,
       defaultClient
     );
+    // Some Responses-only models (o1-pro, o3-pro) reject `stream: true`, and
+    // genkit's default paths always request streaming, so they must fall back
+    // to a non-streaming request answered as a single chunk.
+    const canStream = modelOptions?.streaming !== false;
     try {
       const body = toOpenAIResponsesRequestBody(name, request);
       let response: OpenAIResponse;
-      if (options?.streamingRequested) {
+      if (options?.streamingRequested && canStream) {
         const stream = client.responses.stream(
           { ...body, stream: true },
           { signal: options?.abortSignal }
@@ -740,7 +745,17 @@ export function openAIResponsesModelRunner(
           signal: options?.abortSignal,
         });
       }
-      return fromOpenAIResponse(response, request.output?.format === 'json');
+      const converted = fromOpenAIResponse(
+        response,
+        request.output?.format === 'json'
+      );
+      if (options?.streamingRequested && !canStream && options.sendChunk) {
+        options.sendChunk({
+          index: 0,
+          content: converted.message?.content ?? [],
+        });
+      }
+      return converted;
     } catch (e) {
       rethrowOpenAIError(e);
     }
@@ -766,8 +781,10 @@ export function defineCompatOpenAIResponsesModel<
   client: OpenAI;
   modelRef?: ModelReference<CustomOptions>;
   pluginOptions?: PluginOptions;
+  /** Set false for models that reject `stream: true`; defaults to true. */
+  streaming?: boolean;
 }): ModelAction {
-  const { name, client, pluginOptions, modelRef } = params;
+  const { name, client, pluginOptions, modelRef, streaming } = params;
   const modelName = toModelName(name, pluginOptions?.name);
   const actionName =
     modelRef?.name ?? `${pluginOptions?.name ?? 'compat-oai'}/${modelName}`;
@@ -778,7 +795,7 @@ export function defineCompatOpenAIResponsesModel<
       ...modelRef?.info,
       configSchema: modelRef?.configSchema,
     },
-    openAIResponsesModelRunner(modelName, client, pluginOptions)
+    openAIResponsesModelRunner(modelName, client, pluginOptions, { streaming })
   );
 }
 

--- a/js/plugins/compat-oai/tests/fake_openai_server.ts
+++ b/js/plugins/compat-oai/tests/fake_openai_server.ts
@@ -23,6 +23,9 @@ export interface MockResponse {
   headers?: http.OutgoingHttpHeaders;
   stream?: boolean;
   chunks?: any[]; // For streaming
+  // Verbatim SSE frames, for wire shapes `chunks` cannot express (e.g. an
+  // `event: error` field line). No [DONE] frame is appended.
+  rawSse?: string[];
 }
 
 export class FakeOpenAIServer {
@@ -99,6 +102,13 @@ export class FakeOpenAIServer {
         headers['Connection'] = 'keep-alive';
         res.writeHead(statusCode, headers);
 
+        if (response.rawSse) {
+          for (const frame of response.rawSse) {
+            res.write(frame);
+          }
+          res.end();
+          return;
+        }
         if (response.chunks) {
           for (const chunk of response.chunks) {
             res.write(`data: ${JSON.stringify(chunk)}\n\n`);

--- a/js/plugins/compat-oai/tests/openai_responses_live_test.ts
+++ b/js/plugins/compat-oai/tests/openai_responses_live_test.ts
@@ -15,6 +15,7 @@
  */
 
 import { describe, expect, test } from '@jest/globals';
+import type { GenerateResponseChunkData, MessageData } from 'genkit';
 import OpenAI from 'openai';
 import { openAIResponsesModelRunner } from '../src/responses';
 
@@ -75,4 +76,82 @@ maybeDescribe('openAI responses live', () => {
     };
     expect(typeof data?.colour).toBe('string');
   }, 120_000);
+
+  test('streams text deltas', async () => {
+    const chunks: GenerateResponseChunkData[] = [];
+    const response = await runner()(
+      {
+        messages: [{ role: 'user', content: [{ text: 'Count from 1 to 5.' }] }],
+        config: { maxOutputTokens: 2048 },
+      },
+      { streamingRequested: true, sendChunk: (chunk) => chunks.push(chunk) }
+    );
+
+    expect(response.finishReason).toBe('stop');
+    const streamedText = chunks
+      .flatMap((chunk) => chunk.content)
+      .map((part) => part.text ?? '')
+      .join('');
+    expect(streamedText).toContain('3');
+  }, 120_000);
+
+  test('round-trips a tool call with encrypted reasoning across turns', async () => {
+    const tools = [
+      {
+        name: 'getWeather',
+        description: 'Returns the current weather for a city.',
+        inputSchema: {
+          type: 'object',
+          properties: { city: { type: 'string' } },
+          required: ['city'],
+          additionalProperties: false,
+        } as Record<string, unknown>,
+      },
+    ];
+    const messages: MessageData[] = [
+      {
+        role: 'user',
+        content: [
+          { text: 'Use the getWeather tool to find the weather in Paris.' },
+        ],
+      },
+    ];
+
+    const first = await runner()({
+      messages,
+      tools,
+      config: { maxOutputTokens: 2048 },
+    });
+
+    const toolRequest = first.message?.content.find((p) => p.toolRequest);
+    expect(toolRequest?.toolRequest?.name).toBe('getWeather');
+    // The stateless default must have carried the reasoning payload back.
+    expect(
+      first.message?.content.some((p) => p.metadata?.encryptedContent)
+    ).toBe(true);
+
+    messages.push(first.message!, {
+      role: 'tool',
+      content: [
+        {
+          toolResponse: {
+            name: 'getWeather',
+            ref: toolRequest!.toolRequest!.ref,
+            output: 'Sunny, 24C',
+          },
+        },
+      ],
+    });
+
+    const second = await runner()({
+      messages,
+      tools,
+      config: { maxOutputTokens: 2048 },
+    });
+
+    expect(second.finishReason).toBe('stop');
+    expect(second.message?.content.map((p) => p.text ?? '').join('')).toMatch(
+      /sunny|24/i
+    );
+  }, 240_000);
 });

--- a/js/plugins/compat-oai/tests/openai_responses_test.ts
+++ b/js/plugins/compat-oai/tests/openai_responses_test.ts
@@ -277,6 +277,7 @@ describe('toOpenAIResponsesRequestBody', () => {
       max_output_tokens: 128,
       temperature: 0.5,
       top_p: 0.9,
+      include: ['reasoning.encrypted_content'],
       store: false,
     });
   });
@@ -420,33 +421,186 @@ describe('toOpenAIResponsesRequestBody', () => {
     ]);
   });
 
-  test('rejects genkit tools rather than dropping them', () => {
-    expect(() =>
-      toOpenAIResponsesRequestBody('gpt-5-pro', {
-        messages: [],
-        tools: [{ name: 'lookup', description: 'looks things up' }],
-      })
-    ).toThrow(
-      expect.objectContaining({
-        status: 'INVALID_ARGUMENT',
-        message: expect.stringContaining('Tool calling is not yet supported'),
-      })
-    );
+  test('converts genkit tools into flat function tools', () => {
+    const body = toOpenAIResponsesRequestBody('gpt-5-pro', {
+      messages: [],
+      tools: [
+        {
+          name: 'lookup',
+          description: 'looks things up',
+          inputSchema: {
+            type: 'object',
+            properties: { q: { type: 'string' } },
+          },
+        },
+      ],
+      toolChoice: 'required',
+    });
+
+    expect(body.tools).toStrictEqual([
+      {
+        type: 'function',
+        name: 'lookup',
+        description: 'looks things up',
+        parameters: { type: 'object', properties: { q: { type: 'string' } } },
+        strict: null,
+      },
+    ]);
+    expect(body.tool_choice).toBe('required');
   });
 
-  test('rejects roles the transport does not support yet', () => {
-    expect(() =>
-      toOpenAIResponsesRequestBody('gpt-5-pro', {
-        messages: [
-          {
-            role: 'tool',
-            content: [
-              { toolResponse: { name: 'f', ref: '1', output: 'done' } },
-            ],
-          },
+  test('merges config.tools with converted genkit tools', () => {
+    const body = toOpenAIResponsesRequestBody('gpt-5-pro', {
+      messages: [],
+      tools: [{ name: 'lookup', description: 'looks things up' }],
+      config: { tools: [{ type: 'web_search_preview' }] },
+    });
+
+    expect(body.tools).toHaveLength(2);
+    expect(body.tools![0]).toMatchObject({ type: 'function', name: 'lookup' });
+    expect(body.tools![1]).toStrictEqual({ type: 'web_search_preview' });
+  });
+
+  test('maps tool responses onto function_call_output items', () => {
+    const body = toOpenAIResponsesRequestBody('gpt-5-pro', {
+      messages: [
+        {
+          role: 'tool',
+          content: [
+            { toolResponse: { name: 'f', ref: 'call_1', output: 'done' } },
+            {
+              toolResponse: { name: 'g', ref: 'call_2', output: { ok: true } },
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(body.input).toStrictEqual([
+      { type: 'function_call_output', call_id: 'call_1', output: 'done' },
+      {
+        type: 'function_call_output',
+        call_id: 'call_2',
+        output: '{"ok":true}',
+      },
+    ]);
+  });
+
+  test('replays tool calls and encrypted reasoning in order', () => {
+    const body = toOpenAIResponsesRequestBody('gpt-5-pro', {
+      messages: [
+        {
+          role: 'model',
+          content: [
+            {
+              reasoning: 'thinking',
+              metadata: { itemId: 'rs_1', encryptedContent: 'ENC' },
+            },
+            { reasoning: 'more', metadata: { itemId: 'rs_1' } },
+            {
+              toolRequest: { name: 'lookup', ref: 'call_1', input: { q: 'x' } },
+              metadata: { itemId: 'fc_1' },
+            },
+          ],
+        },
+        {
+          role: 'tool',
+          content: [
+            { toolResponse: { name: 'lookup', ref: 'call_1', output: 'done' } },
+          ],
+        },
+      ],
+    });
+
+    expect(body.input).toStrictEqual([
+      {
+        type: 'reasoning',
+        id: 'rs_1',
+        summary: [
+          { type: 'summary_text', text: 'thinking' },
+          { type: 'summary_text', text: 'more' },
         ],
-      })
-    ).toThrow(/not supported by the OpenAI Responses API transport/);
+        encrypted_content: 'ENC',
+      },
+      {
+        type: 'function_call',
+        call_id: 'call_1',
+        name: 'lookup',
+        arguments: '{"q":"x"}',
+        id: 'fc_1',
+      },
+      { type: 'function_call_output', call_id: 'call_1', output: 'done' },
+    ]);
+  });
+
+  test('replays an encrypted reasoning item that has no summary', () => {
+    const body = toOpenAIResponsesRequestBody('gpt-5-pro', {
+      messages: [
+        {
+          role: 'model',
+          content: [
+            {
+              reasoning: '',
+              metadata: { itemId: 'rs_1', encryptedContent: 'ENC' },
+            },
+            { text: 'answer' },
+          ],
+        },
+      ],
+    });
+
+    expect(body.input).toStrictEqual([
+      { type: 'reasoning', id: 'rs_1', summary: [], encrypted_content: 'ENC' },
+      { role: 'assistant', content: 'answer' },
+    ]);
+  });
+
+  test('preserves text around a tool call instead of dropping it', () => {
+    const body = toOpenAIResponsesRequestBody('gpt-5-pro', {
+      messages: [
+        {
+          role: 'model',
+          content: [
+            { text: 'let me check' },
+            { toolRequest: { name: 'lookup', ref: 'call_1', input: {} } },
+          ],
+        },
+      ],
+    });
+
+    expect(body.input).toStrictEqual([
+      { role: 'assistant', content: 'let me check' },
+      {
+        type: 'function_call',
+        call_id: 'call_1',
+        name: 'lookup',
+        arguments: '{}',
+      },
+    ]);
+  });
+
+  test('requests encrypted reasoning on stateless requests', () => {
+    expect(
+      toOpenAIResponsesRequestBody('gpt-5-pro', { messages: [] }).include
+    ).toStrictEqual(['reasoning.encrypted_content']);
+  });
+
+  test('merges caller include values without duplicating', () => {
+    const body = toOpenAIResponsesRequestBody('gpt-5-pro', {
+      messages: [],
+      config: { include: ['reasoning.encrypted_content'] },
+    });
+
+    expect(body.include).toStrictEqual(['reasoning.encrypted_content']);
+  });
+
+  test('leaves include alone when the caller opts into server-side storage', () => {
+    const body = toOpenAIResponsesRequestBody('gpt-5-pro', {
+      messages: [],
+      config: { store: true, include: ['message.output_text.logprobs'] },
+    });
+
+    expect(body.include).toStrictEqual(['message.output_text.logprobs']);
   });
 });
 
@@ -521,9 +675,88 @@ describe('fromOpenAIResponse', () => {
     });
 
     expect(fromOpenAIResponse(response).message?.content).toStrictEqual([
-      { reasoning: 'thinking' },
-      { reasoning: 'more' },
+      { reasoning: 'thinking', metadata: { itemId: 'rs_1' } },
+      { reasoning: 'more', metadata: { itemId: 'rs_1' } },
       { text: 'answer' },
+    ]);
+  });
+
+  test('carries encrypted reasoning on the item first part only', () => {
+    const response = fakeResponse({
+      output: [
+        {
+          id: 'rs_1',
+          type: 'reasoning',
+          encrypted_content: 'ENC',
+          summary: [
+            { type: 'summary_text', text: 'thinking' },
+            { type: 'summary_text', text: 'more' },
+          ],
+        },
+      ],
+    });
+
+    expect(fromOpenAIResponse(response).message?.content).toStrictEqual([
+      {
+        reasoning: 'thinking',
+        metadata: { itemId: 'rs_1', encryptedContent: 'ENC' },
+      },
+      { reasoning: 'more', metadata: { itemId: 'rs_1' } },
+    ]);
+  });
+
+  test('keeps a summary-less encrypted reasoning item as an empty part', () => {
+    const response = fakeResponse({
+      output: [
+        {
+          id: 'rs_1',
+          type: 'reasoning',
+          encrypted_content: 'ENC',
+          summary: [],
+        },
+      ],
+    });
+
+    expect(fromOpenAIResponse(response).message?.content).toStrictEqual([
+      {
+        reasoning: '',
+        metadata: { itemId: 'rs_1', encryptedContent: 'ENC' },
+      },
+    ]);
+  });
+
+  test('drops a reasoning item with neither summary nor encrypted content', () => {
+    const response = fakeResponse({
+      output: [{ id: 'rs_1', type: 'reasoning', summary: [] }],
+    });
+
+    expect(fromOpenAIResponse(response).message?.content).toStrictEqual([]);
+  });
+
+  test('surfaces citation annotations on the text part', () => {
+    const annotation = {
+      type: 'url_citation' as const,
+      url: 'https://example.com',
+      title: 'Example',
+      start_index: 0,
+      end_index: 5,
+    };
+    const response = fakeResponse({
+      output: [
+        {
+          id: 'msg_1',
+          type: 'message',
+          role: 'assistant',
+          status: 'completed',
+          content: [
+            { type: 'output_text', text: 'cited', annotations: [annotation] },
+          ],
+        },
+      ],
+    });
+
+    expect(fromOpenAIResponse(response).message?.content).toStrictEqual([
+      { text: 'cited', metadata: { annotations: [annotation] } },
     ]);
   });
 
@@ -567,7 +800,7 @@ describe('fromOpenAIResponse', () => {
     ).toBe('blocked');
   });
 
-  test('rejects a response that asks for a tool call', () => {
+  test('converts a function call into a tool request part', () => {
     const response = fakeResponse({
       output: [
         {
@@ -575,15 +808,35 @@ describe('fromOpenAIResponse', () => {
           type: 'function_call',
           call_id: 'call_1',
           name: 'lookup',
-          arguments: '{}',
+          arguments: '{"q":"x"}',
         },
       ],
     });
 
+    const converted = fromOpenAIResponse(response);
+    expect(converted.finishReason).toBe('stop');
+    expect(converted.message?.content).toStrictEqual([
+      {
+        toolRequest: { name: 'lookup', ref: 'call_1', input: { q: 'x' } },
+        metadata: { itemId: 'fc_1' },
+      },
+    ]);
+  });
+
+  test('rejects a custom tool call', () => {
+    const item = {
+      id: 'ct_1',
+      type: 'custom_tool_call',
+      call_id: 'call_1',
+      name: 'grep',
+      input: 'foo',
+    } as unknown as OpenAIResponse['output'][number];
+    const response = fakeResponse({ output: [item] });
+
     expect(() => fromOpenAIResponse(response)).toThrow(
       expect.objectContaining({
         status: 'UNIMPLEMENTED',
-        message: expect.stringContaining('function_call'),
+        message: expect.stringContaining('custom_tool_call'),
       })
     );
   });
@@ -701,27 +954,192 @@ describe('openAIResponsesModelRunner', () => {
     expect(request.body).toStrictEqual({
       model: 'gpt-5-pro',
       input: [{ role: 'user', content: [{ type: 'input_text', text: 'hi' }] }],
+      include: ['reasoning.encrypted_content'],
       store: false,
     });
     expect(response.message?.content).toStrictEqual([{ text: 'hi there' }]);
   });
 
-  test('delivers the completed response as a single chunk when streaming', async () => {
-    server.setNextResponse({ body: textResponse('streamed') });
+  test('streams text and reasoning deltas as chunks', async () => {
+    server.setNextResponse({
+      stream: true,
+      chunks: [
+        {
+          type: 'response.created',
+          response: fakeResponse(),
+          sequence_number: 0,
+        },
+        {
+          type: 'response.output_item.added',
+          output_index: 0,
+          item: { id: 'rs_1', type: 'reasoning', summary: [] },
+          sequence_number: 1,
+        },
+        {
+          type: 'response.reasoning_summary_text.delta',
+          item_id: 'rs_1',
+          output_index: 0,
+          summary_index: 0,
+          delta: 'thinking',
+          sequence_number: 2,
+        },
+        {
+          type: 'response.output_item.added',
+          output_index: 1,
+          item: {
+            id: 'msg_1',
+            type: 'message',
+            role: 'assistant',
+            status: 'in_progress',
+            content: [],
+          },
+          sequence_number: 3,
+        },
+        {
+          type: 'response.content_part.added',
+          item_id: 'msg_1',
+          output_index: 1,
+          content_index: 0,
+          part: { type: 'output_text', text: '', annotations: [] },
+          sequence_number: 4,
+        },
+        {
+          type: 'response.output_text.delta',
+          item_id: 'msg_1',
+          output_index: 1,
+          content_index: 0,
+          delta: 'hel',
+          sequence_number: 5,
+        },
+        {
+          type: 'response.output_text.delta',
+          item_id: 'msg_1',
+          output_index: 1,
+          content_index: 0,
+          delta: 'lo',
+          sequence_number: 6,
+        },
+        {
+          type: 'response.completed',
+          response: textResponse('hello'),
+          sequence_number: 7,
+        },
+      ],
+    });
     const client = new OpenAI({ apiKey: 'key', baseURL: server.baseUrl });
     const runner = openAIResponsesModelRunner('gpt-5-pro', client);
     const sendChunk = jest.fn();
 
-    await runner(
+    const response = await runner(
       { messages: [{ role: 'user', content: [{ text: 'hi' }] }] },
       { streamingRequested: true, sendChunk }
     );
 
-    expect(sendChunk).toHaveBeenCalledTimes(1);
-    expect(sendChunk).toHaveBeenCalledWith({
-      index: 0,
-      content: [{ text: 'streamed' }],
+    expect(sendChunk.mock.calls.map((call) => call[0])).toStrictEqual([
+      { index: 0, content: [{ reasoning: 'thinking' }] },
+      { index: 1, content: [{ text: 'hel' }] },
+      { index: 1, content: [{ text: 'lo' }] },
+    ]);
+    expect(response.message?.content).toStrictEqual([{ text: 'hello' }]);
+    expect(server.requests[server.requests.length - 1].body.stream).toBe(true);
+  });
+
+  test('streams a function call as accumulating partial tool requests', async () => {
+    const finalResponse = fakeResponse({
+      output: [
+        {
+          id: 'fc_1',
+          type: 'function_call',
+          call_id: 'call_1',
+          name: 'lookup',
+          arguments: '{"q":"x"}',
+        },
+      ],
     });
+    server.setNextResponse({
+      stream: true,
+      chunks: [
+        {
+          type: 'response.created',
+          response: fakeResponse(),
+          sequence_number: 0,
+        },
+        {
+          type: 'response.output_item.added',
+          output_index: 0,
+          item: {
+            id: 'fc_1',
+            type: 'function_call',
+            call_id: 'call_1',
+            name: 'lookup',
+            arguments: '',
+            status: 'in_progress',
+          },
+          sequence_number: 1,
+        },
+        {
+          type: 'response.function_call_arguments.delta',
+          item_id: 'fc_1',
+          output_index: 0,
+          delta: '{"q":',
+          sequence_number: 2,
+        },
+        {
+          type: 'response.function_call_arguments.delta',
+          item_id: 'fc_1',
+          output_index: 0,
+          delta: '"x"}',
+          sequence_number: 3,
+        },
+        {
+          type: 'response.completed',
+          response: finalResponse,
+          sequence_number: 4,
+        },
+      ],
+    });
+    const client = new OpenAI({ apiKey: 'key', baseURL: server.baseUrl });
+    const runner = openAIResponsesModelRunner('gpt-5-pro', client);
+    const sendChunk = jest.fn();
+
+    const response = await runner(
+      { messages: [{ role: 'user', content: [{ text: 'hi' }] }] },
+      { streamingRequested: true, sendChunk }
+    );
+
+    const chunks = sendChunk.mock.calls.map((call) => call[0]);
+    expect(chunks[0]).toStrictEqual({
+      index: 0,
+      content: [
+        {
+          toolRequest: {
+            name: 'lookup',
+            ref: 'call_1',
+            input: {},
+            partial: true,
+          },
+        },
+      ],
+    });
+    expect(chunks[chunks.length - 1]).toStrictEqual({
+      index: 0,
+      content: [
+        {
+          toolRequest: {
+            name: 'lookup',
+            ref: 'call_1',
+            input: { q: 'x' },
+            partial: true,
+          },
+        },
+      ],
+    });
+    expect(response.message?.content).toStrictEqual([
+      {
+        toolRequest: { name: 'lookup', ref: 'call_1', input: { q: 'x' } },
+        metadata: { itemId: 'fc_1' },
+      },
+    ]);
   });
 
   test('converts an APIError into a GenkitError', async () => {
@@ -759,7 +1177,8 @@ describe('defineCompatOpenAIResponsesModel', () => {
     expect(action.__action.name).toBe('openai/gpt-5-pro');
     expect(action.__action.metadata?.model.supports).toStrictEqual({
       multiturn: true,
-      tools: false,
+      tools: true,
+      toolChoice: true,
       media: true,
       systemRole: true,
       output: ['text', 'json'],
@@ -795,14 +1214,19 @@ describe('openAI plugin routing', () => {
     const action = await plugin.model('o3-pro-2025-06-10');
 
     expect(action.__action.name).toBe('openai/o3-pro-2025-06-10');
-    expect(action.__action.metadata?.model.supports?.tools).toBe(false);
+    // Only the Responses config schema declares the transport routing key.
+    expect(
+      Object.keys(action.__action.metadata?.model.customOptions.properties)
+    ).toContain('transport');
   });
 
   test('leaves dual-transport names on Chat Completions', async () => {
     const plugin = openAI({ apiKey: 'key' });
     const action = await plugin.model('gpt-5');
 
-    expect(action.__action.metadata?.model.supports?.tools).toBe(true);
+    expect(
+      Object.keys(action.__action.metadata?.model.customOptions.properties)
+    ).not.toContain('transport');
   });
 
   test('gives Responses-only refs the transport-aware config schema', () => {
@@ -857,6 +1281,54 @@ describe('openAI plugin routing', () => {
     expect(JSON.stringify(sent.body.input)).not.toContain('colour');
   });
 
+  test('runs a full tool-calling loop over the Responses transport', async () => {
+    const ai = genkit({ plugins: [openAI({ apiKey: 'key' })] });
+    const getWeather = ai.defineTool(
+      {
+        name: 'getWeather',
+        description: 'gets the weather',
+        inputSchema: z.object({ city: z.string() }),
+        outputSchema: z.string(),
+      },
+      async ({ city }) => `sunny in ${city}`
+    );
+    server.setNextResponse({
+      body: fakeResponse({
+        output: [
+          {
+            id: 'fc_1',
+            type: 'function_call',
+            call_id: 'call_1',
+            name: 'getWeather',
+            arguments: '{"city":"Paris"}',
+          },
+        ],
+      }),
+    });
+    server.setNextResponse({ body: textResponse('It is sunny.') });
+
+    const result = await ai.generate({
+      model: openAI.model('gpt-5-pro'),
+      prompt: 'weather in Paris?',
+      tools: [getWeather],
+    });
+
+    expect(result.text).toBe('It is sunny.');
+    const secondRequest = server.requests[server.requests.length - 1];
+    expect(secondRequest.body.input).toContainEqual({
+      type: 'function_call',
+      call_id: 'call_1',
+      name: 'getWeather',
+      arguments: '{"city":"Paris"}',
+      id: 'fc_1',
+    });
+    expect(secondRequest.body.input).toContainEqual({
+      type: 'function_call_output',
+      call_id: 'call_1',
+      output: 'sunny in Paris',
+    });
+  });
+
   test('sends dual-transport models to the Chat Completions endpoint', async () => {
     const plugin = openAI({ apiKey: 'key' });
     const action = await plugin.model('gpt-4o');
@@ -892,7 +1364,7 @@ describe('openAI plugin routing', () => {
     const [metadata] = await plugin.list!();
 
     expect(metadata.name).toBe('openai/gpt-5-pro');
-    expect(metadata.metadata?.model.supports.tools).toBe(false);
+    expect(metadata.metadata?.model.supports.tools).toBe(true);
     expect(
       Object.keys(metadata.metadata?.model.customOptions.properties)
     ).toContain('transport');

--- a/js/plugins/compat-oai/tests/openai_responses_test.ts
+++ b/js/plugins/compat-oai/tests/openai_responses_test.ts
@@ -1338,6 +1338,43 @@ describe('openAIResponsesModelRunner', () => {
     );
   });
 
+  test('surfaces an SSE error event as a GenkitError', async () => {
+    // The SDK throws an APIError the moment it sees an `event: error` frame,
+    // so the event never reaches the runner's loop; this pins that the
+    // rejection still comes out as a GenkitError.
+    server.setNextResponse({
+      stream: true,
+      rawSse: [
+        `data: ${JSON.stringify({
+          type: 'response.created',
+          response: fakeResponse(),
+          sequence_number: 0,
+        })}\n\n`,
+        `event: error\ndata: ${JSON.stringify({
+          type: 'error',
+          code: 'server_error',
+          message: 'stream blew up',
+          param: null,
+          sequence_number: 1,
+        })}\n\n`,
+      ],
+    });
+    const client = new OpenAI({ apiKey: 'key', baseURL: server.baseUrl });
+    const runner = openAIResponsesModelRunner('gpt-5-pro', client);
+
+    await expect(
+      runner(
+        { messages: [{ role: 'user', content: [{ text: 'hi' }] }] },
+        { streamingRequested: true, sendChunk: jest.fn() }
+      )
+    ).rejects.toThrow(
+      expect.objectContaining({
+        name: 'GenkitError',
+        message: expect.stringContaining('stream blew up'),
+      })
+    );
+  });
+
   test('converts an APIError into a GenkitError', async () => {
     const client = {
       responses: {

--- a/js/plugins/compat-oai/tests/openai_responses_test.ts
+++ b/js/plugins/compat-oai/tests/openai_responses_test.ts
@@ -38,6 +38,7 @@ import {
 import {
   defineCompatOpenAIResponsesModel,
   fromOpenAIResponse,
+  isReasoningModelName,
   openAIResponsesModelRunner,
   toOpenAIResponsesRequestBody,
 } from '../src/responses';
@@ -130,6 +131,25 @@ describe('isNonStreamingResponsesModelName', () => {
     expect(isNonStreamingResponsesModelName('gpt-5-codex')).toBe(false);
     expect(isNonStreamingResponsesModelName('codex-mini-latest')).toBe(false);
     expect(isNonStreamingResponsesModelName(undefined)).toBe(false);
+  });
+});
+
+describe('isReasoningModelName', () => {
+  test('matches the reasoning families', () => {
+    expect(isReasoningModelName('o1-pro')).toBe(true);
+    expect(isReasoningModelName('o3')).toBe(true);
+    expect(isReasoningModelName('o4-mini')).toBe(true);
+    expect(isReasoningModelName('gpt-5-nano')).toBe(true);
+    expect(isReasoningModelName('gpt-5.3-codex')).toBe(true);
+    expect(isReasoningModelName('codex-mini-latest')).toBe(true);
+  });
+
+  test('leaves non-reasoning models out', () => {
+    expect(isReasoningModelName('gpt-4o')).toBe(false);
+    expect(isReasoningModelName('gpt-4o-mini')).toBe(false);
+    expect(isReasoningModelName('gpt-5-chat-latest')).toBe(false);
+    expect(isReasoningModelName('')).toBe(false);
+    expect(isReasoningModelName(undefined)).toBe(false);
   });
 });
 
@@ -617,6 +637,23 @@ describe('toOpenAIResponsesRequestBody', () => {
     expect(
       toOpenAIResponsesRequestBody('gpt-5-pro', { messages: [] }).include
     ).toStrictEqual(['reasoning.encrypted_content']);
+  });
+
+  test('never requests encrypted reasoning from a non-reasoning model', () => {
+    // Non-reasoning models reject the include with a 400, so a dual-transport
+    // opt-in (gpt-4o over Responses) must not carry it.
+    const body = toOpenAIResponsesRequestBody('gpt-4o', { messages: [] });
+
+    expect(body).not.toHaveProperty('include');
+  });
+
+  test('gates encrypted reasoning on the version when one is set', () => {
+    const body = toOpenAIResponsesRequestBody('gpt-4o', {
+      messages: [],
+      config: { version: 'o3-pro-2025-06-10' },
+    });
+
+    expect(body.include).toStrictEqual(['reasoning.encrypted_content']);
   });
 
   test('merges caller include values without duplicating', () => {

--- a/js/plugins/compat-oai/tests/openai_responses_test.ts
+++ b/js/plugins/compat-oai/tests/openai_responses_test.ts
@@ -1046,7 +1046,6 @@ describe('openAIResponsesModelRunner', () => {
     expect(request.body).not.toHaveProperty('stream');
     expect(sendChunk).toHaveBeenCalledTimes(1);
     expect(sendChunk).toHaveBeenCalledWith({
-      index: 0,
       content: [{ text: 'non-streamed' }],
     });
     expect(response.message?.content).toStrictEqual([{ text: 'non-streamed' }]);
@@ -1128,9 +1127,9 @@ describe('openAIResponsesModelRunner', () => {
     );
 
     expect(sendChunk.mock.calls.map((call) => call[0])).toStrictEqual([
-      { index: 0, content: [{ reasoning: 'thinking' }] },
-      { index: 1, content: [{ text: 'hel' }] },
-      { index: 1, content: [{ text: 'lo' }] },
+      { content: [{ reasoning: 'thinking' }] },
+      { content: [{ text: 'hel' }] },
+      { content: [{ text: 'lo' }] },
     ]);
     expect(response.message?.content).toStrictEqual([{ text: 'hello' }]);
     expect(server.requests[server.requests.length - 1].body.stream).toBe(true);
@@ -1201,7 +1200,6 @@ describe('openAIResponsesModelRunner', () => {
 
     const chunks = sendChunk.mock.calls.map((call) => call[0]);
     expect(chunks[0]).toStrictEqual({
-      index: 0,
       content: [
         {
           toolRequest: {
@@ -1214,7 +1212,6 @@ describe('openAIResponsesModelRunner', () => {
       ],
     });
     expect(chunks[chunks.length - 1]).toStrictEqual({
-      index: 0,
       content: [
         {
           toolRequest: {

--- a/js/plugins/compat-oai/tests/openai_responses_test.ts
+++ b/js/plugins/compat-oai/tests/openai_responses_test.ts
@@ -29,7 +29,9 @@ import type { Response as OpenAIResponse } from 'openai/resources/responses/resp
 import { openAIModelRunner } from '../src/model';
 import { openAI } from '../src/openai/index';
 import {
+  NON_STREAMING_RESPONSES_MODELS,
   RESPONSES_ONLY_MODELS,
+  isNonStreamingResponsesModelName,
   isResponsesOnlyModelName,
   openAIResponsesModelRef,
 } from '../src/openai/responses';
@@ -112,6 +114,22 @@ describe('isResponsesOnlyModelName', () => {
     expect(isResponsesOnlyModelName('gpt-5.1-codex')).toBe(true);
     expect(isResponsesOnlyModelName('gpt-5.1-codex-mini')).toBe(true);
     expect(isResponsesOnlyModelName('gpt-5.1-codex-max')).toBe(true);
+  });
+});
+
+describe('isNonStreamingResponsesModelName', () => {
+  test('matches the curated non-streaming models and their suffixed forms', () => {
+    for (const name of NON_STREAMING_RESPONSES_MODELS) {
+      expect(isNonStreamingResponsesModelName(name)).toBe(true);
+    }
+    expect(isNonStreamingResponsesModelName('o3-pro-2025-06-10')).toBe(true);
+  });
+
+  test('leaves the streaming-capable models alone', () => {
+    expect(isNonStreamingResponsesModelName('gpt-5-pro')).toBe(false);
+    expect(isNonStreamingResponsesModelName('gpt-5-codex')).toBe(false);
+    expect(isNonStreamingResponsesModelName('codex-mini-latest')).toBe(false);
+    expect(isNonStreamingResponsesModelName(undefined)).toBe(false);
   });
 });
 
@@ -1011,6 +1029,29 @@ describe('openAIResponsesModelRunner', () => {
     expect(response.message?.content).toStrictEqual([{ text: 'hi there' }]);
   });
 
+  test('answers a streaming caller without streaming when the model cannot stream', async () => {
+    server.setNextResponse({ body: textResponse('non-streamed') });
+    const client = new OpenAI({ apiKey: 'key', baseURL: server.baseUrl });
+    const runner = openAIResponsesModelRunner('o3-pro', client, undefined, {
+      streaming: false,
+    });
+    const sendChunk = jest.fn();
+
+    const response = await runner(
+      { messages: [{ role: 'user', content: [{ text: 'hi' }] }] },
+      { streamingRequested: true, sendChunk }
+    );
+
+    const request = server.requests[server.requests.length - 1];
+    expect(request.body).not.toHaveProperty('stream');
+    expect(sendChunk).toHaveBeenCalledTimes(1);
+    expect(sendChunk).toHaveBeenCalledWith({
+      index: 0,
+      content: [{ text: 'non-streamed' }],
+    });
+    expect(response.message?.content).toStrictEqual([{ text: 'non-streamed' }]);
+  });
+
   test('streams text and reasoning deltas as chunks', async () => {
     server.setNextResponse({
       stream: true,
@@ -1404,6 +1445,27 @@ describe('openAI plugin routing', () => {
     for (const name of RESPONSES_ONLY_MODELS) {
       expect(registered).toContain(`openai/${name}`);
     }
+  });
+
+  test('streams a non-streaming model through the plugin without stream: true', async () => {
+    const ai = genkit({ plugins: [openAI({ apiKey: 'key' })] });
+    server.setNextResponse({ body: textResponse('pro answer') });
+
+    const { response, stream } = ai.generateStream({
+      model: openAI.model('o3-pro'),
+      prompt: 'hi',
+    });
+    const chunks: string[] = [];
+    for await (const chunk of stream) {
+      chunks.push(chunk.text);
+    }
+    const result = await response;
+
+    expect(result.text).toBe('pro answer');
+    expect(chunks.join('')).toBe('pro answer');
+    const sent = server.requests[server.requests.length - 1];
+    expect(sent.url).toBe('/v1/responses');
+    expect(sent.body).not.toHaveProperty('stream');
   });
 
   test('sends Responses-only models to the Responses endpoint', async () => {

--- a/js/plugins/compat-oai/tests/openai_responses_test.ts
+++ b/js/plugins/compat-oai/tests/openai_responses_test.ts
@@ -851,6 +851,29 @@ describe('fromOpenAIResponse', () => {
     ]);
   });
 
+  test('survives truncated function-call arguments and reports length', () => {
+    const response = fakeResponse({
+      status: 'incomplete',
+      incomplete_details: { reason: 'max_output_tokens' },
+      output: [
+        {
+          id: 'fc_1',
+          type: 'function_call',
+          call_id: 'call_1',
+          name: 'lookup',
+          arguments: '{"q":',
+          status: 'incomplete',
+        },
+      ],
+    });
+
+    const converted = fromOpenAIResponse(response);
+    expect(converted.finishReason).toBe('length');
+    const part = converted.message?.content[0];
+    expect(part?.toolRequest?.name).toBe('lookup');
+    expect(part?.toolRequest?.ref).toBe('call_1');
+  });
+
   test('rejects a custom tool call', () => {
     const item = {
       id: 'ct_1',
@@ -1168,6 +1191,110 @@ describe('openAIResponsesModelRunner', () => {
         metadata: { itemId: 'fc_1' },
       },
     ]);
+  });
+
+  test('reports truncation from a stream that ends incomplete', async () => {
+    const incompleteResponse = fakeResponse({
+      status: 'incomplete',
+      incomplete_details: { reason: 'max_output_tokens' },
+      usage: {
+        input_tokens: 10,
+        output_tokens: 4,
+        total_tokens: 14,
+        input_tokens_details: { cached_tokens: 0 },
+        output_tokens_details: { reasoning_tokens: 0 },
+      },
+      output: [
+        {
+          id: 'fc_1',
+          type: 'function_call',
+          call_id: 'call_1',
+          name: 'lookup',
+          arguments: '{"q":',
+          status: 'incomplete',
+        },
+      ],
+    });
+    server.setNextResponse({
+      stream: true,
+      chunks: [
+        {
+          type: 'response.created',
+          response: fakeResponse(),
+          sequence_number: 0,
+        },
+        {
+          type: 'response.output_item.added',
+          output_index: 0,
+          item: {
+            id: 'fc_1',
+            type: 'function_call',
+            call_id: 'call_1',
+            name: 'lookup',
+            arguments: '',
+            status: 'in_progress',
+          },
+          sequence_number: 1,
+        },
+        {
+          type: 'response.function_call_arguments.delta',
+          item_id: 'fc_1',
+          output_index: 0,
+          delta: '{"q":',
+          sequence_number: 2,
+        },
+        {
+          type: 'response.incomplete',
+          response: incompleteResponse,
+          sequence_number: 3,
+        },
+      ],
+    });
+    const client = new OpenAI({ apiKey: 'key', baseURL: server.baseUrl });
+    const runner = openAIResponsesModelRunner('gpt-5-pro', client);
+
+    const response = await runner(
+      { messages: [{ role: 'user', content: [{ text: 'hi' }] }] },
+      { streamingRequested: true, sendChunk: jest.fn() }
+    );
+
+    expect(response.finishReason).toBe('length');
+    expect(response.usage?.totalTokens).toBe(14);
+  });
+
+  test('surfaces a failure from a stream that ends failed', async () => {
+    server.setNextResponse({
+      stream: true,
+      chunks: [
+        {
+          type: 'response.created',
+          response: fakeResponse(),
+          sequence_number: 0,
+        },
+        {
+          type: 'response.failed',
+          response: fakeResponse({
+            status: 'failed',
+            error: { code: 'server_error', message: 'upstream exploded' },
+          }),
+          sequence_number: 1,
+        },
+      ],
+    });
+    const client = new OpenAI({ apiKey: 'key', baseURL: server.baseUrl });
+    const runner = openAIResponsesModelRunner('gpt-5-pro', client);
+
+    await expect(
+      runner(
+        { messages: [{ role: 'user', content: [{ text: 'hi' }] }] },
+        { streamingRequested: true, sendChunk: jest.fn() }
+      )
+    ).rejects.toThrow(
+      expect.objectContaining({
+        status: 'INTERNAL',
+        message: expect.stringContaining('upstream exploded'),
+      })
+    );
   });
 
   test('converts an APIError into a GenkitError', async () => {

--- a/js/plugins/compat-oai/tests/openai_responses_test.ts
+++ b/js/plugins/compat-oai/tests/openai_responses_test.ts
@@ -486,6 +486,22 @@ describe('toOpenAIResponsesRequestBody', () => {
     ]);
   });
 
+  test('serializes a void tool response instead of dropping the output key', () => {
+    const body = toOpenAIResponsesRequestBody('gpt-5-pro', {
+      messages: [
+        {
+          role: 'tool',
+          content: [{ toolResponse: { name: 'f', ref: 'call_1' } }],
+        },
+      ],
+    });
+
+    expect(body.input).toStrictEqual([
+      { type: 'function_call_output', call_id: 'call_1', output: 'null' },
+    ]);
+    expect(JSON.parse(JSON.stringify(body.input))[0]).toHaveProperty('output');
+  });
+
   test('replays tool calls and encrypted reasoning in order', () => {
     const body = toOpenAIResponsesRequestBody('gpt-5-pro', {
       messages: [
@@ -592,6 +608,18 @@ describe('toOpenAIResponsesRequestBody', () => {
     });
 
     expect(body.include).toStrictEqual(['reasoning.encrypted_content']);
+  });
+
+  test('normalizes a bare-string include instead of spreading its characters', () => {
+    const body = toOpenAIResponsesRequestBody('gpt-5-pro', {
+      messages: [],
+      config: { include: 'message.output_text.logprobs' },
+    });
+
+    expect(body.include).toStrictEqual([
+      'message.output_text.logprobs',
+      'reasoning.encrypted_content',
+    ]);
   });
 
   test('leaves include alone when the caller opts into server-side storage', () => {


### PR DESCRIPTION
Part of #6002, closes #6004. Stacked on #6006; review the top commit.

Streaming, tool calling and the encrypted reasoning round-trip land together because they interact - the shared failure mode is reasoning items dropped on tool-call turns.

- **Streaming**: `client.responses.stream()` + `finalResponse()`, replacing the single-chunk fallback from #6003. Text and reasoning-summary deltas map to parts; function-call argument deltas accumulate into partial tool requests; `chunk.index` carries `output_index`. Annotations attach to the final text part's `metadata.annotations` rather than streaming.
- **Tool calling**: flat `FunctionTool` converter (`strict: null`), `ref = call_id` with the item `id` riding `part.metadata.itemId` for stateless replay, tool responses as `function_call_output` items, `config.tools` passthrough merged. Conversion is order-preserving in both directions - text around tool calls survives. `supports.tools`/`toolChoice` flip to true.
- **Encrypted reasoning**: stateless requests (the pinned `store: false` default) always send `include: ['reasoning.encrypted_content']`; reasoning items round-trip through part metadata so reasoning models keep their context across tool-call boundaries.

Testing: unit + fake-server wire assertions, SSE streaming through the real SDK `ResponseStream`, end-to-end `ai.generate` tool loop. Live smoke tests extended (streaming; multi-turn tool call asserting the encrypted payload survives) but not yet run - draft until then, same as #6006.
