### PR TITLE
feat(go/ai): return partial responses from the generate loop

### DIFF
--- a/go/README.md
+++ b/go/README.md
@@ -1224,6 +1224,18 @@ case errors.Is(err, status.ErrResourceExhausted):
 
 Models, tools, prompts, and provider APIs all report failures this way, so recovery logic reads as a switch rather than a string match.
 
+A generation failure keeps the progress the loop made: once the request has resolved, the classified error comes back alongside a partial `ai.ModelResponse`. When the loop stopped early (a failed model call, a failed tool, max turns), the response reports `ai.FinishReasonFailed` with the cause in `FinishMessage` (a cancellation reports `ai.FinishReasonAborted` instead), and `History()` carries the conversation up to the failure:
+
+```go
+resp, err := genkit.Generate(ctx, g /* ... */)
+if err != nil && resp != nil {
+    transcript := resp.History() // A conversation you can send again.
+    cause := resp.Error          // The same failure, classified.
+}
+```
+
+`resp.Error` is the structured form of `FinishMessage`, so a response that travelled as data (a trace, a persisted turn) still says why it stopped without anyone matching a string. That history stops at a turn seam: the completed tool rounds, and nothing from the turn that failed. A model message whose tools did not all answer is dropped along with the round it opened, because no provider accepts a conversation that ends in an unanswered tool request. Send the history back to retry the failed step without repeating the tool calls that already succeeded. Text streamed before the failure reached your callback, so watch the stream if you want to show it.
+
 Your own failures work the same way. Derive a subtype to keep a parent's status, and use `PublicErrorf` when the message is safe to return to a client:
 
 ```go

--- a/go/README.md
+++ b/go/README.md
@@ -1224,7 +1224,7 @@ case errors.Is(err, status.ErrResourceExhausted):
 
 Models, tools, prompts, and provider APIs all report failures this way, so recovery logic reads as a switch rather than a string match.
 
-A generation failure keeps the progress the loop made: once the request has resolved, the classified error comes back alongside a partial `ai.ModelResponse`. When the loop stopped early (a failed model call, a failed tool, max turns), the response reports `ai.FinishReasonFailed` with the cause in `FinishMessage` (a cancellation reports `ai.FinishReasonAborted` instead), and `History()` carries the conversation up to the failure:
+A generation failure keeps the progress the loop made: once the request has resolved, the classified error comes back alongside a partial `ai.ModelResponse`. When the loop stopped early, the response reports `ai.FinishReasonFailed` with the cause in `FinishMessage` if something broke (a failed model call, a failed tool), or `ai.FinishReasonAborted` if the caller stopped it: a cancelled context, an expired deadline, or a limit it set such as max turns. `History()` carries the conversation up to that point:
 
 ```go
 resp, err := genkit.Generate(ctx, g /* ... */)

--- a/go/ai/errors.go
+++ b/go/ai/errors.go
@@ -36,13 +36,15 @@ var (
 
 	// ErrMaxTurnsExceeded means the tool-calling loop hit its turn limit before
 	// the model produced a final response. Raise the limit with WithMaxTurns, or
-	// look for a tool the model keeps retrying.
+	// look for a tool the model keeps retrying. The loop's partial
+	// [ModelResponse] rides alongside this error (see [Generate]).
 	ErrMaxTurnsExceeded = status.ErrAborted.Subtype("max turns exceeded")
 
 	// ErrToolFailed means a tool returned an error or produced output that does
 	// not match its declared schema. The tool's own error is wrapped, so
 	// errors.Is and errors.As still reach it; the status is INTERNAL because a
-	// tool's failure is not a failure of the caller's request.
+	// tool's failure is not a failure of the caller's request. The loop's
+	// partial [ModelResponse] rides alongside this error (see [Generate]).
 	ErrToolFailed = status.ErrInternal.Subtype("tool failed")
 
 	// ErrUnsupportedByModel means the request used a capability the model does

--- a/go/ai/errors.go
+++ b/go/ai/errors.go
@@ -45,6 +45,10 @@ var (
 	// errors.Is and errors.As still reach it; the status is INTERNAL because a
 	// tool's failure is not a failure of the caller's request. The loop's
 	// partial [ModelResponse] rides alongside this error (see [Generate]).
+	//
+	// A tool that stopped because the call's context ended is not a tool
+	// failure: that error carries CANCELLED instead, so the partial response
+	// reports [FinishReasonAborted].
 	ErrToolFailed = status.ErrInternal.Subtype("tool failed")
 
 	// ErrUnsupportedByModel means the request used a capability the model does

--- a/go/ai/gen.go
+++ b/go/ai/gen.go
@@ -96,7 +96,7 @@ type GenerateActionOptions struct {
 	// Docs provides retrieved documents to be used as context for this generation.
 	Docs []*Document `json:"docs,omitempty"`
 	// MaxTurns is the maximum number of tool call iterations that can be performed
-	// in a single generate call. Defaults to 5.
+	// in a single generate call. Defaults to 50 in Go; other runtimes set their own.
 	MaxTurns int `json:"maxTurns,omitempty"`
 	// Messages contains the conversation history for multi-turn prompting when supported.
 	Messages []*Message `json:"messages,omitempty"`

--- a/go/ai/generate.go
+++ b/go/ai/generate.go
@@ -1492,6 +1492,19 @@ func clone[T any](obj *T) *T {
 	return &newObj
 }
 
+// toolFailureError classifies a tool's error for the loop. A tool that failed
+// on its own terms is [ErrToolFailed], which the loop reports as a failed
+// generation. A tool that stopped because the call's context ended is not a
+// tool failure at all: the cancellation is returned with its own status, so
+// the partial response carries [FinishReasonAborted] rather than blaming the
+// tool for a stop the caller asked for.
+func toolFailureError(ctx context.Context, name string, cause error) error {
+	if ctx.Err() != nil {
+		return status.Errorf(status.ErrCancelled, "tool %q stopped: %w", name, cause)
+	}
+	return status.Errorf(ErrToolFailed, "tool %q failed: %w", name, cause)
+}
+
 // toolRunnerFunc runs a tool through the WrapTool hook chain and returns the
 // raw [MultipartToolResponse]. Returned by [buildToolRunner].
 type toolRunnerFunc = func(ctx context.Context, tool Tool, req *ToolRequest) (*MultipartToolResponse, error)
@@ -1622,7 +1635,7 @@ func handleToolRequests(ctx context.Context, r api.Registry, req *ModelRequest, 
 					return
 				}
 
-				resultChan <- result[*MultipartToolResponse]{index: idx, err: status.Errorf(ErrToolFailed, "tool %q failed: %w", toolReq.Name, err)}
+				resultChan <- result[*MultipartToolResponse]{index: idx, err: toolFailureError(ctx, toolReq.Name, err)}
 				return
 			}
 
@@ -2241,7 +2254,7 @@ func handleResumedToolRequest(ctx context.Context, r api.Registry, genOpts *Gene
 						}, nil
 					}
 
-					return nil, status.Errorf(ErrToolFailed, "tool %q failed: %w", restartPart.ToolRequest.Name, err)
+					return nil, toolFailureError(ctx, restartPart.ToolRequest.Name, err)
 				}
 
 				newToolReq := clone(p)

--- a/go/ai/generate.go
+++ b/go/ai/generate.go
@@ -372,6 +372,16 @@ func responseError(cause error) *status.Error {
 	return e
 }
 
+// callerStopped are the statuses that say the caller ended the loop rather
+// than something breaking inside it: it cancelled the context, its deadline
+// expired, or it set a limit the loop reached ([ErrMaxTurnsExceeded] is an
+// ABORTED subtype). They report [FinishReasonAborted].
+var callerStopped = map[status.Name]bool{
+	status.Cancelled:        true,
+	status.DeadlineExceeded: true,
+	status.Aborted:          true,
+}
+
 // failurePartial builds the partial [ModelResponse] that accompanies the
 // error when the generate loop stops before it produced a final response.
 //
@@ -390,8 +400,9 @@ func responseError(cause error) *status.Error {
 // implementation and hooks may retain the original.
 //
 // The finish reason is [FinishReasonFailed] with the cause as the finish
-// message, or [FinishReasonAborted] when the cause is a cancellation: the
-// caller stopped the loop, nothing broke. Error carries the same cause
+// message, or [FinishReasonAborted] when the caller stopped the loop rather
+// than anything breaking: a cancelled context, an expired deadline, or a
+// limit the caller set such as [WithMaxTurns]. Error carries the same cause
 // classified, so a consumer reading the response as data branches on a status
 // rather than a string. Downstream consumers treat both finishes as abnormal:
 // output parsing is skipped and the typed helpers extract nothing from it.
@@ -402,7 +413,7 @@ func failurePartial(base *ModelResponse, req *ModelRequest, cause error) *ModelR
 	}
 	p.Message = nil
 	p.FinishReason = FinishReasonFailed
-	if s, ok := status.Classified(cause); ok && s == status.Cancelled {
+	if s, ok := status.Classified(cause); ok && callerStopped[s] {
 		p.FinishReason = FinishReasonAborted
 	}
 	p.FinishMessage = cause.Error()
@@ -1044,10 +1055,11 @@ func recordToolShortCircuit(ctx context.Context, name string, input any, resp *M
 // When generation fails after the request has resolved, the classified error
 // is returned together with a non-nil partial [ModelResponse].
 //
-// A loop that stopped early (a failed model call, a failed tool,
-// [WithMaxTurns] exceeded) reports FinishReason [FinishReasonFailed] with the
-// cause as the FinishMessage, or [FinishReasonAborted] when the cause is a
-// cancellation, and leaves Message nil. Error carries the same cause
+// A loop that stopped early leaves Message nil and reports FinishReason
+// [FinishReasonFailed] with the cause as the FinishMessage when something
+// broke (a failed model call, a failed tool), or [FinishReasonAborted] when
+// the caller stopped it instead: a cancelled context, an expired deadline, or
+// a limit it set such as [WithMaxTurns]. Error carries the same cause
 // classified, the structured form of the FinishMessage beside it.
 // [ModelResponse.History] is then a
 // conversation that can be sent again: it ends at a turn seam, meaning the

--- a/go/ai/generate.go
+++ b/go/ai/generate.go
@@ -745,8 +745,7 @@ func generateWithRequest(ctx context.Context, r api.Registry, opts *GenerateActi
 			// The whole round goes, the model message that opened it
 			// included: a failed tool leaves its request unanswered, and
 			// [failurePartial] hands back a conversation that can be
-			// re-sent. revisedMsg records interrupt bookkeeping for a round
-			// that is being discarded, so it is dropped with the rest.
+			// re-sent.
 			return failurePartial(resp, req, err), err
 		}
 		if revisedMsg != nil {
@@ -1558,12 +1557,10 @@ func stampPendingToolOutcome(part *Part, resp *MultipartToolResponse) {
 // handleToolRequests processes any tool requests in the response. On success
 // it returns either a new request to continue the conversation, or, when a
 // tool interrupted, a nil request and the revised model message carrying the
-// interrupt metadata. On error it returns a partial model message alongside
-// the error: tool calls whose results arrived by the time the error was
-// collected carry their pendingOutput or interrupt metadata, so the caller
-// can preserve that work. The error is reported as soon as it arrives; a
-// still-running sibling is left to finish detached and its result is
-// discarded.
+// interrupt metadata. On error it returns no message: the caller drops the
+// whole round, so the results that did arrive have nowhere to go. The error
+// is reported as soon as it arrives; a still-running sibling is left to
+// finish detached and its result is discarded.
 func handleToolRequests(ctx context.Context, r api.Registry, req *ModelRequest, resp *ModelResponse, cb ModelStreamCallback, messageIndex int, runTool toolRunnerFunc) (*ModelRequest, *Message, error) {
 	toolRequests := resp.ToolRequests()
 	if len(toolRequests) == 0 {
@@ -1691,28 +1688,13 @@ func handleToolRequests(ctx context.Context, r api.Registry, req *ModelRequest, 
 	}
 
 	if toolErr != nil {
-		// A slow or hung sibling must not hold the failure hostage: harvest
-		// the results that already arrived without blocking and leave the
-		// rest to finish detached.
-	drain:
-		for len(receivedIndexes) < len(toolRequests) {
-			select {
-			case res := <-resultChan:
-				receivedIndexes = append(receivedIndexes, res.index)
-			default:
-				break drain
-			}
-		}
-		// The partial message is assembled on an isolated copy of the model
-		// message, since the stragglers keep writing into revisedMsg after
-		// this returns. Each received index is safe to take: its goroutine's
-		// revision (pendingOutput, interrupt metadata) was published by the
-		// channel send, and no other goroutine writes that element.
-		partialMsg := clone(resp.Message)
-		for _, idx := range receivedIndexes {
-			partialMsg.Content[idx] = revisedMsg.Content[idx]
-		}
-		return nil, partialMsg, toolErr
+		// Nothing rides back with the error. The caller drops the whole
+		// round, the model message that opened it included, because a
+		// conversation ending on a tool request nothing answered is one no
+		// provider accepts. A still-running sibling keeps revising its own
+		// element of revisedMsg after this returns, which nothing reads, and
+		// its send cannot block: resultChan buffers one slot per request.
+		return nil, nil, toolErr
 	}
 
 	if hasInterrupts {
@@ -1738,7 +1720,7 @@ func handleToolRequests(ctx context.Context, r api.Registry, req *ModelRequest, 
 			Index:   messageIndex + 1,
 		})
 		if err != nil {
-			return nil, revisedMsg, fmt.Errorf("streaming callback failed: %w", err)
+			return nil, nil, fmt.Errorf("streaming callback failed: %w", err)
 		}
 	}
 

--- a/go/ai/generate.go
+++ b/go/ai/generate.go
@@ -496,7 +496,7 @@ func generateWithRequest(ctx context.Context, r api.Registry, opts *GenerateActi
 		return nil, status.Errorf(status.ErrInvalidArgument, "ai.GenerateWithRequest: max turns must be greater than 0, got %d", maxTurns)
 	}
 	if maxTurns == 0 {
-		maxTurns = 5 // Default max turns.
+		maxTurns = 50 // Default max turns.
 	}
 
 	var outputCfg ModelOutputConfig

--- a/go/ai/generate.go
+++ b/go/ai/generate.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"iter"
 	"log/slog"
+	"maps"
 	"slices"
 	"strings"
 	"sync"
@@ -334,7 +335,7 @@ func LookupModel(r api.Registry, name string) Model {
 // report [ErrGenerationBlocked] instead of reaching here.
 func (fr FinishReason) isAbnormal() bool {
 	switch fr {
-	case FinishReasonBlocked, FinishReasonAborted, FinishReasonInterrupted, FinishReasonOther:
+	case FinishReasonBlocked, FinishReasonAborted, FinishReasonFailed, FinishReasonInterrupted, FinishReasonOther:
 		return true
 	default:
 		return false
@@ -352,7 +353,69 @@ func blockedError(resp *ModelResponse) error {
 	return status.Errorf(ErrGenerationBlocked, "generation blocked: %s", resp.FinishMessage)
 }
 
+// responseError renders cause as the structured error a response carries
+// alongside it. [status.Convert] supplies the status, classified or inferred,
+// and the message is replaced with the error's own text so it matches the
+// FinishMessage beside it: a wrapped error's sentinel carries only the
+// innermost wording. A public error keeps the wording it was given, which was
+// chosen for a caller to read.
+func responseError(cause error) *status.Error {
+	e := status.Convert(cause)
+	if e == nil {
+		return nil
+	}
+	if !e.Public && e.Message != cause.Error() {
+		ne := *e
+		ne.Message = cause.Error()
+		return &ne
+	}
+	return e
+}
+
+// failurePartial builds the partial [ModelResponse] that accompanies the
+// error when the generate loop stops before it produced a final response.
+//
+// The partial ends at a turn seam: req carries the conversation as it stood
+// when the failing turn began, which is either the caller's own messages or
+// a run of completed [model with tool requests, tool with every response]
+// rounds, and Message is cleared so nothing half-finished rides along. The
+// failing turn's own output is dropped whatever it was, a partially streamed
+// model message, a model message whose tools did not all answer, or the tool
+// requests [WithMaxTurns] refused to run, because a conversation ending in
+// an unanswered tool request is one no provider will accept back. What the
+// caller gets is therefore a conversation it can re-send.
+//
+// base, when non-nil, supplies the accounting the turn already earned (usage
+// and custom data); it is copied, not mutated, since the model
+// implementation and hooks may retain the original.
+//
+// The finish reason is [FinishReasonFailed] with the cause as the finish
+// message, or [FinishReasonAborted] when the cause is a cancellation: the
+// caller stopped the loop, nothing broke. Error carries the same cause
+// classified, so a consumer reading the response as data branches on a status
+// rather than a string. Downstream consumers treat both finishes as abnormal:
+// output parsing is skipped and the typed helpers extract nothing from it.
+func failurePartial(base *ModelResponse, req *ModelRequest, cause error) *ModelResponse {
+	p := ModelResponse{}
+	if base != nil {
+		p = *base
+	}
+	p.Message = nil
+	p.FinishReason = FinishReasonFailed
+	if s, ok := status.Classified(cause); ok && s == status.Cancelled {
+		p.FinishReason = FinishReasonAborted
+	}
+	p.FinishMessage = cause.Error()
+	p.Error = responseError(cause)
+	if req != nil {
+		p.Request = req
+	}
+	return &p
+}
+
 // GenerateWithRequest is the central generation implementation for ai.Generate(), prompt.Execute(), and the GenerateAction direct call.
+//
+// Failures follow the partial-response contract documented on [Generate].
 func GenerateWithRequest(ctx context.Context, r api.Registry, opts *GenerateActionOptions, mmws []ModelMiddleware, cb ModelStreamCallback) (*ModelResponse, error) {
 	return generateWithRequest(ctx, r, opts, mmws, cb, true /* spanTurnZero */)
 }
@@ -527,7 +590,16 @@ func generateWithRequest(ctx context.Context, r api.Registry, opts *GenerateActi
 
 	var generate func(context.Context, *ModelRequest, int, int) (*ModelResponse, error)
 
-	runTurn := func(ctx context.Context, params *GenerateParams) (*ModelResponse, error) {
+	// The loop records the conversation behind each turn so a failure hands
+	// back the rounds that completed: runTurn records each failing turn's
+	// partial response, and lastReq tracks the conversation entering the
+	// current turn as a fallback for errors raised outside a turn (e.g. by a
+	// WrapGenerate hook). The loop is sequential, so neither needs
+	// synchronization.
+	var lastPartial *ModelResponse
+	lastReq := req
+
+	turnBody := func(ctx context.Context, params *GenerateParams) (*ModelResponse, error) {
 		req := params.Request
 		currentTurn := params.Iteration
 		messageIndex := params.MessageIndex
@@ -559,37 +631,45 @@ func generateWithRequest(ctx context.Context, r api.Registry, opts *GenerateActi
 				return nil, err
 			}
 
-			if resumeOutput.interruptedResponse != nil {
-				return nil, status.Errorf(status.ErrFailedPrecondition,
+			if ir := resumeOutput.interruptedResponse; ir != nil {
+				err := status.Errorf(status.ErrFailedPrecondition,
 					"One or more tools triggered an interrupt during a restarted execution.")
+				ir.Error = responseError(err)
+				// ir.Message is the conversation's revised last message, so
+				// the request carries the messages before it and History()
+				// reproduces the full conversation. Copied from the turn's
+				// request so a field added to ModelRequest carries through.
+				irReq := *req
+				irReq.Messages = opts.Messages[:len(opts.Messages)-1]
+				ir.Request = &irReq
+				return ir, err
 			}
 
 			opts = resumeOutput.revisedRequest
+
+			resumeReq := *req
+			resumeReq.Messages = opts.Messages
 
 			if resumeOutput.toolMessage != nil && wrappedCb != nil {
 				if err := wrappedCb(ctx, &ModelResponseChunk{
 					Content: resumeOutput.toolMessage.Content,
 					Role:    RoleTool,
 				}); err != nil {
-					return nil, fmt.Errorf("streaming callback failed for resumed tool message: %w", err)
+					err = fmt.Errorf("streaming callback failed for resumed tool message: %w", err)
+					return failurePartial(nil, &resumeReq, err), err
 				}
 			}
 
-			resumeReq := &ModelRequest{
-				Messages:   opts.Messages,
-				Config:     req.Config,
-				Docs:       req.Docs,
-				ToolChoice: req.ToolChoice,
-				Tools:      req.Tools,
-				Output:     req.Output,
-			}
-			return generate(ctx, resumeReq, currentTurn+1, currentIndex)
+			return generate(ctx, &resumeReq, currentTurn+1, currentIndex)
 		}
 
 		logger.Debug(ctx, "calling model", "model", opts.Model, "turn", currentTurn, "messages", len(req.Messages))
 		resp, err := fn(ctx, req, wrappedCb)
 		if err != nil {
-			return nil, err
+			// The model's own output is dropped, complete or not: only the
+			// conversation entering this turn survives. Chunks already
+			// streamed reached the callback, so nothing observable is lost.
+			return failurePartial(resp, req, err), err
 		}
 
 		// ToolRequests allocates a scan of the message, so only build the
@@ -622,11 +702,21 @@ func generateWithRequest(ctx context.Context, r api.Registry, opts *GenerateActi
 					"finishMessage", resp.FinishMessage)
 			} else {
 				// This is legacy behavior. New format handlers should implement ParseMessage as a passthrough.
-				resp.Message, err = formatHandler.ParseMessage(resp.Message)
-				if err != nil {
-					logger.Debug(ctx, "model output does not match the expected schema", "model", opts.Model, "error", err)
-					return nil, status.Errorf(status.ErrInvalidOutput, "model failed to generate output matching expected schema: %w", err)
+				parsed, perr := formatHandler.ParseMessage(resp.Message)
+				if perr != nil {
+					logger.Debug(ctx, "model output does not match the expected schema", "model", opts.Model, "error", perr)
+					// The response rides back with its original message and
+					// finish reason, not marked aborted: the model finished,
+					// post-processing did not, and the raw output is often
+					// exactly what the caller needs to see.
+					if resp.Request == nil {
+						resp.Request = req
+					}
+					err := status.Errorf(status.ErrInvalidOutput, "model failed to generate output matching expected schema: %w", perr)
+					resp.Error = responseError(err)
+					return resp, err
 				}
+				resp.Message = parsed
 			}
 		}
 
@@ -635,18 +725,24 @@ func generateWithRequest(ctx context.Context, r api.Registry, opts *GenerateActi
 		}
 
 		if currentTurn+1 > maxTurns {
-			return nil, status.Errorf(ErrMaxTurnsExceeded, "exceeded maximum tool call iterations (%d)", maxTurns)
+			err := status.Errorf(ErrMaxTurnsExceeded, "exceeded maximum tool call iterations (%d)", maxTurns)
+			return failurePartial(resp, req, err), err
 		}
 
-		newReq, interruptMsg, err := handleToolRequests(ctx, r, req, resp, wrappedCb, currentIndex, runTool)
+		newReq, revisedMsg, err := handleToolRequests(ctx, r, req, resp, wrappedCb, currentIndex, runTool)
 		if err != nil {
-			return nil, err
+			// The whole round goes, the model message that opened it
+			// included: a failed tool leaves its request unanswered, and
+			// [failurePartial] hands back a conversation that can be
+			// re-sent. revisedMsg records interrupt bookkeeping for a round
+			// that is being discarded, so it is dropped with the rest.
+			return failurePartial(resp, req, err), err
 		}
-		if interruptMsg != nil {
+		if revisedMsg != nil {
 			logger.Debug(ctx, "generation paused by tool interrupts", "model", opts.Model, "turn", currentTurn)
 			resp.FinishReason = "interrupted"
 			resp.FinishMessage = "One or more tool calls resulted in interrupts."
-			resp.Message = interruptMsg
+			resp.Message = revisedMsg
 			return resp, nil
 		}
 		if newReq == nil {
@@ -654,6 +750,17 @@ func generateWithRequest(ctx context.Context, r api.Registry, opts *GenerateActi
 		}
 
 		return generate(ctx, newReq, currentTurn+1, currentIndex+1)
+	}
+
+	// runTurn records the turn's partial result before it enters the
+	// WrapGenerate chain, so a hook that drops the response on the way up
+	// does not lose it.
+	runTurn := func(ctx context.Context, params *GenerateParams) (*ModelResponse, error) {
+		resp, err := turnBody(ctx, params)
+		if err != nil && resp != nil {
+			lastPartial = resp
+		}
+		return resp, err
 	}
 
 	// runGenerate opens the turn's span around runTurn. The span records the
@@ -687,6 +794,11 @@ func generateWithRequest(ctx context.Context, r api.Registry, opts *GenerateActi
 	hookedGenerate := buildGenerateChain(mws, runGenerate)
 
 	generate = func(ctx context.Context, req *ModelRequest, currentTurn int, messageIndex int) (*ModelResponse, error) {
+		// A fresh turn invalidates the previous turn's recorded partial: a
+		// hook may have recovered that failure, and pairing its stale partial
+		// with a later error would regress the conversation.
+		lastReq = req
+		lastPartial = nil
 		return hookedGenerate(ctx, &GenerateParams{
 			// The hooks get their own copy of the options: a hook writing to
 			// it must reach neither the loop nor the turns after it.
@@ -712,7 +824,20 @@ func generateWithRequest(ctx context.Context, r api.Registry, opts *GenerateActi
 	}
 	logger.Debug(ctx, "generate request resolved", resolvedArgs...)
 
-	return generate(ctx, req, 0, 0)
+	resp, err := generate(ctx, req, 0, 0)
+	if err != nil && resp == nil {
+		// Every error after this point comes with a partial response. A
+		// failing turn built its own; when it was lost on the way up (a
+		// WrapGenerate hook that returns (nil, err)) the recorded one is
+		// restored, and an error raised outside a turn gets one synthesized
+		// from the conversation entering the current turn.
+		if lastPartial != nil {
+			resp = lastPartial
+		} else {
+			resp = failurePartial(nil, lastReq, err)
+		}
+	}
+	return resp, err
 }
 
 // turnOptions returns a per-turn copy of opts for the WrapGenerate hooks and
@@ -915,6 +1040,32 @@ func recordToolShortCircuit(ctx context.Context, name string, input any, resp *M
 }
 
 // Generate generates a model response based on the provided options.
+//
+// When generation fails after the request has resolved, the classified error
+// is returned together with a non-nil partial [ModelResponse].
+//
+// A loop that stopped early (a failed model call, a failed tool,
+// [WithMaxTurns] exceeded) reports FinishReason [FinishReasonFailed] with the
+// cause as the FinishMessage, or [FinishReasonAborted] when the cause is a
+// cancellation, and leaves Message nil. Error carries the same cause
+// classified, the structured form of the FinishMessage beside it.
+// [ModelResponse.History] is then a
+// conversation that can be sent again: it ends at a turn seam, meaning the
+// messages the failing turn started from, which are the caller's own or a run
+// of completed [model with tool requests, tool with every response] rounds.
+// Nothing from the failing turn rides along, since a conversation ending in a
+// tool request nothing answered is one no provider accepts. Text streamed
+// before the failure still reached the callback.
+//
+// Two errors are not loop failures and keep their response's message: a
+// response the model completed but post-processing rejected (structured
+// output that does not match the schema), which keeps the model's own finish
+// reason, and a resume whose restarted tool interrupted again, which keeps
+// FinishReason interrupted under its FAILED_PRECONDITION error and is
+// answered with [WithResume] rather than re-sent.
+//
+// Errors reported before a request is made (unknown model or tool, invalid
+// options) carry a nil response.
 func Generate(ctx context.Context, r api.Registry, opts ...GenerateOption) (*ModelResponse, error) {
 	genOpts := &generateOptions{}
 	for _, opt := range opts {
@@ -1044,18 +1195,18 @@ func Generate(ctx context.Context, r api.Registry, opts ...GenerateOption) (*Mod
 }
 
 // GenerateText run generate request for this model. Returns generated text only.
+// On error, the text of the partial response (see [Generate]), usually empty,
+// is returned with the error.
 func GenerateText(ctx context.Context, r api.Registry, opts ...GenerateOption) (string, error) {
 	res, err := Generate(ctx, r, opts...)
-	if err != nil {
-		return "", err
-	}
-
-	return res.Text(), nil
+	return res.Text(), err
 }
 
 // A refusal is an error: when the response finished blocked, the output is nil
 // and the error is [ErrGenerationBlocked], carrying the provider's explanation.
-// The response is still returned alongside it.
+// The response is still returned alongside it. A generation failure likewise
+// returns its error alongside the partial response [Generate] documents, with
+// a nil output.
 //
 // Every other finish that yields nothing to extract is not an error. If the
 // response carries no text (tool requests or interrupts instead), or ended
@@ -1077,7 +1228,7 @@ func GenerateData[Out any](ctx context.Context, r api.Registry, opts ...Generate
 
 	resp, err := Generate(ctx, r, opts...)
 	if err != nil {
-		return nil, nil, err
+		return nil, resp, err
 	}
 
 	// A refusal cannot produce the value this helper promises, so it is
@@ -1122,7 +1273,10 @@ var errStop = errors.New("stop")
 // It returns an iterator that yields streaming results.
 //
 // If the yield function is passed a non-nil error, generation has failed with that
-// error; the yield function will not be called again.
+// error; the yield function will not be called again. The value beside it is
+// still Done and still carries the partial Response, the same pair [Generate]
+// returns, so a consumer that streamed a tool loop reads the conversation it
+// can send again.
 //
 // If the yield function's [ModelStreamValue] argument has Done == true, the value's
 // Response field contains the final response; the yield function will not be called
@@ -1154,11 +1308,10 @@ func GenerateStream(ctx context.Context, r api.Registry, opts ...GenerateOption)
 		if done || errors.Is(err, errStop) {
 			return
 		}
-		if err != nil {
-			yield(nil, err)
-		} else {
-			yield(&ModelStreamValue{Done: true, Response: resp}, nil)
-		}
+		// A failure yields its partial beside the error, the same pair
+		// [Generate] returns, so a consumer that streamed a tool loop can
+		// still read the conversation it should send again.
+		yield(&ModelStreamValue{Done: true, Response: resp}, err)
 	}
 }
 
@@ -1166,7 +1319,9 @@ func GenerateStream(ctx context.Context, r api.Registry, opts ...GenerateOption)
 // It returns an iterator that yields streaming results.
 //
 // If the yield function is passed a non-nil error, generation has failed with that
-// error; the yield function will not be called again.
+// error; the yield function will not be called again. The value beside it is
+// still Done and still carries the partial Response (Output stays zero, since
+// a failed call produced no value), the same pair [GenerateData] returns.
 //
 // If the yield function's [StreamValue] argument has Done == true, the value's
 // Output and Response fields contain the final typed output and response; the yield function
@@ -1225,7 +1380,9 @@ func GenerateDataStream[Out any](ctx context.Context, r api.Registry, opts ...Ge
 			return
 		}
 		if err != nil {
-			yield(nil, err)
+			// The partial rides along, as on [Generate]; Output stays zero,
+			// since a failed call produced no value to extract.
+			yield(&StreamValue[Out, Out]{Done: true, Response: resp}, err)
 			return
 		}
 
@@ -1248,7 +1405,7 @@ func GenerateDataStream[Out any](ctx context.Context, r api.Registry, opts ...Ge
 
 		output, err := extractTypedOutput[Out](resp)
 		if err != nil {
-			yield(nil, err)
+			yield(&StreamValue[Out, Out]{Done: true, Response: resp}, err)
 			return
 		}
 
@@ -1308,7 +1465,9 @@ func ensureToolRequestRefs(msg *Message) {
 		return
 	}
 	for _, part := range msg.Content {
-		if part.IsToolRequest() && part.ToolRequest.Ref == "" {
+		// The kind is a string a plugin sets, so the pointer it promises is
+		// guarded too rather than dereferenced on trust.
+		if part.IsToolRequest() && part.ToolRequest != nil && part.ToolRequest.Ref == "" {
 			part.ToolRequest.Ref = uuid.New().String()
 		}
 	}
@@ -1337,9 +1496,49 @@ func clone[T any](obj *T) *T {
 // raw [MultipartToolResponse]. Returned by [buildToolRunner].
 type toolRunnerFunc = func(ctx context.Context, tool Tool, req *ToolRequest) (*MultipartToolResponse, error)
 
-// handleToolRequests processes any tool requests in the response, returning
-// either a new request to continue the conversation or nil if no tool requests
-// need handling.
+// interruptedPart clones a tool request part and marks it interrupted. The
+// interrupt's metadata is the marker when it carries any; otherwise the
+// marker is true, since a nil value would make the part read as not
+// interrupted at all (see [Part.IsInterrupt]).
+func interruptedPart(p *Part, tie *toolInterruptError) *Part {
+	newPart := clone(p)
+	if newPart.Metadata == nil {
+		newPart.Metadata = make(map[string]any)
+	}
+	if tie.Metadata != nil {
+		newPart.Metadata["interrupt"] = tie.Metadata
+	} else {
+		newPart.Metadata["interrupt"] = true
+	}
+	return newPart
+}
+
+// stampPendingToolOutcome records a resolved tool call's response on its
+// request part so a later resume replays it (see handleResumedToolRequest).
+// The response's metadata and content ride under their own keys;
+// pendingOutput itself stays output-only for cross-SDK parity.
+func stampPendingToolOutcome(part *Part, resp *MultipartToolResponse) {
+	if part.Metadata == nil {
+		part.Metadata = make(map[string]any)
+	}
+	part.Metadata["pendingOutput"] = resp.Output
+	if len(resp.Metadata) > 0 {
+		part.Metadata["pendingMetadata"] = resp.Metadata
+	}
+	if len(resp.Content) > 0 {
+		part.Metadata["pendingContent"] = resp.Content
+	}
+}
+
+// handleToolRequests processes any tool requests in the response. On success
+// it returns either a new request to continue the conversation, or, when a
+// tool interrupted, a nil request and the revised model message carrying the
+// interrupt metadata. On error it returns a partial model message alongside
+// the error: tool calls whose results arrived by the time the error was
+// collected carry their pendingOutput or interrupt metadata, so the caller
+// can preserve that work. The error is reported as soon as it arrives; a
+// still-running sibling is left to finish detached and its result is
+// discarded.
 func handleToolRequests(ctx context.Context, r api.Registry, req *ModelRequest, resp *ModelResponse, cb ModelStreamCallback, messageIndex int, runTool toolRunnerFunc) (*ModelRequest, *Message, error) {
 	toolRequests := resp.ToolRequests()
 	if len(toolRequests) == 0 {
@@ -1418,19 +1617,7 @@ func handleToolRequests(ctx context.Context, r api.Registry, req *ModelRequest, 
 				var tie *toolInterruptError
 				if errors.As(err, &tie) {
 					logger.Debug(ctx, "tool triggered an interrupt", "tool", toolReq.Name)
-
-					newPart := clone(p)
-					if newPart.Metadata == nil {
-						newPart.Metadata = make(map[string]any)
-					}
-					if tie.Metadata != nil {
-						newPart.Metadata["interrupt"] = tie.Metadata
-					} else {
-						newPart.Metadata["interrupt"] = true
-					}
-
-					revisedMsg.Content[idx] = newPart
-
+					revisedMsg.Content[idx] = interruptedPart(p, tie)
 					resultChan <- result[*MultipartToolResponse]{index: idx, err: tie}
 					return
 				}
@@ -1440,10 +1627,7 @@ func handleToolRequests(ctx context.Context, r api.Registry, req *ModelRequest, 
 			}
 
 			newPart := clone(p)
-			if newPart.Metadata == nil {
-				newPart.Metadata = make(map[string]any)
-			}
-			newPart.Metadata["pendingOutput"] = multipartResp.Output
+			stampPendingToolOutcome(newPart, multipartResp)
 			revisedMsg.Content[idx] = newPart
 
 			resultChan <- result[*MultipartToolResponse]{index: idx, value: multipartResp}
@@ -1454,17 +1638,20 @@ func handleToolRequests(ctx context.Context, r api.Registry, req *ModelRequest, 
 	// order. Collect them keyed by the request's position in the model message
 	// so they can be re-emitted in request order below.
 	toolRespByIndex := make(map[int]*Part, len(toolRequests))
+	receivedIndexes := make([]int, 0, len(toolRequests))
 	hasInterrupts := false
-	for range len(toolRequests) {
+	var toolErr error
+	for len(receivedIndexes) < len(toolRequests) && toolErr == nil {
 		res := <-resultChan
+		receivedIndexes = append(receivedIndexes, res.index)
 		if res.err != nil {
 			var tie *toolInterruptError
 			if errors.As(res.err, &tie) {
 				hasInterrupts = true
 				continue
 			}
-
-			return nil, nil, res.err
+			toolErr = res.err
+			continue
 		}
 
 		toolReq := revisedMsg.Content[res.index].ToolRequest
@@ -1476,6 +1663,31 @@ func handleToolRequests(ctx context.Context, r api.Registry, req *ModelRequest, 
 		})
 		newToolResp.Metadata = res.value.Metadata
 		toolRespByIndex[res.index] = newToolResp
+	}
+
+	if toolErr != nil {
+		// A slow or hung sibling must not hold the failure hostage: harvest
+		// the results that already arrived without blocking and leave the
+		// rest to finish detached.
+	drain:
+		for len(receivedIndexes) < len(toolRequests) {
+			select {
+			case res := <-resultChan:
+				receivedIndexes = append(receivedIndexes, res.index)
+			default:
+				break drain
+			}
+		}
+		// The partial message is assembled on an isolated copy of the model
+		// message, since the stragglers keep writing into revisedMsg after
+		// this returns. Each received index is safe to take: its goroutine's
+		// revision (pendingOutput, interrupt metadata) was published by the
+		// channel send, and no other goroutine writes that element.
+		partialMsg := clone(resp.Message)
+		for _, idx := range receivedIndexes {
+			partialMsg.Content[idx] = revisedMsg.Content[idx]
+		}
+		return nil, partialMsg, toolErr
 	}
 
 	if hasInterrupts {
@@ -1501,7 +1713,7 @@ func handleToolRequests(ctx context.Context, r api.Registry, req *ModelRequest, 
 			Index:   messageIndex + 1,
 		})
 		if err != nil {
-			return nil, nil, fmt.Errorf("streaming callback failed: %w", err)
+			return nil, revisedMsg, fmt.Errorf("streaming callback failed: %w", err)
 		}
 	}
 
@@ -1916,14 +2128,30 @@ func handleResumedToolRequest(ctx context.Context, r api.Registry, genOpts *Gene
 	}
 
 	if pendingOutputVal, ok := p.Metadata["pendingOutput"]; ok {
-		newReqPart := clone(p)
-		delete(newReqPart.Metadata, "pendingOutput")
+		// Only the metadata map needs detaching from the caller's part; a
+		// deep clone would JSON round-trip the (possibly large) pending
+		// payload just to delete it.
+		reqPart := *p
+		reqPart.Metadata = maps.Clone(p.Metadata)
+		delete(reqPart.Metadata, "pendingOutput")
+		delete(reqPart.Metadata, "pendingMetadata")
+		delete(reqPart.Metadata, "pendingContent")
 
 		newRespPart := NewResponseForToolRequest(p, pendingOutputVal)
 		newRespPart.Metadata = map[string]any{"source": "pending"}
+		// Restore the response metadata and content parts the original call
+		// carried, stashed next to pendingOutput. The content is []*Part in
+		// process and generic JSON after a wire or persistence round-trip;
+		// ConvertTo decodes both.
+		if pm, ok := p.Metadata["pendingMetadata"].(map[string]any); ok {
+			maps.Copy(newRespPart.Metadata, pm)
+		}
+		if content, ok := base.ConvertTo[[]*Part](p.Metadata["pendingContent"]); ok && len(content) > 0 {
+			newRespPart.ToolResponse.Content = content
+		}
 
 		return &resumedToolRequestOutput{
-			toolRequest:  newReqPart,
+			toolRequest:  &reqPart,
 			toolResponse: newRespPart,
 		}, nil
 	}
@@ -2008,15 +2236,8 @@ func handleResumedToolRequest(ctx context.Context, r api.Registry, genOpts *Gene
 					var tie *toolInterruptError
 					if errors.As(err, &tie) {
 						logger.Debug(ctx, "restarted tool triggered an interrupt", "tool", restartPart.ToolRequest.Name)
-
-						interruptPart := clone(p)
-						if interruptPart.Metadata == nil {
-							interruptPart.Metadata = make(map[string]any)
-						}
-						interruptPart.Metadata["interrupt"] = tie.Metadata
-
 						return &resumedToolRequestOutput{
-							interrupt: interruptPart,
+							interrupt: interruptedPart(p, tie),
 						}, nil
 					}
 
@@ -2070,13 +2291,10 @@ func handleResumeOption(ctx context.Context, r api.Registry, genOpts *GenerateAc
 		}
 	}
 
-	toolDefMap := make(map[string]*ToolDefinition)
 	for _, t := range genOpts.Tools {
-		tool := LookupTool(r, t)
-		if tool == nil {
+		if LookupTool(r, t) == nil {
 			return nil, status.Errorf(ErrToolNotFound, "handleResumeOption: tool %q not found", t)
 		}
-		toolDefMap[t] = tool.Definition()
 	}
 
 	messages := genOpts.Messages
@@ -2115,7 +2333,7 @@ func handleResumeOption(ctx context.Context, r api.Registry, genOpts *GenerateAc
 		}(i, part)
 	}
 
-	var toolResps []*Part
+	respByIndex := make(map[int]*Part, toolReqCount)
 	interrupted := false
 
 	for range toolReqCount {
@@ -2128,7 +2346,7 @@ func handleResumeOption(ctx context.Context, r api.Registry, genOpts *GenerateAc
 			interrupted = true
 			newContent[res.index] = res.value.interrupt
 		} else {
-			toolResps = append(toolResps, res.value.toolResponse)
+			respByIndex[res.index] = res.value.toolResponse
 			newContent[res.index] = res.value.toolRequest
 		}
 	}
@@ -2136,6 +2354,18 @@ func handleResumeOption(ctx context.Context, r api.Registry, genOpts *GenerateAc
 	lastMessage.Content = newContent
 
 	if interrupted {
+		// Siblings resolved in this resume (restarted runs, supplied
+		// responses, replayed pending outputs) are preserved as
+		// pendingOutput on their request parts, the way a first-run
+		// interrupt preserves completed siblings, so the next resume
+		// replays their outcomes instead of demanding new directives.
+		for idx, respPart := range respByIndex {
+			stampPendingToolOutcome(newContent[idx], &MultipartToolResponse{
+				Output:   respPart.ToolResponse.Output,
+				Content:  respPart.ToolResponse.Content,
+				Metadata: respPart.Metadata,
+			})
+		}
 		return &resumeOptionOutput{
 			interruptedResponse: &ModelResponse{
 				Message:       lastMessage,
@@ -2145,8 +2375,18 @@ func handleResumeOption(ctx context.Context, r api.Registry, genOpts *GenerateAc
 		}, nil
 	}
 
-	if len(toolResps) != toolReqCount {
-		return nil, status.Errorf(status.ErrFailedPrecondition, "handleResumeOption: Expected %d tool responses but resolved to %d.", toolReqCount, len(toolResps))
+	if len(respByIndex) != toolReqCount {
+		return nil, status.Errorf(status.ErrFailedPrecondition, "handleResumeOption: Expected %d tool responses but resolved to %d.", toolReqCount, len(respByIndex))
+	}
+
+	// Emit tool responses in the order their requests appear in the model
+	// message, matching handleToolRequests, so the resumed tool message is
+	// deterministic across runs.
+	toolResps := make([]*Part, 0, len(respByIndex))
+	for i := range newContent {
+		if part, ok := respByIndex[i]; ok {
+			toolResps = append(toolResps, part)
+		}
 	}
 
 	toolMessage := &Message{

--- a/go/ai/generate_test.go
+++ b/go/ai/generate_test.go
@@ -2920,6 +2920,16 @@ func TestGenerateDataAbnormalFinish(t *testing.T) {
 			},
 		},
 		{
+			// What the loop's failure partial reports; parsing must skip it
+			// the same way.
+			name: "failed with failure text",
+			response: &ModelResponse{
+				FinishReason:  FinishReasonFailed,
+				FinishMessage: "provider down",
+				Message:       NewModelTextMessage("Error: provider down"),
+			},
+		},
+		{
 			name: "other with filter details",
 			response: &ModelResponse{
 				FinishReason:  FinishReasonOther,
@@ -3539,4 +3549,1051 @@ func TestResumeCarriesOptionsForward(t *testing.T) {
 			t.Errorf("resumed response = %q, want %q", got, "done")
 		}
 	})
+}
+
+// TestGeneratePartialResponseOnFailure covers the partial-response contract:
+// when the generate loop fails after the request has resolved, the classified
+// error is returned together with a partial [ModelResponse] that preserves
+// the loop's progress.
+func TestGeneratePartialResponseOnFailure(t *testing.T) {
+	t.Parallel()
+
+	// loopSetup defines a model that always answers with a tool request and a
+	// tool that succeeds, so only the configured turn limit ends the loop.
+	loopSetup := func(t *testing.T) api.Registry {
+		t.Helper()
+		r := newTestRegistry(t)
+		defineFakeModel(t, r, fakeModelConfig{
+			name:    "test/loopModel",
+			handler: loopingToolModel("myTool", 100),
+		})
+		defineTool(r, "myTool", "A test tool",
+			func(ctx *ToolContext, in map[string]any) (string, error) { return "ok", nil })
+		return r
+	}
+
+	// badJSONSetup defines a model whose final text does not parse against a
+	// requested JSON output schema.
+	badJSONSetup := func(t *testing.T) api.Registry {
+		t.Helper()
+		r := newTestRegistry(t)
+		defineFakeModel(t, r, fakeModelConfig{
+			name: "test/badJSON",
+			handler: func(ctx context.Context, req *ModelRequest, cb ModelStreamCallback) (*ModelResponse, error) {
+				return &ModelResponse{
+					Request:      req,
+					FinishReason: FinishReasonStop,
+					Message:      NewModelTextMessage("this is not json"),
+				}, nil
+			},
+		})
+		return r
+	}
+
+	t.Run("max turns drops the round it will not run", func(t *testing.T) {
+		r := loopSetup(t)
+
+		resp, err := Generate(testCtx, r,
+			WithModelName("test/loopModel"),
+			WithPrompt("start"),
+			WithTools(LookupTool(r, "myTool")),
+			WithMaxTurns(2),
+		)
+		if !errors.Is(err, ErrMaxTurnsExceeded) {
+			t.Fatalf("err = %v, want ErrMaxTurnsExceeded", err)
+		}
+		if resp == nil {
+			t.Fatal("response is nil, want the loop's partial response")
+		}
+		if resp.FinishReason != FinishReasonFailed {
+			t.Errorf("FinishReason = %q, want %q", resp.FinishReason, FinishReasonFailed)
+		}
+		if !strings.Contains(resp.FinishMessage, "exceeded maximum tool call iterations (2)") {
+			t.Errorf("FinishMessage = %q, want the max-turns cause", resp.FinishMessage)
+		}
+		// The same cause classified, so a consumer reading the response as
+		// data branches on a status rather than matching the message.
+		if resp.Error == nil {
+			t.Fatal("Error is nil, want the classified cause")
+		}
+		if resp.Error.Status != status.Aborted {
+			t.Errorf("Error.Status = %q, want %q", resp.Error.Status, status.Aborted)
+		}
+		if resp.Error.Message != resp.FinishMessage {
+			t.Errorf("Error.Message = %q, want the FinishMessage %q", resp.Error.Message, resp.FinishMessage)
+		}
+		// Two completed rounds and nothing else: the model message whose
+		// tools the limit refused to run goes with the round it opened.
+		history := resp.History()
+		if len(history) != 5 {
+			t.Fatalf("History() has %d messages, want 5 (user, model, tool, model, tool)", len(history))
+		}
+		if history[4].Role != RoleTool {
+			t.Errorf("history ends with a %s message, want the tool message closing the last round", history[4].Role)
+		}
+		if resp.Message != nil {
+			t.Errorf("Message = %v, want nil: the refused round is not handed back", resp.Message)
+		}
+	})
+
+	t.Run("model failure keeps completed turns", func(t *testing.T) {
+		r := newTestRegistry(t)
+		calls := 0
+		defineFakeModel(t, r, fakeModelConfig{
+			name: "test/failsSecond",
+			handler: func(ctx context.Context, req *ModelRequest, cb ModelStreamCallback) (*ModelResponse, error) {
+				calls++
+				if calls == 1 {
+					return &ModelResponse{Request: req, Message: &Message{
+						Role:    RoleModel,
+						Content: []*Part{NewToolRequestPart(&ToolRequest{Name: "myTool", Input: map[string]any{}})},
+					}}, nil
+				}
+				return nil, errors.New("model exploded")
+			},
+		})
+		defineTool(r, "myTool", "A test tool",
+			func(ctx *ToolContext, in map[string]any) (string, error) { return "ok", nil })
+
+		resp, err := Generate(testCtx, r,
+			WithModelName("test/failsSecond"),
+			WithPrompt("start"),
+			WithTools(LookupTool(r, "myTool")),
+		)
+		errorContains(t, err, "model exploded")
+		if resp == nil {
+			t.Fatal("response is nil, want the loop's partial response")
+		}
+		if resp.FinishReason != FinishReasonFailed {
+			t.Errorf("FinishReason = %q, want %q", resp.FinishReason, FinishReasonFailed)
+		}
+		if !strings.Contains(resp.FinishMessage, "model exploded") {
+			t.Errorf("FinishMessage = %q, want the model error", resp.FinishMessage)
+		}
+		if resp.Message != nil {
+			t.Errorf("Message = %v, want nil: the failing call produced nothing", resp.Message)
+		}
+		history := resp.History()
+		if len(history) != 3 {
+			t.Fatalf("History() has %d messages, want 3 (user, model, tool)", len(history))
+		}
+		if history[1].Role != RoleModel || history[2].Role != RoleTool {
+			t.Errorf("history roles = %s, %s, want model, tool", history[1].Role, history[2].Role)
+		}
+	})
+
+	t.Run("cancellation reports aborted, not failed", func(t *testing.T) {
+		r := newTestRegistry(t)
+		defineFakeModel(t, r, fakeModelConfig{
+			name: "test/cancelled",
+			handler: func(ctx context.Context, req *ModelRequest, cb ModelStreamCallback) (*ModelResponse, error) {
+				return nil, fmt.Errorf("call gave up: %w", context.Canceled)
+			},
+		})
+
+		resp, err := Generate(testCtx, r,
+			WithModelName("test/cancelled"),
+			WithPrompt("start"),
+		)
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("err = %v, want context.Canceled", err)
+		}
+		if resp == nil {
+			t.Fatal("response is nil, want the loop's partial response")
+		}
+		if resp.FinishReason != FinishReasonAborted {
+			t.Errorf("FinishReason = %q, want %q: the caller stopped the loop", resp.FinishReason, FinishReasonAborted)
+		}
+		if resp.Error == nil || resp.Error.Status != status.Cancelled {
+			t.Errorf("Error = %+v, want a CANCELLED classification", resp.Error)
+		}
+	})
+
+	t.Run("mid-stream failure drops the unfinished message", func(t *testing.T) {
+		r := newTestRegistry(t)
+		defineFakeModel(t, r, fakeModelConfig{
+			name: "test/failsMidStream",
+			handler: func(ctx context.Context, req *ModelRequest, cb ModelStreamCallback) (*ModelResponse, error) {
+				cb(ctx, &ModelResponseChunk{Content: []*Part{NewTextPart("Hello, ")}})
+				cb(ctx, &ModelResponseChunk{Content: []*Part{NewTextPart("wor")}})
+				return nil, errors.New("stream died")
+			},
+		})
+
+		var streamed strings.Builder
+		resp, err := Generate(testCtx, r,
+			WithModelName("test/failsMidStream"),
+			WithPrompt("start"),
+			WithStreaming(func(ctx context.Context, c *ModelResponseChunk) error {
+				streamed.WriteString(c.Text())
+				return nil
+			}),
+		)
+		errorContains(t, err, "stream died")
+		if resp == nil {
+			t.Fatal("response is nil, want the loop's partial response")
+		}
+		// The prefix reached the caller through the stream; it does not also
+		// ride back on a conversation the caller would send again.
+		if got := streamed.String(); got != "Hello, wor" {
+			t.Errorf("streamed = %q, want the prefix %q", got, "Hello, wor")
+		}
+		if resp.Message != nil {
+			t.Errorf("Message = %v, want nil: the model never finished it", resp.Message)
+		}
+		if got := len(resp.History()); got != 1 {
+			t.Errorf("History() has %d messages, want 1 (the user message alone)", got)
+		}
+		if resp.FinishReason != FinishReasonFailed {
+			t.Errorf("FinishReason = %q, want %q", resp.FinishReason, FinishReasonFailed)
+		}
+	})
+
+	t.Run("tool failure drops the whole round", func(t *testing.T) {
+		r := newTestRegistry(t)
+		defineFakeModel(t, r, fakeModelConfig{
+			name: "test/twoTools",
+			handler: func(ctx context.Context, req *ModelRequest, cb ModelStreamCallback) (*ModelResponse, error) {
+				return &ModelResponse{Request: req, Message: &Message{
+					Role: RoleModel,
+					Content: []*Part{
+						NewToolRequestPart(&ToolRequest{Name: "boomTool", Input: map[string]any{}}),
+						NewToolRequestPart(&ToolRequest{Name: "okTool", Input: map[string]any{}}),
+					},
+				}}, nil
+			},
+		})
+		// The handshake orders the failure after okTool completes, so the
+		// round demonstrably held a finished sibling before it was dropped.
+		okDone := make(chan struct{})
+		defineTool(r, "boomTool", "always fails",
+			func(ctx *ToolContext, in map[string]any) (string, error) {
+				<-okDone
+				return "", errors.New("boom")
+			})
+		defineTool(r, "okTool", "succeeds",
+			func(ctx *ToolContext, in map[string]any) (string, error) {
+				defer close(okDone)
+				return "fine", nil
+			})
+
+		resp, err := Generate(testCtx, r,
+			WithModelName("test/twoTools"),
+			WithPrompt("start"),
+			WithTools(LookupTool(r, "boomTool"), LookupTool(r, "okTool")),
+		)
+		if !errors.Is(err, ErrToolFailed) {
+			t.Fatalf("err = %v, want ErrToolFailed", err)
+		}
+		if resp == nil {
+			t.Fatal("response is nil, want the loop's partial response")
+		}
+		if resp.FinishReason != FinishReasonFailed {
+			t.Errorf("FinishReason = %q, want %q", resp.FinishReason, FinishReasonFailed)
+		}
+		// okTool finished, but its output cannot be handed back on its own:
+		// the round's other request has no response, and a conversation that
+		// ends there is one no provider accepts.
+		if resp.Message != nil {
+			t.Errorf("Message = %v, want nil: the round goes with the tool that failed", resp.Message)
+		}
+		if got := len(resp.ToolRequests()); got != 0 {
+			t.Errorf("ToolRequests() = %d parts, want none", got)
+		}
+		history := resp.History()
+		if len(history) != 1 || history[0].Role != RoleUser {
+			t.Errorf("History() = %d messages ending in %v, want the user message alone", len(history), history[len(history)-1].Role)
+		}
+	})
+
+	t.Run("invalid structured output returns the full response", func(t *testing.T) {
+		r := badJSONSetup(t)
+
+		resp, err := Generate(testCtx, r,
+			WithModelName("test/badJSON"),
+			WithPrompt("start"),
+			WithOutputType(StructuredResponse{}),
+		)
+		if !errors.Is(err, status.ErrInvalidOutput) {
+			t.Fatalf("err = %v, want ErrInvalidOutput", err)
+		}
+		if resp == nil {
+			t.Fatal("response is nil, want the model's full response")
+		}
+		// The model finished; only post-processing failed. The response keeps
+		// the model's own finish reason and raw output.
+		if resp.FinishReason != FinishReasonStop {
+			t.Errorf("FinishReason = %q, want the model's own %q", resp.FinishReason, FinishReasonStop)
+		}
+		if got := resp.Text(); got != "this is not json" {
+			t.Errorf("Text() = %q, want the raw model output", got)
+		}
+	})
+
+	t.Run("GenerateData returns the partial response with the error", func(t *testing.T) {
+		r := badJSONSetup(t)
+
+		out, resp, err := GenerateData[StructuredResponse](testCtx, r,
+			WithModelName("test/badJSON"),
+			WithPrompt("start"),
+		)
+		if !errors.Is(err, status.ErrInvalidOutput) {
+			t.Fatalf("err = %v, want ErrInvalidOutput", err)
+		}
+		if out != nil {
+			t.Errorf("output = %v, want nil", out)
+		}
+		if resp == nil || resp.Text() != "this is not json" {
+			t.Errorf("response = %v, want the raw model output", resp)
+		}
+	})
+
+	t.Run("GenerateText returns the partial text", func(t *testing.T) {
+		r := badJSONSetup(t)
+
+		text, err := GenerateText(testCtx, r,
+			WithModelName("test/badJSON"),
+			WithPrompt("start"),
+			WithOutputType(StructuredResponse{}),
+		)
+		if !errors.Is(err, status.ErrInvalidOutput) {
+			t.Fatalf("err = %v, want ErrInvalidOutput", err)
+		}
+		if text != "this is not json" {
+			t.Errorf("text = %q, want the raw model output", text)
+		}
+	})
+
+	t.Run("a hook dropping the response still yields the partial", func(t *testing.T) {
+		r := loopSetup(t)
+		drop := MiddlewareFunc(func(ctx context.Context) (*Hooks, error) {
+			return &Hooks{
+				WrapGenerate: func(ctx context.Context, p *GenerateParams, next GenerateNext) (*ModelResponse, error) {
+					resp, err := next(ctx, p)
+					if err != nil {
+						return nil, err // The common reflex that loses the response.
+					}
+					return resp, nil
+				},
+			}, nil
+		})
+
+		resp, err := Generate(testCtx, r,
+			WithModelName("test/loopModel"),
+			WithPrompt("start"),
+			WithTools(LookupTool(r, "myTool")),
+			WithMaxTurns(1),
+			WithUse(drop),
+		)
+		if !errors.Is(err, ErrMaxTurnsExceeded) {
+			t.Fatalf("err = %v, want ErrMaxTurnsExceeded", err)
+		}
+		if resp == nil {
+			t.Fatal("response is nil, want the loop's recorded partial restored")
+		}
+		if resp.FinishReason != FinishReasonFailed {
+			t.Errorf("FinishReason = %q, want %q", resp.FinishReason, FinishReasonFailed)
+		}
+		// One completed round: the model message the limit refused goes with
+		// the round it opened, restored partial or not.
+		if got := len(resp.History()); got != 3 {
+			t.Errorf("History() has %d messages, want 3 (user, model, tool)", got)
+		}
+	})
+
+	t.Run("an error outside a turn synthesizes a partial", func(t *testing.T) {
+		r := loopSetup(t)
+		deny := MiddlewareFunc(func(ctx context.Context) (*Hooks, error) {
+			return &Hooks{
+				WrapGenerate: func(ctx context.Context, p *GenerateParams, next GenerateNext) (*ModelResponse, error) {
+					if p.Iteration == 1 {
+						return nil, errors.New("hook denied")
+					}
+					return next(ctx, p)
+				},
+			}, nil
+		})
+
+		resp, err := Generate(testCtx, r,
+			WithModelName("test/loopModel"),
+			WithPrompt("start"),
+			WithTools(LookupTool(r, "myTool")),
+			WithUse(deny),
+		)
+		errorContains(t, err, "hook denied")
+		if resp == nil {
+			t.Fatal("response is nil, want a synthesized partial")
+		}
+		if resp.FinishReason != FinishReasonFailed {
+			t.Errorf("FinishReason = %q, want %q", resp.FinishReason, FinishReasonFailed)
+		}
+		if resp.Message != nil {
+			t.Errorf("Message = %v, want nil: no turn produced a message for this failure", resp.Message)
+		}
+		// The conversation entering the denied turn: user, model, tool.
+		if got := len(resp.History()); got != 3 {
+			t.Errorf("History() has %d messages, want 3", got)
+		}
+	})
+
+	t.Run("the stream helpers yield the partial with the error", func(t *testing.T) {
+		r := loopSetup(t)
+
+		var last *ModelStreamValue
+		var streamErr error
+		for v, err := range GenerateStream(testCtx, r,
+			WithModelName("test/loopModel"),
+			WithPrompt("start"),
+			WithTools(LookupTool(r, "myTool")),
+			WithMaxTurns(1),
+		) {
+			if err != nil {
+				last, streamErr = v, err
+			}
+		}
+		if !errors.Is(streamErr, ErrMaxTurnsExceeded) {
+			t.Fatalf("err = %v, want ErrMaxTurnsExceeded", streamErr)
+		}
+		if last == nil || last.Response == nil {
+			t.Fatal("stream yielded no response with its error, want the partial")
+		}
+		if !last.Done {
+			t.Error("the failing value is not marked Done")
+		}
+		if got := len(last.Response.History()); got != 3 {
+			t.Errorf("History() has %d messages, want 3 (user, model, tool)", got)
+		}
+
+		var typed *StreamValue[StructuredResponse, StructuredResponse]
+		for v, err := range GenerateDataStream[StructuredResponse](testCtx, r,
+			WithModelName("test/loopModel"),
+			WithPrompt("start"),
+			WithTools(LookupTool(r, "myTool")),
+			WithMaxTurns(1),
+		) {
+			if err != nil {
+				typed, streamErr = v, err
+			}
+		}
+		if !errors.Is(streamErr, ErrMaxTurnsExceeded) {
+			t.Fatalf("typed err = %v, want ErrMaxTurnsExceeded", streamErr)
+		}
+		if typed == nil || typed.Response == nil {
+			t.Fatal("typed stream yielded no response with its error, want the partial")
+		}
+		var zero StructuredResponse
+		if typed.Output != zero {
+			t.Errorf("Output = %v, want the zero value: the call produced none", typed.Output)
+		}
+	})
+}
+
+// TestGenerateLoopFailureHardening covers edge cases of the partial-response
+// machinery: stale partials do not survive recovered failures, sibling
+// outcomes (interrupts, resolved restarts) survive into partials and
+// resumes, and the model layer's own partial responses are adopted.
+func TestGenerateLoopFailureHardening(t *testing.T) {
+	t.Parallel()
+
+	t.Run("a recovered failure does not leak a stale partial", func(t *testing.T) {
+		r := newTestRegistry(t)
+		calls := 0
+		defineFakeModel(t, r, fakeModelConfig{
+			name: "test/flakyThenTool",
+			handler: func(ctx context.Context, req *ModelRequest, cb ModelStreamCallback) (*ModelResponse, error) {
+				calls++
+				if calls == 1 {
+					return nil, errors.New("transient model error")
+				}
+				return &ModelResponse{Request: req, Message: &Message{
+					Role:    RoleModel,
+					Content: []*Part{NewToolRequestPart(&ToolRequest{Name: "myTool", Input: map[string]any{}})},
+				}}, nil
+			},
+		})
+		defineTool(r, "myTool", "A test tool",
+			func(ctx *ToolContext, in map[string]any) (string, error) { return "ok", nil })
+
+		retryThenDeny := MiddlewareFunc(func(ctx context.Context) (*Hooks, error) {
+			return &Hooks{
+				WrapGenerate: func(ctx context.Context, p *GenerateParams, next GenerateNext) (*ModelResponse, error) {
+					if p.Iteration == 1 {
+						return nil, errors.New("budget denied")
+					}
+					resp, err := next(ctx, p)
+					if err != nil {
+						return next(ctx, p) // Retry the turn once.
+					}
+					return resp, nil
+				},
+			}, nil
+		})
+
+		resp, err := Generate(testCtx, r,
+			WithModelName("test/flakyThenTool"),
+			WithPrompt("start"),
+			WithTools(LookupTool(r, "myTool")),
+			WithUse(retryThenDeny),
+		)
+		errorContains(t, err, "budget denied")
+		if resp == nil {
+			t.Fatal("response is nil, want a synthesized partial")
+		}
+		if !strings.Contains(resp.FinishMessage, "budget denied") {
+			t.Errorf("FinishMessage = %q, want the current failure, not the recovered one", resp.FinishMessage)
+		}
+		// The conversation entering the denied turn: user, model, tool. The
+		// recovered turn-0 failure must not regress it to just the user
+		// message.
+		if got := len(resp.History()); got != 3 {
+			t.Errorf("History() has %d messages, want 3", got)
+		}
+	})
+
+	t.Run("a sibling interrupt goes with the failed round", func(t *testing.T) {
+		r := newTestRegistry(t)
+		defineFakeModel(t, r, fakeModelConfig{
+			name: "test/interruptAndBoom",
+			handler: func(ctx context.Context, req *ModelRequest, cb ModelStreamCallback) (*ModelResponse, error) {
+				return &ModelResponse{Request: req, Message: &Message{
+					Role: RoleModel,
+					Content: []*Part{
+						NewToolRequestPart(&ToolRequest{Name: "pauser", Input: map[string]any{}}),
+						NewToolRequestPart(&ToolRequest{Name: "boomTool", Input: map[string]any{}}),
+					},
+				}}, nil
+			},
+		})
+		pauseDone := make(chan struct{})
+		pauser := defineTool(r, "pauser", "interrupts",
+			func(ctx *ToolContext, in map[string]any) (string, error) {
+				defer close(pauseDone)
+				return "", ctx.Interrupt(&InterruptOptions{Metadata: map[string]any{"reason": "approval"}})
+			})
+		boom := defineTool(r, "boomTool", "fails after the interrupt arrived",
+			func(ctx *ToolContext, in map[string]any) (string, error) {
+				<-pauseDone
+				return "", errors.New("boom")
+			})
+
+		resp, err := Generate(testCtx, r,
+			WithModelName("test/interruptAndBoom"),
+			WithPrompt("start"),
+			WithTools(pauser, boom),
+		)
+		if !errors.Is(err, ErrToolFailed) {
+			t.Fatalf("err = %v, want ErrToolFailed", err)
+		}
+		// An interrupt is a resume point only while its round can still be
+		// answered. This one cannot, so it is dropped rather than handed
+		// back as an interrupt the caller could never resolve.
+		if got := len(resp.Interrupts()); got != 0 {
+			t.Errorf("partial has %d interrupt parts, want none", got)
+		}
+		if resp.Message != nil {
+			t.Errorf("Message = %v, want nil", resp.Message)
+		}
+		if got := len(resp.History()); got != 1 {
+			t.Errorf("History() has %d messages, want 1 (the user message alone)", got)
+		}
+	})
+
+	t.Run("response metadata survives a resume replay", func(t *testing.T) {
+		r := newTestRegistry(t)
+		defineFakeModel(t, r, fakeModelConfig{
+			name: "test/auditPlusInterrupt",
+			handler: func(ctx context.Context, req *ModelRequest, cb ModelStreamCallback) (*ModelResponse, error) {
+				for _, m := range req.Messages {
+					if m.Role == RoleTool {
+						return &ModelResponse{Request: req, Message: NewModelTextMessage("done")}, nil
+					}
+				}
+				return &ModelResponse{Request: req, Message: &Message{
+					Role: RoleModel,
+					Content: []*Part{
+						NewToolRequestPart(&ToolRequest{Name: "pauser", Input: map[string]any{}}),
+						NewToolRequestPart(&ToolRequest{Name: "auditTool", Input: map[string]any{}}),
+					},
+				}}, nil
+			},
+		})
+		pauser := defineTool(r, "pauser", "interrupts",
+			func(ctx *ToolContext, in map[string]any) (string, error) {
+				return "", ctx.Interrupt(&InterruptOptions{Metadata: map[string]any{"reason": "approval"}})
+			})
+		audit := defineMultipartTool(r, "auditTool", "annotates its response",
+			func(ctx *ToolContext, in map[string]any) (*MultipartToolResponse, error) {
+				return &MultipartToolResponse{
+					Output:   "ok",
+					Metadata: map[string]any{"audit": "checked"},
+				}, nil
+			})
+
+		res, err := Generate(testCtx, r,
+			WithModelName("test/auditPlusInterrupt"),
+			WithPrompt("start"),
+			WithTools(pauser, audit),
+		)
+		assertNoError(t, err)
+		if res.FinishReason != FinishReasonInterrupted {
+			t.Fatalf("FinishReason = %q, want interrupted", res.FinishReason)
+		}
+
+		respond := pauser.Respond(res.Interrupts()[0], "approved", nil)
+		resumed, err := Generate(testCtx, r,
+			WithModelName("test/auditPlusInterrupt"),
+			WithMessages(res.History()...),
+			WithTools(pauser, audit),
+			WithToolResponses(respond),
+		)
+		assertNoError(t, err)
+
+		var auditResp *Part
+		for _, m := range resumed.History() {
+			if m.Role != RoleTool {
+				continue
+			}
+			for _, p := range m.Content {
+				if p.IsToolResponse() && p.ToolResponse.Name == "auditTool" {
+					auditResp = p
+				}
+			}
+		}
+		if auditResp == nil {
+			t.Fatal("resumed history has no tool response for auditTool")
+		}
+		if auditResp.Metadata["audit"] != "checked" {
+			t.Errorf("replayed metadata = %v, want the tool's own audit key restored", auditResp.Metadata)
+		}
+		if auditResp.Metadata["source"] != "pending" {
+			t.Errorf("replayed metadata = %v, want source pending kept", auditResp.Metadata)
+		}
+	})
+
+	t.Run("the model layer's accounting outlives its dropped message", func(t *testing.T) {
+		r := newTestRegistry(t)
+		defineFakeModel(t, r, fakeModelConfig{name: "test/plainModel"})
+
+		partialModel := MiddlewareFunc(func(ctx context.Context) (*Hooks, error) {
+			return &Hooks{
+				WrapModel: func(ctx context.Context, p *ModelParams, next ModelNext) (*ModelResponse, error) {
+					return &ModelResponse{
+						Message: NewModelTextMessage("half an answer"),
+						Usage:   &GenerationUsage{OutputTokens: 7},
+					}, errors.New("model died")
+				},
+			}, nil
+		})
+
+		resp, err := Generate(testCtx, r,
+			WithModelName("test/plainModel"),
+			WithPrompt("start"),
+			WithUse(partialModel),
+		)
+		errorContains(t, err, "model died")
+		// The tokens were spent, so the accounting rides back; the message
+		// they produced does not, since the call did not finish.
+		if resp.Message != nil {
+			t.Errorf("Message = %v, want nil", resp.Message)
+		}
+		if resp.Usage == nil || resp.Usage.OutputTokens != 7 {
+			t.Errorf("Usage = %+v, want the model layer's accounting kept", resp.Usage)
+		}
+		if resp.FinishReason != FinishReasonFailed {
+			t.Errorf("FinishReason = %q, want %q", resp.FinishReason, FinishReasonFailed)
+		}
+	})
+
+	t.Run("restarted interrupt with no metadata is still an interrupt", func(t *testing.T) {
+		r := newTestRegistry(t)
+		calls := 0
+		fragile := defineTool(r, "fragile", "always interrupts",
+			func(ctx *ToolContext, in map[string]any) (string, error) {
+				calls++
+				return "", ctx.Interrupt(&InterruptOptions{})
+			})
+		defineFakeModel(t, r, fakeModelConfig{
+			name: "test/reinterrupt",
+			handler: func(ctx context.Context, req *ModelRequest, cb ModelStreamCallback) (*ModelResponse, error) {
+				return &ModelResponse{Request: req, Message: &Message{
+					Role:    RoleModel,
+					Content: []*Part{NewToolRequestPart(&ToolRequest{Name: "fragile", Input: map[string]any{}})},
+				}}, nil
+			},
+		})
+
+		res, err := Generate(testCtx, r,
+			WithModelName("test/reinterrupt"),
+			WithPrompt("start"),
+			WithTools(fragile),
+		)
+		assertNoError(t, err)
+
+		restart := fragile.Restart(res.Interrupts()[0], nil)
+		resumed, err := Generate(testCtx, r,
+			WithModelName("test/reinterrupt"),
+			WithMessages(res.History()...),
+			WithTools(fragile),
+			WithToolRestarts(restart),
+		)
+		if !errors.Is(err, status.ErrFailedPrecondition) {
+			t.Fatalf("err = %v, want FAILED_PRECONDITION", err)
+		}
+		if resumed == nil {
+			t.Fatal("response is nil, want the re-interrupted partial")
+		}
+		if resumed.FinishReason != FinishReasonInterrupted {
+			t.Errorf("FinishReason = %q, want interrupted", resumed.FinishReason)
+		}
+		if got := len(resumed.Interrupts()); got != 1 {
+			t.Errorf("Interrupts() = %d parts, want the metadata-free interrupt detectable", got)
+		}
+		if got := len(resumed.History()); got != len(res.History()) {
+			t.Errorf("History() has %d messages, want %d", got, len(res.History()))
+		}
+		if calls != 2 {
+			t.Errorf("tool ran %d times, want 2", calls)
+		}
+	})
+
+	t.Run("re-interrupt preserves resolved siblings", func(t *testing.T) {
+		r := newTestRegistry(t)
+		aCalls, bCalls := 0, 0
+		toolA := defineTool(r, "toolA", "interrupts once, then succeeds",
+			func(ctx *ToolContext, in map[string]any) (string, error) {
+				aCalls++
+				if aCalls == 1 {
+					return "", ctx.Interrupt(&InterruptOptions{Metadata: map[string]any{"which": "A"}})
+				}
+				return "A done", nil
+			})
+		toolB := defineTool(r, "toolB", "always interrupts",
+			func(ctx *ToolContext, in map[string]any) (string, error) {
+				bCalls++
+				return "", ctx.Interrupt(&InterruptOptions{Metadata: map[string]any{"which": "B"}})
+			})
+		defineFakeModel(t, r, fakeModelConfig{
+			name: "test/twoInterrupts",
+			handler: func(ctx context.Context, req *ModelRequest, cb ModelStreamCallback) (*ModelResponse, error) {
+				return &ModelResponse{Request: req, Message: &Message{
+					Role: RoleModel,
+					Content: []*Part{
+						NewToolRequestPart(&ToolRequest{Name: "toolA", Input: map[string]any{}}),
+						NewToolRequestPart(&ToolRequest{Name: "toolB", Input: map[string]any{}}),
+					},
+				}}, nil
+			},
+		})
+
+		res, err := Generate(testCtx, r,
+			WithModelName("test/twoInterrupts"),
+			WithPrompt("start"),
+			WithTools(toolA, toolB),
+		)
+		assertNoError(t, err)
+
+		var partA, partB *Part
+		for _, p := range res.Interrupts() {
+			switch p.ToolRequest.Name {
+			case "toolA":
+				partA = p
+			case "toolB":
+				partB = p
+			}
+		}
+		resumed, err := Generate(testCtx, r,
+			WithModelName("test/twoInterrupts"),
+			WithMessages(res.History()...),
+			WithTools(toolA, toolB),
+			WithToolRestarts(toolA.Restart(partA, nil), toolB.Restart(partB, nil)),
+		)
+		if !errors.Is(err, status.ErrFailedPrecondition) {
+			t.Fatalf("err = %v, want FAILED_PRECONDITION from toolB's re-interrupt", err)
+		}
+		if resumed == nil {
+			t.Fatal("response is nil, want the re-interrupted partial")
+		}
+		var resolvedA *Part
+		for _, p := range resumed.Message.Content {
+			if p.IsToolRequest() && p.ToolRequest.Name == "toolA" {
+				resolvedA = p
+			}
+		}
+		if resolvedA == nil {
+			t.Fatal("toolA's request part missing from the partial")
+		}
+		if resolvedA.Metadata["pendingOutput"] != "A done" {
+			t.Errorf("toolA pendingOutput = %v, want its completed output preserved", resolvedA.Metadata["pendingOutput"])
+		}
+	})
+}
+
+// TestGenerateResumePreservesMultipartContent covers pendingContent: a
+// multipart tool's content parts survive an interrupted turn and a wire
+// round-trip, and reappear on the replayed tool response when the
+// generation resumes.
+func TestGenerateResumePreservesMultipartContent(t *testing.T) {
+	t.Parallel()
+
+	t.Run("replay restores multipart content", func(t *testing.T) {
+		r := newTestRegistry(t)
+		pauser := defineTool(r, "pauser", "interrupts",
+			func(ctx *ToolContext, in map[string]any) (string, error) {
+				return "", ctx.Interrupt(&InterruptOptions{Metadata: map[string]any{"reason": "approval"}})
+			})
+		media := NewMultipartTool("mediaTool", "returns a chart",
+			func(ctx *ToolContext, in map[string]any) (*MultipartToolResponse, error) {
+				return &MultipartToolResponse{
+					Output:  "described",
+					Content: []*Part{NewMediaPart("image/png", "data:image/png;base64,AAA")},
+				}, nil
+			})
+		media.Register(r)
+
+		defineFakeModel(t, r, fakeModelConfig{
+			name: "test/mediaAndPause",
+			handler: func(ctx context.Context, req *ModelRequest, cb ModelStreamCallback) (*ModelResponse, error) {
+				for _, m := range req.Messages {
+					if m.Role == RoleTool {
+						return &ModelResponse{Request: req, Message: NewModelTextMessage("done")}, nil
+					}
+				}
+				return &ModelResponse{Request: req, Message: &Message{
+					Role: RoleModel,
+					Content: []*Part{
+						NewToolRequestPart(&ToolRequest{Name: "pauser", Input: map[string]any{}}),
+						NewToolRequestPart(&ToolRequest{Name: "mediaTool", Input: map[string]any{}}),
+					},
+				}}, nil
+			},
+		})
+
+		res, err := Generate(testCtx, r,
+			WithModelName("test/mediaAndPause"),
+			WithPrompt("start"),
+			WithTools(pauser, media),
+		)
+		assertNoError(t, err)
+		if res.FinishReason != FinishReasonInterrupted {
+			t.Fatalf("FinishReason = %q, want interrupted", res.FinishReason)
+		}
+
+		// A persistence round-trip degrades metadata values to generic JSON;
+		// the replay must decode pendingContent from that form too.
+		raw, err := json.Marshal(res.History())
+		if err != nil {
+			t.Fatal(err)
+		}
+		var msgs []*Message
+		if err := json.Unmarshal(raw, &msgs); err != nil {
+			t.Fatal(err)
+		}
+
+		var interruptPart *Part
+		for _, p := range msgs[len(msgs)-1].Content {
+			if p.IsInterrupt() {
+				interruptPart = p
+			}
+		}
+		if interruptPart == nil {
+			t.Fatal("no interrupt part survived the round-trip")
+		}
+
+		resumed, err := Generate(testCtx, r,
+			WithModelName("test/mediaAndPause"),
+			WithMessages(msgs...),
+			WithTools(pauser, media),
+			WithToolResponses(pauser.Respond(interruptPart, "approved", nil)),
+		)
+		assertNoError(t, err)
+
+		var mediaResp *Part
+		for _, m := range resumed.History() {
+			if m.Role != RoleTool {
+				continue
+			}
+			for _, p := range m.Content {
+				if p.IsToolResponse() && p.ToolResponse.Name == "mediaTool" {
+					mediaResp = p
+				}
+			}
+		}
+		if mediaResp == nil {
+			t.Fatal("resumed history has no tool response for mediaTool")
+		}
+		if mediaResp.ToolResponse.Output != "described" {
+			t.Errorf("replayed output = %v, want %q", mediaResp.ToolResponse.Output, "described")
+		}
+		content := mediaResp.ToolResponse.Content
+		if len(content) != 1 || !content[0].IsMedia() || content[0].ContentType != "image/png" {
+			t.Fatalf("replayed content = %+v, want the tool's media part restored", content)
+		}
+		if _, ok := mediaResp.Metadata["pendingContent"]; ok {
+			t.Error("pendingContent metadata leaked onto the replayed response")
+		}
+	})
+
+	t.Run("re-interrupt stamps content for resolved siblings", func(t *testing.T) {
+		r := newTestRegistry(t)
+		aCalls := 0
+		multiA := NewMultipartTool("multiA", "interrupts once, then returns media",
+			func(ctx *ToolContext, in map[string]any) (*MultipartToolResponse, error) {
+				aCalls++
+				if aCalls == 1 {
+					return nil, ctx.Interrupt(&InterruptOptions{Metadata: map[string]any{"which": "A"}})
+				}
+				return &MultipartToolResponse{
+					Output:  "A done",
+					Content: []*Part{NewMediaPart("image/png", "data:image/png;base64,BBB")},
+				}, nil
+			})
+		multiA.Register(r)
+		toolB := defineTool(r, "toolB", "always interrupts",
+			func(ctx *ToolContext, in map[string]any) (string, error) {
+				return "", ctx.Interrupt(&InterruptOptions{Metadata: map[string]any{"which": "B"}})
+			})
+		defineFakeModel(t, r, fakeModelConfig{
+			name: "test/multiInterrupts",
+			handler: func(ctx context.Context, req *ModelRequest, cb ModelStreamCallback) (*ModelResponse, error) {
+				return &ModelResponse{Request: req, Message: &Message{
+					Role: RoleModel,
+					Content: []*Part{
+						NewToolRequestPart(&ToolRequest{Name: "multiA", Input: map[string]any{}}),
+						NewToolRequestPart(&ToolRequest{Name: "toolB", Input: map[string]any{}}),
+					},
+				}}, nil
+			},
+		})
+
+		res, err := Generate(testCtx, r,
+			WithModelName("test/multiInterrupts"),
+			WithPrompt("start"),
+			WithTools(multiA, toolB),
+		)
+		assertNoError(t, err)
+
+		var partA, partB *Part
+		for _, p := range res.Interrupts() {
+			switch p.ToolRequest.Name {
+			case "multiA":
+				partA = p
+			case "toolB":
+				partB = p
+			}
+		}
+		resumed, err := Generate(testCtx, r,
+			WithModelName("test/multiInterrupts"),
+			WithMessages(res.History()...),
+			WithTools(multiA, toolB),
+			WithToolRestarts(multiA.Restart(partA, nil), toolB.Restart(partB, nil)),
+		)
+		if !errors.Is(err, status.ErrFailedPrecondition) {
+			t.Fatalf("err = %v, want FAILED_PRECONDITION from toolB's re-interrupt", err)
+		}
+		var resolvedA *Part
+		for _, p := range resumed.Message.Content {
+			if p.IsToolRequest() && p.ToolRequest.Name == "multiA" {
+				resolvedA = p
+			}
+		}
+		if resolvedA == nil {
+			t.Fatal("multiA's request part missing from the partial")
+		}
+		content, ok := resolvedA.Metadata["pendingContent"].([]*Part)
+		if !ok || len(content) != 1 || !content[0].IsMedia() {
+			t.Errorf("multiA pendingContent = %v, want its media part preserved", resolvedA.Metadata["pendingContent"])
+		}
+	})
+}
+
+// TestResumedToolMessageOrder pins that a resumed tool message carries its
+// responses in the order their requests appear in the model message, not the
+// order the concurrent resolutions finished, the same guarantee
+// handleToolRequests gives the first run.
+func TestResumedToolMessageOrder(t *testing.T) {
+	t.Parallel()
+	r := newTestRegistry(t)
+
+	// On restart, beta finishes first and alpha waits for it, so completion
+	// order inverts request order. The sleep gives beta's result time to
+	// reach the collection loop ahead of alpha's.
+	betaDone := make(chan struct{})
+	aCalls, bCalls := 0, 0
+	alpha := defineTool(r, "alpha", "interrupts once, then finishes last",
+		func(ctx *ToolContext, in map[string]any) (string, error) {
+			aCalls++
+			if aCalls == 1 {
+				return "", ctx.Interrupt(&InterruptOptions{Metadata: map[string]any{"which": "A"}})
+			}
+			<-betaDone
+			time.Sleep(10 * time.Millisecond)
+			return "A", nil
+		})
+	beta := defineTool(r, "beta", "interrupts once, then finishes first",
+		func(ctx *ToolContext, in map[string]any) (string, error) {
+			bCalls++
+			if bCalls == 1 {
+				return "", ctx.Interrupt(&InterruptOptions{Metadata: map[string]any{"which": "B"}})
+			}
+			defer close(betaDone)
+			return "B", nil
+		})
+
+	var resumedToolMsg *Message
+	defineFakeModel(t, r, fakeModelConfig{
+		name: "test/orderedResume",
+		handler: func(ctx context.Context, req *ModelRequest, cb ModelStreamCallback) (*ModelResponse, error) {
+			if last := req.Messages[len(req.Messages)-1]; last.Role == RoleTool {
+				resumedToolMsg = last
+				return &ModelResponse{Request: req, Message: NewModelTextMessage("done")}, nil
+			}
+			return &ModelResponse{Request: req, Message: &Message{
+				Role: RoleModel,
+				Content: []*Part{
+					NewToolRequestPart(&ToolRequest{Name: "alpha", Input: map[string]any{}}),
+					NewToolRequestPart(&ToolRequest{Name: "beta", Input: map[string]any{}}),
+				},
+			}}, nil
+		},
+	})
+
+	res, err := Generate(testCtx, r,
+		WithModelName("test/orderedResume"),
+		WithPrompt("start"),
+		WithTools(alpha, beta),
+	)
+	assertNoError(t, err)
+
+	var partA, partB *Part
+	for _, p := range res.Interrupts() {
+		switch p.ToolRequest.Name {
+		case "alpha":
+			partA = p
+		case "beta":
+			partB = p
+		}
+	}
+	resumed, err := Generate(testCtx, r,
+		WithModelName("test/orderedResume"),
+		WithMessages(res.History()...),
+		WithTools(alpha, beta),
+		WithToolRestarts(alpha.Restart(partA, nil), beta.Restart(partB, nil)),
+	)
+	assertNoError(t, err)
+	if got := resumed.Text(); got != "done" {
+		t.Errorf("Text() = %q, want %q", got, "done")
+	}
+
+	if resumedToolMsg == nil {
+		t.Fatal("the model never received a tool message")
+	}
+	var names []string
+	for _, p := range resumedToolMsg.Content {
+		if p.IsToolResponse() {
+			names = append(names, p.ToolResponse.Name)
+		}
+	}
+	if want := []string{"alpha", "beta"}; !slices.Equal(names, want) {
+		t.Errorf("resumed tool message order = %v, want %v", names, want)
+	}
 }

--- a/go/ai/generate_test.go
+++ b/go/ai/generate_test.go
@@ -3605,8 +3605,10 @@ func TestGeneratePartialResponseOnFailure(t *testing.T) {
 		if resp == nil {
 			t.Fatal("response is nil, want the loop's partial response")
 		}
-		if resp.FinishReason != FinishReasonFailed {
-			t.Errorf("FinishReason = %q, want %q", resp.FinishReason, FinishReasonFailed)
+		// The caller set the limit, so reaching it stopped the loop rather
+		// than breaking it.
+		if resp.FinishReason != FinishReasonAborted {
+			t.Errorf("FinishReason = %q, want %q", resp.FinishReason, FinishReasonAborted)
 		}
 		if !strings.Contains(resp.FinishMessage, "exceeded maximum tool call iterations (2)") {
 			t.Errorf("FinishMessage = %q, want the max-turns cause", resp.FinishMessage)
@@ -3943,8 +3945,10 @@ func TestGeneratePartialResponseOnFailure(t *testing.T) {
 		if resp == nil {
 			t.Fatal("response is nil, want the loop's recorded partial restored")
 		}
-		if resp.FinishReason != FinishReasonFailed {
-			t.Errorf("FinishReason = %q, want %q", resp.FinishReason, FinishReasonFailed)
+		// The caller set the limit, so reaching it stopped the loop rather
+		// than breaking it.
+		if resp.FinishReason != FinishReasonAborted {
+			t.Errorf("FinishReason = %q, want %q", resp.FinishReason, FinishReasonAborted)
 		}
 		// One completed round: the model message the limit refused goes with
 		// the round it opened, restored partial or not.

--- a/go/ai/generate_test.go
+++ b/go/ai/generate_test.go
@@ -3709,6 +3709,58 @@ func TestGeneratePartialResponseOnFailure(t *testing.T) {
 		}
 	})
 
+	t.Run("cancellation inside a tool reports aborted", func(t *testing.T) {
+		r := newTestRegistry(t)
+		defineFakeModel(t, r, fakeModelConfig{
+			name: "test/toolCancel",
+			handler: func(ctx context.Context, req *ModelRequest, cb ModelStreamCallback) (*ModelResponse, error) {
+				return &ModelResponse{Request: req, Message: &Message{
+					Role:    RoleModel,
+					Content: []*Part{NewToolRequestPart(&ToolRequest{Name: "blockingTool", Input: map[string]any{}})},
+				}}, nil
+			},
+		})
+		running := make(chan struct{})
+		defineTool(r, "blockingTool", "blocks until the call is cancelled",
+			func(tc *ToolContext, in map[string]any) (string, error) {
+				close(running)
+				<-tc.Context.Done()
+				return "", tc.Context.Err()
+			})
+
+		ctx, cancel := context.WithCancel(testCtx)
+		go func() {
+			<-running
+			cancel()
+		}()
+		resp, err := Generate(ctx, r,
+			WithModelName("test/toolCancel"),
+			WithPrompt("start"),
+			WithTools(LookupTool(r, "blockingTool")),
+		)
+		// The tool stopped because the caller did, so the loop reports the
+		// cancellation rather than blaming the tool for it.
+		if errors.Is(err, ErrToolFailed) {
+			t.Errorf("err = %v, want a cancellation rather than ErrToolFailed", err)
+		}
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("err = %v, want context.Canceled", err)
+		}
+		if resp == nil {
+			t.Fatal("response is nil, want the loop's partial response")
+		}
+		if resp.FinishReason != FinishReasonAborted {
+			t.Errorf("FinishReason = %q, want %q: the caller stopped the loop", resp.FinishReason, FinishReasonAborted)
+		}
+		if resp.Error == nil || resp.Error.Status != status.Cancelled {
+			t.Errorf("Error = %+v, want a CANCELLED classification", resp.Error)
+		}
+		history := resp.History()
+		if len(history) != 1 || history[0].Role != RoleUser {
+			t.Errorf("History() = %d messages, want the user message alone: the unfinished round goes", len(history))
+		}
+	})
+
 	t.Run("mid-stream failure drops the unfinished message", func(t *testing.T) {
 		r := newTestRegistry(t)
 		defineFakeModel(t, r, fakeModelConfig{

--- a/go/ai/option.go
+++ b/go/ai/option.go
@@ -337,6 +337,7 @@ func WithStepName(name string) GenerateOption {
 // WithMaxTurns sets the maximum number of tool call iterations before erroring.
 // A tool call happens when tools are provided in the request and a model decides to call one or more as a response.
 // Each round trip, including multiple tools in parallel, counts as one turn.
+// Defaults to 50.
 func WithMaxTurns(maxTurns int) CommonGenOption {
 	return &commonGenOptions{MaxTurns: maxTurns}
 }

--- a/go/ai/prompt.go
+++ b/go/ai/prompt.go
@@ -1143,10 +1143,12 @@ func AsDataPrompt[In, Out any](p Prompt) *DataPrompt[In, Out] {
 //
 // A refusal is an error: when the response finished blocked, the output is the
 // zero value of Out and the error is [ErrGenerationBlocked], carrying the
-// provider's explanation. The response is still returned alongside it.
+// provider's explanation. The response is still returned alongside it. A
+// generation failure likewise returns its error alongside the partial
+// response [Generate] documents, with a zero-value output.
 //
 // The output is the zero value of Out with no error in two other cases:
-// generation ended aborted, interrupted, or other, or the response carried no
+// generation ended failed, aborted, interrupted, or other, or the response carried no
 // text to parse, which is what a turn holding tool requests, interrupts, or
 // media looks like. Check resp.FinishReason, resp.Interrupts(), and
 // resp.ToolRequests() to handle them.
@@ -1162,7 +1164,7 @@ func (dp *DataPrompt[In, Out]) Execute(ctx context.Context, input In, opts ...Pr
 	allOpts := append(slices.Clone(opts), WithInput(input))
 	resp, err := dp.prompt.Execute(ctx, allOpts...)
 	if err != nil {
-		return base.Zero[Out](), nil, err
+		return base.Zero[Out](), resp, err
 	}
 
 	// A refusal cannot produce the value this helper promises, so it is
@@ -1205,7 +1207,7 @@ func (dp *DataPrompt[In, Out]) Execute(ctx context.Context, input In, opts ...Pr
 // [WithInput] passed in opts.
 //
 // Like [DataPrompt.Execute], a blocked response fails with
-// [ErrGenerationBlocked], while one that ends aborted, interrupted, or other,
+// [ErrGenerationBlocked], while one that ends failed, aborted, interrupted, or other,
 // or carries no text to parse, yields zero-value Output and no error; check
 // Response.FinishReason, Response.Interrupts(), and Response.ToolRequests().
 //

--- a/go/ai/prompt_test.go
+++ b/go/ai/prompt_test.go
@@ -1994,6 +1994,16 @@ func TestDataPromptAbnormalFinish(t *testing.T) {
 			},
 		},
 		{
+			// What the loop's failure partial reports; parsing must skip it
+			// the same way.
+			name: "failed with failure text",
+			response: &ModelResponse{
+				FinishReason:  FinishReasonFailed,
+				FinishMessage: "provider down",
+				Message:       NewModelTextMessage("Error: provider down"),
+			},
+		},
+		{
 			name: "other with filter details",
 			response: &ModelResponse{
 				FinishReason:  FinishReasonOther,

--- a/go/core/action.go
+++ b/go/core/action.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/firebase/genkit/go/core/api"
+	"github.com/firebase/genkit/go/core/logger"
 	"github.com/firebase/genkit/go/core/status"
 	"github.com/firebase/genkit/go/core/tracing"
 	"github.com/firebase/genkit/go/internal/base"
@@ -230,12 +231,15 @@ func isNilValue(v any) bool {
 func (a *Action[In, Out, Stream]) Name() string { return a.desc.Name }
 
 // Run executes the Action's function in a new trace span.
+//
+// A failure returns whatever the function produced alongside its error rather
+// than a zero value: the generate loop returns the conversation it completed,
+// and an output that failed its own schema is still the output. The value is
+// the function's, so an action that returns nothing on error still yields the
+// zero one, and a caller that checks err first sees no difference.
 func (a *Action[In, Out, Stream]) Run(ctx context.Context, input In, cb StreamCallback[Stream]) (output Out, err error) {
 	r, err := a.runWithTelemetry(ctx, input, cb, a.fn, nil)
-	if err != nil {
-		return base.Zero[Out](), err
-	}
-	return r.Result, nil
+	return r.Result, err
 }
 
 // runWithTelemetry executes fn in a new trace span and returns telemetry
@@ -331,13 +335,14 @@ func (a *Action[In, Out, Stream]) validateOutput(out Out, schema map[string]any)
 	return nil
 }
 
-// RunJSON runs the action with a JSON input, and returns a JSON result.
+// RunJSON runs the action with a JSON input, and returns a JSON result. Like
+// [Action.Run], a failure carries whatever the function produced.
 func (a *Action[In, Out, Stream]) RunJSON(ctx context.Context, input json.RawMessage, cb StreamCallback[json.RawMessage]) (json.RawMessage, error) {
 	r, err := a.RunJSONWithTelemetry(ctx, input, cb)
-	if err != nil {
+	if r == nil {
 		return nil, err
 	}
-	return r.Result, nil
+	return r.Result, err
 }
 
 // RunJSONWithTelemetry runs the action with a JSON input, and returns a JSON result along with telemetry info.
@@ -366,10 +371,23 @@ func (a *Action[In, Out, Stream]) runJSONWithTelemetry(ctx context.Context, inpu
 
 	r, err := a.runWithTelemetry(ctx, i, scb, fn, spanInit)
 	if err != nil {
-		return &api.ActionRunResult[json.RawMessage]{
+		res := &api.ActionRunResult[json.RawMessage]{
 			TraceId: r.TraceId,
 			SpanId:  r.SpanId,
-		}, err
+		}
+		// Carry the partial result the way [Action.Run] does. Guarded, since
+		// a function that returns nothing on error would otherwise put a null
+		// result on every failure; a marshal that fails is logged and dropped
+		// rather than replacing the error the caller is waiting for.
+		if !base.IsNil(r.Result) {
+			if bytes, merr := json.Marshal(r.Result); merr != nil {
+				logger.Error(ctx, "failed to marshal partial action result",
+					"action", a.desc.Key, "error", merr)
+			} else {
+				res.Result = json.RawMessage(bytes)
+			}
+		}
+		return res, err
 	}
 
 	bytes, err := json.Marshal(r.Result)

--- a/go/core/action_test.go
+++ b/go/core/action_test.go
@@ -60,6 +60,50 @@ func TestActionRunJSON(t *testing.T) {
 	}
 }
 
+// TestActionRunPartialResult pins that a failure carries whatever the
+// function produced. The generate loop returns the conversation it completed
+// alongside its error, and that value has to survive the action boundary to
+// reach a caller or the reflection wire.
+func TestActionRunPartialResult(t *testing.T) {
+	boom := errors.New("boom")
+
+	t.Run("a partial value rides back with the error", func(t *testing.T) {
+		r := registry.New()
+		a := defineStreamingAction(r, "test/partial", api.ActionTypeCustom, nil, nil,
+			func(_ context.Context, x int, _ noStream) (int, error) { return x + 1, boom })
+
+		got, err := a.Run(context.Background(), 3, nil)
+		if !errors.Is(err, boom) {
+			t.Fatalf("err = %v, want boom", err)
+		}
+		if want := 4; got != want {
+			t.Errorf("got %d, want the partial %d", got, want)
+		}
+
+		raw, err := a.RunJSON(context.Background(), []byte("3"), nil)
+		if !errors.Is(err, boom) {
+			t.Fatalf("RunJSON err = %v, want boom", err)
+		}
+		if !bytes.Equal(raw, []byte("4")) {
+			t.Errorf("RunJSON result = %s, want the marshaled partial 4", raw)
+		}
+	})
+
+	t.Run("a function that produced nothing yields no result", func(t *testing.T) {
+		r := registry.New()
+		a := defineStreamingAction(r, "test/nothing", api.ActionTypeCustom, nil, nil,
+			func(_ context.Context, _ int, _ noStream) (*int, error) { return nil, boom })
+
+		res, err := a.RunJSONWithTelemetry(context.Background(), []byte("3"), nil)
+		if !errors.Is(err, boom) {
+			t.Fatalf("err = %v, want boom", err)
+		}
+		if res.Result != nil {
+			t.Errorf("result = %s, want none rather than a null", res.Result)
+		}
+	})
+}
+
 // TestActionInvalidInput pins how an action classifies input it refuses, on
 // both entry points: Run validates the typed value against the schema, and
 // RunJSON fails earlier, deserializing the bytes. Each is reported with

--- a/go/core/schemas.config
+++ b/go/core/schemas.config
@@ -734,7 +734,7 @@ automatically resolving them.
 
 GenerateActionOptions.maxTurns doc
 MaxTurns is the maximum number of tool call iterations that can be performed
-in a single generate call. Defaults to 5.
+in a single generate call. Defaults to 50 in Go; other runtimes set their own.
 .
 
 GenerateActionOptions.stepName doc

--- a/go/core/tracing/tracing.go
+++ b/go/core/tracing/tracing.go
@@ -333,6 +333,14 @@ func RunInNewSpan[I, O any](
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())
 		}
+		// A failure can still carry a result: the generate loop returns the
+		// conversation it completed alongside its error. Record it so the
+		// span shows what the call produced and not only that it stopped.
+		// Guarded, because a function that returns nothing on error would
+		// otherwise stamp a null output on every failing span.
+		if !base.IsNil(output) {
+			sm.Output = output
+		}
 	} else {
 		sm.State = spanStateSuccess
 		sm.Output = output

--- a/go/core/tracing/tracing_test.go
+++ b/go/core/tracing/tracing_test.go
@@ -18,6 +18,7 @@ package tracing
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"slices"
 	"strconv"
@@ -541,6 +542,47 @@ func TestIsFailureSourceOnError(t *testing.T) {
 	// on the span via span.SetAttributes() during error handling
 	if err == nil {
 		t.Fatal("Expected error to be returned")
+	}
+}
+
+func TestRunInNewSpanRecordsPartialOutputOnError(t *testing.T) {
+	// A failure can still carry a result, so the span records it and a trace
+	// shows what the call produced. A failure that produced nothing records
+	// no output at all, rather than stamping a null one on every failing span.
+	ctx := context.Background()
+	boom := errors.New("boom")
+
+	// The metadata is filled in after the function returns, so the test keeps
+	// the pointer the run handed its callback and reads it afterwards.
+	run := func(t *testing.T, fn func() (*string, error)) *spanMetadata {
+		t.Helper()
+		var sm *spanMetadata
+		_, err := RunInNewSpan(ctx, &SpanMetadata{Name: "partial"}, "in",
+			func(ctx context.Context, in string) (*string, error) {
+				sm = spanMetaKey.FromContext(ctx)
+				return fn()
+			})
+		if !errors.Is(err, boom) {
+			t.Fatalf("err = %v, want boom", err)
+		}
+		return sm
+	}
+
+	partial := "as far as it got"
+	sm := run(t, func() (*string, error) { return &partial, boom })
+	if sm.State != spanStateError {
+		t.Errorf("state = %q, want %q", sm.State, spanStateError)
+	}
+	got, ok := sm.Output.(*string)
+	if !ok {
+		t.Fatalf("failing span recorded output %v, want the partial result", sm.Output)
+	}
+	if got != &partial {
+		t.Errorf("output = %q, want the returned partial", *got)
+	}
+
+	if sm := run(t, func() (*string, error) { return nil, boom }); sm.Output != nil {
+		t.Errorf("output = %v, want none: the call produced nothing", sm.Output)
 	}
 }
 

--- a/go/genkit/genkit.go
+++ b/go/genkit/genkit.go
@@ -1264,6 +1264,10 @@ func GenerateWithRequest(ctx context.Context, g *Genkit, actionOpts *ai.Generate
 // provided via [ai.GenerateOption] arguments. It's a convenient way to make
 // generation calls without pre-defining a prompt object.
 //
+// A generation failure returns the classified error together with a partial
+// [ai.ModelResponse] that preserves the progress the tool loop made before
+// failing; see [ai.Generate] for the contract.
+//
 // # Options
 //
 // Model and Configuration:
@@ -1406,7 +1410,8 @@ func CheckModelOperation(ctx context.Context, g *Genkit, op *ai.ModelOperation) 
 
 // GenerateText performs a model generation request similar to [Generate], but
 // directly returns the generated text content as a string. It's a convenience
-// wrapper for cases where only the textual output is needed.
+// wrapper for cases where only the textual output is needed. On error, the
+// text of the partial response (usually empty) is returned with the error.
 //
 // GenerateText accepts the same options as [Generate]. See [Generate] for the full
 // list of available options.
@@ -1437,7 +1442,8 @@ func GenerateText(ctx context.Context, g *Genkit, opts ...ai.GenerateOption) (st
 // text output (tool requests or interrupts instead), or generation ended
 // aborted, interrupted, or other, the typed output is nil and no error is
 // returned; check the returned response's FinishReason, Interrupts(), and
-// ToolRequests() to handle those.
+// ToolRequests() to handle those. A generation failure returns its error
+// alongside the partial response [ai.Generate] documents, with a nil output.
 //
 // Example:
 //

--- a/go/samples/basic-middleware/filesystem/main.go
+++ b/go/samples/basic-middleware/filesystem/main.go
@@ -109,7 +109,6 @@ func DefineExploreFlow(g *genkit.Genkit) {
 				ai.WithModel(model),
 				ai.WithSystem("You are a helpful project analyst. Use the filesystem tools to explore the workspace before answering."),
 				ai.WithPrompt(input.Question),
-				ai.WithMaxTurns(20),
 				ai.WithUse(&middleware.Filesystem{RootDir: workspaceDir}),
 				ai.WithStreaming(func(ctx context.Context, chunk *ai.ModelResponseChunk) error {
 					// Every tool turn streams as well, and those chunks carry no
@@ -143,7 +142,6 @@ func DefineEditFlow(g *genkit.Genkit) {
 						"Keep unrelated content unchanged.",
 				),
 				ai.WithPrompt("Apply the following change to the workspace and report what you did:\n\n%s", input.Instruction),
-				ai.WithMaxTurns(20),
 				ai.WithUse(&middleware.Filesystem{
 					RootDir:          workspaceDir,
 					AllowWriteAccess: true,

--- a/go/samples/basic-middleware/skills/main.go
+++ b/go/samples/basic-middleware/skills/main.go
@@ -108,9 +108,6 @@ func DefineAskFlow(g *genkit.Genkit) {
 						"that name first. Then answer in the loaded style.",
 				),
 				ai.WithPrompt(input.Question),
-				// Loading a skill costs one tool-loop turn, so raise the cap from
-				// the default of 5 to leave room for the answer.
-				ai.WithMaxTurns(8),
 				ai.WithUse(&middleware.Skills{SkillPaths: []string{skillsDir}}),
 				ai.WithStreaming(func(ctx context.Context, chunk *ai.ModelResponseChunk) error {
 					// The use_skill turn streams too, and carries no text, so the


### PR DESCRIPTION
Returns the generate loop's completed work alongside its classified errors: Go's multiple return values carry both, where JS attaches the response to a thrown `GenerationResponseError`. Base of a three-PR train, on the shared schema from #6202.

## A failed generate returns a conversation you can send again

Once the request has resolved, an error comes back with a non-nil partial `ModelResponse` instead of discarding everything the loop did:

```go
resp, err := genkit.Generate(ctx, g,
    ai.WithModelName("googleai/gemini-flash-latest"),
    ai.WithPrompt("Plan the trip."),
    ai.WithTools(searchFlights, bookHotel),
    ai.WithMaxTurns(3),
)
if err != nil && resp != nil {
    resp.History()     // The completed rounds. Send them back to retry the failed step.
    resp.FinishReason  // Failed if something broke, aborted if the caller stopped it.
    resp.FinishMessage // The cause, e.g. "exceeded maximum tool call iterations (3)".
    resp.Error         // The same cause, classified: {status, message, details}.
}
```

`History()` ends at a turn seam: the completed `[model with tool requests, tool with every response]` rounds, and nothing from the turn that failed. That is a seam rather than a high-water mark because no provider accepts a conversation ending in a tool request nothing answered. So a failed tool discards the whole round including the model message that opened it, `WithMaxTurns` discards the round it refused to run, a model call that dies mid-stream discards its message, and `Message` is nil on all three. What is left is a conversation the caller can re-send without repeating the tool calls that already succeeded.

- **One rule for the finish reason**: `FinishReasonFailed` when something broke (a model call, a tool), `FinishReasonAborted` when the caller stopped the loop (a cancelled context, an expired deadline, or a limit it set such as `WithMaxTurns`, whose `ErrMaxTurnsExceeded` is an ABORTED subtype). The cause is the `FinishMessage` either way.
- **A tool that stopped because the call's context ended is a caller stop**, so it carries CANCELLED rather than `ErrToolFailed`, whose INTERNAL status would otherwise win `status.Classified`. The check keys on the call's context, so a tool that returns `context.Canceled` on its own terms is still a tool failure.
- **A failed tool reports as soon as its error arrives**, while its siblings finish detached (`TestGenerateNoGoroutineLeak` pins that they are not leaked). Their outcomes go with the discarded round.
- **A completed response that post-processing rejected** (`ErrInvalidOutput`) is not a loop stop: it keeps the model's own message and finish reason, since the raw output is usually what the caller needs to see.
- **A resume whose restarted tool interrupts again** keeps `FinishReason` interrupted under its FAILED_PRECONDITION error. An interrupt tip is the one non-seam shape a partial carries, because it is answered with `WithResume` rather than re-sent.
- **Errors before the request resolves** (unknown model or tool, invalid options) still return a nil response.

`Error` is a `RuntimeError` on the shared schema, the same shape a session snapshot carries, and it is what makes a partial useful once it has travelled: `FinishMessage` is a string, and nobody reading a response out of a trace or a persisted turn should be matching one. Both stream helpers yield the partial beside their error too, with the value still `Done` and still carrying `Response`, so a consumer that streamed a tool loop reads the same conversation the non-streaming call returns.

The contract survives `WrapGenerate` hooks that drop the response on the way up: the loop records each failing turn's partial and restores it, or synthesizes one from the conversation entering the turn for errors raised outside one.

## The action boundary stops discarding the value

```go
// Before: any error erased what the function produced.
r, err := a.runWithTelemetry(ctx, input, cb, a.fn, nil)
if err != nil {
    return base.Zero[Out](), err
}
return r.Result, nil
```

Three places threw the partial away before anyone could read it. `Action.Run` zeroed its output whenever err was non-nil, `RunJSON` marshaled nothing, and `RunInNewSpan` set `genkit:output` only on the success branch. All three now carry whatever the function returned, so the partial reaches an in-process caller, the JSON surface, and a trace, which is what puts a failed generate's conversation in front of the Dev UI. The value is the function's own, so an action that returns nothing on error still yields the zero one and still stamps no output; the JSON and span paths guard on that explicitly rather than writing a null.

Two consequences beyond generate. An output that failed the action's own schema validation now comes back with its error instead of being erased, which is the same call the loop makes for `ErrInvalidOutput`. And any flow whose function returns a value alongside an error now hands that value to its caller.

## Interrupt replays restore the full tool response

A `pendingOutput` replay used to rebuild a resolved sibling's tool response from its output alone, dropping a multipart response's `Content` and its `Metadata`. JS drops them too. The loop now stashes both beside `pendingOutput` (`pendingContent`, `pendingMetadata`) and restores them on replay, tolerating the generic JSON a persistence round-trip leaves behind. `pendingOutput` itself is unchanged, for cross-SDK parity; the two new keys are Go-first and candidates for JS adoption.

## Resumed tool messages are request-ordered

`handleResumeOption` resolved directives concurrently and emitted tool responses in completion order, while first-run tool messages are deliberately request-ordered. Both paths now order responses by their requests' positions in the model message (`TestResumedToolMessageOrder` pins it). JS is completion-ordered on both paths, an artifact of pushing inside `Promise.all`, so there is no deterministic JS ordering to mirror; models match responses by ref, so the wire is unaffected.

## Not a breaking change

No new exported symbols and no signature changes. `ai.FinishReasonFailed` and `ai.ModelResponse.Error`, which the loop sets, arrive with the schema in #6202. At runtime the change is a strict relaxation: paths that returned a zero value beside an error now return whatever was produced, and a caller that checks err first never reads it. The pattern that could notice is branching on the value without checking the error, and it is worth naming that the action boundary widens this beyond generate: any action, flow, or tool whose function returns a value alongside an error now hands that value to its caller. Relatedly, `GenerateText` returns the partial's text alongside the error on the post-processing path, where it returned `""`.

## What was deliberately deferred

- **No salvage of the failing turn's output.** The seam rule is uniform, so a single-turn call that dies mid-stream hands back no text on the response. The chunks reached the streaming callback and the trace; keeping them on a response the caller might re-send would produce a conversation providers reject, and the response would have to be two shapes instead of one.
- **The reflection API's error response has no result slot**: on failure the server writes `{"error": {message, code, details}}`, a shape the dev UI validates against, so a "Run" there shows the partial in the trace view and not in its result pane. Widening that envelope is a dev UI protocol change, not a Go one.
- **Agents are unchanged**: a failed turn keeps the last good session snapshot, as the conformance spec pins. Persisting the partial is a separate, spec-visible decision, taken in #6196.

