### PR TITLE
fix(py): remove wildcard CORS policy from reflection server

### DIFF
--- a/py/packages/genkit/src/genkit/_core/_reflection.py
+++ b/py/packages/genkit/src/genkit/_core/_reflection.py
@@ -32,8 +32,6 @@ from uuid import uuid4
 import uvicorn
 from pydantic import BaseModel
 from starlette.applications import Starlette
-from starlette.middleware import Middleware
-from starlette.middleware.cors import CORSMiddleware
 from starlette.requests import Request
 from starlette.responses import JSONResponse, Response, StreamingResponse
 from starlette.routing import Route
@@ -313,15 +311,6 @@ def create_reflection_asgi_app(
             Route('/api/notify', notify, methods=['POST']),
             Route('/api/runAction', run, methods=['POST']),
             Route('/api/cancelAction', cancel, methods=['POST']),
-        ],
-        middleware=[
-            Middleware(
-                CORSMiddleware,  # type: ignore[arg-type]
-                allow_origins=['*'],
-                allow_methods=['*'],
-                allow_headers=['*'],
-                expose_headers=['X-Genkit-Trace-Id', 'X-Genkit-Span-Id', 'x-genkit-version'],
-            )
         ],
         lifespan=lifespan,
     )

--- a/py/packages/genkit/tests/genkit/core/endpoints/reflection_test.py
+++ b/py/packages/genkit/tests/genkit/core/endpoints/reflection_test.py
@@ -443,3 +443,21 @@ async def test_values_default_model_ref_is_name() -> None:
         assert response.json() == {'defaultModel': 'echoModel'}
     finally:
         await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_no_cors_headers_returned(asgi_client: AsyncClient) -> None:
+    """Test that the reflection server does not return CORS headers, matching JS/Go."""
+    response = await asgi_client.get('/api/__health', headers={'Origin': 'https://evil.example'})
+    assert response.status_code == 200
+    assert 'access-control-allow-origin' not in response.headers
+
+    preflight = await asgi_client.options(
+        '/api/runAction',
+        headers={
+            'Origin': 'https://evil.example',
+            'Access-Control-Request-Method': 'POST',
+            'Access-Control-Request-Headers': 'content-type',
+        },
+    )
+    assert 'access-control-allow-origin' not in preflight.headers


### PR DESCRIPTION
## Description
Removes the wildcard CORS middleware from the development reflection server in the Python SDK, aligning it with the JS and Go reflection server implementations where no CORS headers are returned.

### How the Dev UI continues to work
The Genkit Dev UI frontend (`http://localhost:4000`) communicates with running application runtimes through the local CLI / Tools manager (`RuntimeManagerV1`). When a developer interacts with the Dev UI, requests are routed to the Tools Express server (`localhost:4000/api/*`), which proxies requests to the Python reflection server (`127.0.0.1:<port>`) via backend server-to-server HTTP (`axios`). 

Because server-side proxy requests are not subject to browser Same-Origin Policy, the runtime reflection server does not require CORS middleware to interact with the Dev UI, matching the existing behavior of the JS and Go SDKs.

## Changes
- Removed `CORSMiddleware` from Starlette app instantiation in `_reflection.py`.
- Added unit tests in `reflection_test.py` verifying no `access-control-allow-origin` headers are returned.

## Verification
- `ruff check --preview` & `ruff format` passed
- Type checkers (`pyright`, `pyrefly`, `ty`) passed with 0 errors
- Pytest unit tests passed (86 passed in core reflection suite, 1,047 passed full suite)
- Live verification: Started Dev UI with `genkit start` and verified action discovery, flow execution, and telemetry streaming work end-to-end.