### PR TITLE
feat(go/ai/exp): make a failed agent turn a resume point

### DIFF
--- a/docs/agents-conformance-testing.md
+++ b/docs/agents-conformance-testing.md
@@ -26,10 +26,20 @@ tests:
   - name: <string>              # Human-readable test name
     description: <string>       # Optional description
     agent: <string>             # Name of the harness-provided agent
+    requires: [<capability>]    # Optional capability gate; see below
     steps:                      # Ordered sequence of operations
       - type: send | getSnapshotData | abort | waitUntilCompleted
         ...                     # Fields depend on step type
 ```
+
+`requires` lists the capabilities a test depends on. Each harness declares
+the capabilities its runtime implements and **skips** (not fails) any test
+naming one it does not, so the shared spec can carry cases for features an
+SDK has not adopted yet. Known capabilities:
+
+| Capability | Meaning |
+|------------|---------|
+| `resumable-failures` | A failed turn commits what the generate call left at its last turn seam and persists it as a `failed` snapshot carrying the error; resume accepts that snapshot, and an input with no payload of its own re-attempts the turn. Gates model `error` entries, the empty input, a `failed` snapshot as a resume target, and the `promptAgentWithToolsAndStore` fixture. Implemented by: Go. |
 
 ### Step Types
 
@@ -42,8 +52,8 @@ Sends inputs to the agent via its bidirectional streaming interface (e.g.
 |-------|------|-------------|
 | `type` | `"send"` | Required. |
 | `init` | `AgentInit` | Initialization payload. May contain `snapshotId`, `state`, or be empty `{}`. |
-| `inputs` | `AgentInput[]` | Ordered list of inputs to send. Each may contain `messages`, `resume` (with `respond` and/or `restart`), and/or `detach`. |
-| `modelResponses` | `GenerateResponseData[]` | Pre-programmed responses for the programmable model, one per `generate` call made by the agent. |
+| `inputs` | `AgentInput[]` | Ordered list of inputs to send. Each may contain `messages`, `resume` (with `respond` and/or `restart`), and/or `detach`. An input with none of those continues the conversation already in the session (requires `resumable-failures`). |
+| `modelResponses` | `GenerateResponseData[]` | Pre-programmed turns for the programmable model, one per `generate` call made by the agent. An entry whose `error` is set (`{ status, message }`) fails that call with a classified error rather than returning (requires `resumable-failures`). |
 | `streamChunks` | `GenerateResponseChunkData[][]` | Optional. Pre-programmed streaming chunks, indexed by model call. Each inner array is emitted as a stream before the corresponding `modelResponses` entry. |
 | `expectChunks` | `AgentStreamChunk[]` | **Strict ordered** list of expected stream chunks. |
 | `expectOutput` | Object | Expected fields on the `AgentOutput`. See [Output Assertions](#output-assertions). |
@@ -185,6 +195,7 @@ via the `modelResponses` / `streamChunks` fields in `send` steps.
 | `promptAgentWithTools` | A prompt agent with `testTool` registered. Client-managed state. |
 | `promptAgentWithInterrupt` | A prompt agent with `interruptTool` registered and a server-managed store (for snapshot-based resume). |
 | `promptAgentWithRestartTool` | A prompt agent with `restartTool` registered and a server-managed store. Used for `resume.restart` tests. |
+| `promptAgentWithToolsAndStore` | A prompt agent with `testTool` and `flakyTool` registered and a server-managed store. Used for `resumable-failures` tests; only required by harnesses declaring that capability. |
 
 #### Custom agents (hardcoded behavior)
 
@@ -209,6 +220,7 @@ is not needed for tests targeting these agents.
 | `testTool` | A simple tool | `{}` (empty) | `"tool called"` (string) |
 | `interruptTool` | An interrupt tool | `{ query: string }` | `{ answer: string }` |
 | `restartTool` | A tool that requires confirmation; throws `ToolInterruptError` on first call, succeeds when `resumed` metadata is provided | `{ action: string }` | `{ result: string }` |
+| `flakyTool` | Fails its first call in each test with an UNAVAILABLE error (`flaky tool failed`), succeeds after with `"tool recovered"`. Requires `resumable-failures`. | `{}` (empty) | `"tool recovered"` (string) |
 
 ### Programmable Model
 

--- a/docs/agents-conformance-testing.md
+++ b/docs/agents-conformance-testing.md
@@ -22,6 +22,7 @@ The pattern mirrors `tests/specs/generate.yaml` for the Generate API.
 ### Top-Level Structure
 
 ```yaml
+capabilities: [<capability>]    # Every name `requires` may use; see below
 tests:
   - name: <string>              # Human-readable test name
     description: <string>       # Optional description
@@ -35,7 +36,13 @@ tests:
 `requires` lists the capabilities a test depends on. Each harness declares
 the capabilities its runtime implements and **skips** (not fails) any test
 naming one it does not, so the shared spec can carry cases for features an
-SDK has not adopted yet. Known capabilities:
+SDK has not adopted yet.
+
+Because every harness skips what it does not recognize, a misspelled name
+would otherwise skip the test in all of them and be reported by none. The
+top-level `capabilities` list is the spec's own registry of valid names, and
+a `requires` entry absent from it **fails** in every harness. Adding a
+capability means adding it there and to the table below. Known capabilities:
 
 | Capability | Meaning |
 |------------|---------|

--- a/go/README.md
+++ b/go/README.md
@@ -108,6 +108,7 @@ Multi-turn conversations that own their own loop and state.
 [Load the Prompt from a File](#load-the-prompt-from-a-file) &middot;
 [Custom Turn Loops](#custom-turn-loops) &middot;
 [Persist and Resume](#persist-and-resume) &middot;
+[Re-attempt Failed Turns](#re-attempt-failed-turns) &middot;
 [Redact on the Way Out](#redact-on-the-way-out) &middot;
 [Background Agents](#background-agents) &middot;
 [Delegate to Sub-Agents](#delegate-to-sub-agents) &middot;
@@ -340,7 +341,7 @@ chatAgent := genkitx.DefineCustomAgent(g, "chat",
 
 ### Persist and Resume
 
-With a session store configured, every successful turn writes a snapshot. The caller only needs the `SessionID` from a previous result to pick the conversation back up:
+With a session store configured, each turn writes a snapshot as it ends. The caller only needs the `SessionID` from a previous result to pick the conversation back up:
 
 ```go
 first, _ := chatAgent.RunText(ctx, "My name is Alex and I'm planning a trip to Japan.")
@@ -354,6 +355,25 @@ fmt.Println(second.Message.Text()) // "Your name is Alex."
 Resume from one specific point in history with `aix.WithSnapshotID`, or skip the server store entirely and round-trip the state yourself with `aix.WithState` (the conversation's identity travels inside the state object).
 
 [See full example](samples/basic-agents)
+
+### Re-attempt Failed Turns
+
+A turn that fails keeps the tool rounds it completed. The generate call hands back the conversation as it stood at the last turn seam, the agent commits that, and it persists as a `failed` snapshot carrying the error. Resume that snapshot like any other and send an input with no payload: the turn runs again on the committed messages, so the tool calls that already succeeded are not repeated.
+
+```go
+out, _ := agent.RunText(ctx, "Book the full itinerary.")
+if out.FinishReason == aix.AgentFinishReasonFailed {
+    // out.Error carries the status. Retry the transient ones.
+    if out.Error.Status == status.Unavailable {
+        retried, _ := agent.Run(ctx, &aix.AgentInput{},
+            aix.WithSessionID[any](out.SessionID))
+    }
+}
+```
+
+Whether a failure is worth another attempt is yours to decide; the framework records the error and leaves the snapshot resumable either way. A new message works there too, and rewinding past the failure is a resume from the previous snapshot ID.
+
+Without a store, the failed output's `State` carries the same resume point inline; initialize the next invocation with it. A turn rejected before it reached the model (an invalid input, for example) commits nothing, and the resume point stays the turn before it. Custom agents opt in by returning a `TurnResult` alongside the turn's error; a bare error keeps the discard-the-turn behavior.
 
 ### Redact on the Way Out
 
@@ -388,7 +408,7 @@ snap, _ := chatAgent.GetSnapshot(ctx, snapshotID)
 switch snap.Status {
 case aix.SnapshotStatusPending:   // still working
 case aix.SnapshotStatusCompleted: // snap.State holds the final state; resume it
-case aix.SnapshotStatusFailed:    // snap.Error holds the structured failure
+case aix.SnapshotStatusFailed:    // snap.Error holds the failure; still resumable
 }
 
 // Or stop it early; the runtime observes the abort and cancels the work.

--- a/go/ai/exp/agent.go
+++ b/go/ai/exp/agent.go
@@ -122,22 +122,30 @@ type SessionRunner[State any] struct {
 	// to the fn goroutine (Run and its synchronous onEndTurn callback) until
 	// fn completes, after which the terminal paths read it with a
 	// happens-before edge through the fnDone channel, so no lock is needed.
-	// The same confinement applies to lastTurnFailed and lastGoodState; the
-	// terminal paths that read them (handleFnDone and the detach-failure
-	// paths) all wait on fnDone first.
+	// The same confinement applies to lastTurnErr, lastTurnCommitted, and
+	// lastGoodState; the terminal paths that read them (handleFnDone and the
+	// detach-failure paths) all wait on fnDone first.
 	lastTurnFinishReason AgentFinishReason
 
-	// lastTurnFailed reports whether the most recent turn ended in error.
-	// Set by endTurn each turn.
-	lastTurnFailed bool
+	// lastTurnErr is the error the most recent turn ended with, or nil when
+	// it succeeded. Set by endTurn each turn, and recorded on the turn's
+	// snapshot so a client reading the row can branch on the status the
+	// failure carried.
+	lastTurnErr error
+
+	// lastTurnCommitted reports whether the most recent turn left state
+	// worth continuing from. A successful turn always has; a failed one has
+	// when its callback returned a [TurnResult] alongside the error. Set by
+	// endTurn each turn, and what decides whether the turn snapshots.
+	lastTurnCommitted bool
 
 	// lastGoodState is a deep copy of the session state as of the most
-	// recent successful turn (or the initial state when no turn has
-	// completed yet), kept only for client-managed agents (no store). The
+	// recent committed turn (or the initial state when no turn has committed
+	// yet), kept only for client-managed agents (no store). The
 	// client-managed failure path returns it inline so the caller resumes
-	// from the last committed turn, excluding the failed turn's partial
-	// mutations. Nil and unused for server-managed agents, whose failure
-	// path returns the last turn-end snapshot instead.
+	// from the last committed turn, excluding a later turn that failed
+	// before committing. Nil and unused for server-managed agents, whose
+	// failure path returns the last turn snapshot instead.
 	lastGoodState *SessionState[State]
 }
 
@@ -164,6 +172,10 @@ func (s *SessionRunner[State]) suspendSnapshots() (parentID string) {
 // Returning nil (or a zero TurnResult) omits the reason: the framework
 // performs no implicit inference. A prompt-backed agent populates it
 // automatically from the underlying generate response.
+//
+// Returned alongside an error, it also says the failed turn left state worth
+// continuing from, which is what makes the turn snapshot and the session
+// resumable; see [SessionRunner.Run].
 type TurnResult struct {
 	// FinishReason is why this turn ended (e.g. [AgentFinishReasonStop],
 	// [AgentFinishReasonInterrupted]). Empty to report no reason.
@@ -186,10 +198,10 @@ var turnCtxKey = base.NewContextKey[*TurnContext]()
 type TurnContext struct {
 	// SnapshotID is the ID the turn-end snapshot will be saved under, minted
 	// before the turn runs so the handler knows it in advance. A server-managed
-	// turn persists its snapshot under this ID on success. It is empty for a
-	// client-managed agent (no store, so no snapshot) and is the reserved-but-
-	// unused ID for a turn that writes none (a failed turn, or one whose
-	// snapshots a detach suspended).
+	// turn persists its snapshot under this ID, whether it succeeded or failed.
+	// It is empty for a client-managed agent (no store, so no snapshot) and is
+	// the reserved-but-unused ID for a turn that writes none (one that failed
+	// before committing anything, or one whose snapshots a detach suspended).
 	SnapshotID string
 	// ParentSnapshotID is the ID of the snapshot this turn continues from: the
 	// previous turn's snapshot, or the snapshot the invocation resumed from. It
@@ -228,13 +240,20 @@ type turnSpanOutput[State any] struct {
 // reason); returning nil reports nothing. The reason rides the turn's
 // [TurnEnd] chunk and is persisted on the turn-end snapshot.
 //
-// When fn returns an error, Run records the failure ([TurnEnd] is emitted
-// with [AgentFinishReasonFailed] and no snapshot is taken of the turn's
-// partial state), stops looping, and returns the error. A custom agent may
-// recover (e.g. call Run again to keep processing inputs) or propagate the
-// error out of the agent function, which resolves the invocation with a
-// failed [AgentOutput] carrying the error and the last-good state rather
-// than failing the action.
+// When fn returns an error, Run records the failure, stops looping, and
+// returns the error. What it does with the turn's state depends on what fn
+// returned beside the error: a [TurnResult] commits the turn, which snapshots
+// the session under [SnapshotStatusFailed] with the error on the row, and nil
+// rolls it back, leaving the previous snapshot as the resume point. A
+// prompt-backed agent commits whenever the generate call produced a partial
+// response, because that partial ends at a turn seam and is a conversation
+// the caller can continue from; a custom agent commits when it knows the same
+// of its own state.
+//
+// A custom agent may then recover (e.g. call Run again to keep processing
+// inputs) or propagate the error out of the agent function, which resolves
+// the invocation with a failed [AgentOutput] carrying the error and the
+// resume point rather than failing the action.
 func (s *SessionRunner[State]) Run(ctx context.Context, fn func(ctx context.Context, input *AgentInput) (*TurnResult, error)) error {
 	for input := range s.inputCh {
 		// Deep-copy at the framework boundary: an in-process caller
@@ -266,6 +285,9 @@ func (s *SessionRunner[State]) Run(ctx context.Context, fn func(ctx context.Cont
 			Name: fmt.Sprintf("runTurn-%d", s.turnIndex+1),
 			Type: "flowStep",
 		}
+		// The result of a turn that errored, captured on the way out of the
+		// span so the failure arm below can read it: non-nil commits.
+		var failedResult *TurnResult
 		_, err := tracing.RunInNewSpan(ctx, spanMeta, input,
 			func(ctx context.Context, input *AgentInput) (any, error) {
 				// Carry the reserved turn context on the per-turn fn's context
@@ -278,6 +300,7 @@ func (s *SessionRunner[State]) Run(ctx context.Context, fn func(ctx context.Cont
 				}
 				tr, err := fn(ctx, input)
 				if err != nil {
+					failedResult = tr
 					return nil, err
 				}
 				// A returned TurnResult sets the reason, nil reports none.
@@ -285,14 +308,18 @@ func (s *SessionRunner[State]) Run(ctx context.Context, fn func(ctx context.Cont
 				if tr != nil {
 					reason = tr.FinishReason
 				}
-				s.endTurn(ctx, reason, false)
+				s.endTurn(ctx, reason, nil, true)
 				// The turn span's output is the committed session state at
 				// turn end, recorded as {state: ...} (see turnSpanOutput).
 				return turnSpanOutput[State]{State: s.State()}, nil
 			},
 		)
 		if err != nil {
-			s.endTurn(ctx, AgentFinishReasonFailed, true)
+			reason := AgentFinishReasonFailed
+			if failedResult != nil && failedResult.FinishReason != "" {
+				reason = failedResult.FinishReason
+			}
+			s.endTurn(ctx, reason, err, failedResult != nil)
 			return err
 		}
 	}
@@ -312,13 +339,15 @@ func (s *SessionRunner[State]) reserveTurnSnapshotID() string {
 }
 
 // endTurn records how the turn ended and runs the shared turn-end tail:
-// the turn-end emit, the last-good capture on success, and the turn
-// advance.
-func (s *SessionRunner[State]) endTurn(ctx context.Context, reason AgentFinishReason, failed bool) {
+// the turn-end emit, the last-good capture, and the turn advance. cause is
+// the turn's error, nil on success; committed says whether its state is a
+// resume point (always so on success).
+func (s *SessionRunner[State]) endTurn(ctx context.Context, reason AgentFinishReason, cause error, committed bool) {
 	s.lastTurnFinishReason = reason
-	s.lastTurnFailed = failed
+	s.lastTurnErr = cause
+	s.lastTurnCommitted = committed
 	s.onEndTurn(ctx)
-	if !failed {
+	if committed {
 		s.captureLastGood()
 	}
 	s.turnIndex++
@@ -326,11 +355,12 @@ func (s *SessionRunner[State]) endTurn(ctx context.Context, reason AgentFinishRe
 
 // captureLastGood deep-copies the committed session state as the
 // client-managed failure fallback: the state a failed invocation returns
-// inline (see failedOutput), excluding a later failed turn's partial
-// mutations. Called once at session start (the initial state is the
-// fallback until a turn completes) and after every successful turn. It is
-// a no-op for server-managed agents, whose failure path returns the last
-// turn-end snapshot instead, so they pay no per-turn copy.
+// inline (see failedOutput), excluding the partial mutations of a later
+// turn that failed before committing. Called once at session start (the
+// initial state is the fallback until a turn commits) and after every
+// committed turn, failed or not. It is a no-op for server-managed agents,
+// whose failure path returns the last turn-end snapshot instead, so they
+// pay no per-turn copy.
 func (s *SessionRunner[State]) captureLastGood() {
 	if s.store != nil {
 		return
@@ -380,19 +410,21 @@ func (s *SessionRunner[State]) invocationReason(result *AgentResult) AgentFinish
 // from its [TurnContext] is the ID the snapshot persists under. It is a no-op
 // returning "" when no store is configured or snapshots have been suspended by
 // a detach. finishReason records how the captured turn ended so a resumed task
-// can report it.
+// can report it, and cause is the turn's error: nil writes
+// [SnapshotStatusCompleted], and an error writes [SnapshotStatusFailed] with
+// the error on the row for a client to branch on.
 //
-// The turn-end snapshot is the agent's only routine persistence point: a
-// failed turn never writes one (its partial state is not a resume point),
-// so the newest snapshot is always the last successful turn, which is what
-// the failed and detached outputs resume from.
+// The turn-end snapshot is the agent's only routine persistence point, and
+// every committed turn writes one, so the newest snapshot is the resume point
+// the failed and detached outputs report. Only a turn that failed before
+// committing anything writes none, leaving its predecessor as that point.
 //
 // The body runs under snapMu so the detach handler's suspend-and-capture
 // (suspendSnapshots) cannot interleave with a write: it either waits for
 // this write to commit or suspends before it starts. Persistence is
 // best-effort: a store failure must not kill the in-flight turn, so it is
 // logged and "" is returned.
-func (s *SessionRunner[State]) snapshotTurnEnd(ctx context.Context, finishReason AgentFinishReason) string {
+func (s *SessionRunner[State]) snapshotTurnEnd(ctx context.Context, finishReason AgentFinishReason, cause error) string {
 	if s.store == nil {
 		return ""
 	}
@@ -412,13 +444,18 @@ func (s *SessionRunner[State]) snapshotTurnEnd(ctx context.Context, finishReason
 	// Timestamps are caller-managed (the store persists them verbatim); a fresh
 	// turn-end snapshot is created now, so CreatedAt and UpdatedAt are equal.
 	now := time.Now()
+	snapStatus := SnapshotStatusCompleted
+	if cause != nil {
+		snapStatus = SnapshotStatusFailed
+	}
 	saved, err := s.store.SaveSnapshot(ctx, s.turnSnapshotID,
 		func(_ *SessionSnapshot[State]) (*SessionSnapshot[State], error) {
 			return &SessionSnapshot[State]{
 				SessionID:    sessionID,
 				ParentID:     parentID,
-				Status:       SnapshotStatusCompleted,
+				Status:       snapStatus,
 				FinishReason: finishReason,
+				Error:        convertKeepText(cause),
 				State:        &state,
 				CreatedAt:    now,
 				UpdatedAt:    now,
@@ -1146,23 +1183,23 @@ func newAgentRuntime[State any](
 // [Responder] before each Send returns, and fn returned before this
 // runs, so there is no in-flight router work to wait out.
 //
-// The snapshot is skipped when the turn failed (the live state holds the
-// turn's partial mutations) and when detach has landed (snapshotTurnEnd
-// observes the suspension under snapMu; the pending row already captures
-// the invocation and a single finalize rewrite records the cumulative
-// state once the queued inputs drain).
+// The snapshot is skipped when the turn failed without committing (the live
+// state holds mutations nothing can be resumed from) and when detach has
+// landed (snapshotTurnEnd observes the suspension under snapMu; the pending
+// row already captures the invocation and a single finalize rewrite records
+// the cumulative state once the queued inputs drain).
 func (rt *agentRuntime[State]) emitTurnEnd(ctx context.Context) {
 	rt.intake.releaseForward()
 	reason := rt.sess.lastTurnFinishReason
 	var snapshotID string
-	if !rt.sess.lastTurnFailed {
-		snapshotID = rt.sess.snapshotTurnEnd(ctx, reason)
+	if rt.sess.lastTurnCommitted {
+		snapshotID = rt.sess.snapshotTurnEnd(ctx, reason, rt.sess.lastTurnErr)
 	}
 	// Tag the turn span with the snapshot it persisted, so a server-managed
 	// turn's trace links to its snapshot. ctx is the turn span's context (this
 	// runs inside the runTurn-N span via onEndTurn). The ID is empty, and the
-	// attribute omitted, when client-managed, when the turn failed, or when a
-	// detach suspended snapshots.
+	// attribute omitted, when client-managed, when the turn failed without
+	// committing, or when a detach suspended snapshots.
 	if snapshotID != "" {
 		trace.SpanFromContext(ctx).SetAttributes(
 			attribute.String(snapshotIDSpanAttrKey, snapshotID))
@@ -1468,14 +1505,14 @@ func convertKeepText(cause error) *status.Error {
 
 // failedOutput assembles the output for an invocation that ended in
 // failure: [AgentFinishReasonFailed], the error with its original status,
-// and the last-good resume point: the last turn-end snapshot's ID when
-// server-managed, or the last-good state inline when client-managed. Both
-// hold the state through the last successful turn, excluding the failed
-// turn's partial mutations, because a failed turn never snapshots and never
-// updates lastGoodState. When no turn committed, the server-managed ID is
-// "" (or the resumed snapshot's ID) and the client-managed state is the
-// initial state. Message and Artifacts are left empty; they describe the
-// result of a completed run.
+// and the resume point: the last turn snapshot's ID when server-managed, or
+// the last-good state inline when client-managed. Both hold the state
+// through the last committed turn, which is the failed turn itself when it
+// committed and its predecessor when it did not, since only a committed turn
+// snapshots and updates lastGoodState. When no turn committed at all, the
+// server-managed ID is "" (or the resumed snapshot's ID) and the
+// client-managed state is the initial state. Message and Artifacts are left
+// empty; they describe the result of a completed run.
 func (rt *agentRuntime[State]) failedOutput(ctx context.Context, cause error) *AgentOutput[State] {
 	out := &AgentOutput[State]{
 		SessionID:    rt.session.SessionID(),
@@ -1860,20 +1897,15 @@ func loadSession[State any](
 
 // resumeSessionFrom validates that snap is in a resumable status and loads
 // its state into s. Shared by the snapshot-ID and session-ID init paths:
-// both reject a failed, aborted, or pending snapshot, since none can be
-// continued from. The session-ID path reaches them too, because
-// GetLatestSnapshot returns the literal latest row whatever its status; a
-// caller wanting to continue past a dead-end tip must name an earlier good
-// snapshot explicitly via SnapshotID.
+// both reject an aborted or pending snapshot, since neither can be continued
+// from. A failed one can: the turn that wrote it committed a conversation
+// ending at a turn seam, and whether the recorded error is worth another
+// attempt is the caller's judgement, not the framework's. The session-ID
+// path reaches the rejections too, because GetLatestSnapshot returns the
+// literal latest row whatever its status; a caller wanting to continue past
+// a dead-end tip must name an earlier snapshot explicitly via SnapshotID.
 func resumeSessionFrom[State any](s *Session[State], snap *SessionSnapshot[State]) (*Session[State], *SessionSnapshot[State], error) {
 	switch snap.Status {
-	case SnapshotStatusFailed:
-		msg := "snapshot recorded an error"
-		if snap.Error != nil && snap.Error.Message != "" {
-			msg = snap.Error.Message
-		}
-		return nil, nil, status.Errorf(status.ErrFailedPrecondition,
-			"snapshot %q terminated with error: %s", snap.SnapshotID, msg)
 	case SnapshotStatusPending:
 		return nil, nil, status.Errorf(status.ErrFailedPrecondition,
 			"snapshot %q is still pending: its detached invocation is still running; wait for it to finalize or abort it before resuming", snap.SnapshotID)
@@ -2375,9 +2407,11 @@ drainLoop:
 	close(i.detachCh)
 }
 
-// hasInputPayload reports whether the input carries data the runner would
-// otherwise process. Used to filter pure detach signals out of the
-// queue so they don't trigger no-op turns.
+// hasInputPayload reports whether the input carries data of its own. It
+// filters pure detach signals out of the queue so they don't trigger no-op
+// turns, and it marks the inputs a turn can start from: one without a
+// payload runs on the conversation already in the session, so there has to
+// be a conversation there.
 func hasInputPayload(in *AgentInput) bool {
 	if in == nil {
 		return false
@@ -2716,9 +2750,6 @@ func toolRefSuffix(ref string) string {
 func agentLoop[State any](r api.Registry, prompt ai.Prompt, defaultInput any) AgentFunc[State] {
 	return func(ctx context.Context, resp Responder, sess *SessionRunner[State]) (*AgentResult, error) {
 		if err := sess.Run(ctx, func(ctx context.Context, input *AgentInput) (*TurnResult, error) {
-			if !hasInputPayload(input) {
-				return nil, status.Errorf(status.ErrInvalidArgument, "agent input message or resume is required")
-			}
 			if err := validateUserMessage(input.Message); err != nil {
 				return nil, err
 			}
@@ -2734,6 +2765,17 @@ func agentLoop[State any](r api.Registry, prompt ai.Prompt, defaultInput any) Ag
 			// conversation does not ride along into tools and prompts
 			// invoked inside the generate loop.
 			history := sess.Messages()
+
+			// An input with no payload of its own runs the turn on the
+			// conversation as it stands, which is how a failed turn is
+			// re-attempted: the failed snapshot holds the messages the turn
+			// committed, and the model is called on them again. There has to
+			// be something to continue.
+			if !hasInputPayload(input) && len(history) == 0 {
+				return nil, status.Errorf(status.ErrInvalidArgument,
+					"agent input message or resume is required to start a conversation")
+			}
+
 			actionOpts, err := prompt.Render(ai.NewHistoryContext(ctx, markSessionMessages(history)), defaultInput)
 			if err != nil {
 				return nil, fmt.Errorf("prompt render: %w", err)
@@ -2767,7 +2809,17 @@ func agentLoop[State any](r api.Registry, prompt ai.Prompt, defaultInput any) Ag
 				},
 			)
 			if err != nil {
-				return nil, fmt.Errorf("generate: %w", err)
+				// The partial's history ends at a turn seam (see
+				// [ai.Generate]), so it is a conversation the caller can
+				// continue. Fold it into the session and commit the turn as a
+				// resume point: the [TurnResult] beside the error is what says
+				// so; see [SessionRunner.Run]. Without a partial the call
+				// never reached the model, and the turn rolls back instead.
+				if modelResp == nil || modelResp.Request == nil {
+					return nil, fmt.Errorf("generate: %w", err)
+				}
+				sess.SetMessages(turnSessionMessages(modelResp.History()))
+				return &TurnResult{FinishReason: AgentFinishReasonFailed}, fmt.Errorf("generate: %w", err)
 			}
 
 			// Replace session messages with the full history minus the

--- a/go/ai/exp/agent.go
+++ b/go/ai/exp/agent.go
@@ -424,6 +424,11 @@ func (s *SessionRunner[State]) invocationReason(result *AgentResult) AgentFinish
 // this write to commit or suspends before it starts. Persistence is
 // best-effort: a store failure must not kill the in-flight turn, so it is
 // logged and "" is returned.
+//
+// The write is decoupled from ctx. A turn that ends because the invocation's
+// context was cancelled is exactly the turn whose snapshot a client needs, so
+// the row must land even though the context it ran under is gone. ctx is
+// still what the write is traced and logged under.
 func (s *SessionRunner[State]) snapshotTurnEnd(ctx context.Context, finishReason AgentFinishReason, cause error) string {
 	if s.store == nil {
 		return ""
@@ -448,7 +453,7 @@ func (s *SessionRunner[State]) snapshotTurnEnd(ctx context.Context, finishReason
 	if cause != nil {
 		snapStatus = SnapshotStatusFailed
 	}
-	saved, err := s.store.SaveSnapshot(ctx, s.turnSnapshotID,
+	saved, err := s.store.SaveSnapshot(context.WithoutCancel(ctx), s.turnSnapshotID,
 		func(_ *SessionSnapshot[State]) (*SessionSnapshot[State], error) {
 			return &SessionSnapshot[State]{
 				SessionID:    sessionID,

--- a/go/ai/exp/agent.go
+++ b/go/ai/exp/agent.go
@@ -2813,6 +2813,17 @@ func agentLoop[State any](r api.Registry, prompt ai.Prompt, defaultInput any) Ag
 					return nil
 				},
 			)
+			// An interrupt is a turn outcome, not a failure, even when it
+			// arrives as one. [ai.Generate] reports a restarted tool that
+			// interrupted again with a FAILED_PRECONDITION, because its
+			// caller asked for a completed generation; the agent's caller did
+			// not. The tip that comes back is the same answerable interrupt a
+			// first-run interrupt leaves, and only [Resume] can answer either,
+			// so the turn takes the success path and commits the same way
+			// both times. No other error carries this finish reason.
+			if err != nil && modelResp != nil && modelResp.FinishReason == ai.FinishReasonInterrupted {
+				err = nil
+			}
 			if err != nil {
 				// The partial's history ends at a turn seam (see
 				// [ai.Generate]), so it is a conversation the caller can

--- a/go/ai/exp/agent_test.go
+++ b/go/ai/exp/agent_test.go
@@ -6395,6 +6395,123 @@ func TestPromptAgent_ForwardsInterruptedFinishReason(t *testing.T) {
 	}
 }
 
+// TestPromptAgent_RestartInterruptsAgain_CommitsAsInterrupted pins the second
+// interrupt to the same landing as the first. [ai.Generate] reports a
+// restarted tool that interrupts again with a FAILED_PRECONDITION, because its
+// caller asked for a completed generation, and taking that at face value would
+// write a failed row whose documented recovery cannot work: the tip it holds
+// ends on a model message carrying an unanswered tool request, which is not a
+// turn seam, so re-attempting the turn sends the model a conversation no
+// provider accepts. Only Resume answers this row, exactly as for the first
+// interrupt.
+func TestPromptAgent_RestartInterruptsAgain_CommitsAsInterrupted(t *testing.T) {
+	ctx := context.Background()
+	reg := registry.New()
+	ai.ConfigureFormats(reg)
+	store := newTestInMemStore[testState]()
+
+	interruptTool := defineTestTool(reg, "interruptor", "interrupts every time",
+		func(tc *ai.ToolContext, input any) (any, error) {
+			return nil, tc.Interrupt(&ai.InterruptOptions{
+				Metadata: map[string]any{"reason": "needs approval"},
+			})
+		},
+	)
+	var modelCalls atomic.Int32
+	defineTestModel(reg, "test/interrupt", &ai.ModelOptions{Supports: &ai.ModelSupports{Multiturn: true, Tools: true}},
+		func(ctx context.Context, req *ai.ModelRequest, cb ai.ModelStreamCallback) (*ai.ModelResponse, error) {
+			modelCalls.Add(1)
+			return &ai.ModelResponse{
+				Request: req,
+				Message: &ai.Message{
+					Role:    ai.RoleModel,
+					Content: []*ai.Part{ai.NewToolRequestPart(&ai.ToolRequest{Name: "interruptor"})},
+				},
+			}, nil
+		})
+	ai.DefineGenerateAction(ctx, reg)
+	ai.DefinePrompt(reg, "interruptPrompt",
+		ai.WithModelName("test/interrupt"),
+		ai.WithTools(interruptTool),
+	)
+
+	af := DefinePromptAgent[testState](reg, "interruptPrompt", WithSessionStore[testState](store))
+
+	conn, err := af.Connect(ctx)
+	if err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+
+	// Turn 1: the tool interrupts on its first run.
+	te := sendTurn(t, conn, "do it")
+	if te.FinishReason != AgentFinishReasonInterrupted {
+		t.Fatalf("first TurnEnd.FinishReason = %q, want %q", te.FinishReason, AgentFinishReasonInterrupted)
+	}
+	first, err := store.GetSnapshot(ctx, te.SnapshotID)
+	if err != nil {
+		t.Fatalf("GetSnapshot: %v", err)
+	}
+	pending := interruptParts(first.State.Messages)
+	if len(pending) != 1 {
+		t.Fatalf("first turn left %d interrupts, want 1", len(pending))
+	}
+
+	// Turn 2: restart the interrupted tool, which interrupts again.
+	if err := conn.SendResume(&ToolResume{Restart: pending}); err != nil {
+		t.Fatalf("SendResume: %v", err)
+	}
+
+	out, err := conn.Output()
+	if err != nil {
+		t.Fatalf("Output: %v", err)
+	}
+	if out.FinishReason != AgentFinishReasonInterrupted {
+		t.Fatalf("FinishReason = %q, want %q", out.FinishReason, AgentFinishReasonInterrupted)
+	}
+	if out.Error != nil {
+		t.Errorf("Error = %+v, want none: a second interrupt is a turn outcome", out.Error)
+	}
+	// The restart resolves before the model is consulted again, so the second
+	// turn adds no model call.
+	if got := modelCalls.Load(); got != 1 {
+		t.Errorf("model calls = %d, want 1 (the restart interrupted before generate)", got)
+	}
+
+	snap, err := store.GetSnapshot(ctx, out.SnapshotID)
+	if err != nil {
+		t.Fatalf("GetSnapshot: %v", err)
+	}
+	if snap.Status != SnapshotStatusCompleted {
+		t.Errorf("snapshot status = %q, want %q", snap.Status, SnapshotStatusCompleted)
+	}
+	if snap.FinishReason != AgentFinishReasonInterrupted {
+		t.Errorf("snapshot finish reason = %q, want %q", snap.FinishReason, AgentFinishReasonInterrupted)
+	}
+	if snap.Error != nil {
+		t.Errorf("snapshot error = %+v, want none", snap.Error)
+	}
+	// The row is answerable: it holds a fresh interrupt, so Resume has
+	// something to resolve.
+	if got := len(interruptParts(snap.State.Messages)); got != 1 {
+		t.Errorf("snapshot carries %d interrupts, want the fresh one", got)
+	}
+}
+
+// interruptParts collects the unanswered interrupt parts on a conversation's
+// last model message.
+func interruptParts(msgs []*ai.Message) []*ai.Part {
+	if len(msgs) == 0 {
+		return nil
+	}
+	var parts []*ai.Part
+	for _, p := range msgs[len(msgs)-1].Content {
+		if p.IsInterrupt() {
+			parts = append(parts, p)
+		}
+	}
+	return parts
+}
+
 // TestAgent_Detach_CompletedHonorsResultOverride verifies the detach finalizer
 // applies an AgentResult.FinishReason override on clean success, matching the
 // synchronous path (the override does not leak into the failed/aborted cases,

--- a/go/ai/exp/agent_test.go
+++ b/go/ai/exp/agent_test.go
@@ -4002,6 +4002,68 @@ func TestAgent_Detach_NormalCompletionStillEmitsTurnEnd(t *testing.T) {
 	}
 }
 
+func TestAgent_TurnSnapshotSurvivesCancelledContext(t *testing.T) {
+	// A turn that ends because the invocation's context was cancelled is
+	// exactly the turn whose snapshot the client needs, so the write must not
+	// ride the context that just died. Both in-memory stores ignore their
+	// context, so the wrapper is what makes the defect visible.
+	reg := newTestRegistry(t)
+	store := &ctxHonoringStore[testState]{SessionStore: newTestInMemStore[testState]()}
+
+	entered := make(chan struct{})
+	snapshotIDs := make(chan string, 1)
+
+	af := DefineCustomAgent(reg, "cancelCommits",
+		func(ctx context.Context, resp Responder, sess *SessionRunner[testState]) (*AgentResult, error) {
+			err := sess.Run(ctx, func(ctx context.Context, input *AgentInput) (*TurnResult, error) {
+				snapshotIDs <- TurnContextFromContext(ctx).SnapshotID
+				close(entered)
+				<-ctx.Done()
+				// Commit: the turn has state worth continuing from, which is
+				// what makes it snapshot. See [SessionRunner.Run].
+				return &TurnResult{FinishReason: AgentFinishReasonFailed}, ctx.Err()
+			})
+			return nil, err
+		},
+		WithSessionStore(store),
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	conn, err := af.Connect(ctx)
+	if err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	drainInBackground(conn)
+
+	sendText(t, conn, "go")
+	<-entered
+	cancel()
+
+	turnID := <-snapshotIDs
+	// The write is asynchronous with respect to this goroutine only in that fn
+	// is still unwinding; poll briefly rather than sleeping a fixed time.
+	var snap *SessionSnapshot[testState]
+	for range 100 {
+		snap, err = store.GetSnapshot(context.Background(), turnID)
+		if err == nil && snap != nil {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if err != nil {
+		t.Fatalf("GetSnapshot: %v", err)
+	}
+	if snap == nil {
+		t.Fatalf("turn snapshot %q was never written (%d writes rejected on a dead context)", turnID, store.rejected.Load())
+	}
+	// The subject is that the row landed at all. Which terminal status a
+	// cancelled turn writes is a separate question, asserted where it is
+	// decided.
+	if snap.Status == SnapshotStatusPending {
+		t.Errorf("status = %q, want a terminal status", snap.Status)
+	}
+}
+
 func TestAgent_Detach_ClientDisconnectBeforeDetachCancels(t *testing.T) {
 	// Without detach, a client cancel still cancels the work — this is
 	// the regression guard for "until detach=true is called, this is a

--- a/go/ai/exp/agent_test.go
+++ b/go/ai/exp/agent_test.go
@@ -1156,6 +1156,93 @@ func TestAgent_FailedTurn_ServerManagedReturnsLastTurnSnapshot(t *testing.T) {
 	}
 }
 
+// defineCommittingFailureAgent is defineLastGoodTestAgent's counterpart for a
+// turn that fails holding state worth continuing from: it mutates the session
+// and returns a TurnResult alongside the error, which commits the turn.
+func defineCommittingFailureAgent(reg api.Registry, name string, opts ...AgentOption[testState]) *Agent[testState] {
+	return DefineCustomAgent(reg, name,
+		func(ctx context.Context, resp Responder, sess *SessionRunner[testState]) (*AgentResult, error) {
+			return nil, sess.Run(ctx, func(ctx context.Context, input *AgentInput) (*TurnResult, error) {
+				sess.AddMessages(ai.NewModelTextMessage("as far as it got"))
+				sess.UpdateCustom(func(s testState) testState {
+					s.Counter = 5
+					return s
+				})
+				return &TurnResult{FinishReason: AgentFinishReasonFailed},
+					status.Errorf(status.ErrUnavailable, "model timeout")
+			})
+		},
+		opts...,
+	)
+}
+
+func TestAgent_CommittedFailedTurn_SnapshotsUnderFailed(t *testing.T) {
+	// A failed turn that committed writes its own row: status failed, the
+	// error on it for the client to judge, and the state the turn reached.
+	// That row is the resume point the failed output reports.
+	ctx := context.Background()
+	reg := newTestRegistry(t)
+	store := newTestInMemStore[testState]()
+
+	af := defineCommittingFailureAgent(reg, "committedFailure", WithSessionStore[testState](store))
+
+	out, err := af.RunText(ctx, "go")
+	if err != nil {
+		t.Fatalf("RunText: %v", err)
+	}
+	if out.FinishReason != AgentFinishReasonFailed {
+		t.Fatalf("FinishReason = %q, want %q", out.FinishReason, AgentFinishReasonFailed)
+	}
+	if out.SnapshotID == "" {
+		t.Fatal("committed failure wrote no snapshot")
+	}
+
+	snap, err := store.GetSnapshot(ctx, out.SnapshotID)
+	if err != nil {
+		t.Fatalf("GetSnapshot: %v", err)
+	}
+	if snap.Status != SnapshotStatusFailed {
+		t.Errorf("snapshot status = %q, want %q", snap.Status, SnapshotStatusFailed)
+	}
+	if snap.Error == nil || snap.Error.Status != core.UNAVAILABLE {
+		t.Errorf("snapshot error = %+v, want the turn's UNAVAILABLE", snap.Error)
+	}
+	if got := snap.State.Custom.Counter; got != 5 {
+		t.Errorf("snapshot counter = %d, want the failed turn's own 5", got)
+	}
+	if got := len(snap.State.Messages); got != 2 {
+		t.Errorf("snapshot has %d messages, want 2 (the input and what the turn added)", got)
+	}
+}
+
+func TestAgent_CommittedFailedTurn_AdvancesLastGoodState(t *testing.T) {
+	// Client-managed: the state a committed failure hands back is the failed
+	// turn's own, not the state it started with. Nothing else moves
+	// lastGoodState, so this pins the capture on a committed failure.
+	ctx := context.Background()
+	reg := newTestRegistry(t)
+
+	af := defineCommittingFailureAgent(reg, "committedFailureClient")
+
+	out, err := af.RunText(ctx, "go", WithState(&SessionState[testState]{
+		Messages: []*ai.Message{ai.NewUserTextMessage("earlier")},
+		Custom:   testState{Counter: 1},
+	}))
+	if err != nil {
+		t.Fatalf("RunText: %v", err)
+	}
+	if out.State == nil {
+		t.Fatal("expected state on the failed output")
+	}
+	if got := out.State.Custom.Counter; got != 5 {
+		t.Errorf("counter = %d, want the failed turn's own 5", got)
+	}
+	last := out.State.Messages[len(out.State.Messages)-1]
+	if got := last.Content[0].Text; got != "as far as it got" {
+		t.Errorf("last message = %q, want what the failed turn added", got)
+	}
+}
+
 func TestAgent_FailedFirstTurn_AfterResume_ReturnsParentSnapshotID(t *testing.T) {
 	// Resuming from a snapshot and failing before any turn completes:
 	// the parent snapshot already captures the last-good state, so the
@@ -3794,14 +3881,17 @@ func TestAgent_Detach_FlowErrorsBecomesError(t *testing.T) {
 		t.Errorf("expected snapshot.Error.Message to contain %q, got %+v", "kaboom", snap.Error)
 	}
 
-	// Resuming from an errored detached snapshot is rejected before the
-	// invocation starts, so the action fails with the original error.
+	// The failure is recorded, not sealed: the row carries the error for the
+	// caller to judge, and resuming from it is admitted rather than rejected
+	// at init. This agent fails the same way every turn, so the resumed
+	// invocation resolves with a failed output instead of an init error.
+	go func() { <-entered }()
 	resumeOut, err := af.RunText(context.Background(), "retry", WithSnapshotID[testState](out.SnapshotID))
-	if err == nil {
-		t.Fatalf("expected error resuming errored snapshot, got output: %+v", resumeOut)
+	if err != nil {
+		t.Fatalf("resume from the failed snapshot was rejected: %v", err)
 	}
-	if !strings.Contains(err.Error(), "kaboom") {
-		t.Errorf("expected resume error to surface the original failure, got: %v", err)
+	if resumeOut.FinishReason != AgentFinishReasonFailed {
+		t.Errorf("resumed FinishReason = %q, want %q", resumeOut.FinishReason, AgentFinishReasonFailed)
 	}
 }
 
@@ -4037,7 +4127,10 @@ func TestAgent_Detach_CommitSurvivesClientDeadline(t *testing.T) {
 	})
 }
 
-func TestAgent_ResumeFromErrorSnapshot_Rejected(t *testing.T) {
+func TestAgent_ResumeFromErrorSnapshot_Allowed(t *testing.T) {
+	// A failed row is a resume point, not a dead end: its state is what the
+	// turn committed, and whether the recorded error is worth another attempt
+	// is the caller's call.
 	reg := newTestRegistry(t)
 	store := newTestInMemStore[testState]()
 
@@ -4050,29 +4143,32 @@ func TestAgent_ResumeFromErrorSnapshot_Rejected(t *testing.T) {
 					Status:  core.INTERNAL,
 					Message: "underlying failure",
 				},
-				State: &SessionState[testState]{},
+				State: &SessionState[testState]{
+					Custom: testState{Counter: 7},
+				},
 			}, nil
 		}); err != nil {
 		t.Fatalf("SaveSnapshot: %v", err)
 	}
 
+	var resumed testState
 	af := DefineCustomAgent(reg, "resumeErrored",
 		func(ctx context.Context, resp Responder, sess *SessionRunner[testState]) (*AgentResult, error) {
+			resumed = sess.State().Custom
 			return nil, nil
 		},
 		WithSessionStore(store),
 	)
 
 	out, err := af.RunText(context.Background(), "hi", WithSnapshotID[testState](erroredID))
-	if err == nil {
-		t.Fatalf("expected error when resuming from errored snapshot, got output: %+v", out)
+	if err != nil {
+		t.Fatalf("resume from the failed snapshot: %v", err)
 	}
-	ge := core.AsGenkitError(err)
-	if ge.Status != core.FAILED_PRECONDITION {
-		t.Errorf("expected status %q, got %q", core.FAILED_PRECONDITION, ge.Status)
+	if out.FinishReason == AgentFinishReasonFailed {
+		t.Fatalf("resumed invocation failed: %+v", out.Error)
 	}
-	if !strings.Contains(ge.Message, "underlying failure") {
-		t.Errorf("expected error to surface underlying failure, got: %v", err)
+	if resumed.Counter != 7 {
+		t.Errorf("resumed counter = %d, want the failed row's committed state (7)", resumed.Counter)
 	}
 }
 
@@ -6522,11 +6618,11 @@ func TestAgent_ResumeFromSessionID_ForkContinuesLatestBranch(t *testing.T) {
 	}
 }
 
-func TestAgent_ResumeFromSessionID_FailedTipRejected(t *testing.T) {
-	// GetLatestSnapshot returns the session's literal latest row, so a failed
-	// (or aborted) tip is no longer skipped: resuming the session by ID hits
-	// the dead end and is rejected. To continue past it the caller names an
-	// earlier good snapshot via WithSnapshotID.
+func TestAgent_ResumeFromSessionID_FailedTipResumes(t *testing.T) {
+	// GetLatestSnapshot returns the session's literal latest row. A failed tip
+	// is a resume point, so resuming the session by ID continues from it; to
+	// go back further the caller names an earlier snapshot via WithSnapshotID,
+	// which is how a failed turn's state is rolled back rather than continued.
 	ctx := context.Background()
 	reg := newTestRegistry(t)
 	store := newTestInMemStore[testState]()
@@ -6553,14 +6649,16 @@ func TestAgent_ResumeFromSessionID_FailedTipRejected(t *testing.T) {
 		t.Fatalf("SaveSnapshot failed row: %v", err)
 	}
 
-	// Resuming by session ID hits the failed tip and is rejected.
-	if _, err := af.RunText(ctx, "second", WithSessionID[testState](out1.SessionID)); err == nil {
-		t.Fatal("expected resume to be rejected for a failed tip, got nil")
-	} else if ge := core.AsGenkitError(err); ge.Status != core.FAILED_PRECONDITION {
-		t.Fatalf("expected FAILED_PRECONDITION, got %q (err: %v)", ge.Status, err)
+	// Resuming by session ID continues from the failed tip.
+	out2, err := af.RunText(ctx, "second", WithSessionID[testState](out1.SessionID))
+	if err != nil {
+		t.Fatalf("resume from the failed tip: %v", err)
+	}
+	if out2.FinishReason == AgentFinishReasonFailed {
+		t.Fatalf("resume from the failed tip failed: %+v", out2.Error)
 	}
 
-	// Naming the last good snapshot explicitly still resumes past the dead end.
+	// Naming the earlier snapshot explicitly rewinds past the failed tip.
 	out3, err := af.RunText(ctx, "third", WithSnapshotID[testState](out1.SnapshotID))
 	if err != nil {
 		t.Fatalf("RunText resume from good snapshot: %v", err)

--- a/go/ai/exp/agents_conformance_test.go
+++ b/go/ai/exp/agents_conformance_test.go
@@ -60,7 +60,8 @@ const specPath = "../../../tests/specs/agent.yaml"
 // supportedRequires lists the gated spec capabilities this runtime
 // implements. A test whose `requires` names anything absent here is
 // skipped, so the shared spec can carry cases for features an SDK has not
-// adopted yet.
+// adopted yet. A name absent from the spec's own `capabilities` list is a
+// typo instead, and fails.
 var supportedRequires = map[string]bool{
 	"resumable-failures": true,
 }
@@ -77,7 +78,11 @@ type customState = map[string]any
 // ---------------------------------------------------------------------------
 
 type specSuite struct {
-	Tests []specTest `yaml:"tests"`
+	// Capabilities is every name a test may put in `requires`. It is the
+	// spec's own registry, so a misspelled capability fails here rather than
+	// skipping the test in every SDK at once.
+	Capabilities []string   `yaml:"capabilities"`
+	Tests        []specTest `yaml:"tests"`
 }
 
 type specTest struct {
@@ -384,9 +389,17 @@ func TestAgentConformance(t *testing.T) {
 		t.Fatal("spec contains no tests")
 	}
 
+	known := map[string]bool{}
+	for _, c := range suite.Capabilities {
+		known[c] = true
+	}
+
 	for _, tc := range suite.Tests {
 		t.Run(tc.Name, func(t *testing.T) {
 			for _, req := range tc.Requires {
+				if !known[req] {
+					t.Fatalf("unknown capability %q; add it to the spec's capabilities list or fix the spelling", req)
+				}
 				if !supportedRequires[req] {
 					t.Skipf("requires unsupported capability %q", req)
 				}

--- a/go/ai/exp/agents_conformance_test.go
+++ b/go/ai/exp/agents_conformance_test.go
@@ -39,6 +39,7 @@ import (
 	"regexp"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -49,11 +50,20 @@ import (
 	"github.com/firebase/genkit/go/ai/exp/localstore"
 	"github.com/firebase/genkit/go/core"
 	"github.com/firebase/genkit/go/core/api"
+	"github.com/firebase/genkit/go/core/status"
 	"github.com/firebase/genkit/go/internal/registry"
 )
 
 // specPath is relative to this package directory (go/ai/exp).
 const specPath = "../../../tests/specs/agent.yaml"
+
+// supportedRequires lists the gated spec capabilities this runtime
+// implements. A test whose `requires` names anything absent here is
+// skipped, so the shared spec can carry cases for features an SDK has not
+// adopted yet.
+var supportedRequires = map[string]bool{
+	"resumable-failures": true,
+}
 
 // customState is the single session-state type used by every conformance
 // agent. A free-form map lets the custom-state agents manipulate arbitrary
@@ -74,6 +84,7 @@ type specTest struct {
 	Name        string           `yaml:"name"`
 	Description string           `yaml:"description"`
 	Agent       string           `yaml:"agent"`
+	Requires    []string         `yaml:"requires"`
 	Steps       []map[string]any `yaml:"steps"`
 }
 
@@ -173,6 +184,19 @@ func setupHarness(t *testing.T) *harness {
 			return restartOut{Result: "confirmed: " + in.Action}, nil
 		})
 
+	// flakyTool fails its first call and succeeds after, so a spec case can
+	// fail a turn mid tool round and re-attempt it. The counter is per
+	// harness, and setupHarness runs per test, so each test's first call
+	// fails.
+	var flakyCalls atomic.Int32
+	flakyTool := defineTestTool(reg, "flakyTool", "A tool that fails its first call",
+		func(tc *ai.ToolContext, _ struct{}) (string, error) {
+			if flakyCalls.Add(1) == 1 {
+				return "", status.Errorf(status.ErrUnavailable, "flaky tool failed")
+			}
+			return "tool recovered", nil
+		})
+
 	h := &harness{
 		pm:     pm,
 		agents: map[string]*exp.Agent[customState]{},
@@ -207,6 +231,10 @@ func setupHarness(t *testing.T) *harness {
 	h.agents["promptAgentWithRestartTool"] = exp.DefineAgent[customState](reg, "promptAgentWithRestartTool",
 		exp.InlinePrompt{model, ai.WithConfig(cfg), ai.WithTools(restartTool)},
 		newStore("promptAgentWithRestartTool"))
+
+	h.agents["promptAgentWithToolsAndStore"] = exp.DefineAgent[customState](reg, "promptAgentWithToolsAndStore",
+		exp.InlinePrompt{model, ai.WithConfig(cfg), ai.WithTools(testTool, flakyTool)},
+		newStore("promptAgentWithToolsAndStore"))
 
 	// --- Custom agents ---
 
@@ -358,6 +386,11 @@ func TestAgentConformance(t *testing.T) {
 
 	for _, tc := range suite.Tests {
 		t.Run(tc.Name, func(t *testing.T) {
+			for _, req := range tc.Requires {
+				if !supportedRequires[req] {
+					t.Skipf("requires unsupported capability %q", req)
+				}
+			}
 			h := setupHarness(t)
 			agent, ok := h.agents[tc.Agent]
 			if !ok {
@@ -399,10 +432,33 @@ func (h *harness) executeSend(t *testing.T, label string, agent *exp.Agent[custo
 	t.Helper()
 	resolved := resolveTemplates(t, label, step, captures)
 
-	// Program the model for this step.
-	if _, hasResp := resolved["modelResponses"]; hasResp {
-		var modelResponses []*ai.ModelResponse
-		jsonConvert(t, label, resolved["modelResponses"], &modelResponses)
+	// Program the model for this step. An entry may be a response, or
+	// `error: {status, message}` to fail that call with a classified error
+	// (how a spec case makes a turn fail mid loop).
+	if raw, hasResp := resolved["modelResponses"]; hasResp {
+		rawTurns, ok := raw.([]any)
+		if !ok {
+			t.Fatalf("%s: modelResponses is not a list", label)
+		}
+		type modelTurn struct {
+			resp *ai.ModelResponse
+			err  error
+		}
+		turns := make([]modelTurn, len(rawTurns))
+		for i, raw := range rawTurns {
+			if m, ok := raw.(map[string]any); ok {
+				if e, ok := m["error"].(map[string]any); ok {
+					msg := asString(e["message"])
+					if name := asString(e["status"]); name != "" {
+						turns[i].err = status.Errorf(status.Base(status.Name(name)), "%s", msg)
+					} else {
+						turns[i].err = errors.New(msg)
+					}
+					continue
+				}
+			}
+			jsonConvert(t, label, raw, &turns[i].resp)
+		}
 		var streamChunks [][]*ai.ModelResponseChunk
 		if sc, ok := resolved["streamChunks"]; ok {
 			jsonConvert(t, label, sc, &streamChunks)
@@ -418,13 +474,16 @@ func (h *harness) executeSend(t *testing.T, label string, agent *exp.Agent[custo
 					}
 				}
 			}
-			if i < len(modelResponses) {
+			if i < len(turns) {
+				if turns[i].err != nil {
+					return nil, turns[i].err
+				}
 				// Echo the request back on the response, as every real model
 				// does. The prompt agent's tool loop relies on response.Request
 				// to thread intermediate tool-request/response messages into
 				// session history (modelResp.History()); without it the loop
 				// falls back to recording only the final message.
-				resp := modelResponses[i]
+				resp := turns[i].resp
 				resp.Request = req
 				return resp, nil
 			}

--- a/go/ai/exp/option.go
+++ b/go/ai/exp/option.go
@@ -323,11 +323,13 @@ func WithSnapshotID[State any](id string) InvocationOption[State] {
 // state). Combined with [WithSnapshotID], the snapshot picks the resume point
 // and the session ID is validated against it.
 //
-// The resume is rejected if the latest snapshot is a failed, aborted, or
-// pending dead end; a pending tip means a detached invocation is still running,
-// so wait for it to finalize or abort it. If history was forked, the most
-// recently updated branch wins; use [WithSnapshotID] for a specific branch. An
-// empty ID is an error, not a no-op.
+// The resume is rejected if the latest snapshot is an aborted or pending dead
+// end; a pending tip means a detached invocation is still running, so wait for
+// it to finalize or abort it. A failed tip is not a dead end: it resumes with
+// what the failed turn committed, and an input with no payload of its own
+// re-attempts the turn. If history was forked, the most recently created
+// branch wins; use [WithSnapshotID] for a specific branch. An empty ID is an
+// error, not a no-op.
 func WithSessionID[State any](id string) InvocationOption[State] {
 	return &invocationOptions[State]{sessionID: id, sessionIDSet: true}
 }

--- a/go/ai/exp/session.go
+++ b/go/ai/exp/session.go
@@ -245,8 +245,8 @@ func readSnapshot[State any](
 	// Return a normalized copy: the documented defaults (empty status means
 	// completed, zero UpdatedAt means CreatedAt) are resolved here so every
 	// caller sees the same shaping, and the state transform shapes what leaves
-	// the server. A failed snapshot's state is its last-good state, so it is
-	// returned like any other.
+	// the server. A failed snapshot's state is what its turn committed, so it
+	// is returned like any other row's.
 	resp := *snap
 	// Surface a pending snapshot whose heartbeat has gone stale as expired: its
 	// detached background worker is presumed dead, so report the orphan rather

--- a/go/ai/exp/teststore_test.go
+++ b/go/ai/exp/teststore_test.go
@@ -30,6 +30,7 @@ import (
 	"fmt"
 	"slices"
 	"sync"
+	"sync/atomic"
 
 	"github.com/google/uuid"
 )
@@ -189,6 +190,30 @@ func (s *testInMemStore[State]) notifyLocked(snapshotID string, status SnapshotS
 		default:
 		}
 	}
+}
+
+// ctxHonoringStore wraps a store and rejects a write whose context has been
+// cancelled, the way a store doing real I/O does. testInMemStore and
+// localstore.InMemorySessionStore both ignore their context, so a write made
+// on a dead context succeeds there and hides the defect; this is what a test
+// needs to see it.
+type ctxHonoringStore[State any] struct {
+	SessionStore[State]
+	// rejected counts the writes turned away, so a test can tell a write
+	// that landed on a live context from one that was never attempted.
+	rejected atomic.Int32
+}
+
+func (s *ctxHonoringStore[State]) SaveSnapshot(
+	ctx context.Context,
+	id string,
+	fn func(existing *SessionSnapshot[State]) (*SessionSnapshot[State], error),
+) (*SessionSnapshot[State], error) {
+	if err := ctx.Err(); err != nil {
+		s.rejected.Add(1)
+		return nil, err
+	}
+	return s.SessionStore.SaveSnapshot(ctx, id, fn)
 }
 
 func testCopySnapshot[State any](snap *SessionSnapshot[State]) (*SessionSnapshot[State], error) {

--- a/go/samples/basic-agents/cli.go
+++ b/go/samples/basic-agents/cli.go
@@ -377,10 +377,10 @@ func handlePending[State any](ctx context.Context, inputCh <-chan string, a *aix
 				return nil, true
 			}
 			fmt.Println(style(fmt.Sprintf("Done (%s).", final.Status), ansiGreen))
-			if final.Status != aix.SnapshotStatusCompleted {
-				// failed / aborted snapshots aren't resumable; the
-				// agent runtime would reject WithSnapshotID on them.
-				// Fall through to a fresh chat instead.
+			if !resumableStatus(final.Status) {
+				// aborted / pending snapshots are dead ends; the agent
+				// runtime would reject WithSnapshotID on them. Fall
+				// through to a fresh chat instead.
 				fmt.Println(style("Cannot resume this snapshot. Starting a new conversation.", ansiYellow))
 				return nil, true
 			}
@@ -397,12 +397,19 @@ func handlePending[State any](ctx context.Context, inputCh <-chan string, a *aix
 	}
 }
 
+// resumableStatus reports whether a settled snapshot can be continued from.
+// A failed row qualifies: it holds what its turn committed before the
+// failure, so resuming it picks up there and re-attempts that turn.
+func resumableStatus(s aix.SnapshotStatus) bool {
+	return s == aix.SnapshotStatusCompleted || s == aix.SnapshotStatusFailed
+}
+
 // pickSession decides which snapshot (if any) to resume from. It only
 // offers two paths so the demo stays focused: resume from the most
 // recent terminal snapshot (returns the snapshot pointer), or start
 // fresh (returns nil).
 func pickSession[State any](ctx context.Context, inputCh <-chan string, a *aix.Agent[State], latest *aix.SessionSnapshot[State]) (*aix.SessionSnapshot[State], bool) {
-	if latest == nil || latest.Status != aix.SnapshotStatusCompleted {
+	if latest == nil || !resumableStatus(latest.Status) {
 		fmt.Printf("\nStarting a new conversation with %s.\n", style(a.Name(), ansiBold))
 		return nil, true
 	}
@@ -414,6 +421,13 @@ func pickSession[State any](ctx context.Context, inputCh <-chan string, a *aix.A
 	fmt.Printf("\nLast %s session: %s\n",
 		style(a.Name(), ansiBold),
 		style(fmt.Sprintf("%s (%s, %d msgs)", shortID(latest.SnapshotID), latest.UpdatedAt.Format(time.RFC822), msgs), ansiDim))
+	if latest.Status == aix.SnapshotStatusFailed {
+		why := "its last turn failed"
+		if latest.Error != nil && latest.Error.Message != "" {
+			why = latest.Error.Message
+		}
+		fmt.Println(style("Resuming re-attempts the failed turn: "+why, ansiYellow))
+	}
 	fmt.Println("Resume from it? " + style("[Y/n] (n = start a new conversation)", ansiDim))
 
 	line, ok := promptLine(ctx, inputCh, chevron)
@@ -485,8 +499,29 @@ func runChat[State any](ctx context.Context, inputCh <-chan string, a *aix.Agent
 		failedTurn bool
 	)
 
+	// A failed snapshot opens on the turn that failed, holding the messages
+	// it committed. An input with no payload runs that turn again on them,
+	// which is the whole re-attempt: nothing the turn already did is redone.
+	if resume != nil && resume.Status == aix.SnapshotStatusFailed {
+		fmt.Println(style("Re-attempting the failed turn...", ansiYellow))
+		fmt.Println()
+		if err := conn.Send(&aix.AgentInput{}); err != nil {
+			fmt.Fprintf(os.Stderr, "Re-attempt error: %v\n", err)
+		} else if end, _, ok := streamReply(conn, hooks, prompter); !ok {
+			failedTurn = true
+		} else if end.FinishReason == aix.AgentFinishReasonFailed {
+			// It failed again, so the invocation is over; Output below
+			// reports the error and the snapshot to pick up from.
+			failedTurn = true
+		}
+		fmt.Println()
+	}
+
 repl:
 	for {
+		if failedTurn {
+			break
+		}
 		line, ok := promptLine(ctx, inputCh, chevron)
 		if !ok {
 			break
@@ -602,7 +637,9 @@ repl:
 			}
 		}
 		if out.SnapshotID != "" {
-			fmt.Printf("%s\n", style(fmt.Sprintf("Last-good snapshot: %s. Pick this agent again to resume from it.", shortID(out.SnapshotID)), ansiDim))
+			// The failed turn's own row when it committed anything, the turn
+			// before it otherwise. Either way it is where to pick up.
+			fmt.Printf("%s\n", style(fmt.Sprintf("Resume point: %s. Pick this agent again to continue from it.", shortID(out.SnapshotID)), ansiDim))
 		}
 	case out != nil && out.SnapshotID != "":
 		fmt.Printf("%s Final snapshot: %s.\n",

--- a/js/ai/tests/agents_spec_test.ts
+++ b/js/ai/tests/agents_spec_test.ts
@@ -131,6 +131,9 @@ const SpecTestSchema = z.object({
   name: z.string(),
   description: z.string().optional(),
   agent: z.string(),
+  // Capability gate; tests naming a capability outside SUPPORTED_REQUIRES
+  // are skipped. See docs/agents-conformance-testing.md.
+  requires: z.array(z.string()).optional(),
   steps: z.array(SpecStepSchema),
 });
 
@@ -986,7 +989,25 @@ describe('Agent conformance spec', () => {
     agents = setupHarness(registry, pm);
   });
 
+  // Gated spec capabilities this runtime implements; a test whose `requires`
+  // names anything absent here is skipped, so the shared spec can carry
+  // cases for features this SDK has not adopted yet.
+  const SUPPORTED_REQUIRES = new Set<string>();
+
   for (const test of spec.tests) {
+    const unsupported = (test.requires ?? []).filter(
+      (r) => !SUPPORTED_REQUIRES.has(r)
+    );
+    if (unsupported.length > 0) {
+      it(
+        test.name,
+        {
+          skip: `requires unsupported capabilities: ${unsupported.join(', ')}`,
+        },
+        () => {}
+      );
+      continue;
+    }
     it(test.name, async () => {
       const agent = agents[test.agent];
       assert.ok(agent, `Unknown agent '${test.agent}' in test '${test.name}'`);

--- a/js/ai/tests/agents_spec_test.ts
+++ b/js/ai/tests/agents_spec_test.ts
@@ -132,12 +132,17 @@ const SpecTestSchema = z.object({
   description: z.string().optional(),
   agent: z.string(),
   // Capability gate; tests naming a capability outside SUPPORTED_REQUIRES
-  // are skipped. See docs/agents-conformance-testing.md.
+  // are skipped, and one outside the suite's own `capabilities` fails. See
+  // docs/agents-conformance-testing.md.
   requires: z.array(z.string()).optional(),
   steps: z.array(SpecStepSchema),
 });
 
 const SpecSuiteSchema = z.object({
+  // Every name a test may put in `requires`. It is the spec's own registry,
+  // so a misspelled capability fails here rather than skipping the test in
+  // every SDK at once.
+  capabilities: z.array(z.string()).default([]),
   tests: z.array(SpecTestSchema),
 });
 
@@ -993,8 +998,18 @@ describe('Agent conformance spec', () => {
   // names anything absent here is skipped, so the shared spec can carry
   // cases for features this SDK has not adopted yet.
   const SUPPORTED_REQUIRES = new Set<string>();
+  const KNOWN_REQUIRES = new Set(spec.capabilities);
 
   for (const test of spec.tests) {
+    const unknown = (test.requires ?? []).filter((r) => !KNOWN_REQUIRES.has(r));
+    if (unknown.length > 0) {
+      it(test.name, () => {
+        assert.fail(
+          `unknown capabilities: ${unknown.join(', ')}; add them to the spec's capabilities list or fix the spelling`
+        );
+      });
+      continue;
+    }
     const unsupported = (test.requires ?? []).filter(
       (r) => !SUPPORTED_REQUIRES.has(r)
     );

--- a/py/packages/genkit/tests/genkit/ai/agent_conformance_test.py
+++ b/py/packages/genkit/tests/genkit/ai/agent_conformance_test.py
@@ -201,16 +201,21 @@ class SpecTest(SpecModel):
     agent: str
     # Capabilities the test depends on. A test naming a capability outside
     # SUPPORTED_REQUIRES is skipped, so the shared spec can carry cases for
-    # features this runtime has not adopted yet.
+    # features this runtime has not adopted yet; one outside the suite's own
+    # capabilities list is a typo and fails.
     requires: list[str] | None = None
     steps: list[SpecStep]
 
 
 class SpecSuite(SpecModel):
+    # Every name a test may put in `requires`. It is the spec's own registry,
+    # so a misspelled capability fails here rather than skipping the test in
+    # every SDK at once.
+    capabilities: list[str] = []
     tests: list[SpecTest]
 
 
-def load_spec() -> list[SpecTest]:
+def load_spec() -> SpecSuite:
     path = spec_path()
     with path.open() as f:
         raw = yaml.safe_load(f)
@@ -220,10 +225,12 @@ def load_spec() -> list[SpecTest]:
         raise AssertionError(f'agent.yaml: {e}') from e
     if not suite.tests:
         raise AssertionError('agent.yaml contains no tests')
-    return suite.tests
+    return suite
 
 
-SPEC_TESTS = load_spec()
+SPEC_SUITE = load_spec()
+SPEC_TESTS = SPEC_SUITE.tests
+KNOWN_REQUIRES: frozenset[str] = frozenset(SPEC_SUITE.capabilities)
 
 
 # ---------------------------------------------------------------------------
@@ -847,6 +854,10 @@ SUPPORTED_REQUIRES: frozenset[str] = frozenset()
 @pytest.mark.asyncio
 @pytest.mark.parametrize('spec_test', SPEC_TESTS, ids=[t.name for t in SPEC_TESTS])
 async def test_agent_conformance(spec_test: SpecTest) -> None:
+    unknown = [r for r in (spec_test.requires or []) if r not in KNOWN_REQUIRES]
+    assert not unknown, (
+        f"unknown capabilities: {', '.join(unknown)}; add them to the spec's capabilities list or fix the spelling"
+    )
     unsupported = [r for r in (spec_test.requires or []) if r not in SUPPORTED_REQUIRES]
     if unsupported:
         pytest.skip(f'requires unsupported capabilities: {", ".join(unsupported)}')

--- a/py/packages/genkit/tests/genkit/ai/agent_conformance_test.py
+++ b/py/packages/genkit/tests/genkit/ai/agent_conformance_test.py
@@ -199,6 +199,10 @@ class SpecTest(SpecModel):
     name: str
     description: str | None = None
     agent: str
+    # Capabilities the test depends on. A test naming a capability outside
+    # SUPPORTED_REQUIRES is skipped, so the shared spec can carry cases for
+    # features this runtime has not adopted yet.
+    requires: list[str] | None = None
     steps: list[SpecStep]
 
 
@@ -836,9 +840,16 @@ async def execute_wait_until_completed(*, agent: Agent, step: WaitUntilCompleted
 # ---------------------------------------------------------------------------
 
 
+# Gated spec capabilities this runtime implements; see SpecTest.requires.
+SUPPORTED_REQUIRES: frozenset[str] = frozenset()
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize('spec_test', SPEC_TESTS, ids=[t.name for t in SPEC_TESTS])
 async def test_agent_conformance(spec_test: SpecTest) -> None:
+    unsupported = [r for r in (spec_test.requires or []) if r not in SUPPORTED_REQUIRES]
+    if unsupported:
+        pytest.skip(f'requires unsupported capabilities: {", ".join(unsupported)}')
     harness = setup_harness()
     agent = harness.agents.get(spec_test.agent)
     assert agent is not None, f'Unknown agent {spec_test.agent!r} in test {spec_test.name!r}'

--- a/tests/specs/agent.yaml
+++ b/tests/specs/agent.yaml
@@ -1394,3 +1394,301 @@ tests:
         expectError:
           status: INVALID_ARGUMENT
           message: 'does not belong to session'
+
+  # ---------------------------------------------------------------------------
+  # Resumable failures (requires: resumable-failures)
+  # ---------------------------------------------------------------------------
+  # A failed turn commits what the generate call left at its last turn seam,
+  # persists it as a `failed` snapshot carrying the error, and resume accepts
+  # that snapshot. An input with no payload of its own re-attempts the turn on
+  # those committed messages. These cases use vocabulary gated behind the
+  # `resumable-failures` capability: model entries of the form
+  # `error: {status, message}` that fail a generate call, an empty input
+  # object, and a `failed` snapshot as a resume target. Their fixture,
+  # promptAgentWithToolsAndStore, wires testTool and flakyTool (fails its
+  # first call per test, then succeeds) behind a session store.
+
+  # ---------------------------------------------------------------------------
+  # Model failure after a completed tool round
+  # ---------------------------------------------------------------------------
+  - name: a model failure keeps the completed round and an empty input re-attempts it
+    requires: [resumable-failures]
+    description: >
+      A turn completes a tool round and then the model call fails. The output
+      reports the failure with the model's status, and the snapshot carries
+      the conversation up to the seam: the user message, the tool request, and
+      the tool response, with no fragment of the failed call. A second
+      invocation resumes the session by sessionId and sends an empty input,
+      which runs the turn again on those messages without repeating the tool.
+    agent: promptAgentWithToolsAndStore
+    steps:
+      - type: send
+        init: { sessionId: 22222222-2222-4222-8222-222222222222 }
+        inputs:
+          - message: { role: user, content: [{ text: do the work }] }
+        modelResponses:
+          - message:
+              role: model
+              content:
+                - toolRequest: { name: testTool, input: {}, ref: r1 }
+          - error: { status: UNAVAILABLE, message: model melted }
+        expectOutput:
+          finishReason: failed
+          hasSnapshotId: true
+          errorContains:
+            status: UNAVAILABLE
+            message: model melted
+        captureSnapshotId: snap1
+
+      - type: getSnapshotData
+        snapshotId: '{{snap1}}'
+        expectSnapshot:
+          status: failed
+          finishReason: failed
+          errorContains:
+            status: UNAVAILABLE
+            message: model melted
+          stateContains:
+            sessionId: 22222222-2222-4222-8222-222222222222
+            messages:
+              - { role: user, content: [{ text: do the work }] }
+              - role: model
+                content:
+                  - toolRequest: { name: testTool, input: {}, ref: r1 }
+              - role: tool
+                content:
+                  - toolResponse:
+                      { name: testTool, ref: r1, output: tool called }
+
+      - type: send
+        init: { sessionId: 22222222-2222-4222-8222-222222222222 }
+        inputs:
+          - {}
+        modelResponses:
+          - message: { role: model, content: [{ text: all done }] }
+            finishReason: stop
+        expectOutput:
+          message: { role: model, content: [{ text: all done }] }
+          finishReason: stop
+          hasSnapshotId: true
+        captureSnapshotId: snap2
+
+      - type: getSnapshotData
+        snapshotId: '{{snap2}}'
+        expectSnapshot:
+          parentId: '{{snap1}}'
+          status: completed
+          stateContains:
+            messages:
+              - { role: user, content: [{ text: do the work }] }
+              - role: model
+                content:
+                  - toolRequest: { name: testTool, input: {}, ref: r1 }
+              - role: tool
+                content:
+                  - toolResponse:
+                      { name: testTool, ref: r1, output: tool called }
+              - { role: model, content: [{ text: all done }] }
+
+  # ---------------------------------------------------------------------------
+  # Tool failure mid round
+  # ---------------------------------------------------------------------------
+  - name: a tool failure drops the round it opened and the re-attempt runs it again
+    requires: [resumable-failures]
+    description: >
+      A hard tool failure leaves the round unanswerable, so the model message
+      that opened it goes with the failed call: the snapshot's messages stop
+      at the user turn. Re-attempting calls the model again, which asks for
+      the tool a second time; it succeeds and the loop runs to the reply. A
+      tool failure is classified INTERNAL regardless of the tool's own status.
+    agent: promptAgentWithToolsAndStore
+    steps:
+      - type: send
+        init: { sessionId: 33333333-3333-4333-8333-333333333333 }
+        inputs:
+          - message: { role: user, content: [{ text: risky }] }
+        modelResponses:
+          - message:
+              role: model
+              content:
+                - toolRequest: { name: flakyTool, input: {}, ref: f1 }
+        expectOutput:
+          finishReason: failed
+          hasSnapshotId: true
+          errorContains:
+            status: INTERNAL
+            message: flaky tool failed
+        captureSnapshotId: snap1
+
+      - type: getSnapshotData
+        snapshotId: '{{snap1}}'
+        expectSnapshot:
+          status: failed
+          finishReason: failed
+          stateContains:
+            messages:
+              - { role: user, content: [{ text: risky }] }
+
+      - type: send
+        init: { sessionId: 33333333-3333-4333-8333-333333333333 }
+        inputs:
+          - {}
+        modelResponses:
+          - message:
+              role: model
+              content:
+                - toolRequest: { name: flakyTool, input: {}, ref: f2 }
+          - message: { role: model, content: [{ text: recovered fine }] }
+            finishReason: stop
+        expectOutput:
+          message: { role: model, content: [{ text: recovered fine }] }
+          finishReason: stop
+        captureSnapshotId: snap2
+
+      - type: getSnapshotData
+        snapshotId: '{{snap2}}'
+        expectSnapshot:
+          status: completed
+          stateContains:
+            messages:
+              - { role: user, content: [{ text: risky }] }
+              - role: model
+                content:
+                  - toolRequest: { name: flakyTool, input: {}, ref: f2 }
+              - role: tool
+                content:
+                  - toolResponse:
+                      { name: flakyTool, ref: f2, output: tool recovered }
+              - { role: model, content: [{ text: recovered fine }] }
+
+  # ---------------------------------------------------------------------------
+  # The client decides
+  # ---------------------------------------------------------------------------
+  - name: a failed snapshot accepts a new message like any other resume point
+    requires: [resumable-failures]
+    description: >
+      Re-attempting is one option, not the only one. The conversation a failed
+      turn committed ends at a turn seam, so a new user message continues it
+      the way it would continue a successful turn's snapshot.
+    agent: promptAgentWithToolsAndStore
+    steps:
+      - type: send
+        init: { sessionId: 55555555-5555-4555-8555-555555555555 }
+        inputs:
+          - message: { role: user, content: [{ text: do the work }] }
+        modelResponses:
+          - message:
+              role: model
+              content:
+                - toolRequest: { name: testTool, input: {}, ref: r1 }
+          - error: { status: UNAVAILABLE, message: model melted }
+        expectOutput:
+          finishReason: failed
+
+      - type: send
+        init: { sessionId: 55555555-5555-4555-8555-555555555555 }
+        inputs:
+          - message: { role: user, content: [{ text: never mind, just talk }] }
+        modelResponses:
+          - message: { role: model, content: [{ text: happy to }] }
+            finishReason: stop
+        expectOutput:
+          message: { role: model, content: [{ text: happy to }] }
+          finishReason: stop
+        captureSnapshotId: snap2
+
+      - type: getSnapshotData
+        snapshotId: '{{snap2}}'
+        expectSnapshot:
+          status: completed
+          stateContains:
+            messages:
+              - { role: user, content: [{ text: do the work }] }
+              - role: model
+                content:
+                  - toolRequest: { name: testTool, input: {}, ref: r1 }
+              - role: tool
+                content:
+                  - toolResponse:
+                      { name: testTool, ref: r1, output: tool called }
+              - { role: user, content: [{ text: never mind, just talk }] }
+              - { role: model, content: [{ text: happy to }] }
+
+  # ---------------------------------------------------------------------------
+  # Guards
+  # ---------------------------------------------------------------------------
+  - name: an empty input is rejected when there is nothing to continue
+    requires: [resumable-failures]
+    description: >
+      An input with no payload runs the turn on the conversation as it stands.
+      A fresh conversation has none, so the send resolves as an
+      INVALID_ARGUMENT failure rather than calling the model on nothing.
+    agent: promptAgentWithStore
+    steps:
+      - type: send
+        init: {}
+        inputs:
+          - {}
+        expectOutput:
+          finishReason: failed
+          errorContains:
+            status: INVALID_ARGUMENT
+
+  # ---------------------------------------------------------------------------
+  # Client-managed state
+  # ---------------------------------------------------------------------------
+  - name: a client-managed failure round-trips its committed state
+    requires: [resumable-failures]
+    description: >
+      Without a store, a failed turn hands its committed state back on the
+      output, and a new invocation initialized with that state re-attempts the
+      turn to completion.
+    agent: promptAgentWithTools
+    steps:
+      - type: send
+        init: {}
+        inputs:
+          - message: { role: user, content: [{ text: do the work }] }
+        modelResponses:
+          - message:
+              role: model
+              content:
+                - toolRequest: { name: testTool, input: {}, ref: r1 }
+          - error: { status: UNAVAILABLE, message: model melted }
+        expectOutput:
+          finishReason: failed
+          errorContains:
+            status: UNAVAILABLE
+          stateContains:
+            messages:
+              - { role: user, content: [{ text: do the work }] }
+              - role: model
+                content:
+                  - toolRequest: { name: testTool, input: {}, ref: r1 }
+              - role: tool
+                content:
+                  - toolResponse:
+                      { name: testTool, ref: r1, output: tool called }
+        captureState: st1
+
+      - type: send
+        init: { state: '{{st1}}' }
+        inputs:
+          - {}
+        modelResponses:
+          - message: { role: model, content: [{ text: all done }] }
+            finishReason: stop
+        expectOutput:
+          message: { role: model, content: [{ text: all done }] }
+          finishReason: stop
+          stateContains:
+            messages:
+              - { role: user, content: [{ text: do the work }] }
+              - role: model
+                content:
+                  - toolRequest: { name: testTool, input: {}, ref: r1 }
+              - role: tool
+                content:
+                  - toolResponse:
+                      { name: testTool, ref: r1, output: tool called }
+              - { role: model, content: [{ text: all done }] }

--- a/tests/specs/agent.yaml
+++ b/tests/specs/agent.yaml
@@ -9,6 +9,13 @@
 # See docs/agents-conformance-testing.md for harness requirements and
 # full spec format reference.
 
+# Every capability a test may name in `requires`. A harness skips a test
+# naming a capability it does not implement, so this list is what separates
+# "not adopted yet" from a misspelled name: a `requires` entry absent here
+# fails every harness instead of silently skipping in all of them.
+capabilities:
+  - resumable-failures
+
 tests:
   # ---------------------------------------------------------------------------
   # Basic single-turn

--- a/tests/specs/agent.yaml
+++ b/tests/specs/agent.yaml
@@ -1634,6 +1634,48 @@ tests:
           errorContains:
             status: INVALID_ARGUMENT
 
+  - name: an empty input runs a fresh turn on a conversation that did not fail
+    requires: [resumable-failures]
+    description: >
+      Nothing in the rule is specific to a failure. An input with no payload
+      runs the turn on the conversation as it stands, so a completed tip gets a
+      fresh model call on the messages already there and no new user message
+      joins them.
+    agent: promptAgentWithStore
+    steps:
+      - type: send
+        init: { sessionId: 66666666-6666-4666-8666-666666666666 }
+        inputs:
+          - message: { role: user, content: [{ text: hello }] }
+        modelResponses:
+          - message: { role: model, content: [{ text: hi there }] }
+            finishReason: stop
+        expectOutput:
+          finishReason: stop
+
+      - type: send
+        init: { sessionId: 66666666-6666-4666-8666-666666666666 }
+        inputs:
+          - {}
+        modelResponses:
+          - message: { role: model, content: [{ text: anything else }] }
+            finishReason: stop
+        expectOutput:
+          message: { role: model, content: [{ text: anything else }] }
+          finishReason: stop
+          hasSnapshotId: true
+        captureSnapshotId: snapContinued
+
+      - type: getSnapshotData
+        snapshotId: '{{snapContinued}}'
+        expectSnapshot:
+          status: completed
+          stateContains:
+            messages:
+              - { role: user, content: [{ text: hello }] }
+              - { role: model, content: [{ text: hi there }] }
+              - { role: model, content: [{ text: anything else }] }
+
   # ---------------------------------------------------------------------------
   # Client-managed state
   # ---------------------------------------------------------------------------


### PR DESCRIPTION
Makes a failed agent turn a resume point instead of a dead end. Base of a two-PR train on top of #6173's partial response, which supplies the conversation: an hour of tool calls no longer dies with the model call that blinked.

## A failed turn writes a `failed` snapshot, and resume accepts it

```go
out, _ := agent.RunText(ctx, "Book the full itinerary.")
// out.FinishReason == failed, out.Error carries the classified cause.

snap, _ := agent.GetSnapshot(ctx, out.SnapshotID)
snap.Status         // aix.SnapshotStatusFailed, no longer a dead end
snap.Error          // the same classified failure
snap.State.Messages // what the turn committed: the tool rounds it completed
```

The prompt loop folds #6173's partial into the session, and because that partial ends at a turn seam, what it commits is a conversation the model can be called on again. `resumeSessionFrom` now rejects `aborted` and `pending` only; #6213 takes `aborted` too.

- **Which failures commit**: any the generate call produced a partial for, which is every failure past the model call. A turn that fails before it (an invalid input, a render failure) rolls back, because the only thing in the session by then is the input it just rejected. Either way the newest snapshot is the latest resumable state, which is the rule `AgentOutput.SnapshotID` reports on a failure.
- **Custom agents opt in** by returning a `TurnResult` alongside the turn's error, mirroring generate's `(resp, err)`; a bare error keeps the discard-the-turn contract the spec pins.
- **Client-managed agents** get the same resume point inline: `lastGoodState` advances on every committed turn, failed or not, so the failed output's `State` is what the turn committed.
- **A restarted tool that interrupts again** commits the completed row a first-run interrupt commits, not a failed one. `ai.Generate` reports the second interrupt with a FAILED_PRECONDITION because that call's caller asked for a completed generation; the agent's caller did not, and the tip handed back is the same interrupt `Resume` answers. Calling it failed pointed clients at the empty-input re-attempt, which cannot work there: that tip ends on a model message holding an unanswered tool request, which is not a turn seam.

## The turn-end snapshot write outlives the turn's context

`snapshotTurnEnd` passed the turn's own context to `SaveSnapshot`. A turn that ends because the invocation's context was cancelled is exactly the turn whose snapshot a client needs, and that write ran on the context that had just died. Persistence is best-effort, so the store error was logged and the row silently did not exist. The write now runs on `context.WithoutCancel(ctx)`, still traced and logged under `ctx`.

Every in-memory store ignores its context, so no test could see this. `ctxHonoringStore` wraps one and rejects a write on a dead context the way a store doing real I/O does.

## Re-attempting is an input with no payload

```go
retried, _ := agent.Run(ctx, &aix.AgentInput{}, aix.WithSessionID[any](out.SessionID))
```

The turn runs again on the committed messages, so the tool calls that already succeeded are not repeated. No new field carries this: the "message or resume is required" check relaxes to reject an empty input only when the session has no messages to continue. A new message works on that snapshot too, and rewinding past the failure is a resume from the previous snapshot ID.

**Whether a failure is worth another attempt is the client's decision.** The runtime writes the status on the row and never classifies it. A `RESOURCE_EXHAUSTED` wants a wait, an `INVALID_ARGUMENT` wants a different message, and a `FAILED_PRECONDITION` from a tool guard may want neither; only the caller knows which, and it already has the status.

## Conformance rides the shared spec behind a `requires` gate

Six cases land in `tests/specs/agent.yaml` behind the `requires: [resumable-failures]` gate this PR adds to the spec format, and only the Go harness declares that capability; the JS and Python harnesses learn to read the field and skip. Because every harness skips what it does not recognize, a misspelled capability would skip in all of them and be reported by none, so the spec carries its own top-level `capabilities` registry and all three harnesses fail a `requires` entry absent from it. `docs/agents-conformance-testing.md` gains the format entry, the capability, and the two fixtures it needs. Go runs 45/45; JS 39 passed, 6 skipped; Python 53 passed, 6 skipped.

## Behavior shifts inside exp

The `SessionRunner.Run` callback contract widens: a non-nil `TurnResult` beside an error commits the turn. The package is exp and may change in minor releases, but four shifts are worth naming for anyone already on it.

- Resume from a `failed` snapshot succeeds where it raised FAILED_PRECONDITION.
- `AgentInput{}` runs a turn where it was always INVALID_ARGUMENT.
- A custom agent that already returned a non-nil `TurnResult` together with an error, previously ignored, now commits its failed turns.
- A restarted tool that interrupts again resolves the invocation as interrupted where it failed it.

## What was deliberately deferred

- **No mid-round resume.** A failed tool round is re-run whole, siblings that succeeded included, because the round cannot be handed back half-answered. Keeping their outputs would need the failed request answered too, which is what `WithSoftFailure` is for.
- **No retryable-status set in the framework.** A canonical list looks tempting here, but it would put the runtime in the business of judging a failure it did not raise. `middleware.Retry` keeps its own list for re-invoking a model call; the agent layer records and hands off.
- **No error redaction seam.** A `failed` row persists the full error text, and `WithStateTransform` shapes only `State`. `convertKeepText` and the failed detached row both predate this PR, so what changes is how often a raw message is stored, not what is stored; the hook is a follow-up.
- **Crash durability**: only a graceful failure commits, so a killed process mid-turn still loses the turn (a detached one surfaces as `expired`). Mid-turn checkpointing is a separate feature.
- **Telemetry counts the failed turn as failed** even when the next attempt succeeds; a recovered-failure marker is a follow-up shared with the soft-failure work in #6205.
- **JS and Python adoption**: the spec cases and harness gating are in place; the runtimes implement later.
