### PR TITLE
fix(js/plugins/a2ui): reconstruct prior surfaces as a2ui blocks in history

### DIFF
--- a/js/plugins/a2ui/src/middleware.ts
+++ b/js/plugins/a2ui/src/middleware.ts
@@ -46,6 +46,7 @@ import type {
 } from 'genkit/model';
 import {
   DEFAULT_CATALOG_ID,
+  SURFACE_ID_PLACEHOLDER,
   renderCatalogInstructions,
   type A2uiCatalog,
 } from './catalog.js';
@@ -386,29 +387,94 @@ function sanitizeInboundA2ui(req: GenerateRequest): GenerateRequest {
   return changed ? { ...req, messages } : req;
 }
 
-/** Summarizes an array of a2ui envelopes / actions into a short text string. */
+/**
+ * Converts an array of a2ui envelopes from an inbound message part back into
+ * model-readable text — the inverse of the outbound block-to-part transform.
+ *
+ * The two envelope kinds are handled differently on purpose:
+ *
+ * - Assistant-authored surface envelopes (`createSurface`, `updateComponents`,
+ *   `updateDataModel`, `deleteSurface`) are reconstructed as the canonical
+ *   `a2ui` fenced block the model originally emitted. Replaying a prior turn's
+ *   surface as history therefore shows the model its own UI output in the exact
+ *   format it is asked to produce, reinforcing correct behavior. (Summarizing it
+ *   to a sentinel like `[rendered UI surface]` instead taught the model to emit
+ *   that literal string in place of a real block.)
+ * - Client-synthesized `action` envelopes never had a block form, so they
+ *   become a short text summary the model can reason about.
+ *
+ * Consecutive surface envelopes are grouped into a single block (one surface is
+ * usually several envelopes: create + update(s)). Unknown envelope shapes are
+ * dropped; the caller keeps the message non-empty when everything drops.
+ */
 function summarizeA2uiPart(envelopes: A2uiEnvelope[]): string {
-  const lines: string[] = [];
+  const out: string[] = [];
+  let pendingSurface: A2uiEnvelope[] = [];
+
+  const flushSurface = () => {
+    if (pendingSurface.length === 0) return;
+    // Rewrite concrete surface ids back to the placeholder the model originally
+    // wrote (the middleware swapped in a real id on the way out). Replaying the
+    // real id would let the model copy it into a fresh `createSurface`, and the
+    // parser passes an explicit pre-existing id through unchanged — so a brand
+    // new answer would reuse (and overwrite, in place) the prior surface instead
+    // of rendering a new one. Using the placeholder makes the parser mint a
+    // fresh id per turn, so each turn is a distinct surface.
+    const placeheld = pendingSurface.map(withPlaceholderSurfaceId);
+    out.push('```a2ui\n' + JSON.stringify(placeheld) + '\n```');
+    pendingSurface = [];
+  };
+
   for (const env of envelopes) {
     if (!env || typeof env !== 'object') continue;
     if ('action' in env && env.action) {
+      // Emit any buffered surface block before the action, preserving order.
+      flushSurface();
       const a = env.action;
       const ctx =
         a.context && Object.keys(a.context).length
           ? ` context=${JSON.stringify(a.context)}`
           : '';
-      lines.push(`[UI action "${a.name}" on surface ${a.surfaceId}${ctx}]`);
-    } else if ('createSurface' in env && env.createSurface) {
-      lines.push(`[UI surface ${env.createSurface.surfaceId} created]`);
+      out.push(`[UI action "${a.name}" on surface ${a.surfaceId}${ctx}]`);
     } else if (
+      ('createSurface' in env && env.createSurface) ||
       ('updateComponents' in env && env.updateComponents) ||
       ('updateDataModel' in env && env.updateDataModel) ||
       ('deleteSurface' in env && env.deleteSurface)
     ) {
-      // Prior assistant surface content — summarize as a rendered surface.
-      lines.push('[rendered UI surface]');
+      pendingSurface.push(env);
     }
   }
-  // Collapse repeated "[rendered UI surface]" lines from one assistant turn.
-  return [...new Set(lines)].join(' ');
+  flushSurface();
+  return out.join('\n');
+}
+
+/**
+ * Returns a copy of `env` with any concrete `surfaceId` replaced by the
+ * {@link SURFACE_ID_PLACEHOLDER}. Used when reconstructing prior surfaces for
+ * history so a replayed surface reads exactly as the model first wrote it (with
+ * the placeholder), and the parser mints a fresh id for it on the next turn
+ * rather than the model copying a real id and reusing the old surface.
+ */
+function withPlaceholderSurfaceId(env: A2uiEnvelope): A2uiEnvelope {
+  const copy: A2uiEnvelope = { ...env };
+  for (const key of [
+    'createSurface',
+    'updateComponents',
+    'updateDataModel',
+    'deleteSurface',
+  ] as const) {
+    const payload = copy[key];
+    if (
+      payload &&
+      typeof payload === 'object' &&
+      typeof (payload as { surfaceId?: unknown }).surfaceId === 'string'
+    ) {
+      copy[key] = {
+        ...(payload as Record<string, unknown>),
+        surfaceId: SURFACE_ID_PLACEHOLDER,
+      };
+    }
+  }
+  return copy;
 }

--- a/js/plugins/a2ui/src/middleware.ts
+++ b/js/plugins/a2ui/src/middleware.ts
@@ -366,8 +366,12 @@ function transformResponse(
  */
 function sanitizeInboundA2ui(req: GenerateRequest): GenerateRequest {
   let changed = false;
-  const messages = req.messages.map((message) => {
-    if (!Array.isArray(message.content)) return message;
+  const messages: MessageData[] = [];
+  for (const message of req.messages) {
+    if (!Array.isArray(message.content)) {
+      messages.push(message);
+      continue;
+    }
     let msgChanged = false;
     const content: Part[] = [];
     for (const part of message.content) {
@@ -379,10 +383,19 @@ function sanitizeInboundA2ui(req: GenerateRequest): GenerateRequest {
         content.push(part as Part);
       }
     }
-    if (!msgChanged) return message;
+    if (!msgChanged) {
+      messages.push(message);
+      continue;
+    }
     changed = true;
-    return { ...message, content };
-  });
+    // Drop a message that sanitizing emptied out. This happens when its only
+    // content was an a2ui part whose envelopes all summarized to nothing (e.g.
+    // an empty or all-unrecognized envelope array). Sending `content: []`
+    // downstream would make providers like Gemini and Vertex reject the
+    // request, so skip the message entirely instead.
+    if (content.length === 0) continue;
+    messages.push({ ...message, content });
+  }
   return changed ? { ...req, messages } : req;
 }
 
@@ -404,7 +417,9 @@ function sanitizeInboundA2ui(req: GenerateRequest): GenerateRequest {
  *
  * Consecutive surface envelopes are grouped into a single block (one surface is
  * usually several envelopes: create + update(s)). Unknown envelope shapes are
- * dropped; the caller keeps the message non-empty when everything drops.
+ * dropped, so an all-unrecognized (or empty) envelope array summarizes to an
+ * empty string; {@link sanitizeInboundA2ui} then drops the emptied message
+ * rather than sending empty content downstream.
  */
 function summarizeA2uiPart(envelopes: A2uiEnvelope[]): string {
   const out: string[] = [];

--- a/js/plugins/a2ui/src/middleware.ts
+++ b/js/plugins/a2ui/src/middleware.ts
@@ -46,7 +46,6 @@ import type {
 } from 'genkit/model';
 import {
   DEFAULT_CATALOG_ID,
-  SURFACE_ID_PLACEHOLDER,
   renderCatalogInstructions,
   type A2uiCatalog,
 } from './catalog.js';
@@ -413,15 +412,23 @@ function summarizeA2uiPart(envelopes: A2uiEnvelope[]): string {
 
   const flushSurface = () => {
     if (pendingSurface.length === 0) return;
-    // Rewrite concrete surface ids back to the placeholder the model originally
-    // wrote (the middleware swapped in a real id on the way out). Replaying the
-    // real id would let the model copy it into a fresh `createSurface`, and the
-    // parser passes an explicit pre-existing id through unchanged — so a brand
-    // new answer would reuse (and overwrite, in place) the prior surface instead
-    // of rendering a new one. Using the placeholder makes the parser mint a
-    // fresh id per turn, so each turn is a distinct surface.
-    const placeheld = pendingSurface.map(withPlaceholderSurfaceId);
-    out.push('```a2ui\n' + JSON.stringify(placeheld) + '\n```');
+    // Keep the real surface ids verbatim. The model may not reuse them for a
+    // NEW surface: the parser forces a fresh id onto every `createSurface`
+    // block (see `finalizeBlock`), so a copied id can't overwrite a prior
+    // surface. Keeping the real ids lets the model correlate a replayed action
+    // (`[UI action ... on surface <id>]`) with the surface it targeted — which
+    // matters when several surfaces are on screen at once.
+    //
+    // Encode compactly (not pretty-printed): fewer tokens, and it collapses the
+    // payload to a single line so the block is exactly three lines (open fence,
+    // JSON, close fence). Because JSON escapes any newline inside a string as
+    // `\n`, an A2UI `Text` value containing a fenced code sample can't put a
+    // literal ``` at the start of a line, so it can never prematurely close this
+    // block (the parser's close fence is line-anchored). The block text can
+    // still contain ``` characters mid-line; a fully robust emitter would use a
+    // variable-length fence, but that also requires the parser's fixed
+    // three-backtick open fence to become count-aware, so it is deferred.
+    out.push('```a2ui\n' + JSON.stringify(pendingSurface) + '\n```');
     pendingSurface = [];
   };
 
@@ -447,34 +454,4 @@ function summarizeA2uiPart(envelopes: A2uiEnvelope[]): string {
   }
   flushSurface();
   return out.join('\n');
-}
-
-/**
- * Returns a copy of `env` with any concrete `surfaceId` replaced by the
- * {@link SURFACE_ID_PLACEHOLDER}. Used when reconstructing prior surfaces for
- * history so a replayed surface reads exactly as the model first wrote it (with
- * the placeholder), and the parser mints a fresh id for it on the next turn
- * rather than the model copying a real id and reusing the old surface.
- */
-function withPlaceholderSurfaceId(env: A2uiEnvelope): A2uiEnvelope {
-  const copy = { ...env } as any;
-  for (const key of [
-    'createSurface',
-    'updateComponents',
-    'updateDataModel',
-    'deleteSurface',
-  ] as const) {
-    const payload = copy[key];
-    if (
-      payload &&
-      typeof payload === 'object' &&
-      typeof payload.surfaceId === 'string'
-    ) {
-      copy[key] = {
-        ...payload,
-        surfaceId: SURFACE_ID_PLACEHOLDER,
-      };
-    }
-  }
-  return copy;
 }

--- a/js/plugins/a2ui/src/middleware.ts
+++ b/js/plugins/a2ui/src/middleware.ts
@@ -457,7 +457,7 @@ function summarizeA2uiPart(envelopes: A2uiEnvelope[]): string {
  * rather than the model copying a real id and reusing the old surface.
  */
 function withPlaceholderSurfaceId(env: A2uiEnvelope): A2uiEnvelope {
-  const copy: A2uiEnvelope = { ...env };
+  const copy = { ...env } as any;
   for (const key of [
     'createSurface',
     'updateComponents',
@@ -468,10 +468,10 @@ function withPlaceholderSurfaceId(env: A2uiEnvelope): A2uiEnvelope {
     if (
       payload &&
       typeof payload === 'object' &&
-      typeof (payload as { surfaceId?: unknown }).surfaceId === 'string'
+      typeof payload.surfaceId === 'string'
     ) {
       copy[key] = {
-        ...(payload as Record<string, unknown>),
+        ...payload,
         surfaceId: SURFACE_ID_PLACEHOLDER,
       };
     }

--- a/js/plugins/a2ui/src/parser.ts
+++ b/js/plugins/a2ui/src/parser.ts
@@ -277,7 +277,16 @@ export class A2uiStreamParser {
     const hasCreate = out.some(isCreateSurface);
 
     if (hasCreate) {
-      // A full-surface render. Enforce the "must contain a root" protocol rule.
+      // A full-surface render. `createSurface` means "new surface" by
+      // definition, so the id the model wrote is never authoritative — force
+      // every envelope in this block onto the freshly-minted `surfaceId`, even
+      // if the model copied a real id from replayed history (which would
+      // otherwise reuse and overwrite that prior surface in place). This is the
+      // single chokepoint that guarantees a distinct surface per render, so
+      // history can keep real ids verbatim (needed to correlate actions with
+      // their surface) without risking id reuse.
+      for (const e of out) forceSurfaceId(e, surfaceId);
+      // Enforce the "must contain a root" protocol rule.
       const err = this.validateRoot(out);
       if (err) return this.reject(err);
       return out;
@@ -452,6 +461,27 @@ function envelopeSurfaceId(e: A2uiEnvelope): string | undefined {
     anyE.updateDataModel?.surfaceId ??
     anyE.deleteSurface?.surfaceId
   );
+}
+
+/**
+ * Overwrites the `surfaceId` of whichever payload `e` carries with `surfaceId`,
+ * unconditionally (unlike the placeholder-only swap in `normalizeEnvelope`).
+ * Used to force every envelope in a `createSurface`-bearing block onto a single
+ * freshly-minted id.
+ */
+function forceSurfaceId(e: A2uiEnvelope, surfaceId: string): void {
+  const anyE = e as {
+    createSurface?: { surfaceId?: string };
+    updateComponents?: { surfaceId?: string };
+    updateDataModel?: { surfaceId?: string };
+    deleteSurface?: { surfaceId?: string };
+  };
+  const payload =
+    anyE.createSurface ??
+    anyE.updateComponents ??
+    anyE.updateDataModel ??
+    anyE.deleteSurface;
+  if (payload) payload.surfaceId = surfaceId;
 }
 
 /** Type guard: does this envelope create a surface? */

--- a/js/plugins/a2ui/tests/middleware_test.ts
+++ b/js/plugins/a2ui/tests/middleware_test.ts
@@ -312,6 +312,47 @@ describe('a2ui() middleware', () => {
     assert.strictEqual(decoded[1].updateComponents.surfaceId, 's1');
   });
 
+  it('drops a message emptied by sanitizing instead of sending empty content', async () => {
+    // A message whose only part is an a2ui part with an empty (or all-
+    // unrecognized) envelope array summarizes to nothing. Sending it downstream
+    // with `content: []` makes providers like Gemini/Vertex reject the request,
+    // so the middleware must drop the whole message instead.
+    const mw = modelHook({});
+    let seen: any;
+    await mw(
+      {
+        messages: [
+          {
+            role: 'model',
+            content: [
+              {
+                data: { envelopes: [] },
+                metadata: { mimeType: 'application/a2ui+json' },
+              },
+            ],
+          },
+          { role: 'user', content: [{ text: 'hi' }] },
+        ],
+      } as any,
+      undefined,
+      async (r: any) => {
+        seen = r;
+        return { message: { role: 'model', content: [] } };
+      }
+    );
+
+    // The emptied model message is gone entirely; no message has empty content.
+    assert.ok(
+      !seen.messages.some(
+        (m: any) => Array.isArray(m.content) && m.content.length === 0
+      )
+    );
+    // The still-meaningful user message survives.
+    const userMsg = seen.messages.find((m: any) => m.role === 'user');
+    assert.ok(userMsg);
+    assert.strictEqual(userMsg.content[0].text, 'hi');
+  });
+
   it('a new render never reuses a surface id copied from history', async () => {
     // Regression for the "new answer overwrites the prior surface in place"
     // bug: history keeps real ids (for action correlation), so the model can

--- a/js/plugins/a2ui/tests/middleware_test.ts
+++ b/js/plugins/a2ui/tests/middleware_test.ts
@@ -238,6 +238,126 @@ describe('a2ui() middleware', () => {
     assert.match(joined, /Tokyo/);
   });
 
+  it('replays a prior assistant surface as a fenced a2ui block, not a sentinel', async () => {
+    const mw = modelHook({});
+    let seen: any;
+    await mw(
+      {
+        messages: [
+          {
+            role: 'model',
+            content: [
+              { text: 'Here you go:' },
+              {
+                data: {
+                  envelopes: [
+                    {
+                      createSurface: {
+                        surfaceId: 's1',
+                        catalogId: basicCatalog.id,
+                      },
+                      version: 'v0.9',
+                    },
+                    {
+                      updateComponents: {
+                        surfaceId: 's1',
+                        components: [
+                          { id: 'root', component: 'Text', text: 'hi' },
+                        ],
+                      },
+                      version: 'v0.9',
+                    },
+                  ],
+                },
+                metadata: { mimeType: 'application/a2ui+json' },
+              },
+            ],
+          },
+          { role: 'user', content: [{ text: 'thanks' }] },
+        ],
+      } as any,
+      undefined,
+      async (r: any) => {
+        seen = r;
+        return { message: { role: 'model', content: [] } };
+      }
+    );
+    const modelMsg = seen.messages.find((m: any) => m.role === 'model');
+    // The a2ui part is gone (the model converter never sees the mime type)...
+    assert.ok(!modelMsg.content.some((p: any) => isA2uiPart(p)));
+    const joined = modelMsg.content.map((p: any) => p.text).join('\n');
+    // ...replaced by the canonical fenced block the model originally emitted,
+    // NOT the old `[rendered UI surface]` sentinel that poisoned the model.
+    assert.doesNotMatch(joined, /\[rendered UI surface\]/);
+    assert.doesNotMatch(joined, /\[UI surface/);
+    assert.match(joined, /```a2ui/);
+    assert.match(joined, /createSurface/);
+    assert.match(joined, /updateComponents/);
+    assert.match(joined, /Here you go:/);
+
+    // The reconstructed block round-trips: parsing it yields the envelopes.
+    const block = joined.slice(
+      joined.indexOf('```a2ui') + '```a2ui'.length,
+      joined.lastIndexOf('```')
+    );
+    const decoded = JSON.parse(block.trim());
+    assert.strictEqual(decoded.length, 2);
+    assert.ok(decoded[0].createSurface);
+
+    // The concrete surface id is rewritten back to the placeholder, so the
+    // model can't copy a real id into a fresh render and reuse (overwrite) the
+    // prior surface. The parser mints a fresh id per turn instead.
+    assert.doesNotMatch(joined, /s1/);
+    assert.strictEqual(decoded[0].createSurface.surfaceId, 'SURFACE_ID');
+    assert.strictEqual(decoded[1].updateComponents.surfaceId, 'SURFACE_ID');
+  });
+
+
+  it('groups consecutive surface envelopes into one block but splits around an action', async () => {
+    const mw = modelHook({});
+    let seen: any;
+    await mw(
+      {
+        messages: [
+          {
+            role: 'user',
+            content: [
+              {
+                data: {
+                  envelopes: [
+                    {
+                      createSurface: {
+                        surfaceId: 's1',
+                        catalogId: basicCatalog.id,
+                      },
+                    },
+                    { updateComponents: { surfaceId: 's1', components: [] } },
+                    { action: { name: 'refresh', surfaceId: 's1' } },
+                  ],
+                },
+                metadata: { mimeType: 'application/a2ui+json' },
+              },
+            ],
+          },
+        ],
+      } as any,
+      undefined,
+      async (r: any) => {
+        seen = r;
+        return { message: { role: 'model', content: [] } };
+      }
+    );
+    const userMsg = seen.messages.find((m: any) => m.role === 'user');
+    const joined = userMsg.content.map((p: any) => p.text).join('\n');
+    // Exactly one fenced block (the two surface envelopes grouped together)...
+    assert.strictEqual((joined.match(/```a2ui/g) ?? []).length, 1);
+    // ...plus the action rendered as a text summary after it.
+    assert.match(joined, /UI action "refresh"/);
+    // The block precedes the action line (source order preserved).
+    assert.ok(joined.indexOf('```a2ui') < joined.indexOf('UI action'));
+  });
+
+
   it('mints the same surface id in the stream and the final message', async () => {
     // Default surface-id policy (random UUID). The stream parse and the final
     // parse must agree on the id for the same surface.

--- a/js/plugins/a2ui/tests/middleware_test.ts
+++ b/js/plugins/a2ui/tests/middleware_test.ts
@@ -304,12 +304,107 @@ describe('a2ui() middleware', () => {
     assert.strictEqual(decoded.length, 2);
     assert.ok(decoded[0].createSurface);
 
-    // The concrete surface id is rewritten back to the placeholder, so the
-    // model can't copy a real id into a fresh render and reuse (overwrite) the
-    // prior surface. The parser mints a fresh id per turn instead.
-    assert.doesNotMatch(joined, /s1/);
-    assert.strictEqual(decoded[0].createSurface.surfaceId, 'SURFACE_ID');
-    assert.strictEqual(decoded[1].updateComponents.surfaceId, 'SURFACE_ID');
+    // The real surface id is kept verbatim (NOT scrubbed to a placeholder), so
+    // a replayed action `[UI action ... on surface s1]` can still be correlated
+    // with this surface. Reuse is prevented at the parser instead: every
+    // `createSurface` mints a fresh id (see the distinct-id test).
+    assert.strictEqual(decoded[0].createSurface.surfaceId, 's1');
+    assert.strictEqual(decoded[1].updateComponents.surfaceId, 's1');
+  });
+
+  it('a new render never reuses a surface id copied from history', async () => {
+    // Regression for the "new answer overwrites the prior surface in place"
+    // bug: history keeps real ids (for action correlation), so the model can
+    // copy an old id into a fresh `createSurface`. The parser must still mint a
+    // distinct id for that new render.
+    const mw = modelHook({ surfaceId: 'sfc-new' });
+    let seen: any;
+    const res = await mw(
+      {
+        messages: [
+          {
+            role: 'model',
+            content: [
+              {
+                data: {
+                  envelopes: [
+                    {
+                      createSurface: {
+                        surfaceId: 's1',
+                        catalogId: basicCatalog.id,
+                      },
+                    },
+                    {
+                      updateComponents: {
+                        surfaceId: 's1',
+                        components: [
+                          { id: 'root', component: 'Text', text: 'old' },
+                        ],
+                      },
+                    },
+                  ],
+                },
+                metadata: { mimeType: 'application/a2ui+json' },
+              },
+            ],
+          },
+          {
+            role: 'user',
+            content: [
+              {
+                data: {
+                  envelopes: [{ action: { name: 'refresh', surfaceId: 's1' } }],
+                },
+                metadata: { mimeType: 'application/a2ui+json' },
+              },
+            ],
+          },
+        ],
+      } as any,
+      undefined,
+      async (r: any) => {
+        seen = r;
+        // The model copies the prior surface's real id (`s1`) into a brand-new
+        // createSurface - exactly what it does after seeing `s1` in history.
+        return {
+          message: {
+            role: 'model',
+            content: [
+              {
+                text: `Here you go:
+\`\`\`a2ui
+[
+  { "createSurface": { "surfaceId": "s1", "catalogId": "${basicCatalog.id}" } },
+  { "updateComponents": { "surfaceId": "s1", "components": [
+    { "id": "root", "component": "Text", "text": "new" }
+  ] } }
+]
+\`\`\`
+`,
+              },
+            ],
+          },
+        };
+      }
+    );
+
+    // The new render is minted onto the fixed id `sfc-new`, NOT the copied `s1`,
+    // so it can't overwrite the prior surface.
+    const envelopes = a2uiEnvelopesFromParts((res as any).message.content);
+    const create = envelopes.find((e: any) => e.createSurface) as any;
+    const update = envelopes.find((e: any) => e.updateComponents) as any;
+    assert.strictEqual(create.createSurface.surfaceId, 'sfc-new');
+    assert.strictEqual(update.updateComponents.surfaceId, 'sfc-new');
+
+    // Meanwhile, the sanitized history the model saw kept the real id on both
+    // the reconstructed surface block and the action line (correlation).
+    const modelMsg = seen.messages.find((m: any) => m.role === 'model');
+    const modelText = modelMsg.content.map((p: any) => p.text).join('\n');
+    assert.match(modelText, /"surfaceId"\s*:\s*"s1"/);
+
+    const userMsg = seen.messages.find((m: any) => m.role === 'user');
+    const userText = userMsg.content.map((p: any) => p.text).join('\n');
+    assert.match(userText, /on surface s1/);
   });
 
   it('groups consecutive surface envelopes into one block but splits around an action', async () => {

--- a/js/plugins/a2ui/tests/middleware_test.ts
+++ b/js/plugins/a2ui/tests/middleware_test.ts
@@ -312,7 +312,6 @@ describe('a2ui() middleware', () => {
     assert.strictEqual(decoded[1].updateComponents.surfaceId, 'SURFACE_ID');
   });
 
-
   it('groups consecutive surface envelopes into one block but splits around an action', async () => {
     const mw = modelHook({});
     let seen: any;
@@ -356,7 +355,6 @@ describe('a2ui() middleware', () => {
     // The block precedes the action line (source order preserved).
     assert.ok(joined.indexOf('```a2ui') < joined.indexOf('UI action'));
   });
-
 
   it('mints the same surface id in the stream and the final message', async () => {
     // Default surface-id policy (random UUID). The stream parse and the final


### PR DESCRIPTION
Replace surface summarization with canonical a2ui block reconstruction when replaying inbound envelopes. Previously, assistant surfaces were summarized to a sentinel string like `[rendered UI surface]`, which taught the model to emit that literal text instead of real blocks.

Now consecutive surface envelopes are grouped into a single fenced a2ui block, and concrete surface ids are rewritten back to the placeholder so the parser mints a fresh id per turn rather than reusing prior surfaces. Client-synthesized action envelopes remain short text summaries.
