### PR TITLE
feat(go/ai): add `WithSoftFailure` to return tool errors to the model

### DIFF
--- a/go/README.md
+++ b/go/README.md
@@ -643,7 +643,17 @@ response, _ := genkit.Generate(ctx, g,
 fmt.Println(response.Text())
 ```
 
-A tool error fails the whole generation rather than being reported to the model, so a miss the model could work around (no such city, no rows matched) belongs in the result rather than in an `error`.
+A tool error fails the whole generation with `ai.ErrToolFailed`. When the failure is something the model could work around (no such city, no rows matched), define the tool with `ai.WithSoftFailure()`: the error is reported to the model as the call's tool response, as `{"error": "<message>"}`, and generation continues.
+
+```go
+weatherTool := genkit.DefineTool(g, "getWeather",
+    "Gets the current weather for a location",
+    func(ctx *ai.ToolContext, input WeatherInput) (string, error) {
+        return callWeatherAPI(input.Location) // An error here goes back to the model.
+    },
+    ai.WithSoftFailure(),
+)
+```
 
 `genkit.DefineMultipartTool` is for a result that is more than one value. It returns an `ai.MultipartToolResponse` instead: `Output` is what a plain tool would have returned, and `Content` carries parts that are not values, such as an image or a document. Those parts reach the model and the client both, and must be media or data parts.
 

--- a/go/ai/errors.go
+++ b/go/ai/errors.go
@@ -42,7 +42,9 @@ var (
 	// ErrToolFailed means a tool returned an error or produced output that does
 	// not match its declared schema. The tool's own error is wrapped, so
 	// errors.Is and errors.As still reach it; the status is INTERNAL because a
-	// tool's failure is not a failure of the caller's request.
+	// tool's failure is not a failure of the caller's request. Tools defined
+	// with [WithSoftFailure] normally report their failures to the model
+	// instead of raising this.
 	ErrToolFailed = status.ErrInternal.Subtype("tool failed")
 
 	// ErrUnsupportedByModel means the request used a capability the model does

--- a/go/ai/generate.go
+++ b/go/ai/generate.go
@@ -1333,6 +1333,19 @@ func clone[T any](obj *T) *T {
 	return &newObj
 }
 
+// resolveFailedToolCall classifies a failed tool call; interrupts are the
+// caller's to detect first. A [WithSoftFailure] tool's failure becomes the
+// error tool response reported to the model, unless the context is done: a
+// cancellation must stop the loop, not feed it. Everything else wraps as
+// [ErrToolFailed].
+func resolveFailedToolCall(ctx context.Context, tool Tool, name string, err error) (*MultipartToolResponse, error) {
+	if ctx.Err() == nil && toolSoftFailure(tool) {
+		logger.Debug(ctx, "tool failed softly, reporting the error to the model", "tool", name, "error", err)
+		return softFailureResponse(err), nil
+	}
+	return nil, status.Errorf(ErrToolFailed, "tool %q failed: %w", name, err)
+}
+
 // toolRunnerFunc runs a tool through the WrapTool hook chain and returns the
 // raw [MultipartToolResponse]. Returned by [buildToolRunner].
 type toolRunnerFunc = func(ctx context.Context, tool Tool, req *ToolRequest) (*MultipartToolResponse, error)
@@ -1435,8 +1448,12 @@ func handleToolRequests(ctx context.Context, r api.Registry, req *ModelRequest, 
 					return
 				}
 
-				resultChan <- result[*MultipartToolResponse]{index: idx, err: status.Errorf(ErrToolFailed, "tool %q failed: %w", toolReq.Name, err)}
-				return
+				softResp, toolErr := resolveFailedToolCall(ctx, tool, toolReq.Name, err)
+				if toolErr != nil {
+					resultChan <- result[*MultipartToolResponse]{index: idx, err: toolErr}
+					return
+				}
+				multipartResp = softResp
 			}
 
 			newPart := clone(p)
@@ -1947,7 +1964,10 @@ func handleResumedToolRequest(ctx context.Context, r api.Registry, genOpts *Gene
 				}
 
 				toolDefinition := tool.Definition()
-				if len(toolDefinition.OutputSchema) > 0 {
+				// The framework's own failure shape (see [WithSoftFailure])
+				// is not tool output: a caller replaying a persisted failure
+				// must not be rejected by the tool's output schema.
+				if !isSoftFailureMeta(respondPart.Metadata) && len(toolDefinition.OutputSchema) > 0 {
 					outputBytes, err := json.Marshal(respondPart.ToolResponse.Output)
 					if err != nil {
 						return nil, status.Errorf(status.ErrInvalidArgument, "handleResumedToolRequest: failed to marshal tool output for validation: %w", err)
@@ -2020,7 +2040,11 @@ func handleResumedToolRequest(ctx context.Context, r api.Registry, genOpts *Gene
 						}, nil
 					}
 
-					return nil, status.Errorf(ErrToolFailed, "tool %q failed: %w", restartPart.ToolRequest.Name, err)
+					softResp, toolErr := resolveFailedToolCall(resumedCtx, tool, restartPart.ToolRequest.Name, err)
+					if toolErr != nil {
+						return nil, toolErr
+					}
+					multipartResp = softResp
 				}
 
 				newToolReq := clone(p)

--- a/go/ai/generate_test.go
+++ b/go/ai/generate_test.go
@@ -3540,3 +3540,313 @@ func TestResumeCarriesOptionsForward(t *testing.T) {
 		}
 	})
 }
+
+// TestGenerateSoftFailureTools covers WithSoftFailure: a failing tool's error
+// returns to the model as an error tool response and generation continues,
+// while tools without the option keep failing the whole request.
+func TestGenerateSoftFailureTools(t *testing.T) {
+	t.Parallel()
+
+	// errorOutput asserts that part is a tool response carrying the soft
+	// failure encoding and returns the error text.
+	errorOutput := func(t *testing.T, part *Part) string {
+		t.Helper()
+		if !part.IsToolResponse() {
+			t.Fatalf("part is %q, want a tool response", part.Kind)
+		}
+		if marked, _ := part.Metadata["error"].(bool); !marked {
+			t.Errorf("part metadata = %v, want error: true", part.Metadata)
+		}
+		out, ok := part.ToolResponse.Output.(map[string]any)
+		if !ok {
+			t.Fatalf("output = %T (%v), want map with error key", part.ToolResponse.Output, part.ToolResponse.Output)
+		}
+		text, ok := out["error"].(string)
+		if !ok {
+			t.Fatalf("output = %v, want an error string", out)
+		}
+		return text
+	}
+
+	// toolMessages returns the tool-role messages of a history.
+	toolMessages := func(msgs []*Message) []*Message {
+		var out []*Message
+		for _, m := range msgs {
+			if m.Role == RoleTool {
+				out = append(out, m)
+			}
+		}
+		return out
+	}
+
+	t.Run("failure returns to the model and generation continues", func(t *testing.T) {
+		r := newTestRegistry(t)
+		flaky := defineTool(r, "flaky", "always fails",
+			func(ctx *ToolContext, in map[string]any) (string, error) {
+				return "", errors.New("backend is down")
+			}, WithSoftFailure())
+
+		var seenByModel *Part
+		defineFakeModel(t, r, fakeModelConfig{
+			name: "test/recovers",
+			handler: func(ctx context.Context, req *ModelRequest, cb ModelStreamCallback) (*ModelResponse, error) {
+				for _, m := range req.Messages {
+					if m.Role == RoleTool {
+						seenByModel = m.Content[0]
+						return &ModelResponse{Request: req, Message: NewModelTextMessage("recovered")}, nil
+					}
+				}
+				return &ModelResponse{Request: req, Message: &Message{
+					Role:    RoleModel,
+					Content: []*Part{NewToolRequestPart(&ToolRequest{Name: "flaky", Input: map[string]any{}})},
+				}}, nil
+			},
+		})
+
+		resp, err := Generate(testCtx, r,
+			WithModelName("test/recovers"),
+			WithPrompt("start"),
+			WithTools(flaky),
+		)
+		assertNoError(t, err)
+		if got := resp.Text(); got != "recovered" {
+			t.Errorf("Text() = %q, want %q", got, "recovered")
+		}
+		if seenByModel == nil {
+			t.Fatal("the model never saw a tool response")
+		}
+		if text := errorOutput(t, seenByModel); !strings.Contains(text, "backend is down") {
+			t.Errorf("error output = %q, want the tool's error text", text)
+		}
+	})
+
+	t.Run("invalid model input is recoverable", func(t *testing.T) {
+		r := newTestRegistry(t)
+		square := defineTool(r, "square", "squares a number",
+			func(ctx *ToolContext, in struct {
+				N float64 `json:"n"`
+			}) (float64, error) {
+				return in.N * in.N, nil
+			}, WithSoftFailure())
+
+		defineFakeModel(t, r, fakeModelConfig{
+			name: "test/fixesInput",
+			handler: func(ctx context.Context, req *ModelRequest, cb ModelStreamCallback) (*ModelResponse, error) {
+				switch len(toolMessages(req.Messages)) {
+				case 0:
+					return &ModelResponse{Request: req, Message: &Message{
+						Role:    RoleModel,
+						Content: []*Part{NewToolRequestPart(&ToolRequest{Name: "square", Input: map[string]any{"n": "banana"}})},
+					}}, nil
+				case 1:
+					return &ModelResponse{Request: req, Message: &Message{
+						Role:    RoleModel,
+						Content: []*Part{NewToolRequestPart(&ToolRequest{Name: "square", Input: map[string]any{"n": 3}})},
+					}}, nil
+				default:
+					return &ModelResponse{Request: req, Message: NewModelTextMessage("the answer is 9")}, nil
+				}
+			},
+		})
+
+		resp, err := Generate(testCtx, r,
+			WithModelName("test/fixesInput"),
+			WithPrompt("start"),
+			WithTools(square),
+		)
+		assertNoError(t, err)
+		if got := resp.Text(); got != "the answer is 9" {
+			t.Errorf("Text() = %q, want %q", got, "the answer is 9")
+		}
+		tms := toolMessages(resp.History())
+		if len(tms) != 2 {
+			t.Fatalf("history has %d tool messages, want 2 (rejected input, then success)", len(tms))
+		}
+		errorOutput(t, tms[0].Content[0])
+		if marked, _ := tms[1].Content[0].Metadata["error"].(bool); marked {
+			t.Error("the successful retry must not be marked as an error")
+		}
+	})
+
+	t.Run("a hard sibling fails the request and takes the soft outcome with it", func(t *testing.T) {
+		r := newTestRegistry(t)
+		softDone := make(chan struct{})
+		soft := defineTool(r, "softTool", "fails fast and softly",
+			func(ctx *ToolContext, in map[string]any) (string, error) {
+				defer close(softDone)
+				return "", errors.New("soft boom")
+			}, WithSoftFailure())
+		defineTool(r, "hardTool", "fails after the soft one",
+			func(ctx *ToolContext, in map[string]any) (string, error) {
+				<-softDone
+				return "", errors.New("hard boom")
+			})
+
+		defineFakeModel(t, r, fakeModelConfig{
+			name: "test/softHard",
+			handler: func(ctx context.Context, req *ModelRequest, cb ModelStreamCallback) (*ModelResponse, error) {
+				return &ModelResponse{Request: req, Message: &Message{
+					Role: RoleModel,
+					Content: []*Part{
+						NewToolRequestPart(&ToolRequest{Name: "softTool", Input: map[string]any{}}),
+						NewToolRequestPart(&ToolRequest{Name: "hardTool", Input: map[string]any{}}),
+					},
+				}}, nil
+			},
+		})
+
+		resp, err := Generate(testCtx, r,
+			WithModelName("test/softHard"),
+			WithPrompt("start"),
+			WithTools(soft, LookupTool(r, "hardTool")),
+		)
+		if !errors.Is(err, ErrToolFailed) || !strings.Contains(err.Error(), `"hardTool"`) {
+			t.Fatalf("err = %v, want ErrToolFailed from hardTool", err)
+		}
+		// A soft failure only reaches the model as part of a finished round,
+		// and the hard sibling means there is no finished round.
+		if resp != nil {
+			t.Errorf("response = %v, want nil", resp)
+		}
+	})
+
+	t.Run("interrupt wins over a soft sibling failure", func(t *testing.T) {
+		r := newTestRegistry(t)
+		soft := defineTool(r, "softTool", "fails softly",
+			func(ctx *ToolContext, in map[string]any) (string, error) {
+				return "", errors.New("soft boom")
+			}, WithSoftFailure())
+		pauser := defineTool(r, "pauser", "interrupts",
+			func(ctx *ToolContext, in map[string]any) (string, error) {
+				return "", ctx.Interrupt(&InterruptOptions{Metadata: map[string]any{"reason": "approval"}})
+			})
+
+		defineFakeModel(t, r, fakeModelConfig{
+			name: "test/softInterrupt",
+			handler: func(ctx context.Context, req *ModelRequest, cb ModelStreamCallback) (*ModelResponse, error) {
+				return &ModelResponse{Request: req, Message: &Message{
+					Role: RoleModel,
+					Content: []*Part{
+						NewToolRequestPart(&ToolRequest{Name: "pauser", Input: map[string]any{}}),
+						NewToolRequestPart(&ToolRequest{Name: "softTool", Input: map[string]any{}}),
+					},
+				}}, nil
+			},
+		})
+
+		resp, err := Generate(testCtx, r,
+			WithModelName("test/softInterrupt"),
+			WithPrompt("start"),
+			WithTools(pauser, soft),
+		)
+		assertNoError(t, err)
+		if resp.FinishReason != FinishReasonInterrupted {
+			t.Fatalf("FinishReason = %q, want interrupted", resp.FinishReason)
+		}
+		var softPart *Part
+		for _, p := range resp.Message.Content {
+			if p.IsToolRequest() && p.ToolRequest.Name == "softTool" {
+				softPart = p
+			}
+		}
+		if softPart == nil {
+			t.Fatal("softTool request part missing from the interrupted message")
+		}
+		pending, ok := softPart.Metadata["pendingOutput"].(map[string]any)
+		if !ok || !strings.Contains(fmt.Sprint(pending["error"]), "soft boom") {
+			t.Errorf("softTool pendingOutput = %v, want the soft error encoding", softPart.Metadata["pendingOutput"])
+		}
+	})
+
+	t.Run("a restarted soft tool reports its failure to the model", func(t *testing.T) {
+		r := newTestRegistry(t)
+		calls := 0
+		fragile := defineTool(r, "fragile", "interrupts, then fails on restart",
+			func(ctx *ToolContext, in map[string]any) (string, error) {
+				calls++
+				if calls == 1 {
+					return "", ctx.Interrupt(&InterruptOptions{Metadata: map[string]any{"reason": "approval"}})
+				}
+				return "", errors.New("still broken")
+			}, WithSoftFailure())
+
+		defineFakeModel(t, r, fakeModelConfig{
+			name: "test/restartSoft",
+			handler: func(ctx context.Context, req *ModelRequest, cb ModelStreamCallback) (*ModelResponse, error) {
+				for _, m := range req.Messages {
+					if m.Role == RoleTool {
+						return &ModelResponse{Request: req, Message: NewModelTextMessage("recovered after restart")}, nil
+					}
+				}
+				return &ModelResponse{Request: req, Message: &Message{
+					Role:    RoleModel,
+					Content: []*Part{NewToolRequestPart(&ToolRequest{Name: "fragile", Input: map[string]any{}})},
+				}}, nil
+			},
+		})
+
+		res, err := Generate(testCtx, r,
+			WithModelName("test/restartSoft"),
+			WithPrompt("start"),
+			WithTools(fragile),
+		)
+		assertNoError(t, err)
+		if res.FinishReason != FinishReasonInterrupted {
+			t.Fatalf("FinishReason = %q, want interrupted", res.FinishReason)
+		}
+
+		restartPart := fragile.Restart(res.Interrupts()[0], nil)
+		resumed, err := Generate(testCtx, r,
+			WithModelName("test/restartSoft"),
+			WithMessages(res.History()...),
+			WithTools(fragile),
+			WithToolRestarts(restartPart),
+		)
+		assertNoError(t, err)
+		if got := resumed.Text(); got != "recovered after restart" {
+			t.Errorf("Text() = %q, want %q", got, "recovered after restart")
+		}
+		tms := toolMessages(resumed.History())
+		if len(tms) != 1 {
+			t.Fatalf("history has %d tool messages, want 1", len(tms))
+		}
+		if text := errorOutput(t, tms[0].Content[0]); !strings.Contains(text, "still broken") {
+			t.Errorf("error output = %q, want the restart failure text", text)
+		}
+	})
+
+	t.Run("cancellation is never soft-failed", func(t *testing.T) {
+		r := newTestRegistry(t)
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		modelCalls := 0
+		defineFakeModel(t, r, fakeModelConfig{
+			name: "test/cancelSoft",
+			handler: func(ctx context.Context, req *ModelRequest, cb ModelStreamCallback) (*ModelResponse, error) {
+				modelCalls++
+				return &ModelResponse{Request: req, Message: &Message{
+					Role:    RoleModel,
+					Content: []*Part{NewToolRequestPart(&ToolRequest{Name: "cancelTool", Input: map[string]any{}})},
+				}}, nil
+			},
+		})
+		soft := defineTool(r, "cancelTool", "cancels the request, then fails",
+			func(tc *ToolContext, in map[string]any) (string, error) {
+				cancel()
+				return "", context.Canceled
+			}, WithSoftFailure())
+
+		_, err := Generate(ctx, r,
+			WithModelName("test/cancelSoft"),
+			WithPrompt("start"),
+			WithTools(soft),
+		)
+		if !errors.Is(err, ErrToolFailed) {
+			t.Fatalf("err = %v, want ErrToolFailed: cancellation must not become model-visible tool output", err)
+		}
+		if modelCalls != 1 {
+			t.Errorf("model called %d times, want 1: the loop must stop on cancellation", modelCalls)
+		}
+	})
+}

--- a/go/ai/option.go
+++ b/go/ai/option.go
@@ -1068,6 +1068,7 @@ type toolOptions struct {
 	inputOptions
 	OutputSchema map[string]any // JSON schema of the tool's output.
 	StrictSchema *bool
+	SoftFailure  bool // Whether the tool's errors return to the model instead of failing generation.
 }
 
 // ToolOption is an option for defining a tool.
@@ -1082,6 +1083,9 @@ func (o *toolOptions) applyTool(opts *toolOptions) {
 	if o.StrictSchema != nil {
 		opts.StrictSchema = o.StrictSchema
 	}
+	if o.SoftFailure {
+		opts.SoftFailure = true
+	}
 	o.inputOptions.applyTool(opts)
 }
 
@@ -1094,6 +1098,25 @@ func (o *toolOptions) applyTool(opts *toolOptions) {
 // support ignore this option.
 func WithStrictSchema(strict bool) ToolOption {
 	return &toolOptions{StrictSchema: &strict}
+}
+
+// WithSoftFailure makes the tool's failures recoverable by the model: when
+// the tool call fails (the tool returns an error, or the call is rejected
+// before the tool runs, such as model-provided input that does not match the
+// input schema), the generate loop reports the failure to the model as this
+// call's tool response, with output {"error": "<message>"} and
+// {"error": true} on the part's metadata, and generation continues. Without
+// this option a tool failure ends generation with [ErrToolFailed], and a
+// failure on a context that is already done always does: a cancellation must
+// stop the loop, not feed it.
+//
+// Use it on tools whose errors carry meaning the model can act on (a lookup
+// that found nothing, a service that is temporarily down). Leave it off when
+// continuing without the tool's result would be unsafe. Interrupts are
+// control flow, not failures, and are never affected; a request for a tool
+// that is not registered still fails generation with [ErrToolNotFound].
+func WithSoftFailure() ToolOption {
+	return &toolOptions{SoftFailure: true}
 }
 
 // promptExecutionOptions are options for generating a model response by executing a prompt.

--- a/go/ai/tools.go
+++ b/go/ai/tools.go
@@ -310,12 +310,64 @@ func applyStrictMetadata(metadata map[string]any, strict *bool) {
 	if strict == nil {
 		return
 	}
+	toolMetaOf(metadata)[toolStrictKey] = *strict
+}
+
+// toolSoftFailureKey is the metadata key under metadata["tool"] that carries
+// the [WithSoftFailure] flag through the action metadata and onto
+// [ToolDefinition.Metadata]. The loop re-resolves tools with [LookupTool],
+// which rebuilds definitions from registered action metadata, so a custom
+// [Tool] opts in through that metadata, not through its own Definition.
+const toolSoftFailureKey = "softFailure"
+
+// applySoftFailureMetadata sets metadata["tool"][toolSoftFailureKey] when the
+// tool was defined with [WithSoftFailure]. False leaves the metadata
+// untouched.
+func applySoftFailureMetadata(metadata map[string]any, softFailure bool) {
+	if !softFailure {
+		return
+	}
+	toolMetaOf(metadata)[toolSoftFailureKey] = true
+}
+
+// toolMetaOf returns metadata's "tool" submap, creating it when absent.
+func toolMetaOf(metadata map[string]any) map[string]any {
 	toolMeta, _ := metadata["tool"].(map[string]any)
 	if toolMeta == nil {
 		toolMeta = map[string]any{}
 		metadata["tool"] = toolMeta
 	}
-	toolMeta[toolStrictKey] = *strict
+	return toolMeta
+}
+
+// toolSoftFailure reports whether the tool opted into [WithSoftFailure],
+// reading the flag off the definition of the registry-resolved tool (see
+// [toolSoftFailureKey] for what that means for custom implementations).
+func toolSoftFailure(t Tool) bool {
+	def := t.Definition()
+	if def == nil || def.Metadata == nil {
+		return false
+	}
+	soft, _ := def.Metadata[toolSoftFailureKey].(bool)
+	return soft
+}
+
+// softFailureResponse builds the tool response reported to the model when a
+// [WithSoftFailure] tool fails: the error text as {"error": "<message>"}
+// output, with {"error": true} carried onto the tool response part's
+// metadata so consumers can detect the failure without parsing the output.
+func softFailureResponse(err error) *MultipartToolResponse {
+	return &MultipartToolResponse{
+		Output:   map[string]any{"error": err.Error()},
+		Metadata: map[string]any{"error": true},
+	}
+}
+
+// isSoftFailureMeta reports whether tool response part metadata carries the
+// [softFailureResponse] error marker.
+func isSoftFailureMeta(meta map[string]any) bool {
+	marked, _ := meta["error"].(bool)
+	return marked
 }
 
 // applyToolOutputSchema records a custom output schema as the tool's
@@ -360,6 +412,7 @@ func NewTool[In, Out any](name, description string, fn ToolFunc[In, Out], opts .
 	metadata["dynamic"] = true
 	applyToolOutputSchema(metadata, toolOpts.OutputSchema)
 	applyStrictMetadata(metadata, toolOpts.StrictSchema)
+	applySoftFailureMetadata(metadata, toolOpts.SoftFailure)
 	action := core.NewActionOf(api.ActionTypeToolV2, name, &core.ActionOptions{Metadata: metadata, InputSchema: toolOpts.InputSchema}, wrappedFn)
 	return &ToolAction[In, Out]{action: action, multipart: false}
 }
@@ -394,6 +447,7 @@ func NewMultipartTool[In any](name, description string, fn MultipartToolFunc[In]
 	metadata["dynamic"] = true
 	applyToolOutputSchema(metadata, toolOpts.OutputSchema)
 	applyStrictMetadata(metadata, toolOpts.StrictSchema)
+	applySoftFailureMetadata(metadata, toolOpts.SoftFailure)
 	action := core.NewActionOf(api.ActionTypeToolV2, name, &core.ActionOptions{Metadata: metadata, InputSchema: toolOpts.InputSchema}, wrappedFn)
 	return &ToolAction[In, *MultipartToolResponse]{action: action, multipart: true}
 }
@@ -487,8 +541,10 @@ func (t *ToolAction[In, Out]) Definition() *ToolDefinition {
 		"multipart": t.multipart,
 	}
 	if toolMeta, ok := desc.Metadata["tool"].(map[string]any); ok {
-		if s, ok := toolMeta[toolStrictKey].(bool); ok {
-			metadata[toolStrictKey] = s
+		for _, key := range []string{toolStrictKey, toolSoftFailureKey} {
+			if s, ok := toolMeta[key].(bool); ok {
+				metadata[key] = s
+			}
 		}
 	}
 

--- a/go/ai/tools_test.go
+++ b/go/ai/tools_test.go
@@ -1538,3 +1538,62 @@ func TestInterruptMetadata(t *testing.T) {
 		}
 	})
 }
+
+// TestWithSoftFailure verifies the soft-failure flag round-trips through
+// Definition().Metadata["softFailure"] and LookupTool, for regular and
+// multipart tools. The loop behavior lives in TestGenerateSoftFailureTools.
+func TestWithSoftFailure(t *testing.T) {
+	check := func(t *testing.T, tl Tool, want bool) {
+		t.Helper()
+		def := tl.Definition()
+		got, ok := def.Metadata["softFailure"]
+		if want && (!ok || got != true) {
+			t.Errorf("softFailure metadata = %v (present %t), want true", got, ok)
+		}
+		if !want && ok {
+			t.Errorf("softFailure metadata = %v, want absent", got)
+		}
+		if toolSoftFailure(tl) != want {
+			t.Errorf("toolSoftFailure() = %t, want %t", toolSoftFailure(tl), want)
+		}
+	}
+
+	t.Run("absent by default", func(t *testing.T) {
+		r := newTestRegistry(t)
+		tl := defineTool(r, "soft/default", "no option",
+			func(ctx *ToolContext, input struct{}) (string, error) { return "", nil })
+		check(t, tl, false)
+	})
+
+	t.Run("surfaced on Definition", func(t *testing.T) {
+		r := newTestRegistry(t)
+		tl := defineTool(r, "soft/on", "soft",
+			func(ctx *ToolContext, input struct{}) (string, error) { return "", nil },
+			WithSoftFailure(),
+		)
+		check(t, tl, true)
+	})
+
+	t.Run("LookupTool round-trips the flag", func(t *testing.T) {
+		r := newTestRegistry(t)
+		defineTool(r, "soft/lookup", "soft",
+			func(ctx *ToolContext, input struct{}) (string, error) { return "", nil },
+			WithSoftFailure(),
+		)
+		found := LookupTool(r, "soft/lookup")
+		if found == nil {
+			t.Fatal("LookupTool returned nil")
+		}
+		check(t, found, true)
+	})
+
+	t.Run("multipart tools carry the flag", func(t *testing.T) {
+		tl := NewMultipartTool("soft/multipart", "soft multipart",
+			func(ctx *ToolContext, input struct{}) (*MultipartToolResponse, error) {
+				return &MultipartToolResponse{Output: "ok"}, nil
+			},
+			WithSoftFailure(),
+		)
+		check(t, tl, true)
+	})
+}


### PR DESCRIPTION
Adds `ai.WithSoftFailure()`, a tool option that reports a tool's failures to the model instead of failing the request. This is what JS reaches for the [`softFail` middleware](https://github.com/pavelgj/genkitx-misc) to get; Go does it inside the loop, so the failure arrives as that call's tool response rather than as a fabricated model message.

## A soft-failing tool's error becomes its tool response

```go
lookup := genkit.DefineTool(g, "lookupOrder", "Looks up an order by ID",
    func(ctx *ai.ToolContext, q OrderQuery) (*Order, error) {
        return findOrder(q.ID) // A miss is an error the model can act on.
    },
    ai.WithSoftFailure(),
)
```

The failure becomes the call's tool response, with output `{"error": "<message>"}` and `{"error": true}` on the part's metadata, and generation continues. Model-provided input that fails the tool's input schema soft-fails the same way, since the model is the one that can correct it.

Three failures stay hard:

- **An interrupt** is control flow, not a failure, and is never converted.
- **`ErrToolNotFound`** has no definition to carry the option.
- **A done context** must stop the loop, so a cancellation is never fed back to the model as recoverable output.

A hard failure elsewhere in the round still ends generation with `ErrToolFailed`, and a soft outcome from a sibling goes with it: its response cannot ride back on a request its neighbor left unanswered.

## The flag rides tool metadata

```go
Metadata["tool"]["softFailure"] = true   // and onto ToolDefinition.Metadata
```

The loop re-resolves tools by name with `LookupTool`, which rebuilds a definition from registered action metadata, so the option cannot live on the `Tool` value the caller passed. It travels the same path as `strict`, which means a custom `Tool` implementation opts in through its action metadata rather than through its own `Definition()`.

One consequence on the resume path: a replayed soft failure skips the tool's output schema. `{"error": "..."}` is the framework's shape, not the tool's, so validating it would reject a caller replaying a persisted failure.

## API surface

```go
// Added
ai.WithSoftFailure() ToolOption
```

Opt-in per tool, and nothing else changes shape.

## What was deliberately deferred

- **Telemetry counts a recovered failure as a failure.** The tool span records the error before the loop converts it, so googlecloud path telemetry still pages on it. It needs a recovered-failure marker; follow-up.
- **The model is told nothing beyond the error text.** `softFail` also injects a model message describing the failure. The loop never fabricates one, because an agent would persist it as model speech.
- **No JS or Python counterpart.** Whether to fold the middleware's job into the loop is each SDK's call.
