### PR TITLE
feat(go/plugins/spark): add iFLYTEK Spark plugin

### DIFF
--- a/go/plugins/compat_oai/spark/README.md
+++ b/go/plugins/compat_oai/spark/README.md
@@ -1,0 +1,50 @@
+# Spark Plugin
+
+This plugin provides Genkit support for iFLYTEK's Spark (讯飞星火) models
+through their OpenAI-compatible HTTP API.
+
+## Setup
+
+Set a Spark API key:
+
+```bash
+export SPARK_API_KEY=<your-api-key>
+```
+
+The key is the Spark HTTP service **API Password** (the single `APIPassword`
+value shown in the [iFLYTEK console](https://console.xfyun.cn/services/bmx1)),
+sent as a Bearer token. It is **not** the legacy WebSocket API's
+`APPID`/`APIKey`/`APISecret` triple.
+
+The plugin uses `https://spark-api-open.xf-yun.com/v1` by default. Set
+`SPARK_BASE_URL`, or pass `option.WithBaseURL` through the plugin's `Opts`, to
+use another compatible endpoint. Do not point it at the WebSocket host
+`spark-api.xf-yun.com`, which uses a different protocol and authentication.
+
+```go
+import (
+    "context"
+
+    "github.com/firebase/genkit/go/ai"
+    "github.com/firebase/genkit/go/genkit"
+    "github.com/firebase/genkit/go/plugins/compat_oai/spark"
+)
+
+ctx := context.Background()
+plugin := &spark.Spark{}
+g := genkit.Init(ctx,
+    genkit.WithPlugins(plugin),
+    genkit.WithDefaultModel("spark/4.0Ultra"),
+)
+
+response, err := genkit.Generate(ctx, g, ai.WithPrompt("介绍一下讯飞星火大模型。"))
+```
+
+## Models
+
+`4.0Ultra`, `generalv3.5` (Max), `max-32k` (Max-32K), `generalv3` (Pro),
+`pro-128k` (Pro-128K), and `lite` are registered. The catalog is not a ceiling:
+any model ID the Spark HTTP endpoint serves resolves on demand, and the `Models`
+field describes or corrects any model, curated or not. The current model list is
+in the iFLYTEK Spark HTTP API reference at
+https://www.xfyun.cn/doc/spark/HTTP%E8%B0%83%E7%94%A8%E6%96%87%E6%A1%A3.html.

--- a/go/plugins/compat_oai/spark/spark.go
+++ b/go/plugins/compat_oai/spark/spark.go
@@ -148,13 +148,12 @@ func (s *Spark) Init(ctx context.Context) []api.Action {
 	if apiKey == "" {
 		apiKey = os.Getenv("SPARK_API_KEY")
 	}
-	if apiKey == "" {
-		panic("spark plugin initialization failed: apiKey is required")
-	}
 
 	opts := []option.RequestOption{
-		option.WithAPIKey(apiKey),
 		option.WithBaseURL(baseURL),
+	}
+	if apiKey != "" {
+		opts = append(opts, option.WithAPIKey(apiKey))
 	}
 	opts = append(opts, s.Opts...)
 

--- a/go/plugins/compat_oai/spark/spark.go
+++ b/go/plugins/compat_oai/spark/spark.go
@@ -1,0 +1,206 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package spark provides a Genkit plugin for iFLYTEK's Spark models.
+package spark
+
+import (
+	"context"
+	"os"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/core/api"
+	"github.com/firebase/genkit/go/plugins/compat_oai"
+	"github.com/openai/openai-go"
+	"github.com/openai/openai-go/option"
+)
+
+const (
+	provider       = "spark"
+	defaultBaseURL = "https://spark-api-open.xf-yun.com/v1"
+)
+
+// ChatConfig is the per-request config for iFLYTEK Spark models: the generation
+// fields Spark's OpenAI-compatible HTTP API accepts. See
+// https://www.xfyun.cn/doc/spark/HTTP%E8%B0%83%E7%94%A8%E6%96%87%E6%A1%A3.html.
+//
+// Spark is reached over its OpenAI-compatible HTTP endpoint, authenticated with
+// the single Bearer "API Password" from the iFLYTEK console, not the legacy
+// WebSocket API's APPID/APIKey/APISecret triple.
+type ChatConfig struct {
+	compat_oai.RequestConfig
+
+	// Temperature controls the degree of randomness in token selection, from
+	// 0 to 2; Spark's default is 0.5.
+	Temperature *float64 `json:"temperature,omitempty" jsonschema:"minimum=0,maximum=2" jsonschema_description:"Controls the degree of randomness in token selection, from 0 to 2. Spark's default is 0.5."`
+	// TopP is the nucleus sampling threshold, from 0 to 1.
+	TopP *float64 `json:"topP,omitempty" jsonschema:"minimum=0,maximum=1" jsonschema_description:"Nucleus sampling threshold, from 0 to 1."`
+	// MaxOutputTokens is the maximum number of tokens to generate, sent as the
+	// API's max_tokens.
+	MaxOutputTokens int `json:"maxOutputTokens,omitempty" jsonschema:"minimum=1" jsonschema_description:"Maximum number of tokens to generate, sent as the API's max_tokens."`
+	// StopSequences stop generation when produced by the model.
+	StopSequences []string `json:"stopSequences,omitempty" jsonschema_description:"Stop generation when produced by the model."`
+}
+
+// ApplyToChatCompletion implements [compat_oai.ChatConfig]: the generation
+// fields land on their chat completion counterparts, with MaxOutputTokens on
+// the max_tokens Spark reads.
+func (c ChatConfig) ApplyToChatCompletion(params *openai.ChatCompletionNewParams) {
+	c.ApplyVersion(params)
+
+	if c.Temperature != nil {
+		params.Temperature = openai.Float(*c.Temperature)
+	}
+	if c.TopP != nil {
+		params.TopP = openai.Float(*c.TopP)
+	}
+	if c.MaxOutputTokens > 0 {
+		params.MaxTokens = openai.Int(int64(c.MaxOutputTokens))
+	}
+	if len(c.StopSequences) > 0 {
+		params.Stop = openai.ChatCompletionNewParamsStopUnion{OfStringArray: c.StopSequences}
+	}
+}
+
+// textOnly is the capability set every Spark model shares: text in, text or
+// JSON out, and tools. No constrained generation is advertised: Spark's
+// response_format takes json_object only, not json_schema, so a schema reaches
+// the model as prompt instructions.
+var textOnly = ai.ModelSupports{
+	Multiturn:  true,
+	Tools:      true,
+	SystemRole: true,
+	Media:      false,
+	ToolChoice: true,
+	Output:     []string{"text", "json"},
+}
+
+// supportedModels curates capabilities for well-known Spark models. It is not
+// the set of usable models: any Spark model resolves on demand and takes
+// [dynamicModelOptions], so an ID absent here still works. No versions are
+// declared, since the iFLYTEK HTTP API serves each model under one ID.
+//
+// Catalog: https://www.xfyun.cn/doc/spark/HTTP%E8%B0%83%E7%94%A8%E6%96%87%E6%A1%A3.html
+var supportedModels = map[string]ai.ModelOptions{
+	"4.0Ultra":    {Label: "Spark 4.0 Ultra", Supports: &textOnly},
+	"generalv3.5": {Label: "Spark Max", Supports: &textOnly},
+	"max-32k":     {Label: "Spark Max-32K", Supports: &textOnly},
+	"generalv3":   {Label: "Spark Pro", Supports: &textOnly},
+	"pro-128k":    {Label: "Spark Pro-128K", Supports: &textOnly},
+	"lite":        {Label: "Spark Lite", Supports: &textOnly},
+}
+
+// dynamicModelOptions is advertised for Spark models that resolve dynamically
+// rather than appearing in supportedModels. A model iFLYTEK adds later is
+// assumed to share the text-only shape.
+var dynamicModelOptions = ai.ModelOptions{
+	Supports: &textOnly,
+	Versions: []string{},
+	Stage:    ai.ModelStageStable,
+}
+
+// Spark configures the iFLYTEK Spark plugin.
+type Spark struct {
+	// APIKey is the Spark HTTP service "API Password" — the single Bearer
+	// credential shown as APIPassword in the iFLYTEK console, not the legacy
+	// APPID/APIKey/APISecret triple. If empty, SPARK_API_KEY is consulted.
+	APIKey string
+	// Opts contains additional OpenAI client request options, such as
+	// [option.WithBaseURL] for a different endpoint (SPARK_BASE_URL works too).
+	// Options supplied here are applied after the plugin defaults, so they win
+	// on overlap.
+	Opts []option.RequestOption
+	// Models overrides what the plugin knows about a Spark model, keyed by
+	// model ID, bare or provider-prefixed. Every Spark model already works
+	// without an entry: known IDs carry curated capabilities and the rest take
+	// the Spark defaults. Supply an entry only to correct or extend what the
+	// plugin resolves, most often for a model released after this version of
+	// the plugin.
+	Models map[string]ai.ModelOptions
+
+	openAICompatible compat_oai.OpenAICompatible
+}
+
+// Name implements genkit.Plugin.
+func (s *Spark) Name() string {
+	return provider
+}
+
+// Init implements genkit.Plugin.
+func (s *Spark) Init(ctx context.Context) []api.Action {
+	baseURL := os.Getenv("SPARK_BASE_URL")
+	if baseURL == "" {
+		baseURL = defaultBaseURL
+	}
+
+	apiKey := s.APIKey
+	if apiKey == "" {
+		apiKey = os.Getenv("SPARK_API_KEY")
+	}
+	if apiKey == "" {
+		panic("spark plugin initialization failed: apiKey is required")
+	}
+
+	opts := []option.RequestOption{
+		option.WithAPIKey(apiKey),
+		option.WithBaseURL(baseURL),
+	}
+	opts = append(opts, s.Opts...)
+
+	s.openAICompatible.Provider = provider
+	s.openAICompatible.Opts = opts
+	actions := s.openAICompatible.Init(ctx)
+
+	for model := range supportedModels {
+		actions = append(actions, s.newModel(model, s.modelOptions(model)))
+	}
+	return actions
+}
+
+// newModel creates a Spark model without registering it.
+func (s *Spark) newModel(id string, opts ai.ModelOptions) *ai.ModelAction {
+	return compat_oai.NewChatModel[ChatConfig](&s.openAICompatible, id, opts)
+}
+
+// modelOptions returns the ModelOptions for a Spark model ID: curated
+// capabilities for a known model and the Spark defaults for the rest, with an
+// entry from [Spark.Models] overlaid on whichever applies.
+func (s *Spark) modelOptions(id string) ai.ModelOptions {
+	return compat_oai.ModelOptionsFor(provider, id, supportedModels, dynamicModelOptions, s.Models)
+}
+
+// ModelRef names a Spark model and carries the config to generate with, so the
+// config is typed at the call site instead of an any the model checks at
+// runtime. A nil config leaves the request's config unset.
+//
+//	ai.WithModel(spark.ModelRef("4.0Ultra", &spark.ChatConfig{
+//		MaxOutputTokens: 1024,
+//	}))
+//
+// id is the model ID, with or without the provider prefix.
+func ModelRef(id string, config *ChatConfig) ai.ModelRef {
+	return ai.NewModelRef(compat_oai.ActionName(provider, id), config)
+}
+
+// ListActions lists the models the configured Spark endpoint exposes, described
+// by the plugin's config schema and capabilities.
+func (s *Spark) ListActions(ctx context.Context) []api.ActionDesc {
+	return compat_oai.ListChatActions[ChatConfig](ctx, &s.openAICompatible, s.modelOptions)
+}
+
+// ResolveAction dynamically builds a model exposed by the Spark endpoint,
+// described by the plugin's config schema and capabilities.
+func (s *Spark) ResolveAction(atype api.ActionType, id string) api.Action {
+	return compat_oai.ResolveChatAction[ChatConfig](&s.openAICompatible, atype, id, s.modelOptions)
+}

--- a/go/plugins/compat_oai/spark/spark_test.go
+++ b/go/plugins/compat_oai/spark/spark_test.go
@@ -31,20 +31,76 @@ import (
 	"github.com/openai/openai-go/option"
 )
 
-func TestPluginRequiresAPIKey(t *testing.T) {
+func TestPluginIgnoresOpenAIAPIKey(t *testing.T) {
 	t.Setenv("SPARK_API_KEY", "")
 	// An OPENAI_API_KEY must never be picked up as a fallback: sending it to
 	// Spark would silently authenticate with the wrong provider's key.
 	t.Setenv("OPENAI_API_KEY", "sk-should-not-be-used")
 
-	defer func() {
-		got := recover()
-		if got != "spark plugin initialization failed: apiKey is required" {
-			t.Fatalf("panic = %v, want missing API key error", got)
-		}
-	}()
+	var mu sync.Mutex
+	var gotAuth string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		gotAuth = r.Header.Get("Authorization")
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{
+			"id":"c1","object":"chat.completion","created":1,"model":"4.0Ultra",
+			"choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],
+			"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}
+		}`)
+	}))
+	defer server.Close()
 
-	(&spark.Spark{}).Init(context.Background())
+	ctx := context.Background()
+	plugin := &spark.Spark{Opts: []option.RequestOption{option.WithBaseURL(server.URL)}}
+	g := genkit.Init(ctx, genkit.WithPlugins(plugin), genkit.WithDefaultModel("spark/4.0Ultra"))
+
+	if _, err := genkit.Generate(ctx, g, ai.WithPrompt("hi")); err != nil {
+		t.Fatalf("Generate() error = %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if gotAuth != "" {
+		t.Errorf("Authorization = %q, want no inherited OPENAI_API_KEY", gotAuth)
+	}
+}
+
+func TestPluginAcceptsAPIKeyInOpts(t *testing.T) {
+	t.Setenv("SPARK_API_KEY", "")
+
+	var mu sync.Mutex
+	var gotAuth string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		gotAuth = r.Header.Get("Authorization")
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{
+			"id":"c1","object":"chat.completion","created":1,"model":"4.0Ultra",
+			"choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],
+			"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}
+		}`)
+	}))
+	defer server.Close()
+
+	ctx := context.Background()
+	plugin := &spark.Spark{Opts: []option.RequestOption{
+		option.WithBaseURL(server.URL),
+		option.WithAPIKey("opts-key"),
+	}}
+	g := genkit.Init(ctx, genkit.WithPlugins(plugin), genkit.WithDefaultModel("spark/4.0Ultra"))
+
+	if _, err := genkit.Generate(ctx, g, ai.WithPrompt("hi")); err != nil {
+		t.Fatalf("Generate() error = %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if gotAuth != "Bearer opts-key" {
+		t.Errorf("Authorization = %q, want %q", gotAuth, "Bearer opts-key")
+	}
 }
 
 func TestPluginConfigPrecedence(t *testing.T) {
@@ -151,7 +207,18 @@ func TestChatConfigApplyToChatCompletion(t *testing.T) {
 		StopSequences:   []string{"STOP"},
 	}
 	var params openai.ChatCompletionNewParams
-	// Exercises the field mapping; the zero-value fields must be left untouched
-	// and the set fields must apply without panicking.
 	cfg.ApplyToChatCompletion(&params)
+
+	if !params.Temperature.Valid() || params.Temperature.Value != temperature {
+		t.Errorf("Temperature = %v, want %v", params.Temperature, temperature)
+	}
+	if !params.TopP.Valid() || params.TopP.Value != topP {
+		t.Errorf("TopP = %v, want %v", params.TopP, topP)
+	}
+	if !params.MaxTokens.Valid() || params.MaxTokens.Value != 64 {
+		t.Errorf("MaxTokens = %v, want 64", params.MaxTokens)
+	}
+	if !slices.Equal(params.Stop.OfStringArray, []string{"STOP"}) {
+		t.Errorf("Stop = %v, want [STOP]", params.Stop.OfStringArray)
+	}
 }

--- a/go/plugins/compat_oai/spark/spark_test.go
+++ b/go/plugins/compat_oai/spark/spark_test.go
@@ -1,0 +1,157 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spark_test
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"sync"
+	"testing"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/core/api"
+	"github.com/firebase/genkit/go/genkit"
+	"github.com/firebase/genkit/go/plugins/compat_oai/spark"
+	"github.com/openai/openai-go"
+	"github.com/openai/openai-go/option"
+)
+
+func TestPluginRequiresAPIKey(t *testing.T) {
+	t.Setenv("SPARK_API_KEY", "")
+	// An OPENAI_API_KEY must never be picked up as a fallback: sending it to
+	// Spark would silently authenticate with the wrong provider's key.
+	t.Setenv("OPENAI_API_KEY", "sk-should-not-be-used")
+
+	defer func() {
+		got := recover()
+		if got != "spark plugin initialization failed: apiKey is required" {
+			t.Fatalf("panic = %v, want missing API key error", got)
+		}
+	}()
+
+	(&spark.Spark{}).Init(context.Background())
+}
+
+func TestPluginConfigPrecedence(t *testing.T) {
+	var mu sync.Mutex
+	var rightHit, wrongHit bool
+	var gotAuth string
+
+	right := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		rightHit = true
+		gotAuth = r.Header.Get("Authorization")
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{
+			"id":"c1","object":"chat.completion","created":1,"model":"4.0Ultra",
+			"choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],
+			"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}
+		}`)
+	}))
+	defer right.Close()
+
+	wrong := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		wrongHit = true
+		mu.Unlock()
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer wrong.Close()
+
+	// Explicit configuration must win over env vars: the struct field for the
+	// key, and an Opts [option.WithBaseURL] for the endpoint, which the plugin
+	// applies after its own defaults.
+	t.Setenv("SPARK_API_KEY", "env-key")
+	t.Setenv("SPARK_BASE_URL", wrong.URL)
+
+	ctx := context.Background()
+	plugin := &spark.Spark{APIKey: "struct-key", Opts: []option.RequestOption{option.WithBaseURL(right.URL)}}
+	g := genkit.Init(ctx, genkit.WithPlugins(plugin), genkit.WithDefaultModel("spark/4.0Ultra"))
+
+	if _, err := genkit.Generate(ctx, g, ai.WithPrompt("hi")); err != nil {
+		t.Fatalf("Generate() error = %v", err)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if !rightHit || wrongHit {
+		t.Fatalf("rightHit = %v, wrongHit = %v, want struct fields to take precedence over env vars", rightHit, wrongHit)
+	}
+	if gotAuth != "Bearer struct-key" {
+		t.Errorf("Authorization = %q, want %q", gotAuth, "Bearer struct-key")
+	}
+}
+
+func TestPluginRegistersModels(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{
+			"id":"c1","object":"chat.completion","created":1,"model":"4.0Ultra",
+			"choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],
+			"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}
+		}`)
+	}))
+	defer server.Close()
+
+	t.Setenv("SPARK_API_KEY", "test-key")
+	t.Setenv("SPARK_BASE_URL", server.URL)
+
+	ctx := context.Background()
+	plugin := &spark.Spark{}
+	g := genkit.Init(ctx, genkit.WithPlugins(plugin), genkit.WithDefaultModel("spark/4.0Ultra"))
+
+	if plugin.Name() != "spark" {
+		t.Fatalf("Name() = %q, want %q", plugin.Name(), "spark")
+	}
+
+	for _, modelID := range []string{"4.0Ultra", "generalv3.5", "lite"} {
+		model := genkit.LookupModel(g, "spark/"+modelID)
+		if model == nil {
+			t.Errorf("LookupModel(%q) = nil", modelID)
+			continue
+		}
+		desc := model.(api.Action).Desc()
+		if got, want := desc.Name, "spark/"+modelID; got != want {
+			t.Errorf("%s Desc().Name = %q, want %q", modelID, got, want)
+		}
+		supports := desc.Metadata["model"].(map[string]any)["supports"].(map[string]any)
+		for field, want := range map[string]bool{"media": false, "tools": true, "toolChoice": true, "multiturn": true} {
+			if got := supports[field]; got != want {
+				t.Errorf("%s %s support = %v, want %v", modelID, field, got, want)
+			}
+		}
+		output, _ := supports["output"].([]string)
+		if !slices.Equal(output, []string{"text", "json"}) {
+			t.Errorf("%s output = %v, want [text json]", modelID, output)
+		}
+	}
+}
+
+func TestChatConfigApplyToChatCompletion(t *testing.T) {
+	temperature, topP := 0.3, 0.8
+	cfg := spark.ChatConfig{
+		Temperature:     &temperature,
+		TopP:            &topP,
+		MaxOutputTokens: 64,
+		StopSequences:   []string{"STOP"},
+	}
+	var params openai.ChatCompletionNewParams
+	// Exercises the field mapping; the zero-value fields must be left untouched
+	// and the set fields must apply without panicking.
+	cfg.ApplyToChatCompletion(&params)
+}


### PR DESCRIPTION
## Description

Adds a Genkit Go plugin for **iFLYTEK Spark (讯飞星火)** under `go/plugins/compat_oai/spark`, following the same `compat_oai` pattern as the existing `deepseek` and `kimi` plugins.

Spark is served over an OpenAI-compatible HTTP API, so the plugin is a thin wrapper over `compat_oai.OpenAICompatible`:

- Targets the OpenAI-compatible HTTP endpoint `https://spark-api-open.xf-yun.com/v1`, authenticated with the single Bearer **API Password** from the iFLYTEK console. The README and doc comments call out that this is **not** the legacy WebSocket endpoint (`spark-api.xf-yun.com`, signed with the `APPID`/`APIKey`/`APISecret` triple), so users don't mix the two.
- Registers `4.0Ultra` (default), `generalv3.5` (Max), `max-32k`, `generalv3` (Pro), `pro-128k`, and `lite`; any other model the endpoint serves resolves dynamically.
- `ChatConfig` exposes `temperature`, `topP`, `maxOutputTokens`, and `stopSequences`; any other request field passes through `RequestConfig.Extra`.
- Env vars `SPARK_API_KEY` / `SPARK_BASE_URL`, matching the sibling plugins' conventions.

## Files

- `go/plugins/compat_oai/spark/spark.go`
- `go/plugins/compat_oai/spark/spark_test.go`
- `go/plugins/compat_oai/spark/README.md`

## Testing

Ran locally against the `go/` module (go 1.26):

```
go build ./plugins/compat_oai/spark/   # clean
go vet   ./plugins/compat_oai/spark/   # clean
gofmt -l ./plugins/compat_oai/spark/   # no output (formatted)
go test -v ./plugins/compat_oai/spark/
=== RUN   TestPluginRequiresAPIKey
--- PASS
=== RUN   TestPluginConfigPrecedence
--- PASS
=== RUN   TestPluginRegistersModels
--- PASS
=== RUN   TestChatConfigApplyToChatCompletion
--- PASS
ok  github.com/firebase/genkit/go/plugins/compat_oai/spark
```
