### PR TITLE
chore(py): clear upgrade message for Python <= 3.9 installs instead of resolving a pre-transfer package

### DIFF
--- a/.github/workflows/publish_python.yml
+++ b/.github/workflows/publish_python.yml
@@ -84,6 +84,20 @@ jobs:
             echo "::endgroup::"
           done
 
+          # Python-floor shim (genkit 0.2.1): gives Python <= 3.9 users a clear
+          # upgrade message instead of resolving an unrelated pre-transfer
+          # package. sdist ONLY - a wheel would install as an empty package on
+          # old Pythons. skip-existing makes this a no-op after first publish.
+          # See py/floor-shim/README.md.
+          echo "::group::py/floor-shim (sdist only)"
+          if uv build --sdist py/floor-shim --out-dir dist/; then
+            echo "Build succeeded: py/floor-shim"
+          else
+            echo "::error::Build failed: py/floor-shim"
+            FAILED+=("py/floor-shim")
+          fi
+          echo "::endgroup::"
+
           if [ ${#FAILED[@]} -gt 0 ]; then
             echo "::error::Failed packages: ${FAILED[*]}"
             exit 1

--- a/.github/workflows/publish_python.yml
+++ b/.github/workflows/publish_python.yml
@@ -84,7 +84,7 @@ jobs:
             echo "::endgroup::"
           done
 
-          # Python-floor shim (genkit 0.2.1): gives Python <= 3.9 users a clear
+          # Python-floor shim (genkit 0.3.0): gives Python <= 3.9 users a clear
           # upgrade message instead of resolving an unrelated pre-transfer
           # package. sdist ONLY - a wheel would install as an empty package on
           # old Pythons. skip-existing makes this a no-op after first publish.

--- a/py/floor-shim/.gitignore
+++ b/py/floor-shim/.gitignore
@@ -1,0 +1,2 @@
+genkit.egg-info/
+dist/

--- a/py/floor-shim/README.md
+++ b/py/floor-shim/README.md
@@ -1,6 +1,6 @@
 # genkit Python-floor shim
 
-A one-time PyPI release (`genkit 0.2.1`, sdist only) that turns the
+A one-time PyPI release (`genkit 0.3.0`, sdist only) that turns the
 old-Python install experience from a silent wrong install into a clear
 upgrade message.
 
@@ -18,15 +18,16 @@ because those pre-transfer releases (0.1.0–0.2.0) declare
 - The shim declares `Requires-Python: <3.10`, so Python >= 3.10 can
   never select it. Fresh installs on current Pythons keep getting the
   real latest genkit.
-- On Python <= 3.9, version 0.2.1 outranks the pre-transfer 0.2.0, pip
+- On Python <= 3.9, version 0.3.0 outranks the pre-transfer 0.2.0, pip
   tries to build the sdist, and `setup.py` stops with a boxed message:
   the 3.10 requirement plus Homebrew / uv / python.org instructions.
 - It is published as an **sdist only**. A wheel would install cleanly as
   an empty package on old Pythons — exactly the silent failure this
   prevents. Keep the `--sdist` flag in `publish_python.yml`.
 
-The version never changes: it must stay above 0.2.0 (the last
-pre-transfer release) and below 0.3.x (the first real genkit release).
+The version never changes: 0.3.0 was never published (the history goes
+0.3.0.dev2 -> 0.3.1), and it sits above 0.2.0 (the last pre-transfer
+release) and below 0.3.1 (the first real genkit release).
 `skip-existing: true` in the publish workflow makes re-publishing it on
 every release tag a no-op after the first upload.
 

--- a/py/floor-shim/README.md
+++ b/py/floor-shim/README.md
@@ -19,8 +19,12 @@ because those pre-transfer releases (0.1.0–0.2.0) declare
   never select it. Fresh installs on current Pythons keep getting the
   real latest genkit.
 - On Python <= 3.9, version 0.3.0 outranks the pre-transfer 0.2.0, pip
-  tries to build the sdist, and `setup.py` stops with a boxed message:
-  the 3.10 requirement plus Homebrew / uv / python.org instructions.
+  commits to it, and `setup.py` fails the **install phase** with a boxed
+  message: the 3.10 requirement plus Homebrew / uv / python.org
+  instructions. The failure must stay out of the metadata phase
+  (`egg_info`/`dist_info`/`sdist` succeed on purpose): old pip treats a
+  metadata failure as a discardable candidate and backtracks to the
+  pre-transfer 0.2.0 with exit 0 — the silent wrong install again.
 - It is published as an **sdist only**. A wheel would install cleanly as
   an empty package on old Pythons — exactly the silent failure this
   prevents. Keep the `--sdist` flag in `publish_python.yml`.
@@ -45,11 +49,25 @@ uv build --sdist py/floor-shim --out-dir /tmp/shim-dist
 /usr/bin/python3 -m venv /tmp/v39 && /tmp/v39/bin/pip install --no-index \
   --find-links /tmp/shim-dist genkit
 
+# The load-bearing case — a competing old release is visible (stands in for
+# the pre-transfer 0.2.0). Expected: exit != 0, boxed message, and NOTHING
+# installed. If genkit 0.2.0 gets installed instead, the shim is failing at
+# the metadata phase and old pip is backtracking past it:
+mkdir -p /tmp/sq && printf 'from setuptools import setup\nsetup(name="genkit", version="0.2.0", python_requires=">=3.6")\n' > /tmp/sq/setup.py
+uv build --wheel /tmp/sq --out-dir /tmp/shim-dist
+/usr/bin/python3 -m venv /tmp/v39b && /tmp/v39b/bin/pip install --no-index \
+  --find-links /tmp/shim-dist genkit; /tmp/v39b/bin/pip show genkit
+
 # Current Python ignores the shim even when visible (expected: installs real genkit):
 python3.13 -m venv /tmp/v313 && /tmp/v313/bin/pip install \
   --find-links /tmp/shim-dist genkit
 ```
 
-Related cleanup: the pre-transfer releases 0.1.0, 0.1.3, 0.1.4, and
-0.2.0 should be yanked on pypi.org so pinned installs are the only way
-to reach them.
+## Required companion step: yank the pre-transfer releases
+
+Yank 0.1.0, 0.1.3, 0.1.4, and 0.2.0 on pypi.org **before or together
+with** the first shim publish. This is a precondition, not optional
+cleanup: those releases are the fallback candidates old pip reaches for
+whenever it decides to skip the shim, and yanking is what makes the
+wrong package unreachable for every resolver generation. After the
+yank, pinned installs (`genkit==0.2.0`) are the only way to reach them.

--- a/py/floor-shim/README.md
+++ b/py/floor-shim/README.md
@@ -1,0 +1,54 @@
+# genkit Python-floor shim
+
+A one-time PyPI release (`genkit 0.2.1`, sdist only) that turns the
+old-Python install experience from a silent wrong install into a clear
+upgrade message.
+
+## Why it exists
+
+Genkit requires Python >= 3.10, but macOS ships Python 3.9 at
+`/usr/bin/python3`. On that interpreter, `pip install genkit` used to
+resolve `genkit 0.2.0` — an unrelated package from before the PyPI name
+was transferred to this project ("random data like phone numbers") —
+because those pre-transfer releases (0.1.0–0.2.0) declare
+`Requires-Python: >=3.6` and pip silently falls back to them.
+
+## How it works
+
+- The shim declares `Requires-Python: <3.10`, so Python >= 3.10 can
+  never select it. Fresh installs on current Pythons keep getting the
+  real latest genkit.
+- On Python <= 3.9, version 0.2.1 outranks the pre-transfer 0.2.0, pip
+  tries to build the sdist, and `setup.py` stops with a boxed message:
+  the 3.10 requirement plus Homebrew / uv / python.org instructions.
+- It is published as an **sdist only**. A wheel would install cleanly as
+  an empty package on old Pythons — exactly the silent failure this
+  prevents. Keep the `--sdist` flag in `publish_python.yml`.
+
+The version never changes: it must stay above 0.2.0 (the last
+pre-transfer release) and below 0.3.x (the first real genkit release).
+`skip-existing: true` in the publish workflow makes re-publishing it on
+every release tag a no-op after the first upload.
+
+This directory is intentionally not a uv workspace member: it shares the
+`genkit` project name with `packages/genkit`, and workspace project
+names must be unique.
+
+## Verifying
+
+```bash
+# Build (any Python >= 3.10):
+uv build --sdist py/floor-shim --out-dir /tmp/shim-dist
+
+# Old Python shows the boxed message (expected: install fails with instructions):
+/usr/bin/python3 -m venv /tmp/v39 && /tmp/v39/bin/pip install --no-index \
+  --find-links /tmp/shim-dist genkit
+
+# Current Python ignores the shim even when visible (expected: installs real genkit):
+python3.13 -m venv /tmp/v313 && /tmp/v313/bin/pip install \
+  --find-links /tmp/shim-dist genkit
+```
+
+Related cleanup: the pre-transfer releases 0.1.0, 0.1.3, 0.1.4, and
+0.2.0 should be yanked on pypi.org so pinned installs are the only way
+to reach them.

--- a/py/floor-shim/README.md
+++ b/py/floor-shim/README.md
@@ -20,7 +20,7 @@ because those pre-transfer releases (0.1.0–0.2.0) declare
   real latest genkit.
 - On Python <= 3.9, version 0.3.0 outranks the pre-transfer 0.2.0, pip
   commits to it, and `setup.py` fails the **install phase** with a boxed
-  message: the 3.10 requirement plus Homebrew / uv / python.org
+  message: the 3.10 requirement plus uv / Homebrew / python.org
   instructions. The failure must stay out of the metadata phase
   (`egg_info`/`dist_info`/`sdist` succeed on purpose): old pip treats a
   metadata failure as a discardable candidate and backtracks to the

--- a/py/floor-shim/README.md
+++ b/py/floor-shim/README.md
@@ -28,6 +28,11 @@ because those pre-transfer releases (0.1.0–0.2.0) declare
 - It is published as an **sdist only**. A wheel would install cleanly as
   an empty package on old Pythons — exactly the silent failure this
   prevents. Keep the `--sdist` flag in `publish_python.yml`.
+- The boxed message is for `pip install genkit` and
+  `uv pip install genkit`. A second name on the same line
+  (`pip install genkit genkit-google-genai`) fails in the resolver on
+  that plugin's `Requires-Python: >=3.10` and never reaches this
+  `setup.py`.
 
 The version never changes: 0.3.0 was never published (the history goes
 0.3.0.dev2 -> 0.3.1), and it sits above 0.2.0 (the last pre-transfer

--- a/py/floor-shim/setup.py
+++ b/py/floor-shim/setup.py
@@ -26,9 +26,10 @@ instead of a resolver error.
 
 Publish as sdist ONLY (`uv build --sdist`). A wheel would install
 "successfully" as an empty package on old Pythons, which is the silent
-failure this shim exists to prevent. Version 0.2.1 sorts above the
-pre-transfer squatter releases (<= 0.2.0) and below every real genkit
-release (>= 0.3.x); it never needs to change.
+failure this shim exists to prevent. Version 0.3.0 was never published
+(the history goes 0.3.0.dev2 -> 0.3.1), so the shim fills that hole:
+above the pre-transfer squatter releases (<= 0.2.0), below every real
+genkit release (>= 0.3.1). It never needs to change.
 """
 
 import sys
@@ -66,7 +67,7 @@ from setuptools import setup  # noqa: E402
 
 setup(
     name='genkit',
-    version='0.2.1',
+    version='0.3.0',
     description=(
         'Genkit requires Python >= 3.10. This placeholder release exists only '
         'to give older interpreters a clear upgrade message.'

--- a/py/floor-shim/setup.py
+++ b/py/floor-shim/setup.py
@@ -1,0 +1,87 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Python-floor shim for the `genkit` package on PyPI.
+
+Real genkit releases require Python >= 3.10. On older interpreters
+(like the Python 3.9 that macOS ships), pip either resolves nothing or
+resolves an unrelated pre-transfer package that holds low version
+numbers on PyPI. This sdist declares `Requires-Python: <3.10`, so
+current interpreters can never select it, while old interpreters pick
+it as their best candidate and get a clear how-to-upgrade message
+instead of a resolver error.
+
+Publish as sdist ONLY (`uv build --sdist`). A wheel would install
+"successfully" as an empty package on old Pythons, which is the silent
+failure this shim exists to prevent. Version 0.2.1 sorts above the
+pre-transfer squatter releases (<= 0.2.0) and below every real genkit
+release (>= 0.3.x); it never needs to change.
+"""
+
+import sys
+
+MIN_PYTHON = (3, 10)
+
+if sys.version_info < MIN_PYTHON:
+    sys.exit(
+        '\n'
+        '========================================================================\n'
+        'Genkit requires Python {min}+, but you are running Python {cur}.\n'
+        '\n'
+        'macOS ships an older Python at /usr/bin/python3. To use Genkit,\n'
+        'install a current Python first. Any one of these works:\n'
+        '\n'
+        '  # Homebrew\n'
+        '  brew install python@3.13\n'
+        '  python3.13 -m venv .venv && source .venv/bin/activate\n'
+        '  pip install genkit\n'
+        '\n'
+        '  # uv (recommended - manages Python for you)\n'
+        '  curl -LsSf https://astral.sh/uv/install.sh | sh\n'
+        '  uv init && uv add genkit\n'
+        '\n'
+        '  # Or download an installer from https://www.python.org/downloads/\n'
+        '\n'
+        'Docs: https://genkit.dev/docs/python/get-started/\n'
+        '========================================================================\n'.format(
+            min='.'.join(map(str, MIN_PYTHON)),
+            cur='.'.join(map(str, sys.version_info[:3])),
+        )
+    )
+
+from setuptools import setup  # noqa: E402
+
+setup(
+    name='genkit',
+    version='0.2.1',
+    description=(
+        'Genkit requires Python >= 3.10. This placeholder release exists only '
+        'to give older interpreters a clear upgrade message.'
+    ),
+    long_description=(
+        'Genkit is an open-source framework for building AI-powered '
+        'applications, from Google. It requires Python 3.10 or newer. '
+        'This placeholder release exists only so that installs on older '
+        'Python versions fail with a clear message instead of a resolver '
+        'error. See https://genkit.dev/docs/python/get-started/'
+    ),
+    long_description_content_type='text/plain',
+    url='https://genkit.dev',
+    author='Google',
+    license='Apache-2.0',
+    python_requires='<3.10',
+    py_modules=[],
+)

--- a/py/floor-shim/setup.py
+++ b/py/floor-shim/setup.py
@@ -36,7 +36,15 @@ import sys
 
 MIN_PYTHON = (3, 10)
 
-if sys.version_info < MIN_PYTHON:
+# Fail at the build/install phase, not the metadata phase: old pip (e.g. the
+# 21.2.4 bundled with macOS system Python) treats a metadata-build failure as
+# a discardable candidate and backtracks to the pre-transfer 0.2.0 — the
+# exact silent wrong-install this shim exists to prevent. An install-phase
+# failure is fatal on every pip generation, so the user actually sees the
+# message and nothing gets installed.
+_METADATA_ONLY_COMMANDS = {'egg_info', 'dist_info', 'sdist'}
+
+if sys.version_info < MIN_PYTHON and not _METADATA_ONLY_COMMANDS.intersection(sys.argv[1:]):
     sys.exit(
         '\n'
         '========================================================================\n'
@@ -46,8 +54,8 @@ if sys.version_info < MIN_PYTHON:
         'install a current Python first. Any one of these works:\n'
         '\n'
         '  # Homebrew\n'
-        '  brew install python@3.13\n'
-        '  python3.13 -m venv .venv && source .venv/bin/activate\n'
+        '  brew install python\n'
+        '  python3 -m venv .venv && source .venv/bin/activate\n'
         '  pip install genkit\n'
         '\n'
         '  # uv (recommended - manages Python for you)\n'

--- a/py/floor-shim/setup.py
+++ b/py/floor-shim/setup.py
@@ -44,32 +44,72 @@ MIN_PYTHON = (3, 10)
 # message and nothing gets installed.
 _METADATA_ONLY_COMMANDS = {'egg_info', 'dist_info', 'sdist'}
 
-if sys.version_info < MIN_PYTHON and not _METADATA_ONLY_COMMANDS.intersection(sys.argv[1:]):
-    sys.exit(
+
+def _format_error_message(min_ver: tuple[int, ...], cur_ver: tuple[int, ...]) -> str:
+    min_str = '.'.join(map(str, min_ver))
+    cur_str = '.'.join(map(str, cur_ver[:3]))
+
+    if sys.platform == 'win32':
+        platform_hint = f'Windows requires Python {min_str}+ to run Genkit.'
+        recipes = (
+            '  # Option 1 (Recommended): uv (manages Python versions automatically)\n'
+            '  powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"\n'
+            '  uv init && uv add genkit\n'
+            '\n'
+            f'  # Option 2: Download Python (>= {min_str}) from https://www.python.org/downloads/\n'
+            '  python -m venv .venv && .venv\\Scripts\\pip install genkit'
+        )
+    elif sys.platform == 'darwin':
+        platform_hint = (
+            'macOS ships an older Python at /usr/bin/python3.\n'
+            f'To use Genkit, install Python {min_str}+ using one of the options below:'
+        )
+        recipes = (
+            '  # Option 1 (Recommended): uv (manages Python for you)\n'
+            '  curl -LsSf https://astral.sh/uv/install.sh | sh\n'
+            '  uv init && uv add genkit\n'
+            '\n'
+            '  # Option 2: Homebrew\n'
+            '  brew install python\n'
+            '  python3 -m venv .venv && source .venv/bin/activate\n'
+            '  pip install genkit\n'
+            '\n'
+            '  # Option 3: Download installer from https://www.python.org/downloads/'
+        )
+    else:
+        platform_hint = (
+            f'Your system Python is older than the required Python {min_str}+.\n'
+            f'To use Genkit, install Python {min_str}+ using one of the options below:'
+        )
+        recipes = (
+            '  # Option 1 (Recommended): uv (standalone, no root required)\n'
+            '  curl -LsSf https://astral.sh/uv/install.sh | sh\n'
+            '  uv init && uv add genkit\n'
+            '\n'
+            '  # Option 2: System Package Manager\n'
+            '  sudo apt update && sudo apt install python3 python3-venv\n'
+            '  python3 -m venv .venv && source .venv/bin/activate\n'
+            '  pip install genkit\n'
+            '\n'
+            '  # Option 3: Download installer from https://www.python.org/downloads/'
+        )
+
+    return (
         '\n'
         '========================================================================\n'
-        'Genkit requires Python {min}+, but you are running Python {cur}.\n'
+        f'Genkit requires Python {min_str}+, but you are running Python {cur_str}.\n'
         '\n'
-        'macOS ships an older Python at /usr/bin/python3. To use Genkit,\n'
-        'install a current Python first. Any one of these works:\n'
+        f'{platform_hint}\n'
         '\n'
-        '  # Homebrew\n'
-        '  brew install python\n'
-        '  python3 -m venv .venv && source .venv/bin/activate\n'
-        '  pip install genkit\n'
-        '\n'
-        '  # uv (recommended - manages Python for you)\n'
-        '  curl -LsSf https://astral.sh/uv/install.sh | sh\n'
-        '  uv init && uv add genkit\n'
-        '\n'
-        '  # Or download an installer from https://www.python.org/downloads/\n'
+        f'{recipes}\n'
         '\n'
         'Docs: https://genkit.dev/docs/python/get-started/\n'
-        '========================================================================\n'.format(
-            min='.'.join(map(str, MIN_PYTHON)),
-            cur='.'.join(map(str, sys.version_info[:3])),
-        )
+        '========================================================================\n'
     )
+
+
+if sys.version_info < MIN_PYTHON and not _METADATA_ONLY_COMMANDS.intersection(sys.argv[1:]):
+    sys.exit(_format_error_message(MIN_PYTHON, sys.version_info))
 
 from setuptools import setup  # noqa: E402
 

--- a/py/floor-shim/setup.py
+++ b/py/floor-shim/setup.py
@@ -45,7 +45,12 @@ MIN_PYTHON = (3, 10)
 _METADATA_ONLY_COMMANDS = {'egg_info', 'dist_info', 'sdist'}
 
 
-def _format_error_message(min_ver: tuple[int, ...], cur_ver: tuple[int, ...]) -> str:
+# Annotations here must stay plain builtin names: this function runs on
+# whatever ancient interpreter the user has (the shim's whole audience), and
+# subscripted generics like `tuple[int, ...]` evaluate at def time and raise
+# TypeError before 3.9 — the user would get a traceback instead of the
+# upgrade message.
+def _format_error_message(min_ver: tuple, cur_ver: tuple) -> str:
     min_str = '.'.join(map(str, min_ver))
     cur_str = '.'.join(map(str, cur_ver[:3]))
 
@@ -110,6 +115,14 @@ def _format_error_message(min_ver: tuple[int, ...], cur_ver: tuple[int, ...]) ->
 
 if sys.version_info < MIN_PYTHON and not _METADATA_ONLY_COMMANDS.intersection(sys.argv[1:]):
     sys.exit(_format_error_message(MIN_PYTHON, sys.version_info))
+
+# The shim must never ship as a wheel: wheels run no code at install time,
+# so on an old Python a wheel would install "successfully" as an empty
+# package — the exact silent failure this shim exists to prevent. Refusing
+# here (after the version guard, so old interpreters still get the upgrade
+# box) makes sdist-only self-enforcing instead of workflow-flag-dependent.
+if 'bdist_wheel' in sys.argv[1:]:
+    sys.exit('The genkit floor shim is sdist-only; refusing to build a wheel. See py/floor-shim/README.md.')
 
 from setuptools import setup  # noqa: E402
 

--- a/py/tests/floor_shim_guard_test.py
+++ b/py/tests/floor_shim_guard_test.py
@@ -1,0 +1,112 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Pins the floor shim's guards (py/floor-shim/setup.py).
+
+The shim's whole job happens inside two `sys.exit` guards. If either
+disappears, nothing else in CI notices: on old pip the metadata phase
+would fail instead of the install phase and pip backtracks to the
+pre-transfer squatter package with exit 0, and a wheel build would
+produce an artifact that installs silently as an empty package. These
+tests execute the real setup.py with spoofed interpreter versions so
+deleting or weakening a guard fails loudly here.
+"""
+
+import ast
+import sys
+from pathlib import Path
+
+import pytest
+
+SHIM_SETUP = Path(__file__).resolve().parents[1] / 'floor-shim' / 'setup.py'
+
+OLD_PYTHON = (3, 9, 6, 'final', 0)
+NEW_PYTHON = (3, 12, 0, 'final', 0)
+
+
+def _run_shim_setup(monkeypatch, argv: list[str], version: tuple) -> list:
+    """Exec the real setup.py under a spoofed version/argv; return setup() calls."""
+    calls: list = []
+    monkeypatch.setattr(sys, 'argv', ['setup.py', *argv])
+    monkeypatch.setattr(sys, 'version_info', version)
+    import setuptools
+
+    monkeypatch.setattr(setuptools, 'setup', lambda **kwargs: calls.append(kwargs))
+    exec(compile(SHIM_SETUP.read_text(), str(SHIM_SETUP), 'exec'), {'__name__': '__main__'})  # noqa: S102
+    return calls
+
+
+def test_old_python_install_exits_with_upgrade_message(monkeypatch) -> None:
+    with pytest.raises(SystemExit) as excinfo:
+        _run_shim_setup(monkeypatch, ['install'], OLD_PYTHON)
+    assert 'Genkit requires Python 3.10+' in str(excinfo.value)
+
+
+def test_old_python_bdist_wheel_still_gets_upgrade_message(monkeypatch) -> None:
+    # Modern pip installs the sdist via build_wheel; the user must see the
+    # upgrade box, not the sdist-only refusal.
+    with pytest.raises(SystemExit) as excinfo:
+        _run_shim_setup(monkeypatch, ['bdist_wheel'], OLD_PYTHON)
+    assert 'Genkit requires Python 3.10+' in str(excinfo.value)
+
+
+def test_old_python_metadata_commands_succeed(monkeypatch) -> None:
+    # Old pip backtracks past metadata failures to the pre-transfer squatter
+    # release, so egg_info must succeed and the failure must wait for the
+    # install phase.
+    for command in ('egg_info', 'dist_info', 'sdist'):
+        calls = _run_shim_setup(monkeypatch, [command], OLD_PYTHON)
+        assert len(calls) == 1, f'{command} must reach setup(), not exit'
+
+
+def test_new_python_wheel_build_is_refused(monkeypatch) -> None:
+    # sdist-only is self-enforcing: even a plain `uv build` (no --sdist) on a
+    # current interpreter must not produce a wheel.
+    with pytest.raises(SystemExit) as excinfo:
+        _run_shim_setup(monkeypatch, ['bdist_wheel'], NEW_PYTHON)
+    assert 'sdist-only' in str(excinfo.value)
+
+
+def test_new_python_sdist_build_succeeds(monkeypatch) -> None:
+    calls = _run_shim_setup(monkeypatch, ['sdist'], NEW_PYTHON)
+    assert len(calls) == 1
+    assert calls[0]['version'] == '0.3.0'
+    assert calls[0]['python_requires'] == '<3.10'
+
+
+def test_setup_py_annotations_stay_runtime_safe_on_old_pythons() -> None:
+    # setup.py executes on whatever ancient interpreter the user has — that
+    # is the shim's whole audience. Annotations evaluate at def time, and
+    # subscripted generics like `tuple[int, ...]` raise TypeError before 3.9,
+    # which would replace the upgrade message with a traceback. Plain builtin
+    # names (`tuple`, `str`) are fine everywhere.
+    tree = ast.parse(SHIM_SETUP.read_text())
+    annotations: list[ast.expr] = []
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            args = node.args
+            for arg in (*args.posonlyargs, *args.args, *args.kwonlyargs):
+                if arg.annotation is not None:
+                    annotations.append(arg.annotation)
+            if node.returns is not None:
+                annotations.append(node.returns)
+        elif isinstance(node, ast.AnnAssign):
+            annotations.append(node.annotation)
+    for annotation in annotations:
+        assert isinstance(annotation, ast.Name), (
+            f'annotation {ast.unparse(annotation)!r} is not a plain name; '
+            'it would evaluate at def time and can crash Python < 3.9'
+        )


### PR DESCRIPTION
`pip install genkit` on Python 3.9 used to resolve an unrelated pre-transfer
package (`genkit 0.2.0`, "random data like phone numbers") because those
releases declare `Requires-Python: >=3.6`. macOS ships 3.9 at
`/usr/bin/python3`, so that was the silent default.

This adds a one-time sdist-only PyPI release (`genkit==0.3.0`) with
`Requires-Python: <3.10`. Old interpreters pick it over 0.2.0 and fail at
install time with a boxed 3.10+ how-to. Current interpreters never select it.

```console
# before (Python 3.9)
$ /usr/bin/python3 -m pip install genkit && pip show genkit
Name: genkit
Version: 0.2.0
Summary: A Python package for generating random data like phone numbers .

# after (Python 3.9)
$ /usr/bin/python3 -m pip install genkit
========================================================================
Genkit requires Python 3.10+, but you are running Python 3.9.6.
...
# Option 1 (Recommended): uv (manages Python for you)
curl -LsSf https://astral.sh/uv/install.sh | sh
uv init && uv add genkit
...
========================================================================

# after (Python 3.10+)
$ pip install genkit           # latest real genkit (0.10.0+)
$ pip install genkit==0.3.0
ERROR: Package 'genkit' requires a different Python: 3.13.11 not in '<3.10'
```

## Decisions

- The boxed how-to is for `pip install genkit` and `uv pip install genkit`. A second name on the same line (`pip install genkit genkit-google-genai`) fails in the resolver on that plugin's `Requires-Python: >=3.10` and never reaches this shim.
- Fail at the install phase, not metadata (`egg_info` / `dist_info` / `sdist` succeed on purpose). Old pip treats a metadata failure as a discardable candidate and would install 0.2.0 again with exit 0.
- Sdist only. A wheel would install as an empty package on old Pythons.
- Yank `0.1.0`, `0.1.3`, `0.1.4`, and `0.2.0` on PyPI before or with the first shim publish. After the yank, only a pin (`genkit==0.2.0`) can still reach those releases.