### PR TITLE
chore(go,py,js): add turn failure to the shared schemas and regenerate

### DIFF
--- a/genkit-tools/common/src/types/agent.ts
+++ b/genkit-tools/common/src/types/agent.ts
@@ -46,8 +46,11 @@ export type Artifact = z.infer<typeof ArtifactSchema>;
  * - `completed`: the snapshot captures a settled state.
  * - `aborted`: the snapshot's invocation was aborted via the
  *   `abort` companion action while detached.
- * - `failed`: the invocation terminated with an error. The snapshot's `error`
- *   field describes the failure and resume is rejected with that same error.
+ * - `failed`: a turn ended with an error. The snapshot's `error` field
+ *   describes the failure, and its state is what the turn committed before
+ *   it: the conversation trimmed back to the last completed tool round.
+ *   Resume is permitted, so whether the failure is worth another attempt is
+ *   the client's decision, taken from `error.status`.
  * - `expired`: a `pending` snapshot whose detached background worker is
  *   presumed dead because its heartbeat went stale. Computed on read from a
  *   stale `heartbeatAt`; never persisted (the dead worker can no longer write
@@ -75,8 +78,10 @@ export type SnapshotStatus = z.infer<typeof SnapshotStatusSchema>;
  *   (e.g. human approval); the turn can be resumed with a `resume` payload.
  * - `other` / `unknown`: anything else / unspecified.
  *
- * The remaining values are agent-specific outcomes with no `generate`-level
- * equivalent (they never arise from forwarding a model finish reason):
+ * The remaining values are agent-specific outcomes that never arise from
+ * forwarding a model finish reason (the model-level namesakes of `aborted`
+ * and `failed` accompany generate errors, which the agent reports as a
+ * failed turn instead):
  *
  * - `aborted`: the turn or invocation was aborted (e.g. a detached
  *   invocation aborted via the `abort` companion action).
@@ -122,6 +127,12 @@ export type SessionState = z.infer<typeof SessionStateSchema>;
 
 /**
  * Zod schema for agent input (per-turn).
+ *
+ * An input with neither `message` nor `resume` continues the conversation
+ * from where it stands, which is how a failed turn is re-attempted: resume
+ * the `failed` snapshot, send an empty input, and the agent runs the turn
+ * again on the messages it committed. It is rejected on a conversation with
+ * no messages to continue.
  */
 export const AgentInputSchema = z.object({
   /**
@@ -156,14 +167,15 @@ export const AgentInitSchema = z.object({
    * mutually exclusive with state (a client-managed conversation carries
    * its identity inside `state.sessionId`). Alone it resumes the session
    * from its latest snapshot: the most recently updated row, whatever its
-   * status. If that row is a failed, aborted, or still-pending dead end
-   * the resume is rejected (pass snapshotId to continue from a specific
-   * earlier point); if the session's history was forked by re-resuming an
-   * earlier snapshot, the most recently updated branch wins. If the
-   * session has no snapshots yet, a brand-new conversation is started
-   * under this caller-chosen ID, and every snapshot it persists carries
-   * it. Combined with snapshotId, it asserts which session the snapshot
-   * belongs to, and a mismatch is rejected.
+   * status. If that row is an aborted or still-pending dead end the resume
+   * is rejected (pass snapshotId to continue from a specific earlier
+   * point); a `failed` row resumes with what the failed turn committed; if
+   * the session's history was forked by re-resuming an earlier snapshot,
+   * the most recently updated branch wins. If the session has no snapshots
+   * yet, a brand-new conversation is started under this caller-chosen ID,
+   * and every snapshot it persists carries it. Combined with snapshotId, it
+   * asserts which session the snapshot belongs to, and a mismatch is
+   * rejected.
    */
   sessionId: z.string().optional(),
   /**
@@ -219,17 +231,16 @@ export const AgentOutputSchema = z.object({
   /**
    * ID of the most recent turn-end snapshot for this invocation. Empty
    * when no store is configured or no turn committed. When `finishReason`
-   * is `detached` it is the pending detach snapshot; when `failed`, it is
-   * the last committed turn's snapshot (the resume point, holding state
-   * through the last successful turn and excluding the failed turn's
-   * partial mutations).
+   * is `detached` it is the pending detach snapshot. When `failed`, it is
+   * the resume point: the failed turn's own snapshot when the turn
+   * committed anything, otherwise the last committed turn's snapshot.
    */
   snapshotId: z.string().optional(),
   /**
    * Final conversation state (only when client-managed). When
-   * `finishReason` is `failed`, this is the last-good state: everything
-   * through the last successful turn, excluding the failed turn's
-   * partial mutations.
+   * `finishReason` is `failed`, this is the resume point: what the failed
+   * turn committed, or the last successful turn's state when the turn
+   * failed before committing anything.
    */
   state: SessionStateSchema.optional(),
   /** Last model response message from the conversation. */
@@ -263,8 +274,9 @@ export type AgentOutput = z.infer<typeof AgentOutputSchema>;
  */
 export const TurnEndSchema = z.object({
   /**
-   * ID of the snapshot persisted at the end of this turn. Empty if no
-   * snapshot was written (no store configured, the turn failed, or
+   * ID of the snapshot persisted at the end of this turn, whether it
+   * succeeded or failed. Empty if no snapshot was written (no store
+   * configured, a turn that failed before committing anything, or
    * snapshots were suspended after detach).
    */
   snapshotId: z.string().optional(),

--- a/genkit-tools/common/src/types/agents-conformance.ts
+++ b/genkit-tools/common/src/types/agents-conformance.ts
@@ -108,7 +108,13 @@ export const SendInvocationSchema = z.object({
   init: AgentInitSchema.optional(),
   /** Ordered list of inputs to send. */
   inputs: z.array(AgentInputSchema).optional(),
-  /** Pre-programmed model responses, one per generate call. */
+  /**
+   * Pre-programmed model turns, one per generate call. An entry carrying
+   * `error` fails that call with a classified error rather than returning,
+   * which is how a spec case fails a turn mid loop (gated behind
+   * `requires: [resumable-failures]`); an entry may carry both, to return a
+   * partial response alongside the error that ended it.
+   */
   modelResponses: z.array(GenerateResponseSchema).optional(),
   /** Pre-programmed streaming chunks, indexed by model call. */
   streamChunks: z.array(z.array(GenerateResponseChunkSchema)).optional(),
@@ -220,6 +226,12 @@ export const SpecTestSchema = z.object({
   description: z.string().optional(),
   /** Name of the harness-provided agent to use. */
   agent: z.string(),
+  /**
+   * Capabilities the test depends on. A harness skips a test naming a
+   * capability its runtime does not implement, so the shared spec can carry
+   * cases for features an SDK has not adopted yet.
+   */
+  requires: z.array(z.string()).optional(),
   /** Ordered sequence of steps to execute. */
   steps: z.array(SpecStepSchema),
 });

--- a/genkit-tools/common/src/types/model.ts
+++ b/genkit-tools/common/src/types/model.ts
@@ -15,6 +15,7 @@
  */
 import { z } from 'zod';
 import { DocumentDataSchema } from './document';
+import { RuntimeErrorSchema } from './error';
 import { MiddlewareRefSchema } from './middleware';
 import {
   CustomPartSchema,
@@ -344,6 +345,7 @@ export const FinishReasonSchema = z.enum([
   'length',
   'blocked',
   'aborted',
+  'failed',
   'interrupted',
   'other',
   'unknown',
@@ -377,6 +379,14 @@ export const ModelResponseSchema = z.object({
   message: MessageSchema.optional(),
   finishReason: FinishReasonSchema,
   finishMessage: z.string().optional(),
+  /**
+   * Structured failure information for a response that accompanies an
+   * error, set whenever `finishReason` is `failed` or `aborted`. It is the
+   * classified form of `finishMessage`, so a caller reading a response that
+   * travelled as data (a trace, a persisted turn) can branch on
+   * `error.status` instead of matching a string.
+   */
+  error: RuntimeErrorSchema.optional(),
   latencyMs: z.number().optional(),
   usage: GenerationUsageSchema.optional(),
   /** @deprecated use `raw` instead */

--- a/genkit-tools/genkit-schema.json
+++ b/genkit-tools/genkit-schema.json
@@ -789,6 +789,7 @@
         "length",
         "blocked",
         "aborted",
+        "failed",
         "interrupted",
         "other",
         "unknown"
@@ -979,6 +980,9 @@
         },
         "finishMessage": {
           "type": "string"
+        },
+        "error": {
+          "$ref": "#/$defs/RuntimeError"
         },
         "latencyMs": {
           "type": "number"
@@ -1301,6 +1305,9 @@
         },
         "finishMessage": {
           "$ref": "#/$defs/GenerateResponse/properties/finishMessage"
+        },
+        "error": {
+          "$ref": "#/$defs/GenerateResponse/properties/error"
         },
         "latencyMs": {
           "$ref": "#/$defs/GenerateResponse/properties/latencyMs"

--- a/go/ai/exp/gen.go
+++ b/go/ai/exp/gen.go
@@ -49,10 +49,11 @@ type AgentAbortResponse struct {
 // [AgentFinishReasonBlocked], [AgentFinishReasonInterrupted],
 // [AgentFinishReasonOther] and [AgentFinishReasonUnknown].
 //
-// The remaining values are agent-specific outcomes with no generate-level
-// equivalent (they never arise from forwarding a model finish reason):
-// [AgentFinishReasonAborted], [AgentFinishReasonDetached] and
-// [AgentFinishReasonFailed].
+// The remaining values are agent-specific outcomes that never arise from
+// forwarding a model finish reason: [AgentFinishReasonAborted],
+// [AgentFinishReasonDetached] and [AgentFinishReasonFailed]. The
+// model-level namesakes of aborted and failed accompany generate errors,
+// whose turns the agent reports as failed rather than forwarding a reason.
 type AgentFinishReason string
 
 const (
@@ -100,10 +101,11 @@ type AgentInit[State any] struct {
 	// SessionID identifies the session (conversation) to resume or start. Only
 	// valid when the agent is server-managed (a session store is configured);
 	// mutually exclusive with State. Alone, it resumes the session's latest
-	// snapshot, rejected if that snapshot is a failed, aborted, or pending dead
-	// end. If the session has no snapshots yet, a fresh conversation starts under
-	// this caller-chosen ID. Combined with SnapshotID, it asserts the snapshot
-	// belongs to that session.
+	// snapshot, rejected if that snapshot is an aborted or pending dead end; a
+	// [SnapshotStatusFailed] snapshot resumes with what the failed turn
+	// committed. If the session has no snapshots yet, a fresh conversation
+	// starts under this caller-chosen ID. Combined with SnapshotID, it asserts
+	// the snapshot belongs to that session.
 	SessionID string `json:"sessionId,omitempty"`
 	// SnapshotID loads state from a persisted snapshot. Only valid when the
 	// agent is server-managed (a session store is configured). May be
@@ -118,6 +120,12 @@ type AgentInit[State any] struct {
 }
 
 // AgentInput is the input sent to an agent during a conversation turn.
+//
+// An input with neither Message nor Resume continues the conversation from
+// where it stands, which is how a failed turn is re-attempted: resume the
+// [SnapshotStatusFailed] snapshot, send an empty input, and the agent runs
+// the turn again on the messages it committed. It is rejected on a
+// conversation with no messages to continue.
 type AgentInput struct {
 	// Detach signals the client will disconnect after this input is accepted. The
 	// server writes a pending snapshot, returns [AgentOutput] with its ID, and
@@ -188,15 +196,15 @@ type AgentOutput[State any] struct {
 	// SnapshotID is the ID of the most recent turn-end snapshot for this
 	// invocation. Empty when no store is configured or no turn committed. When
 	// FinishReason is [AgentFinishReasonDetached] it is the pending detach
-	// snapshot; when [AgentFinishReasonFailed], it is the last committed turn's
-	// snapshot (the resume point, holding state through the last successful turn
-	// and excluding the failed turn's partial mutations).
+	// snapshot. When [AgentFinishReasonFailed], it is the resume point: the
+	// failed turn's own [SnapshotStatusFailed] snapshot when the turn committed
+	// anything, otherwise the last committed turn's snapshot.
 	SnapshotID string `json:"snapshotId,omitempty"`
 	// State contains the final conversation state.
 	// Only populated when state is client-managed (no store configured).
-	// When FinishReason is [AgentFinishReasonFailed], it is the last-good state:
-	// everything through the last successful turn, excluding the failed turn's
-	// partial mutations.
+	// When FinishReason is [AgentFinishReasonFailed], it is the resume point:
+	// what the failed turn committed, or the last-good state through the last
+	// successful turn when the turn failed before committing anything.
 	State *SessionState[State] `json:"state,omitempty"`
 }
 
@@ -384,18 +392,17 @@ type SessionState[State any] struct {
 	SessionID string `json:"sessionId,omitempty"`
 }
 
-// SnapshotStatus describes the lifecycle state of a snapshot. Snapshots
-// written for synchronous turns or invocations are always
-// [SnapshotStatusCompleted] (an empty value is also treated as completed
-// for backwards compatibility).
+// SnapshotStatus describes the lifecycle state of a snapshot. A synchronous
+// turn writes [SnapshotStatusCompleted] on success (an empty value is also
+// treated as completed for backwards compatibility) and
+// [SnapshotStatusFailed] when it fails.
 //
 // When a client sets [AgentInput.Detach], the server writes a single
 // snapshot with [SnapshotStatusPending] (and empty state) and returns its
 // ID immediately. Background processing then either rewrites that snapshot
 // with the cumulative final state and [SnapshotStatusCompleted] /
 // [SnapshotStatusFailed] when the agent finishes, or with
-// [SnapshotStatusAborted] if the client called abort in the
-// meantime.
+// [SnapshotStatusAborted] if the client called abort in the meantime.
 //
 // [SnapshotStatusExpired] is never persisted: it is computed on read for a
 // pending snapshot whose background worker is presumed dead (its heartbeat
@@ -412,9 +419,11 @@ const (
 	// SnapshotStatusAborted indicates the snapshot's invocation was aborted
 	// while detached (e.g. via the abort companion action).
 	SnapshotStatusAborted SnapshotStatus = "aborted"
-	// SnapshotStatusFailed indicates the invocation terminated with an error.
-	// The snapshot's Error field describes the failure and resume is
-	// rejected with that same error.
+	// SnapshotStatusFailed indicates a turn ended with an error. The snapshot's
+	// Error field describes the failure, and its state is what the turn
+	// committed before it: the conversation trimmed back to the last completed
+	// tool round. Resume is permitted, so whether the failure is worth another
+	// attempt is the client's call, taken from the error's status.
 	SnapshotStatusFailed SnapshotStatus = "failed"
 	// SnapshotStatusExpired indicates a pending snapshot whose detached background
 	// worker is presumed dead: its [SessionSnapshot.HeartbeatAt] went stale. It is
@@ -434,11 +443,12 @@ type TurnEnd struct {
 	//
 	// [AgentFinishReasonFailed] reports a failed turn; unless the agent
 	// recovers and keeps processing, the invocation then resolves with a failed
-	// [AgentOutput] carrying the error and the last-good state, and further
+	// [AgentOutput] carrying the error and the resume point, and further
 	// sends fail with [core.ErrActionCompleted].
 	FinishReason AgentFinishReason `json:"finishReason,omitempty"`
-	// SnapshotID is the ID of the snapshot persisted at the end of this turn.
-	// Empty if no snapshot was written (no store configured, the turn failed, or
-	// snapshots were suspended after detach).
+	// SnapshotID is the ID of the snapshot persisted at the end of this turn,
+	// whether it succeeded or failed. Empty if no snapshot was written (no store
+	// configured, a turn that failed before committing anything, or snapshots
+	// were suspended after detach).
 	SnapshotID string `json:"snapshotId,omitempty"`
 }

--- a/go/ai/gen.go
+++ b/go/ai/gen.go
@@ -18,6 +18,10 @@
 
 package ai
 
+import (
+	"github.com/firebase/genkit/go/core/status"
+)
+
 type ActionMetadata struct {
 	ActionType  string `json:"actionType,omitempty"`
 	Description string `json:"description,omitempty"`
@@ -79,6 +83,7 @@ const (
 	FinishReasonLength      FinishReason = "length"
 	FinishReasonBlocked     FinishReason = "blocked"
 	FinishReasonAborted     FinishReason = "aborted"
+	FinishReasonFailed      FinishReason = "failed"
 	FinishReasonInterrupted FinishReason = "interrupted"
 	FinishReasonOther       FinishReason = "other"
 	FinishReasonUnknown     FinishReason = "unknown"
@@ -334,6 +339,13 @@ type ModelRequest struct {
 type ModelResponse struct {
 	// Custom contains model-specific extra information. Deprecated: use Raw instead.
 	Custom any `json:"custom,omitempty"`
+	// Error is the structured failure information for a response that
+	// accompanies an error, set whenever FinishReason is [FinishReasonFailed] or
+	// [FinishReasonAborted]. It is the classified form of FinishMessage, so a
+	// caller reading a response that travelled as data (a trace, a persisted
+	// turn) branches on the status rather than matching a string. Nil on a
+	// response that carries no failure.
+	Error *status.Error `json:"error,omitempty"`
 	// FinishMessage provides additional details about why generation finished.
 	FinishMessage string `json:"finishMessage,omitempty"`
 	// FinishReason indicates why generation stopped (e.g., stop, length, blocked).

--- a/go/core/schemas.config
+++ b/go/core/schemas.config
@@ -359,6 +359,16 @@ ModelResponse.finishMessage doc
 FinishMessage provides additional details about why generation finished.
 .
 
+ModelResponse.error type *status.Error
+ModelResponse.error doc
+Error is the structured failure information for a response that
+accompanies an error, set whenever FinishReason is [FinishReasonFailed] or
+[FinishReasonAborted]. It is the classified form of FinishMessage, so a
+caller reading a response that travelled as data (a trace, a persisted
+turn) branches on the status rather than matching a string. Nil on a
+response that carries no failure.
+.
+
 ModelResponse.latencyMs doc
 LatencyMs is the time the request took in milliseconds.
 .
@@ -1167,6 +1177,10 @@ GenkitErrorDataGenkitErrorDetails       omit
 # AGENT FLOW TYPES (generated into ai/exp package)
 # ============================================================================
 
+# Package configuration: the ai package carries the structured error a
+# partial ModelResponse rides with.
+ai import github.com/firebase/genkit/go/core/status
+
 # Package configuration: ai/exp directory uses "exp" as Go package name.
 ai/exp name exp
 exp import time
@@ -1207,6 +1221,12 @@ AgentInput pkg ai/exp
 
 AgentInput doc
 AgentInput is the input sent to an agent during a conversation turn.
+
+An input with neither Message nor Resume continues the conversation from
+where it stands, which is how a failed turn is re-attempted: resume the
+[SnapshotStatusFailed] snapshot, send an empty input, and the agent runs
+the turn again on the messages it committed. It is rejected on a
+conversation with no messages to continue.
 .
 
 AgentInput.detach doc
@@ -1277,10 +1297,11 @@ AgentInit.sessionId doc
 SessionID identifies the session (conversation) to resume or start. Only
 valid when the agent is server-managed (a session store is configured);
 mutually exclusive with State. Alone, it resumes the session's latest
-snapshot, rejected if that snapshot is a failed, aborted, or pending dead
-end. If the session has no snapshots yet, a fresh conversation starts under
-this caller-chosen ID. Combined with SnapshotID, it asserts the snapshot
-belongs to that session.
+snapshot, rejected if that snapshot is an aborted or pending dead end; a
+[SnapshotStatusFailed] snapshot resumes with what the failed turn
+committed. If the session has no snapshots yet, a fresh conversation
+starts under this caller-chosen ID. Combined with SnapshotID, it asserts
+the snapshot belongs to that session.
 .
 
 AgentInit.snapshotId doc
@@ -1346,17 +1367,17 @@ AgentOutput.snapshotId doc
 SnapshotID is the ID of the most recent turn-end snapshot for this
 invocation. Empty when no store is configured or no turn committed. When
 FinishReason is [AgentFinishReasonDetached] it is the pending detach
-snapshot; when [AgentFinishReasonFailed], it is the last committed turn's
-snapshot (the resume point, holding state through the last successful turn
-and excluding the failed turn's partial mutations).
+snapshot. When [AgentFinishReasonFailed], it is the resume point: the
+failed turn's own [SnapshotStatusFailed] snapshot when the turn committed
+anything, otherwise the last committed turn's snapshot.
 .
 
 AgentOutput.state doc
 State contains the final conversation state.
 Only populated when state is client-managed (no store configured).
-When FinishReason is [AgentFinishReasonFailed], it is the last-good state:
-everything through the last successful turn, excluding the failed turn's
-partial mutations.
+When FinishReason is [AgentFinishReasonFailed], it is the resume point:
+what the failed turn committed, or the last-good state through the last
+successful turn when the turn failed before committing anything.
 .
 
 AgentOutput.message type *ai.Message
@@ -1528,9 +1549,10 @@ snapshot was persisted.
 .
 
 TurnEnd.snapshotId doc
-SnapshotID is the ID of the snapshot persisted at the end of this turn.
-Empty if no snapshot was written (no store configured, the turn failed, or
-snapshots were suspended after detach).
+SnapshotID is the ID of the snapshot persisted at the end of this turn,
+whether it succeeded or failed. Empty if no snapshot was written (no store
+configured, a turn that failed before committing anything, or snapshots
+were suspended after detach).
 .
 
 TurnEnd.finishReason doc
@@ -1541,7 +1563,7 @@ Empty when the turn reported no reason.
 
 [AgentFinishReasonFailed] reports a failed turn; unless the agent
 recovers and keeps processing, the invocation then resolves with a failed
-[AgentOutput] carrying the error and the last-good state, and further
+[AgentOutput] carrying the error and the resume point, and further
 sends fail with [core.ErrActionCompleted].
 .
 
@@ -1670,18 +1692,17 @@ snapshots with the cumulative final state.
 SnapshotStatus pkg ai/exp
 
 SnapshotStatus doc
-SnapshotStatus describes the lifecycle state of a snapshot. Snapshots
-written for synchronous turns or invocations are always
-[SnapshotStatusCompleted] (an empty value is also treated as completed
-for backwards compatibility).
+SnapshotStatus describes the lifecycle state of a snapshot. A synchronous
+turn writes [SnapshotStatusCompleted] on success (an empty value is also
+treated as completed for backwards compatibility) and
+[SnapshotStatusFailed] when it fails.
 
 When a client sets [AgentInput.Detach], the server writes a single
 snapshot with [SnapshotStatusPending] (and empty state) and returns its
 ID immediately. Background processing then either rewrites that snapshot
 with the cumulative final state and [SnapshotStatusCompleted] /
 [SnapshotStatusFailed] when the agent finishes, or with
-[SnapshotStatusAborted] if the client called abort in the
-meantime.
+[SnapshotStatusAborted] if the client called abort in the meantime.
 
 [SnapshotStatusExpired] is never persisted: it is computed on read for a
 pending snapshot whose background worker is presumed dead (its heartbeat
@@ -1704,9 +1725,11 @@ while detached (e.g. via the abort companion action).
 .
 
 SnapshotStatusFailed doc
-SnapshotStatusFailed indicates the invocation terminated with an error.
-The snapshot's Error field describes the failure and resume is
-rejected with that same error.
+SnapshotStatusFailed indicates a turn ended with an error. The snapshot's
+Error field describes the failure, and its state is what the turn
+committed before it: the conversation trimmed back to the last completed
+tool round. Resume is permitted, so whether the failure is worth another
+attempt is the client's call, taken from the error's status.
 .
 
 SnapshotStatusExpired doc
@@ -1731,10 +1754,11 @@ by a single generate call can forward its reason verbatim:
 [AgentFinishReasonBlocked], [AgentFinishReasonInterrupted],
 [AgentFinishReasonOther] and [AgentFinishReasonUnknown].
 
-The remaining values are agent-specific outcomes with no generate-level
-equivalent (they never arise from forwarding a model finish reason):
-[AgentFinishReasonAborted], [AgentFinishReasonDetached] and
-[AgentFinishReasonFailed].
+The remaining values are agent-specific outcomes that never arise from
+forwarding a model finish reason: [AgentFinishReasonAborted],
+[AgentFinishReasonDetached] and [AgentFinishReasonFailed]. The
+model-level namesakes of aborted and failed accompany generate errors,
+whose turns the agent reports as failed rather than forwarding a reason.
 .
 
 AgentFinishReasonStop doc

--- a/js/ai/src/model-types.ts
+++ b/js/ai/src/model-types.ts
@@ -285,6 +285,7 @@ export const FinishReasonSchema = z.enum([
   'length',
   'blocked',
   'aborted',
+  'failed',
   'interrupted',
   'other',
   'unknown',

--- a/py/packages/genkit/src/genkit/_core/_model.py
+++ b/py/packages/genkit/src/genkit/_core/_model.py
@@ -45,6 +45,7 @@ from genkit._core._typing import (
     GenerateActionOutputConfig,
     GenerationCommonConfig,
     GenerationUsage,
+    GenkitRuntimeError,
     Media,
     MediaModel,
     MediaPart,
@@ -491,6 +492,7 @@ class ModelResponse(GenkitModel, Generic[OutputT]):
     message: Message | None = None
     finish_reason: FinishReason | None = None
     finish_message: str | None = None
+    error: GenkitRuntimeError | None = None
     latency_ms: float | None = None
     usage: GenerationUsage | None = None
     custom: dict[str, Any] | None = None

--- a/py/packages/genkit/src/genkit/_core/_typing.py
+++ b/py/packages/genkit/src/genkit/_core/_typing.py
@@ -86,6 +86,7 @@ class FinishReason(StrEnum):
     LENGTH = 'length'
     BLOCKED = 'blocked'
     ABORTED = 'aborted'
+    FAILED = 'failed'
     INTERRUPTED = 'interrupted'
     OTHER = 'other'
     UNKNOWN = 'unknown'


### PR DESCRIPTION
Base of a three-PR train. Splits the shared schema changes out of #6173 and #6196 so those two carry only Go: this one is types, generated code, and the prose that fixes the contract they implement.

## `failed` joins `FinishReason`, and a response carries its error

```ts
export const FinishReasonSchema = z.enum([..., 'aborted', 'failed', ...]);

export const ModelResponseSchema = z.object({
  // ...
  error: RuntimeErrorSchema.optional(),
});
```

`finishMessage` is a string, so a response read back out of a trace or a persisted turn has nothing to branch on. `error` is its classified form, the same `RuntimeError` shape a session snapshot carries, set whenever the reason is `failed` or `aborted`. `failed` is the loop-level counterpart of the agent-level value of the same name: generation stopped because something threw, not because the model chose to stop.

The generated Go and Python types follow. Python's `ModelResponse` is hand-written rather than generated and forbids extra keys, so it declares `error` too: without the declaration Pydantic rejects a wire response carrying one outright, rather than dropping the field. `js/ai/src/model-types.ts` keeps its own copy of `FinishReasonSchema`, so the enum value is added there by hand; JS does not take `error`, since it attaches the response to a thrown `GenerationResponseError` instead.

## A `failed` snapshot is documented as a resume point

The agent schema's prose changes and none of its fields do. `failed` was "the invocation terminated with an error [...] resume is rejected with that same error"; it is now a turn that ended with an error, holding what that turn committed, from which resume is permitted. `AgentInit.sessionId`, `AgentOutput.snapshotId`, `AgentOutput.state` and `TurnEnd.snapshotId` follow it, and `AgentInput` documents an input with neither `message` nor `resume` as the way to re-attempt the turn. #6196 implements it.

## The conformance spec format gains a capability gate

```ts
// SpecTestSchema
requires: z.array(z.string()).optional(),
```

A harness skips a test naming a capability its runtime does not implement, so the shared file can carry cases for features an SDK has not adopted. `modelResponses` needs no widening to go with it: an entry is a `GenerateResponse`, and one whose `error` is set fails that generate call rather than returning it, which is how a spec case fails a turn mid loop.

## API surface

```go
// Added (Go, generated)
ai.FinishReasonFailed   // "failed"
ai.ModelResponse.Error  // *status.Error
```

```python
# Added (Python)
FinishReason.FAILED     # generated
ModelResponse.error     # hand-written, so extra='forbid' accepts it
```

All are optional and nothing emits them yet: `failed` and `error` are produced by the loop in #6173, which lands on top of this.
