### PR TITLE
fix(py/openai): add Whisper translation support

### DIFF
--- a/py/packages/genkit-openai/src/genkit_openai/models/audio.py
+++ b/py/packages/genkit-openai/src/genkit_openai/models/audio.py
@@ -375,6 +375,8 @@ class OpenAISTTModel:
         params = _to_stt_params(self._model_name, request)
         translate = extract_config_dict(request).get('translate', False)
         if translate:
+            params.pop('language', None)
+            params.pop('timestamp_granularities', None)
             result = await self._client.audio.translations.create(**params)
         else:
             result = await self._client.audio.transcriptions.create(

--- a/py/packages/genkit-openai/src/genkit_openai/models/audio.py
+++ b/py/packages/genkit-openai/src/genkit_openai/models/audio.py
@@ -33,6 +33,7 @@ from openai._legacy_response import HttpxBinaryResponseContent
 from openai.types.audio import Transcription, Translation
 
 from genkit import (
+    GenkitError,
     Media,
     MediaPart,
     Message,
@@ -372,8 +373,17 @@ class OpenAISTTModel:
         Returns:
             A ModelResponse containing the transcribed text.
         """
-        params = _to_stt_params(self._model_name, request)
         translate = extract_config_dict(request).get('translate', False)
+        if translate and self._model_name != 'whisper-1':
+            raise GenkitError(
+                status='INVALID_ARGUMENT',
+                message=(
+                    "OpenAI audio translations only support 'whisper-1'; "
+                    f"model '{self._model_name}' cannot use translate=True."
+                ),
+            )
+
+        params = _to_stt_params(self._model_name, request)
         if translate:
             params.pop('language', None)
             params.pop('timestamp_granularities', None)

--- a/py/packages/genkit-openai/src/genkit_openai/models/audio.py
+++ b/py/packages/genkit-openai/src/genkit_openai/models/audio.py
@@ -30,7 +30,7 @@ from typing import Any
 
 from openai import AsyncOpenAI
 from openai._legacy_response import HttpxBinaryResponseContent
-from openai.types.audio import Transcription
+from openai.types.audio import Transcription, Translation
 
 from genkit import (
     Media,
@@ -271,7 +271,7 @@ def _to_stt_params(
     return {k: v for k, v in params.items() if v is not None}
 
 
-def _to_stt_response(result: Transcription | str) -> ModelResponse:
+def _to_stt_response(result: Transcription | Translation | str) -> ModelResponse:
     """Convert an OpenAI transcription result to a Genkit ModelResponse.
 
     Handles the full union of types returned by transcriptions.create().
@@ -373,10 +373,14 @@ class OpenAISTTModel:
             A ModelResponse containing the transcribed text.
         """
         params = _to_stt_params(self._model_name, request)
-        result = await self._client.audio.transcriptions.create(
-            **params,
-            stream=False,
-        )
+        translate = extract_config_dict(request).get('translate', False)
+        if translate:
+            result = await self._client.audio.translations.create(**params)
+        else:
+            result = await self._client.audio.transcriptions.create(
+                **params,
+                stream=False,
+            )
         # transcriptions.create(stream=False) returns a union of
         # Transcription | TranscriptionVerbose | TranscriptionDiarized | str.
         # _to_stt_response handles all of these via isinstance/hasattr checks.

--- a/py/packages/genkit-openai/tests/audio_model_test.py
+++ b/py/packages/genkit-openai/tests/audio_model_test.py
@@ -36,6 +36,7 @@ from genkit_openai.models.audio import (
 )
 
 from genkit import (
+    GenkitError,
     Media,
     MediaPart,
     Message,
@@ -352,8 +353,29 @@ class TestOpenAISTTModel:
         assert isinstance(part, TextPart)
         assert part.text == 'Translated text'
 
+    @pytest.mark.parametrize('model_name', ['gpt-4o-transcribe', 'gpt-4o-mini-transcribe'])
     @pytest.mark.asyncio
-    async def test_generate_calls_transcription_create(self) -> None:
+    async def test_generate_rejects_translation_for_non_whisper_models(self, model_name: str) -> None:
+        """Verify translation is rejected for models unsupported by the API."""
+        mock_client = AsyncMock()
+        model = OpenAISTTModel(model_name, mock_client)
+        request = ModelRequest(messages=[], config={'translate': True})
+
+        with pytest.raises(GenkitError) as exc_info:
+            await model.generate(request, MagicMock())
+
+        assert exc_info.value.status == 'INVALID_ARGUMENT'
+        assert 'whisper-1' in str(exc_info.value)
+        mock_client.audio.translations.create.assert_not_called()
+        mock_client.audio.transcriptions.create.assert_not_called()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        'config',
+        [None, {'translate': False}],
+        ids=['translate-unset', 'translate-explicitly-false'],
+    )
+    async def test_generate_calls_transcription_create(self, config: dict[str, bool] | None) -> None:
         """Verify generate() calls client.audio.transcriptions.create."""
         mock_result = MagicMock()
         mock_result.text = 'Transcribed text'
@@ -379,6 +401,7 @@ class TestOpenAISTTModel:
                     ],
                 ),
             ],
+            config=config,
         )
 
         ctx = MagicMock()

--- a/py/packages/genkit-openai/tests/audio_model_test.py
+++ b/py/packages/genkit-openai/tests/audio_model_test.py
@@ -332,13 +332,20 @@ class TestOpenAISTTModel:
                     ],
                 ),
             ],
-            config={'translate': True},
+            config={
+                'translate': True,
+                'language': 'es',
+                'timestamp_granularities': ['word'],
+            },
         )
 
         got = await model.generate(request, MagicMock())
 
         mock_client.audio.translations.create.assert_called_once()
         mock_client.audio.transcriptions.create.assert_not_called()
+        translation_params = mock_client.audio.translations.create.call_args.kwargs
+        assert 'language' not in translation_params
+        assert 'timestamp_granularities' not in translation_params
         assert got.message is not None
 
         part = got.message.content[0].root

--- a/py/packages/genkit-openai/tests/audio_model_test.py
+++ b/py/packages/genkit-openai/tests/audio_model_test.py
@@ -306,6 +306,46 @@ class TestOpenAISTTModel:
     """Tests for the OpenAISTTModel class."""
 
     @pytest.mark.asyncio
+    async def test_generate_calls_translation_create_when_translate_is_enabled(self) -> None:
+        """Verify Whisper uses the translations API when translate is enabled."""
+        mock_result = MagicMock()
+        mock_result.text = 'Translated text'
+
+        mock_client = AsyncMock()
+        mock_client.audio.translations.create = AsyncMock(return_value=mock_result)
+
+        model = OpenAISTTModel('whisper-1', mock_client)
+        audio_data = base64.b64encode(b'fake audio').decode('ascii')
+        request = ModelRequest(
+            messages=[
+                Message(
+                    role=Role.USER,
+                    content=[
+                        Part(
+                            root=MediaPart(
+                                media=Media(
+                                    content_type='audio/mpeg',
+                                    url=f'data:audio/mpeg;base64,{audio_data}',
+                                )
+                            )
+                        ),
+                    ],
+                ),
+            ],
+            config={'translate': True},
+        )
+
+        got = await model.generate(request, MagicMock())
+
+        mock_client.audio.translations.create.assert_called_once()
+        mock_client.audio.transcriptions.create.assert_not_called()
+        assert got.message is not None
+
+        part = got.message.content[0].root
+        assert isinstance(part, TextPart)
+        assert part.text == 'Translated text'
+
+    @pytest.mark.asyncio
     async def test_generate_calls_transcription_create(self) -> None:
         """Verify generate() calls client.audio.transcriptions.create."""
         mock_result = MagicMock()


### PR DESCRIPTION
## Summary

Fixes #6154.

The Python OpenAI Whisper model now honors `config={"translate": true}` by sending the request to the OpenAI Audio Translations API. The default and explicit false paths continue to use the Transcriptions API.

## Implementation and compatibility

- Route `translate: true` to `client.audio.translations.create` only for the registered `whisper-1` model.
- Reject `translate: true` for `gpt-4o-transcribe` and `gpt-4o-mini-transcribe` with `GenkitError(status="INVALID_ARGUMENT")` before making an API call.
- Keep the existing transcription request construction and `stream=False` behavior unchanged for the default path.
- Remove transcription-only `language` and `timestamp_granularities` parameters from translation requests.
- Accept the OpenAI `Translation` response type in the shared text-response converter.
- Add regression coverage for translation rejection on both non-Whisper models, plus explicit `translate: false` transcription behavior.

This is backward compatible: callers that omit `translate`, set it to `false`, or use `whisper-1` retain the existing behavior.

## Validation

Run in a Linux `ghcr.io/astral-sh/uv:python3.11-bookworm` container with the repository's frozen `uv` workspace:

- `python -m pytest --no-cov packages/genkit-openai/tests -q` — 166 passed.
- `ruff format --check --preview packages/genkit-openai/src/genkit_openai/models/audio.py packages/genkit-openai/tests/audio_model_test.py` — passed after normalizing the Windows checkout's CRLF line endings for the Linux formatter.
- `ruff check --preview packages/genkit-openai/src/genkit_openai/models/audio.py packages/genkit-openai/tests/audio_model_test.py` — passed.
- `uv lock --check` — passed.
- `uv build --package genkit-openai` — passed.
- `python -m compileall -q packages/genkit-openai/src packages/genkit-openai/tests` — passed.
- `git diff --check` — passed using the Windows Git checkout.

Pyright was run against `packages/genkit-openai/src` with the package environment and reported 13 unrelated diagnostics in existing files/lines; the new translation guard introduced no diagnostic. The full repository suite and Python-version matrix remain for CI; no live OpenAI credentials or external services are required for the focused tests.