### PR TITLE
fix(go/ai): keep reasoning parts intact on the wire

### DIFF
--- a/go/ai/document.go
+++ b/go/ai/document.go
@@ -314,7 +314,10 @@ type partSchema struct {
 	Resource     *ResourcePart  `json:"resource,omitempty" yaml:"resource,omitempty"`
 	Custom       map[string]any `json:"custom,omitempty" yaml:"custom,omitempty"`
 	Metadata     map[string]any `json:"metadata,omitempty" yaml:"metadata,omitempty"`
-	Reasoning    string         `json:"reasoning,omitempty" yaml:"reasoning,omitempty"`
+	// Reasoning is a pointer so that a reasoning part with empty text stays a
+	// reasoning part: what marks the kind is the key being present, not the
+	// text being non-empty.
+	Reasoning *string `json:"reasoning,omitempty" yaml:"reasoning,omitempty"`
 }
 
 // unmarshalPartFromSchema updates Part p based on the schema s.
@@ -336,9 +339,9 @@ func (p *Part) unmarshalPartFromSchema(s partSchema) {
 	case s.Custom != nil:
 		p.Kind = PartCustom
 		p.Custom = s.Custom
-	case s.Reasoning != "":
+	case s.Reasoning != nil:
 		p.Kind = PartReasoning
-		p.Text = s.Reasoning
+		p.Text = *s.Reasoning
 		p.ContentType = "plain/text"
 	default:
 		p.Kind = PartText

--- a/go/ai/document.go
+++ b/go/ai/document.go
@@ -140,14 +140,15 @@ func NewCustomPart(customData map[string]any) *Part {
 
 // NewReasoningPart returns a Part containing reasoning text
 func NewReasoningPart(text string, signature []byte) *Part {
-	return &Part{
+	p := &Part{
 		Kind:        PartReasoning,
 		ContentType: "plain/text",
 		Text:        text,
-		Metadata: map[string]any{
-			"signature": signature,
-		},
 	}
+	if len(signature) > 0 {
+		p.Metadata = map[string]any{"signature": signature}
+	}
+	return p
 }
 
 // NewResourcePart returns a Part containing a resource reference.

--- a/go/ai/document.go
+++ b/go/ai/document.go
@@ -146,7 +146,10 @@ func NewReasoningPart(text string, signature []byte) *Part {
 		Text:        text,
 	}
 	if len(signature) > 0 {
-		p.Metadata = map[string]any{"signature": signature}
+		// Cloned because the part outlives the call: [Part.Clone] copies the
+		// metadata map but not the bytes under it, so a caller reusing a
+		// buffer across chunks would mutate signatures already handed off.
+		p.Metadata = map[string]any{"signature": slices.Clone(signature)}
 	}
 	return p
 }

--- a/go/ai/document_test.go
+++ b/go/ai/document_test.go
@@ -165,6 +165,30 @@ func TestReasoningPartWithoutSignature(t *testing.T) {
 	}
 }
 
+func TestEmptyReasoningPartRoundTrip(t *testing.T) {
+	// The reasoning key marks the kind, so it has to survive an empty text:
+	// dropping it turns the part into an empty text part on the way back, and
+	// the wire schema lists reasoning as required.
+	p := NewReasoningPart("", []byte("sig123"))
+
+	b, err := json.Marshal(p)
+	if err != nil {
+		t.Fatalf("failed to marshal reasoning part: %v", err)
+	}
+
+	var got Part
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatalf("failed to unmarshal reasoning part: %v", err)
+	}
+
+	if !got.IsReasoning() {
+		t.Errorf("empty reasoning part became kind %v, want %v (marshaled as %s)", got.Kind, PartReasoning, b)
+	}
+	if got.Text != "" {
+		t.Errorf("Text = %q, want empty", got.Text)
+	}
+}
+
 func TestNewDataPart(t *testing.T) {
 	t.Run("creates data part with content", func(t *testing.T) {
 		p := NewDataPart("some binary data")

--- a/go/ai/document_test.go
+++ b/go/ai/document_test.go
@@ -141,6 +141,28 @@ func TestReasoningPartJSON(t *testing.T) {
 	if unmarshaledPart.ContentType != "plain/text" {
 		t.Errorf("unmarshaled reasoning content type = %q, want %q", unmarshaledPart.ContentType, "plain/text")
 	}
+
+	if got := unmarshaledPart.Metadata["signature"]; got == nil {
+		t.Errorf("unmarshaled reasoning part lost its signature, metadata = %v", unmarshaledPart.Metadata)
+	}
+}
+
+func TestReasoningPartWithoutSignature(t *testing.T) {
+	// A part with no signature carries no metadata at all. A metadata map
+	// holding only a nil signature reads as "this part has metadata" to
+	// consumers, which stops adjacent reasoning parts from being merged.
+	p := NewReasoningPart("thinking", nil)
+	if p.Metadata != nil {
+		t.Errorf("Metadata = %v, want nil", p.Metadata)
+	}
+
+	b, err := json.Marshal(p)
+	if err != nil {
+		t.Fatalf("failed to marshal reasoning part: %v", err)
+	}
+	if got, want := string(b), `{"reasoning":"thinking"}`; got != want {
+		t.Errorf("marshaled = %s, want %s", got, want)
+	}
 }
 
 func TestNewDataPart(t *testing.T) {

--- a/go/ai/document_test.go
+++ b/go/ai/document_test.go
@@ -165,6 +165,22 @@ func TestReasoningPartWithoutSignature(t *testing.T) {
 	}
 }
 
+func TestReasoningPartClonesSignature(t *testing.T) {
+	// A caller reusing a buffer across streamed chunks must not be able to
+	// rewrite a signature it has already handed off.
+	buf := []byte("sig123")
+	p := NewReasoningPart("thinking", buf)
+	copy(buf, "XXXXXX")
+
+	got, ok := p.Metadata["signature"].([]byte)
+	if !ok {
+		t.Fatalf("signature = %#v, want []byte", p.Metadata["signature"])
+	}
+	if string(got) != "sig123" {
+		t.Errorf("signature = %q, want %q: the caller's buffer is aliased", got, "sig123")
+	}
+}
+
 func TestEmptyReasoningPartRoundTrip(t *testing.T) {
 	// The reasoning key marks the kind, so it has to survive an empty text:
 	// dropping it turns the part into an empty text part on the way back, and

--- a/go/ai/gen.go
+++ b/go/ai/gen.go
@@ -445,7 +445,7 @@ type reasoningPart struct {
 	// Metadata contains arbitrary key-value data for this part.
 	Metadata map[string]any `json:"metadata,omitempty"`
 	// Reasoning contains the reasoning text of the message.
-	Reasoning string `json:"reasoning,omitempty"`
+	Reasoning string `json:"reasoning"`
 }
 
 // RerankerRequest represents a request to rerank documents based on relevance.

--- a/go/core/schemas.config
+++ b/go/core/schemas.config
@@ -1053,6 +1053,7 @@ ReasoningPart.toolResponse                      omit
 ReasoningPart.custom                            omit
 ReasoningPart.metadata                          type map[string]any
 ReasoningPart.resource                          omit
+ReasoningPart.reasoning                         noomitempty
 
 CustomPart                                      pkg ai
 CustomPart                                      name customPart


### PR DESCRIPTION
Fixes two defects that keep reasoning parts from surviving the wire.

`NewReasoningPart` stamped a metadata map holding a nil signature onto every part, so a signature-less part still reported that it had metadata. Consumers read that as "this part is distinct" and stop merging it with its neighbors, so the Dev UI shows one collapsed Reasoning box per streamed thought chunk instead of one for the whole thought. The map is now carried only when there is a signature.

`reasoning` also carried `omitempty`, so a reasoning part with empty text serialized without the key and came back as an empty text part: invisible in the Dev UI, and resent to the model as plain text on the next turn. The shared schema lists it as required. Dropped through the generator config, with unmarshal keying on the field being present rather than non-empty.
