### PR TITLE
feat(js/plugins/compat-oai): add responsesModel() opt-in and dual-transport dispatch

### DIFF
--- a/js/plugins/compat-oai/README.md
+++ b/js/plugins/compat-oai/README.md
@@ -198,6 +198,12 @@ const second = await ai.generate({
 
 When threading with `previousResponseId`, send only the new user turn; the server already holds the earlier context.
 
+The pro models can take several minutes per request; raise the SDK's default 10-minute timeout through the plugin's `timeout` option if needed:
+
+```typescript
+openAI({ apiKey: process.env.OPENAI_API_KEY, timeout: 30 * 60 * 1000 });
+```
+
 ### Custom models & other Cloud providers
 
 ```typescript

--- a/js/plugins/compat-oai/README.md
+++ b/js/plugins/compat-oai/README.md
@@ -192,7 +192,7 @@ const first = await ai.generate({
 const second = await ai.generate({
   model: openAI.responsesModel('gpt-4o'),
   prompt: 'Double it.',
-  config: { store: true, previousResponseId: first.raw.id },
+  config: { store: true, previousResponseId: (first.raw as { id: string }).id },
 });
 ```
 

--- a/js/plugins/compat-oai/README.md
+++ b/js/plugins/compat-oai/README.md
@@ -140,6 +140,64 @@ const result = await ai.generate({
 console.log(result.text);
 ```
 
+### OpenAI Responses API
+
+Models that OpenAI serves only over the [Responses API](https://platform.openai.com/docs/api-reference/responses), such as `gpt-5-pro`, `o1-pro`, `o3-pro` and the codex family, are routed there automatically:
+
+```typescript
+import { openAI } from '@genkit-ai/compat-oai/openai';
+
+const response = await ai.generate({
+  model: openAI.model('gpt-5-pro'),
+  prompt: 'Tell me a joke.',
+});
+```
+
+Models available on both transports default to Chat Completions. Opt a request into the Responses API with `openAI.responsesModel()`:
+
+```typescript
+const response = await ai.generate({
+  model: openAI.responsesModel('gpt-4o'),
+  prompt: 'Tell me a joke.',
+});
+```
+
+or from dotprompt frontmatter, or any other place that carries config:
+
+```yaml
+model: openai/gpt-4o
+config:
+  transport: responses
+```
+
+Built-in OpenAI tools such as web search pass through `config.tools`:
+
+```typescript
+const response = await ai.generate({
+  model: openAI.responsesModel('gpt-4o'),
+  prompt: 'What happened in the news today?',
+  config: { tools: [{ type: 'web_search' }] },
+});
+```
+
+By default requests are stateless: the plugin pins `store: false` and asks OpenAI to return encrypted reasoning, so multi-turn conversations replay the full history from Genkit messages and nothing is retained server-side. To use server-side threading instead, opt into storage and thread responses yourself:
+
+```typescript
+const first = await ai.generate({
+  model: openAI.responsesModel('gpt-4o'),
+  prompt: 'Pick a number between 1 and 10.',
+  config: { store: true },
+});
+
+const second = await ai.generate({
+  model: openAI.responsesModel('gpt-4o'),
+  prompt: 'Double it.',
+  config: { store: true, previousResponseId: first.raw.id },
+});
+```
+
+When threading with `previousResponseId`, send only the new user turn; the server already holds the earlier context.
+
 ### Custom models & other Cloud providers
 
 ```typescript

--- a/js/plugins/compat-oai/src/model.ts
+++ b/js/plugins/compat-oai/src/model.ts
@@ -34,7 +34,13 @@ import {
   z,
 } from 'genkit';
 import { parsePartialJson } from 'genkit/extract';
-import type { ModelAction, ModelInfo, ToolDefinition } from 'genkit/model';
+import type {
+  ModelAction,
+  ModelInfo,
+  ModelMiddleware,
+  ToolDefinition,
+} from 'genkit/model';
+import { simulateConstrainedGeneration } from 'genkit/model';
 import { model } from 'genkit/plugin';
 import OpenAI from 'openai';
 import type {
@@ -737,22 +743,34 @@ export function defineCompatOpenAIModel<
           : chatRunner(request, options)
     : chatRunner;
 
-  // A dispatch-capable action must not be wrapped in
-  // simulateConstrainedGeneration: that middleware strips output.schema into
-  // the prompt before the transport decision runs, and both wire formats here
-  // carry the schema natively.
+  // Registering constrained keeps core's simulateConstrainedGeneration off,
+  // because it would strip output.schema into the prompt before the transport
+  // dispatch runs. Models that never declared constrained still need that
+  // simulation on their Chat Completions requests, so the middleware below
+  // re-applies it for exactly those.
+  const ownConstrained = modelRef?.info?.supports?.constrained;
   const supports = params.responsesTransport
     ? {
         ...modelRef?.info?.supports,
-        constrained: modelRef?.info?.supports?.constrained ?? ('all' as const),
+        constrained: ownConstrained ?? ('all' as const),
       }
     : modelRef?.info?.supports;
+  const use: ModelMiddleware[] | undefined =
+    params.responsesTransport && !ownConstrained
+      ? [
+          (req, next) =>
+            req.config?.transport === 'responses'
+              ? next(req)
+              : simulateConstrainedGeneration()(req, next),
+        ]
+      : undefined;
 
   return model(
     {
       name: actionName,
       ...modelRef?.info,
       ...(supports ? { supports } : {}),
+      ...(use ? { use } : {}),
       configSchema: modelRef?.configSchema,
     },
     runner

--- a/js/plugins/compat-oai/src/model.ts
+++ b/js/plugins/compat-oai/src/model.ts
@@ -728,10 +728,22 @@ export function defineCompatOpenAIModel<
           : chatRunner(request, options)
     : chatRunner;
 
+  // A dispatch-capable action must not be wrapped in
+  // simulateConstrainedGeneration: that middleware strips output.schema into
+  // the prompt before the transport decision runs, and both wire formats here
+  // carry the schema natively.
+  const supports = params.responsesTransport
+    ? {
+        ...modelRef?.info?.supports,
+        constrained: modelRef?.info?.supports?.constrained ?? ('all' as const),
+      }
+    : modelRef?.info?.supports;
+
   return model(
     {
       name: actionName,
       ...modelRef?.info,
+      ...(supports ? { supports } : {}),
       configSchema: modelRef?.configSchema,
     },
     runner

--- a/js/plugins/compat-oai/src/model.ts
+++ b/js/plugins/compat-oai/src/model.ts
@@ -537,6 +537,15 @@ export function toOpenAIRequestBody(
       message: `The 'responses' transport is not supported by ${modelVersion ?? modelName}; it is served over the Chat Completions API.`,
     });
   }
+  // Near-miss values ('Responses', a YAML typo) would otherwise be silently
+  // dropped and served over Chat Completions - the one silent cell in the
+  // transport matrix.
+  if (transport !== undefined && transport !== 'chat_completions') {
+    throw new GenkitError({
+      status: 'INVALID_ARGUMENT',
+      message: `Unknown transport '${transport}'.`,
+    });
+  }
 
   const tools: ChatCompletionTool[] = request.tools?.map(toOpenAITool) ?? [];
   if (toolsFromConfig) {

--- a/js/plugins/compat-oai/src/model.ts
+++ b/js/plugins/compat-oai/src/model.ts
@@ -50,6 +50,7 @@ import type {
   CompletionChoice,
 } from 'openai/resources/index.mjs';
 import { PluginOptions } from './index.js';
+import { openAIResponsesModelRunner } from './responses.js';
 import {
   extractDataFromBase64Url,
   generateFilenameFromContentType,
@@ -690,7 +691,10 @@ export function openAIModelRunner(
  * @param params.client The OpenAI client instance.
  * @param params.modelRef Optional reference to the model's configuration and
  * custom options.
-
+ * @param params.responsesTransport Set true when the provider also serves this
+ * model over the Responses API; a request carrying
+ * `config: { transport: 'responses' }` is then dispatched to that transport
+ * instead of Chat Completions.
  * @returns the created {@link ModelAction}
  */
 export function defineCompatOpenAIModel<
@@ -701,11 +705,28 @@ export function defineCompatOpenAIModel<
   modelRef?: ModelReference<CustomOptions>;
   requestBuilder?: ModelRequestBuilder;
   pluginOptions?: PluginOptions;
+  responsesTransport?: boolean;
 }): ModelAction {
   const { name, client, pluginOptions, modelRef, requestBuilder } = params;
   const modelName = toModelName(name, pluginOptions?.name);
   const actionName =
     modelRef?.name ?? `${pluginOptions?.name ?? 'compat-oai'}/${modelName}`;
+
+  const chatRunner = openAIModelRunner(
+    modelName,
+    client,
+    requestBuilder,
+    pluginOptions
+  );
+  const responsesRunner = params.responsesTransport
+    ? openAIResponsesModelRunner(modelName, client, pluginOptions)
+    : undefined;
+  const runner: typeof chatRunner = responsesRunner
+    ? (request, options) =>
+        request.config?.transport === 'responses'
+          ? responsesRunner(request, options)
+          : chatRunner(request, options)
+    : chatRunner;
 
   return model(
     {
@@ -713,7 +734,7 @@ export function defineCompatOpenAIModel<
       ...modelRef?.info,
       configSchema: modelRef?.configSchema,
     },
-    openAIModelRunner(modelName, client, requestBuilder, pluginOptions)
+    runner
   );
 }
 

--- a/js/plugins/compat-oai/src/openai/gpt.ts
+++ b/js/plugins/compat-oai/src/openai/gpt.ts
@@ -37,6 +37,7 @@ const MULTIMODAL_MODEL_INFO: ModelInfo = {
 export const OpenAIChatCompletionConfigSchema =
   ChatCompletionCommonConfigSchema.extend({
     store: z.boolean().optional(),
+    transport: z.enum(['responses']).optional(),
   });
 
 /** OpenAI ModelRef helper, with OpenAI specific config. */

--- a/js/plugins/compat-oai/src/openai/gpt.ts
+++ b/js/plugins/compat-oai/src/openai/gpt.ts
@@ -37,7 +37,7 @@ const MULTIMODAL_MODEL_INFO: ModelInfo = {
 export const OpenAIChatCompletionConfigSchema =
   ChatCompletionCommonConfigSchema.extend({
     store: z.boolean().optional(),
-    transport: z.enum(['responses']).optional(),
+    transport: z.enum(['responses', 'chat_completions']).optional(),
   });
 
 /** OpenAI ModelRef helper, with OpenAI specific config. */

--- a/js/plugins/compat-oai/src/openai/index.ts
+++ b/js/plugins/compat-oai/src/openai/index.ts
@@ -150,6 +150,7 @@ function createResolver(pluginOptions: PluginOptions) {
         client,
         pluginOptions,
         modelRef,
+        responsesTransport: true,
       });
     }
   };
@@ -243,6 +244,7 @@ export function openAIPlugin(options?: OpenAIPluginOptions): GenkitPluginV2 {
             client,
             pluginOptions,
             modelRef,
+            responsesTransport: true,
           })
         )
       );

--- a/js/plugins/compat-oai/src/openai/index.ts
+++ b/js/plugins/compat-oai/src/openai/index.ts
@@ -357,6 +357,10 @@ export type OpenAIPlugin = {
     config?: z.infer<typeof OpenAIChatCompletionConfigSchema>
   ): ModelReference<typeof OpenAIChatCompletionConfigSchema>;
   model(name: string, config?: any): ModelReference<z.ZodTypeAny>;
+  responsesModel(
+    name: string,
+    config?: z.infer<typeof OpenAIResponsesConfigSchema>
+  ): ModelReference<typeof OpenAIResponsesConfigSchema>;
   embedder(
     name:
       | keyof typeof SUPPORTED_EMBEDDING_MODELS
@@ -403,6 +407,33 @@ const model = ((name: string, config?: any): ModelReference<z.ZodTypeAny> => {
   });
 }) as OpenAIPlugin['model'];
 
+/**
+ * Re-injects the transport pin whenever the ref is rebuilt: core `withConfig`
+ * replaces config wholesale and both chain methods mint fresh, unpinned refs.
+ */
+function pinResponsesTransport(
+  ref: ModelReference<typeof OpenAIResponsesConfigSchema>
+): ModelReference<typeof OpenAIResponsesConfigSchema> {
+  const withConfig = ref.withConfig;
+  const withVersion = ref.withVersion;
+  ref.withConfig = (cfg) =>
+    pinResponsesTransport(withConfig({ ...cfg, transport: 'responses' }));
+  ref.withVersion = (version) => pinResponsesTransport(withVersion(version));
+  return ref;
+}
+
+const responsesModel = ((
+  name: string,
+  config?: z.infer<typeof OpenAIResponsesConfigSchema>
+): ModelReference<typeof OpenAIResponsesConfigSchema> => {
+  return pinResponsesTransport(
+    openAIResponsesModelRef({
+      name,
+      config: { ...config, transport: 'responses' },
+    })
+  );
+}) as OpenAIPlugin['responsesModel'];
+
 const embedder = ((
   name: string,
   config?: any
@@ -446,6 +477,7 @@ const embedder = ((
  */
 export const openAI: OpenAIPlugin = Object.assign(openAIPlugin, {
   model,
+  responsesModel,
   embedder,
 });
 

--- a/js/plugins/compat-oai/src/openai/responses.ts
+++ b/js/plugins/compat-oai/src/openai/responses.ts
@@ -97,6 +97,9 @@ export function isNonStreamingResponsesModelName(name?: string): boolean {
 /** OpenAI Responses API custom configuration schema. */
 export const OpenAIResponsesConfigSchema = ResponsesCommonConfigSchema.extend({
   store: z.boolean().optional(),
+  previousResponseId: z.string().optional(),
+  reasoningEffort: z.enum(['minimal', 'low', 'medium', 'high']).optional(),
+  reasoningSummary: z.enum(['auto', 'concise', 'detailed']).optional(),
   transport: z.enum(['responses']).optional(),
 }).passthrough();
 

--- a/js/plugins/compat-oai/src/openai/responses.ts
+++ b/js/plugins/compat-oai/src/openai/responses.ts
@@ -98,7 +98,9 @@ export function isNonStreamingResponsesModelName(name?: string): boolean {
 export const OpenAIResponsesConfigSchema = ResponsesCommonConfigSchema.extend({
   store: z.boolean().optional(),
   previousResponseId: z.string().optional(),
-  reasoningEffort: z.enum(['minimal', 'low', 'medium', 'high']).optional(),
+  reasoningEffort: z
+    .enum(['none', 'minimal', 'low', 'medium', 'high', 'xhigh'])
+    .optional(),
   reasoningSummary: z.enum(['auto', 'concise', 'detailed']).optional(),
   transport: z.enum(['responses']).optional(),
 }).passthrough();

--- a/js/plugins/compat-oai/src/responses.ts
+++ b/js/plugins/compat-oai/src/responses.ts
@@ -426,12 +426,17 @@ export function toOpenAIResponsesRequestBody(
     tools: tools.length ? tools : undefined,
     tool_choice: request.toolChoice,
     include,
-    previous_response_id: previousResponseId,
     // The Responses API retains requests and responses server-side by default;
     // pinning it off matches the Chat Completions retention posture.
     store: storeValue,
     ...restOfConfig,
   };
+
+  // Set after the spread so a declared key beats a raw passthrough one, the
+  // same precedence the reasoning fields below get.
+  if (previousResponseId !== undefined) {
+    body.previous_response_id = previousResponseId;
+  }
 
   // Composed onto any raw `reasoning` object from the passthrough so the
   // declared fields win without discarding the rest of it.

--- a/js/plugins/compat-oai/src/responses.ts
+++ b/js/plugins/compat-oai/src/responses.ts
@@ -340,6 +340,9 @@ export function toOpenAIResponsesRequestBody(
     visualDetailLevel, // consumed while building the input items above
     version: modelVersion,
     store,
+    previousResponseId,
+    reasoningEffort,
+    reasoningSummary,
     instructions: instructionsFromConfig,
     tools: toolsFromConfig,
     include: includeFromConfig,
@@ -417,11 +420,22 @@ export function toOpenAIResponsesRequestBody(
     tools: tools.length ? tools : undefined,
     tool_choice: request.toolChoice,
     include,
+    previous_response_id: previousResponseId,
     // The Responses API retains requests and responses server-side by default;
     // pinning it off matches the Chat Completions retention posture.
     store: storeValue,
     ...restOfConfig,
   };
+
+  // Composed onto any raw `reasoning` object from the passthrough so the
+  // declared fields win without discarding the rest of it.
+  if (reasoningEffort !== undefined || reasoningSummary !== undefined) {
+    body.reasoning = {
+      ...body.reasoning,
+      ...(reasoningEffort !== undefined ? { effort: reasoningEffort } : {}),
+      ...(reasoningSummary !== undefined ? { summary: reasoningSummary } : {}),
+    };
+  }
 
   // Composed onto any raw `text` object from the passthrough (e.g. verbosity)
   // rather than replacing it wholesale.

--- a/js/plugins/compat-oai/src/responses.ts
+++ b/js/plugins/compat-oai/src/responses.ts
@@ -337,6 +337,12 @@ export function toOpenAIResponsesRequestBody(
     topP: top_p,
     topK, // the Responses API has no equivalent
     stopSequences, // the Responses API has no equivalent
+    // Chat Completions schema keys with no Responses equivalent, dropped so a
+    // dual-transport model's declared chat config cannot leak onto this wire.
+    frequencyPenalty,
+    presencePenalty,
+    logProbs,
+    topLogProbs,
     visualDetailLevel, // consumed while building the input items above
     version: modelVersion,
     store,

--- a/js/plugins/compat-oai/tests/openai_responses_test.ts
+++ b/js/plugins/compat-oai/tests/openai_responses_test.ts
@@ -686,6 +686,36 @@ describe('toOpenAIResponsesRequestBody', () => {
     expect(body.include).toStrictEqual(['message.output_text.logprobs']);
   });
 
+  test('drops declared chat-schema keys that have no Responses equivalent', () => {
+    const body = toOpenAIResponsesRequestBody('gpt-4o', {
+      messages: [],
+      config: {
+        transport: 'responses',
+        frequencyPenalty: 0.5,
+        presencePenalty: 0.5,
+        logProbs: true,
+        topLogProbs: 3,
+      },
+    });
+
+    expect(body).not.toHaveProperty('frequencyPenalty');
+    expect(body).not.toHaveProperty('presencePenalty');
+    expect(body).not.toHaveProperty('logProbs');
+    expect(body).not.toHaveProperty('topLogProbs');
+  });
+
+  test('lets a raw previous_response_id passthrough win over the declared key', () => {
+    const body = toOpenAIResponsesRequestBody('gpt-5-pro', {
+      messages: [],
+      config: {
+        previousResponseId: 'resp_declared',
+        previous_response_id: 'resp_raw',
+      },
+    });
+
+    expect(body.previous_response_id).toBe('resp_raw');
+  });
+
   test('maps previousResponseId onto the wire field', () => {
     const body = toOpenAIResponsesRequestBody('gpt-5-pro', {
       messages: [],

--- a/js/plugins/compat-oai/tests/openai_responses_test.ts
+++ b/js/plugins/compat-oai/tests/openai_responses_test.ts
@@ -685,6 +685,42 @@ describe('toOpenAIResponsesRequestBody', () => {
 
     expect(body.include).toStrictEqual(['message.output_text.logprobs']);
   });
+
+  test('maps previousResponseId onto the wire field', () => {
+    const body = toOpenAIResponsesRequestBody('gpt-5-pro', {
+      messages: [],
+      config: { previousResponseId: 'resp_prev' },
+    });
+
+    expect(body.previous_response_id).toBe('resp_prev');
+    expect(body).not.toHaveProperty('previousResponseId');
+  });
+
+  test('maps reasoning effort and summary into the reasoning object', () => {
+    const body = toOpenAIResponsesRequestBody('gpt-5-pro', {
+      messages: [],
+      config: { reasoningEffort: 'low', reasoningSummary: 'auto' },
+    });
+
+    expect(body.reasoning).toStrictEqual({ effort: 'low', summary: 'auto' });
+    expect(body).not.toHaveProperty('reasoningEffort');
+    expect(body).not.toHaveProperty('reasoningSummary');
+  });
+
+  test('composes declared reasoning fields over a raw passthrough object', () => {
+    const body = toOpenAIResponsesRequestBody('gpt-5-pro', {
+      messages: [],
+      config: {
+        reasoningSummary: 'detailed',
+        reasoning: { effort: 'high', summary: 'auto' },
+      },
+    });
+
+    expect(body.reasoning).toStrictEqual({
+      effort: 'high',
+      summary: 'detailed',
+    });
+  });
 });
 
 describe('fromOpenAIResponse', () => {
@@ -1736,6 +1772,85 @@ describe('openAI plugin routing', () => {
     expect(
       Object.keys(metadata.metadata?.model.customOptions.properties)
     ).toContain('transport');
+  });
+});
+
+describe('openAI.responsesModel', () => {
+  test('returns a namespaced ref pinned to the responses transport', () => {
+    const ref = openAI.responsesModel('gpt-4o');
+
+    expect(ref.name).toBe('openai/gpt-4o');
+    expect(ref.config).toStrictEqual({ transport: 'responses' });
+    expect(Object.keys(ref.configSchema!.shape)).toContain(
+      'previousResponseId'
+    );
+  });
+
+  test('merges call-site config under the pin', () => {
+    const ref = openAI.responsesModel('gpt-4o', { reasoningEffort: 'low' });
+
+    expect(ref.config).toStrictEqual({
+      reasoningEffort: 'low',
+      transport: 'responses',
+    });
+  });
+
+  test('withConfig replaces config wholesale but re-injects the pin', () => {
+    const ref = openAI
+      .responsesModel('gpt-4o', { reasoningEffort: 'low' })
+      .withConfig({ temperature: 0.5 });
+
+    expect(ref.config).toStrictEqual({
+      temperature: 0.5,
+      transport: 'responses',
+    });
+  });
+
+  test('keeps the pin through a withConfig().withVersion() chain', () => {
+    const ref = openAI
+      .responsesModel('gpt-4o')
+      .withConfig({ temperature: 0.5 })
+      .withVersion('gpt-4o-2024-08-06');
+
+    expect(ref.version).toBe('gpt-4o-2024-08-06');
+    expect(ref.config).toStrictEqual({
+      temperature: 0.5,
+      transport: 'responses',
+    });
+    // The chained ref must stay pinned for the next withConfig too.
+    expect(ref.withConfig({ temperature: 1 }).config).toStrictEqual({
+      temperature: 1,
+      transport: 'responses',
+    });
+  });
+
+  test('routes a dual-transport model over the Responses API end to end', async () => {
+    const server = new FakeOpenAIServer();
+    await server.start();
+    const previousBaseUrl = process.env.OPENAI_BASE_URL;
+    process.env.OPENAI_BASE_URL = server.baseUrl;
+    try {
+      const ai = genkit({ plugins: [openAI({ apiKey: 'key' })] });
+      server.setNextResponse({ body: textResponse('opted in') });
+
+      const result = await ai.generate({
+        model: openAI.responsesModel('gpt-4o'),
+        prompt: 'hi',
+      });
+
+      expect(result.text).toBe('opted in');
+      const sent = server.requests[server.requests.length - 1];
+      expect(sent.url).toBe('/v1/responses');
+      expect(sent.body.model).toBe('gpt-4o');
+      expect(sent.body).not.toHaveProperty('transport');
+    } finally {
+      if (previousBaseUrl === undefined) {
+        delete process.env.OPENAI_BASE_URL;
+      } else {
+        process.env.OPENAI_BASE_URL = previousBaseUrl;
+      }
+      server.stop();
+    }
   });
 });
 

--- a/js/plugins/compat-oai/tests/openai_responses_test.ts
+++ b/js/plugins/compat-oai/tests/openai_responses_test.ts
@@ -1912,7 +1912,7 @@ describe('openAI.responsesModel', () => {
 
       // gpt-3.5-turbo's Chat Completions API rejects response_format
       // json_schema, so with no transport opt-in the schema must still be
-      // simulated into the prompt, exactly as before the dispatch existed.
+      // simulated into the prompt rather than sent natively.
       await ai.generate({
         model: openAI.model('gpt-3.5-turbo'),
         prompt: 'pick one',

--- a/js/plugins/compat-oai/tests/openai_responses_test.ts
+++ b/js/plugins/compat-oai/tests/openai_responses_test.ts
@@ -1487,13 +1487,13 @@ describe('openAI plugin routing', () => {
     ).toContain('transport');
   });
 
-  test('leaves dual-transport names on Chat Completions', async () => {
+  test('declares the transport key on dual-transport chat models', async () => {
     const plugin = openAI({ apiKey: 'key' });
     const action = await plugin.model('gpt-5');
 
     expect(
       Object.keys(action.__action.metadata?.model.customOptions.properties)
-    ).not.toContain('transport');
+    ).toContain('transport');
   });
 
   test('gives Responses-only refs the transport-aware config schema', () => {
@@ -1636,6 +1636,86 @@ describe('openAI plugin routing', () => {
     expect(server.requests[server.requests.length - 1].url).toBe(
       '/v1/chat/completions'
     );
+  });
+
+  test('dispatches a dual-transport model to Responses on config opt-in', async () => {
+    const plugin = openAI({ apiKey: 'key' });
+    const action = await plugin.model('gpt-4o');
+    server.setNextResponse({ body: textResponse('via responses') });
+
+    const result = await action({
+      messages: [{ role: 'user', content: [{ text: 'hi' }] }],
+      config: { transport: 'responses' },
+    });
+
+    expect(result.message?.content[0].text).toBe('via responses');
+    const sent = server.requests[server.requests.length - 1];
+    expect(sent.url).toBe('/v1/responses');
+    expect(sent.body).not.toHaveProperty('transport');
+  });
+
+  test('streams a dual-transport model over Responses on config opt-in', async () => {
+    const ai = genkit({ plugins: [openAI({ apiKey: 'key' })] });
+    server.setNextResponse({
+      stream: true,
+      chunks: [
+        {
+          type: 'response.created',
+          response: fakeResponse(),
+          sequence_number: 0,
+        },
+        {
+          type: 'response.output_item.added',
+          output_index: 0,
+          item: {
+            id: 'msg_1',
+            type: 'message',
+            role: 'assistant',
+            status: 'in_progress',
+            content: [],
+          },
+          sequence_number: 1,
+        },
+        {
+          type: 'response.content_part.added',
+          item_id: 'msg_1',
+          output_index: 0,
+          content_index: 0,
+          part: { type: 'output_text', text: '', annotations: [] },
+          sequence_number: 2,
+        },
+        {
+          type: 'response.output_text.delta',
+          item_id: 'msg_1',
+          output_index: 0,
+          content_index: 0,
+          delta: 'streamed',
+          sequence_number: 3,
+        },
+        {
+          type: 'response.completed',
+          response: textResponse('streamed'),
+          sequence_number: 4,
+        },
+      ],
+    });
+
+    const { response, stream } = ai.generateStream({
+      model: openAI.model('gpt-4o'),
+      prompt: 'hi',
+      config: { transport: 'responses' },
+    });
+    const chunks: string[] = [];
+    for await (const chunk of stream) {
+      chunks.push(chunk.text);
+    }
+    const result = await response;
+
+    expect(result.text).toBe('streamed');
+    expect(chunks.join('')).toBe('streamed');
+    const sent = server.requests[server.requests.length - 1];
+    expect(sent.url).toBe('/v1/responses');
+    expect(sent.body.stream).toBe(true);
   });
 
   test('lists Responses-only models with the transport-aware config schema', async () => {

--- a/js/plugins/compat-oai/tests/openai_responses_test.ts
+++ b/js/plugins/compat-oai/tests/openai_responses_test.ts
@@ -1882,6 +1882,37 @@ describe('openAI.responsesModel', () => {
       server.stop();
     }
   });
+
+  test('sends an output schema natively on the dispatched path', async () => {
+    const server = new FakeOpenAIServer();
+    await server.start();
+    const previousBaseUrl = process.env.OPENAI_BASE_URL;
+    process.env.OPENAI_BASE_URL = server.baseUrl;
+    try {
+      const ai = genkit({ plugins: [openAI({ apiKey: 'key' })] });
+      server.setNextResponse({ body: textResponse('{"colour":"blue"}') });
+
+      // gpt-5's chat info declares no `constrained`, so without the dispatch
+      // default this would be simulated into the prompt instead.
+      await ai.generate({
+        model: openAI.responsesModel('gpt-5'),
+        prompt: 'pick one',
+        output: { schema: z.object({ colour: z.string() }) },
+      });
+
+      const sent = server.requests[server.requests.length - 1];
+      expect(sent.url).toBe('/v1/responses');
+      expect(sent.body.text.format.type).toBe('json_schema');
+      expect(JSON.stringify(sent.body.input)).not.toContain('colour');
+    } finally {
+      if (previousBaseUrl === undefined) {
+        delete process.env.OPENAI_BASE_URL;
+      } else {
+        process.env.OPENAI_BASE_URL = previousBaseUrl;
+      }
+      server.stop();
+    }
+  });
 });
 
 describe('chat completions transport handling', () => {

--- a/js/plugins/compat-oai/tests/openai_responses_test.ts
+++ b/js/plugins/compat-oai/tests/openai_responses_test.ts
@@ -1892,6 +1892,47 @@ describe('openAI.responsesModel', () => {
     }
   });
 
+  test('keeps simulating an output schema on the plain chat path', async () => {
+    const server = new FakeOpenAIServer();
+    await server.start();
+    const previousBaseUrl = process.env.OPENAI_BASE_URL;
+    process.env.OPENAI_BASE_URL = server.baseUrl;
+    try {
+      const ai = genkit({ plugins: [openAI({ apiKey: 'key' })] });
+      server.setNextResponse({
+        body: {
+          choices: [
+            {
+              message: { role: 'assistant', content: '{"colour":"blue"}' },
+              finish_reason: 'stop',
+            },
+          ],
+        },
+      });
+
+      // gpt-3.5-turbo's Chat Completions API rejects response_format
+      // json_schema, so with no transport opt-in the schema must still be
+      // simulated into the prompt, exactly as before the dispatch existed.
+      await ai.generate({
+        model: openAI.model('gpt-3.5-turbo'),
+        prompt: 'pick one',
+        output: { schema: z.object({ colour: z.string() }) },
+      });
+
+      const sent = server.requests[server.requests.length - 1];
+      expect(sent.url).toBe('/v1/chat/completions');
+      expect(sent.body.response_format?.type).not.toBe('json_schema');
+      expect(JSON.stringify(sent.body.messages)).toContain('colour');
+    } finally {
+      if (previousBaseUrl === undefined) {
+        delete process.env.OPENAI_BASE_URL;
+      } else {
+        process.env.OPENAI_BASE_URL = previousBaseUrl;
+      }
+      server.stop();
+    }
+  });
+
   test('sends an output schema natively on the dispatched path', async () => {
     const server = new FakeOpenAIServer();
     await server.start();

--- a/js/plugins/compat-oai/tests/openai_responses_test.ts
+++ b/js/plugins/compat-oai/tests/openai_responses_test.ts
@@ -704,13 +704,22 @@ describe('toOpenAIResponsesRequestBody', () => {
     expect(body).not.toHaveProperty('topLogProbs');
   });
 
-  test('lets a raw previous_response_id passthrough win over the declared key', () => {
+  test('lets the declared previousResponseId win over a raw passthrough key', () => {
     const body = toOpenAIResponsesRequestBody('gpt-5-pro', {
       messages: [],
       config: {
         previousResponseId: 'resp_declared',
         previous_response_id: 'resp_raw',
       },
+    });
+
+    expect(body.previous_response_id).toBe('resp_declared');
+  });
+
+  test('keeps a raw previous_response_id passthrough when no declared key is set', () => {
+    const body = toOpenAIResponsesRequestBody('gpt-5-pro', {
+      messages: [],
+      config: { previous_response_id: 'resp_raw' },
     });
 
     expect(body.previous_response_id).toBe('resp_raw');

--- a/js/plugins/compat-oai/tests/openai_responses_test.ts
+++ b/js/plugins/compat-oai/tests/openai_responses_test.ts
@@ -1953,4 +1953,16 @@ describe('chat completions transport handling', () => {
       })
     ).rejects.toThrow(expect.objectContaining({ status: 'INVALID_ARGUMENT' }));
   });
+
+  test('rejects a near-miss transport value instead of serving it silently', async () => {
+    const client = new OpenAI({ apiKey: 'key', baseURL: server.baseUrl });
+    const runner = openAIModelRunner('gpt-4o', client);
+
+    await expect(
+      runner({
+        messages: [{ role: 'user', content: [{ text: 'hi' }] }],
+        config: { transport: 'Responses' },
+      })
+    ).rejects.toThrow(expect.objectContaining({ status: 'INVALID_ARGUMENT' }));
+  });
 });


### PR DESCRIPTION
Part of #6002, closes #6005. Slice 3 of the Responses API stack, on top of #6148.

- `openAI.responsesModel(name)`: typed ref pinned to `config: { transport: 'responses' }`; `withConfig`/`withVersion` re-wrapped so the pin survives chaining.
- Dual-transport dispatch: chat-registered OpenAI models route a request carrying `config: { transport: 'responses' }` to the Responses runner, so the opt-in also works from dotprompt frontmatter. Providers that do not opt in keep the INVALID_ARGUMENT rejection.
- Responses config schema declares `previousResponseId`, `reasoningEffort`, `reasoningSummary`, mapped to `previous_response_id` and `reasoning: { effort, summary }` on the wire; declared fields compose over a raw passthrough `reasoning` object.
- README: automatic routing for Responses-only models, the opt-in, built-in tools via `config.tools`, stateless default and opting into server-side threading.

Review hardening applied on top: chat-only config keys (`frequencyPenalty` etc.) are dropped from the Responses wire; dispatch-capable registrations default `supports.constrained` to `'all'` so an output schema reaches the Responses wire natively instead of being simulated into the prompt, while middleware re-applies the simulation to Chat Completions requests on models that never declared constrained support, keeping the plain chat path byte-identical to before; near-miss transport values (e.g. `'Responses'`) throw INVALID_ARGUMENT instead of silently serving Chat Completions; declared `previousResponseId` wins over a raw `previous_response_id` passthrough, matching the reasoning fields.

Known limitations, noted deliberately:

- `responsesModel()`'s config type inherits `.passthrough()` from the schema, so unknown keys (typos included) compile and pass to the wire. Cost of keeping the passthrough escape hatch; consistent with `model()`.
- The registered action for a dual-transport model advertises the Chat Completions config schema, so schema-driven tooling (Dev UI config forms) does not offer `previousResponseId`/`reasoningEffort`/`reasoningSummary` on it. Runtime honors them regardless; inherent to one action serving two transports.
- Dispatch-capable actions advertise `supports.constrained: 'all'` even when their Chat Completions API would reject `response_format: json_schema`; runtime behavior is correct on both transports (see above), the metadata over-claim is display-only.

Live smoke checklist before un-drafting:

- `config.tools: [{ type: 'web_search' }]` passthrough (type absent from the pinned SDK union).
- `previousResponseId` under the default `store: false` (unverified whether OpenAI accepts the combination).
- A non-reasoning model over the dispatch (`responsesModel('gpt-4o')`): confirms the reasoning-gated encrypted-content include.
- A text-only reasoning turn replayed stateless with `reasoningSummary` on (multi-turn, no tools): the assistant message replays without its `msg_` id next to an id-carrying reasoning item; one shape passed live already, ecosystem reports 400s on close variants.
