### PR TITLE
docs(go): fix godoc examples that do not compile

### DIFF
--- a/go/genkit/genkit.go
+++ b/go/genkit/genkit.go
@@ -485,14 +485,11 @@ func DefineFlow[In, Out any](g *Genkit, name string, fn core.Func[In, Out]) *cor
 //		},
 //	)
 //
-//	// Later, run the flow with streaming:
-//	streamCh, err := counterFlow.Stream(ctx, 5)
-//	if err != nil {
-//		// handle error
-//	}
-//	for result := range streamCh {
-//		if result.Err != nil {
-//			log.Printf("Stream error: %v", result.Err)
+//	// Later, run the flow with streaming. Stream returns a range-over-func
+//	// iterator, so the error arrives as the loop's second value.
+//	for result, err := range counterFlow.Stream(ctx, 5) {
+//		if err != nil {
+//			log.Printf("Stream error: %v", err)
 //			break
 //		}
 //		if result.Done {

--- a/go/genkit/servers.go
+++ b/go/genkit/servers.go
@@ -93,9 +93,9 @@ func WithStreamManager(manager streaming.StreamManager) HandlerOption {
 // Example:
 //
 //	genkit.Handler(
-//		g,
-//		genkit.WithContextProviders(func(ctx context.Context, req core.RequestData) (api.ActionContext, error) {
-//			return api.ActionContext{"myKey": "myValue"}, nil
+//		myFlow,
+//		genkit.WithContextProviders(func(ctx context.Context, req core.RequestData) (core.ActionContext, error) {
+//			return core.ActionContext{"uid": req.Headers["authorization"]}, nil
 //		}))
 func Handler(a api.Action, opts ...HandlerOption) http.HandlerFunc {
 	return wrapHandler(HandlerFunc(a, opts...))
@@ -117,9 +117,9 @@ func Handler(a api.Action, opts ...HandlerOption) http.HandlerFunc {
 // Example:
 //
 //	genkit.HandlerFunc(
-//		g,
-//		genkit.WithContextProviders(func(ctx context.Context, req core.RequestData) (api.ActionContext, error) {
-//			return api.ActionContext{"myKey": "myValue"}, nil
+//		myFlow,
+//		genkit.WithContextProviders(func(ctx context.Context, req core.RequestData) (core.ActionContext, error) {
+//			return core.ActionContext{"uid": req.Headers["authorization"]}, nil
 //		}),
 //	)
 func HandlerFunc(a api.Action, opts ...HandlerOption) func(http.ResponseWriter, *http.Request) error {

--- a/go/plugins/firebase/telemetry.go
+++ b/go/plugins/firebase/telemetry.go
@@ -82,7 +82,7 @@ type FirebaseTelemetryOptions struct {
 //
 //	// Basic usage - uses environment variables for project ID
 //	firebase.EnableFirebaseTelemetry(nil)
-//	g, err := genkit.Init(ctx, genkit.WithPlugins(&googlegenai.GoogleAI{}))
+//	g := genkit.Init(ctx, genkit.WithPlugins(&googlegenai.GoogleAI{}))
 //
 //	// With full configuration
 //	firebase.EnableFirebaseTelemetry(&firebase.FirebaseTelemetryOptions{
@@ -93,7 +93,7 @@ type FirebaseTelemetryOptions struct {
 //		DisableTraces:              false,
 //		MetricExportIntervalMillis: &[]int{10000}[0], // 10 seconds
 //	})
-//	g, err := genkit.Init(ctx, genkit.WithPlugins(&googlegenai.GoogleAI{}))
+//	g := genkit.Init(ctx, genkit.WithPlugins(&googlegenai.GoogleAI{}))
 func EnableFirebaseTelemetry(options *FirebaseTelemetryOptions) {
 	if options == nil {
 		options = &FirebaseTelemetryOptions{}

--- a/go/plugins/googlecloud/googlecloud.go
+++ b/go/plugins/googlecloud/googlecloud.go
@@ -64,14 +64,14 @@ var stderrLogger = slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
 //
 //	// Zero-config (auto-detects project ID)
 //	googlecloud.EnableGoogleCloudTelemetry(nil)
-//	g, err := genkit.Init(ctx, genkit.WithPlugins(&googlegenai.GoogleAI{}))
+//	g := genkit.Init(ctx, genkit.WithPlugins(&googlegenai.GoogleAI{}))
 //
 //	// With configuration
 //	googlecloud.EnableGoogleCloudTelemetry(&googlecloud.GoogleCloudTelemetryOptions{
 //		ProjectID:      "my-project",
 //		ForceDevExport: true,
 //	})
-//	g, err := genkit.Init(ctx, genkit.WithPlugins(&googlegenai.GoogleAI{}))
+//	g := genkit.Init(ctx, genkit.WithPlugins(&googlegenai.GoogleAI{}))
 func EnableGoogleCloudTelemetry(options *GoogleCloudTelemetryOptions) {
 	if options == nil {
 		options = &GoogleCloudTelemetryOptions{}


### PR DESCRIPTION
Corrects four godoc examples. `api-references.mdx` sends Go readers to pkg.go.dev, so these are the reference a Go user actually reads, and all four fail if pasted.

`genkit.Handler` and `genkit.HandlerFunc` passed `g` as the first argument, but the signature takes an action, and both used `api.ActionContext`, which does not exist; the type is `core.ActionContext`. `DefineStreamingFlow` showed `Stream` returning a channel, but it returns a range-over-func iterator. The `firebase` and `googlecloud` telemetry examples showed `g, err := genkit.Init(...)`; `Init` returns one value.

Comment-only. I swept for the same three mistakes elsewhere in the module and found none remaining.

Sibling PR in `genkit-ai/docsite` covers the prose documentation.
