### PR TITLE
feat(go/ai/exp): make an aborted agent run a resume point

### DIFF
--- a/docs/agents-conformance-testing.md
+++ b/docs/agents-conformance-testing.md
@@ -47,6 +47,7 @@ capability means adding it there and to the table below. Known capabilities:
 | Capability | Meaning |
 |------------|---------|
 | `resumable-failures` | A failed turn commits what the generate call left at its last turn seam and persists it as a `failed` snapshot carrying the error; resume accepts that snapshot, and an input with no payload of its own re-attempts the turn. Gates model `error` entries, the empty input, a `failed` snapshot as a resume target, and the `promptAgentWithToolsAndStore` fixture. Implemented by: Go. |
+| `resumable-aborts` | An aborted invocation persists the state through the last turn that committed, rolling back the one that did not finish, and resume accepts that snapshot. Gates an `aborted` snapshot carrying state, one as a resume target, and the `customAgentAbortable` fixture. Implemented by: Go. |
 
 ### Step Types
 
@@ -98,6 +99,11 @@ Aborts an agent by snapshot ID.
 
 Polls a snapshot until it reaches a terminal status (`completed`, `failed`, or
 `aborted`).
+
+An aborted snapshot reaches its status in two writes: the abort flips it, and
+the finalize that follows stamps the finish reason and the state. This step
+waits for the second one, so `expectSnapshot` never reads a row that is still
+being written.
 
 | Field | Type | Description |
 |-------|------|-------------|
@@ -212,6 +218,7 @@ is not needed for tests targeting these agents.
 
 | Agent Name | Description |
 |------------|-------------|
+| `customAgentAbortable` | Server-managed. Records each turn's input, replies `ack`, and commits. On the turn whose message is `block` it blocks until its context is cancelled and commits nothing. Used for `resumable-aborts` tests; only required by harnesses declaring that capability. |
 | `customAgentBlocking` | Server-managed. Blocks indefinitely until its abort signal fires. Used for abort-while-pending tests. |
 | `customAgentFailing` | Server-managed. Throws `Error('intentional failure')` during processing. Used for detach + background failure tests. |
 | `customAgentWithArtifacts` | Client-managed. Adds artifact `doc1` (v1), updates it to `doc1` (v2), then adds `doc2`. Returns all artifacts. |

--- a/go/README.md
+++ b/go/README.md
@@ -109,6 +109,7 @@ Multi-turn conversations that own their own loop and state.
 [Custom Turn Loops](#custom-turn-loops) &middot;
 [Persist and Resume](#persist-and-resume) &middot;
 [Re-attempt Failed Turns](#re-attempt-failed-turns) &middot;
+[Stop a Run and Continue It](#stop-a-run-and-continue-it) &middot;
 [Redact on the Way Out](#redact-on-the-way-out) &middot;
 [Background Agents](#background-agents) &middot;
 [Delegate to Sub-Agents](#delegate-to-sub-agents) &middot;
@@ -375,6 +376,23 @@ Whether a failure is worth another attempt is yours to decide; the framework rec
 
 Without a store, the failed output's `State` carries the same resume point inline; initialize the next invocation with it. A turn rejected before it reached the model (an invalid input, for example) commits nothing, and the resume point stays the turn before it. Custom agents opt in by returning a `TurnResult` alongside the turn's error; a bare error keeps the discard-the-turn behavior.
 
+### Stop a Run and Continue It
+
+A run the caller stopped is `aborted`; a run that broke is `failed`. Stopping covers every way the caller ends it: cancelling the context on a live connection, closing the transport, letting a deadline expire, hitting a limit it set such as `ai.WithMaxTurns`, or calling `Abort` on a detached one. All of them land an `aborted` snapshot holding the turns that finished, and all of them resume like a `failed` one:
+
+```go
+ctx, cancel := context.WithCancel(ctx)
+out, err := chatAgent.Run(ctx, &aix.AgentInput{Message: msg})  // cancel() elsewhere
+
+// Both come back: err is what stopped the run, out names where it stopped.
+if out.FinishReason == aix.AgentFinishReasonAborted {
+    resumed, _ := chatAgent.Run(context.Background(), &aix.AgentInput{},
+        aix.WithSnapshotID[any](out.SnapshotID))
+}
+```
+
+The turn that was in flight is discarded whole, so the conversation ends at a turn seam. A tool that had already run inside it loses its response along with the rest of the round, and re-sending the conversation calls it again.
+
 ### Redact on the Way Out
 
 `WithStateTransform` rewrites session state as it leaves the server, on `GetSnapshot` reads, on a client-managed `out.State`, and on the streamed `CustomPatch` diffs, while the persisted snapshot and the state your agent function sees stay raw:
@@ -409,9 +427,11 @@ switch snap.Status {
 case aix.SnapshotStatusPending:   // still working
 case aix.SnapshotStatusCompleted: // snap.State holds the final state; resume it
 case aix.SnapshotStatusFailed:    // snap.Error holds the failure; still resumable
+case aix.SnapshotStatusAborted:   // stopped early; resumable from the last finished turn
 }
 
 // Or stop it early; the runtime observes the abort and cancels the work.
+// The snapshot keeps the turns that finished, so it can be resumed later.
 chatAgent.Abort(ctx, snapshotID)
 ```
 

--- a/go/ai/exp/agent.go
+++ b/go/ai/exp/agent.go
@@ -65,6 +65,14 @@ const (
 	defaultHeartbeatTimeout = 60 * time.Second
 )
 
+// settleGrace is how long [AgentConnection.Output] waits for a cancelled
+// invocation to produce its result before falling back to reporting the bare
+// cancellation. An agent function that honors its context unwinds in well
+// under this, and the wait is what lets the caller see the snapshot the
+// aborted run stopped at. One that ignores its context has nothing to hand
+// back however long the wait, so the grace expires and the caller escapes.
+const settleGrace = 2 * time.Second
+
 // isHeartbeatExpired reports whether snap is a pending (detached, in-flight)
 // snapshot whose heartbeat is older than timeout, i.e. its background worker is
 // presumed dead. A pending snapshot that has not yet written a first heartbeat
@@ -141,11 +149,12 @@ type SessionRunner[State any] struct {
 
 	// lastGoodState is a deep copy of the session state as of the most
 	// recent committed turn (or the initial state when no turn has committed
-	// yet), kept only for client-managed agents (no store). The
-	// client-managed failure path returns it inline so the caller resumes
-	// from the last committed turn, excluding a later turn that failed
-	// before committing. Nil and unused for server-managed agents, whose
-	// failure path returns the last turn snapshot instead.
+	// yet). It is kept for a client-managed agent (no store), whose failure
+	// path returns it inline, and for a detached one, whose finalize writes
+	// it to the pending row; both then resume from the last committed turn,
+	// excluding a later turn that failed before committing. Nil and unused
+	// for an attached server-managed agent, whose failure path returns the
+	// last turn snapshot instead. See captureLastGood.
 	lastGoodState *SessionState[State]
 }
 
@@ -162,6 +171,15 @@ func (s *SessionRunner[State]) suspendSnapshots() (parentID string) {
 	defer s.snapMu.Unlock()
 	s.snapshotsSuspended = true
 	return s.lastSnapshotID
+}
+
+// snapshotsAreSuspended reports whether a detach has stopped turn-end
+// snapshot writes. Read by captureLastGood in the fn goroutine, so it takes
+// snapMu against the detach handler's write.
+func (s *SessionRunner[State]) snapshotsAreSuspended() bool {
+	s.snapMu.Lock()
+	defer s.snapMu.Unlock()
+	return s.snapshotsSuspended
 }
 
 // TurnResult is the optional return value of a [SessionRunner.Run] per-turn
@@ -319,6 +337,13 @@ func (s *SessionRunner[State]) Run(ctx context.Context, fn func(ctx context.Cont
 			if failedResult != nil && failedResult.FinishReason != "" {
 				reason = failedResult.FinishReason
 			}
+			// The caller stopping the run wins over whatever the turn
+			// reported. The detached path settles the same race the same
+			// way: an abort that lands while a turn is settling keeps the
+			// aborted terminal.
+			if callerStopped(ctx, err) {
+				reason = AgentFinishReasonAborted
+			}
 			s.endTurn(ctx, reason, err, failedResult != nil)
 			return err
 		}
@@ -353,16 +378,19 @@ func (s *SessionRunner[State]) endTurn(ctx context.Context, reason AgentFinishRe
 	s.turnIndex++
 }
 
-// captureLastGood deep-copies the committed session state as the
-// client-managed failure fallback: the state a failed invocation returns
-// inline (see failedOutput), excluding the partial mutations of a later
-// turn that failed before committing. Called once at session start (the
-// initial state is the fallback until a turn commits) and after every
-// committed turn, failed or not. It is a no-op for server-managed agents,
-// whose failure path returns the last turn-end snapshot instead, so they
-// pay no per-turn copy.
+// captureLastGood deep-copies the committed session state as the failure
+// fallback, excluding the partial mutations of a later turn that failed
+// before committing. Called once at session start (the initial state is the
+// fallback until a turn commits) and after every committed turn, failed or
+// not.
+//
+// It is kept for a client-managed agent, whose failed invocation returns it
+// inline (see failedOutput), and for a detached one, whose finalize has no
+// per-turn snapshot to fall back on because detach suspended them. An
+// attached server-managed agent needs neither and pays no per-turn copy: its
+// last turn snapshot is the resume point.
 func (s *SessionRunner[State]) captureLastGood() {
-	if s.store != nil {
+	if s.store != nil && !s.snapshotsAreSuspended() {
 		return
 	}
 	s.mu.RLock()
@@ -412,7 +440,12 @@ func (s *SessionRunner[State]) invocationReason(result *AgentResult) AgentFinish
 // a detach. finishReason records how the captured turn ended so a resumed task
 // can report it, and cause is the turn's error: nil writes
 // [SnapshotStatusCompleted], and an error writes [SnapshotStatusFailed] with
-// the error on the row for a client to branch on.
+// the error on the row for a client to branch on, or [SnapshotStatusAborted]
+// when finishReason says the turn was stopped rather than broken. The status
+// follows the reason so the two cannot disagree, and Run stamps the aborted
+// reason whenever callerStopped says so. That is what makes an attached run's
+// abort indistinguishable from a detached one's: both land an aborted row
+// holding the work up to the turn that did not finish.
 //
 // The turn-end snapshot is the agent's only routine persistence point, and
 // every committed turn writes one, so the newest snapshot is the resume point
@@ -452,6 +485,9 @@ func (s *SessionRunner[State]) snapshotTurnEnd(ctx context.Context, finishReason
 	snapStatus := SnapshotStatusCompleted
 	if cause != nil {
 		snapStatus = SnapshotStatusFailed
+		if finishReason == AgentFinishReasonAborted {
+			snapStatus = SnapshotStatusAborted
+		}
 	}
 	saved, err := s.store.SaveSnapshot(context.WithoutCancel(ctx), s.turnSnapshotID,
 		func(_ *SessionSnapshot[State]) (*SessionSnapshot[State], error) {
@@ -1306,10 +1342,15 @@ func (rt *agentRuntime[State]) run(
 
 	case <-clientCtx.Done():
 		res := rt.drainAndWait(cancelWork)
-		if res.err != nil {
-			return nil, res.err
+		cause := res.err
+		if cause == nil {
+			cause = clientCtx.Err()
 		}
-		return nil, clientCtx.Err()
+		// Both, the way ai.Generate hands back a partial response beside the
+		// error that ended it: the error is what stopped the run, and the
+		// output names the snapshot it stopped at. Returning the error alone
+		// left an in-process caller holding nothing to resume from.
+		return rt.failedOutput(clientCtx, cause), cause
 	}
 }
 
@@ -1330,10 +1371,10 @@ func (rt *agentRuntime[State]) handleTransformFailure(
 	cause error,
 ) (*AgentOutput[State], error) {
 	rt.drainAndWait(cancelWork)
-	// A disconnect that raced the failure keeps error semantics: there is no
-	// client to hand a graceful failed output to (mirrors handleFnDone).
+	// A disconnect that raced the failure keeps error semantics, with the
+	// resume point alongside it (mirrors handleFnDone).
 	if clientCtx.Err() != nil {
-		return nil, cause
+		return rt.failedOutput(clientCtx, cause), cause
 	}
 	return rt.failedOutput(clientCtx, cause), nil
 }
@@ -1417,19 +1458,18 @@ func (rt *agentRuntime[State]) handleFnDone(
 	// data it refused to shape.
 	if fatal != nil {
 		if ctx.Err() != nil {
-			return nil, fatal
+			return rt.failedOutput(ctx, fatal), fatal
 		}
 		return rt.failedOutput(ctx, fatal), nil
 	}
 
 	if res.err != nil {
-		// A disconnect-driven failure keeps its error semantics: the
-		// client is gone, so there is no one to hand a graceful failed
-		// output to. The clientCtx.Done arm of the run select handles the
-		// common ordering; this guards the race where fn observes the
-		// cancellation first and its result wins the select.
+		// A disconnect-driven failure keeps its error semantics, and carries
+		// the resume point alongside it. The clientCtx.Done arm of the run
+		// select handles the common ordering; this guards the race where fn
+		// observes the cancellation first and its result wins the select.
 		if ctx.Err() != nil {
-			return nil, res.err
+			return rt.failedOutput(ctx, res.err), res.err
 		}
 		return rt.failedOutput(ctx, res.err), nil
 	}
@@ -1508,8 +1548,40 @@ func convertKeepText(cause error) *status.Error {
 	return e
 }
 
-// failedOutput assembles the output for an invocation that ended in
-// failure: [AgentFinishReasonFailed], the error with its original status,
+// callerStopped reports whether the invocation ended because the caller
+// stopped it rather than because something inside it broke. Two roads reach
+// the same place:
+//
+// The context ended. A caller holding a live connection cancels it directly
+// or by closing the transport under it, a deadline it set expires, or a
+// detached caller calls the abort companion action, which cancels the work
+// context on the status flip.
+//
+// Or the run reached a limit the caller set, which [ai] reports with an
+// ABORTED status ([ai.ErrMaxTurnsExceeded]). A turn that propagates such an
+// error unchanged is stopped, not broken, and reports so without having to
+// say it in a [TurnResult].
+func callerStopped(ctx context.Context, cause error) bool {
+	if ctx.Err() != nil {
+		return true
+	}
+	s, ok := status.Classified(cause)
+	return ok && (s == status.Cancelled || s == status.DeadlineExceeded || s == status.Aborted)
+}
+
+// terminalReason is how an invocation or turn that ended with cause reports
+// itself: aborted when the caller stopped it, failed when it broke.
+func terminalReason(ctx context.Context, cause error) AgentFinishReason {
+	if callerStopped(ctx, cause) {
+		return AgentFinishReasonAborted
+	}
+	return AgentFinishReasonFailed
+}
+
+// failedOutput assembles the output for an invocation that did not run to
+// completion: [AgentFinishReasonFailed], or [AgentFinishReasonAborted] when
+// the caller stopped it (see callerStopped), the error with its original
+// status,
 // and the resume point: the last turn snapshot's ID when server-managed, or
 // the last-good state inline when client-managed. Both hold the state
 // through the last committed turn, which is the failed turn itself when it
@@ -1521,7 +1593,7 @@ func convertKeepText(cause error) *status.Error {
 func (rt *agentRuntime[State]) failedOutput(ctx context.Context, cause error) *AgentOutput[State] {
 	out := &AgentOutput[State]{
 		SessionID:    rt.session.SessionID(),
-		FinishReason: AgentFinishReasonFailed,
+		FinishReason: terminalReason(ctx, cause),
 		Error:        convertKeepText(cause),
 	}
 	if rt.cfg.store == nil {
@@ -1742,7 +1814,20 @@ func (rt *agentRuntime[State]) finalizePendingSnapshot(
 	fnErr error,
 	abortedByUser bool,
 ) {
+	// The state the row lands with. The live state is every turn's work when
+	// they all committed; when the last one did not, its partial mutations
+	// have to go, the same rollback an attached turn gets by not snapshotting.
+	// Detach suspended those snapshots, so the fallbacks are the copy
+	// captureLastGood took at the last committed turn, and the parent row when
+	// nothing has committed since the detach.
 	finalState := *rt.session.State()
+	if !rt.sess.lastTurnCommitted {
+		if last := rt.sess.lastGoodState; last != nil {
+			finalState = *last
+		} else if pending.ParentID != "" {
+			finalState = rt.parentState(ctx, pending.ParentID, finalState)
+		}
+	}
 	// Captured outside the SaveSnapshot callback (which must stay pure): the
 	// finalizer runs after fn returned, so these are stable. The abort/error
 	// branches below own their reasons and ignore this clean-success default.
@@ -1752,16 +1837,18 @@ func (rt *agentRuntime[State]) finalizePendingSnapshot(
 	_, err := rt.cfg.store.SaveSnapshot(ctx, pending.SnapshotID,
 		func(existing *SessionSnapshot[State]) (*SessionSnapshot[State], error) {
 			// Late abort wins over the terminal we were about to land: keep
-			// the aborted status and whatever state the abort left, but
-			// stamp the aborted finish reason so the snapshot is
-			// self-describing. (The abort write only flips status; the runtime
-			// owns the semantic reason.) Skip the write once already stamped.
+			// the aborted status, but stamp the aborted finish reason and the
+			// state so the snapshot is self-describing and resumable. (The
+			// abort write only flips status on a pending row that carries
+			// none; the runtime owns the semantic reason and the state.) Skip
+			// the write once already stamped.
 			if existing != nil && existing.Status == SnapshotStatusAborted {
 				if existing.FinishReason == AgentFinishReasonAborted {
 					return nil, nil
 				}
 				annotated := *existing
 				annotated.FinishReason = AgentFinishReasonAborted
+				annotated.State = &finalState
 				annotated.UpdatedAt = now
 				// The row is terminal now; drop the liveness heartbeat so it
 				// does not linger on a settled snapshot. CreatedAt is preserved
@@ -1784,8 +1871,14 @@ func (rt *agentRuntime[State]) finalizePendingSnapshot(
 					snapErr = convertKeepText(fnErr) // aborted wins, preserve text
 				}
 			case fnErr != nil:
+				// ctx is decoupled from the client's and still live here, so
+				// this reads the error: a background run that reached a
+				// caller-set limit was stopped, not broken.
+				finishReason = terminalReason(ctx, fnErr)
 				snapStatus = SnapshotStatusFailed
-				finishReason = AgentFinishReasonFailed
+				if finishReason == AgentFinishReasonAborted {
+					snapStatus = SnapshotStatusAborted
+				}
 				snapErr = convertKeepText(fnErr)
 			}
 
@@ -1807,6 +1900,25 @@ func (rt *agentRuntime[State]) finalizePendingSnapshot(
 		logger.Error(ctx, "agent: failed to finalize pending snapshot",
 			"snapshotId", pending.SnapshotID, "error", err)
 	}
+}
+
+// parentState reads the state off the pending row's parent, the last snapshot
+// written before the detach suspended them. It backs the finalize's rollback
+// for a run that aborted or failed before any post-detach turn committed:
+// there is nothing in memory to fall back to, and the parent is the last
+// committed turn. Returns fallback when the parent cannot be read or carries
+// no state, which loses the rollback but never the row.
+func (rt *agentRuntime[State]) parentState(ctx context.Context, parentID string, fallback SessionState[State]) SessionState[State] {
+	parent, err := rt.cfg.store.GetSnapshot(ctx, parentID)
+	if err != nil {
+		logger.Error(ctx, "agent: failed to read parent snapshot for finalize rollback",
+			"parentId", parentID, "error", err)
+		return fallback
+	}
+	if parent == nil || parent.State == nil {
+		return fallback
+	}
+	return *jsonClone(parent.State)
 }
 
 // loadSession constructs a Session from the invocation's init payload,
@@ -1902,21 +2014,19 @@ func loadSession[State any](
 
 // resumeSessionFrom validates that snap is in a resumable status and loads
 // its state into s. Shared by the snapshot-ID and session-ID init paths:
-// both reject an aborted or pending snapshot, since neither can be continued
-// from. A failed one can: the turn that wrote it committed a conversation
-// ending at a turn seam, and whether the recorded error is worth another
-// attempt is the caller's judgement, not the framework's. The session-ID
-// path reaches the rejections too, because GetLatestSnapshot returns the
-// literal latest row whatever its status; a caller wanting to continue past
-// a dead-end tip must name an earlier snapshot explicitly via SnapshotID.
+// both reject a pending snapshot, whose invocation is still writing to it.
+// A failed or aborted one resumes: the turn that wrote it committed a
+// conversation ending at a turn seam, and whether to continue from a run
+// that broke or one that was stopped is the caller's judgement, not the
+// framework's. The session-ID path reaches the rejection too, because
+// GetLatestSnapshot returns the literal latest row whatever its status; a
+// caller wanting to continue past a dead-end tip must name an earlier
+// snapshot explicitly via SnapshotID.
 func resumeSessionFrom[State any](s *Session[State], snap *SessionSnapshot[State]) (*Session[State], *SessionSnapshot[State], error) {
 	switch snap.Status {
 	case SnapshotStatusPending:
 		return nil, nil, status.Errorf(status.ErrFailedPrecondition,
 			"snapshot %q is still pending: its detached invocation is still running; wait for it to finalize or abort it before resuming", snap.SnapshotID)
-	case SnapshotStatusAborted:
-		return nil, nil, status.Errorf(status.ErrFailedPrecondition,
-			"snapshot %q was aborted", snap.SnapshotID)
 	}
 	if snap.State != nil {
 		// Stores may return rows sharing memory with their internal
@@ -2835,7 +2945,10 @@ func agentLoop[State any](r api.Registry, prompt ai.Prompt, defaultInput any) Ag
 					return nil, fmt.Errorf("generate: %w", err)
 				}
 				sess.SetMessages(turnSessionMessages(modelResp.History()))
-				return &TurnResult{FinishReason: AgentFinishReasonFailed}, fmt.Errorf("generate: %w", err)
+				// The generate response's reason verbatim, as on the success
+				// arm: a cancelled loop reports "aborted", so the turn's
+				// snapshot lands aborted rather than failed.
+				return &TurnResult{FinishReason: AgentFinishReason(modelResp.FinishReason)}, fmt.Errorf("generate: %w", err)
 			}
 
 			// Replace session messages with the full history minus the
@@ -3115,7 +3228,29 @@ func (c *AgentConnection[State]) Output() (*AgentOutput[State], error) {
 	// Output prefers the finalized result when both are ready.
 	for range c.conn.Receive() {
 	}
-	return c.conn.Output()
+	out, err := c.conn.Output()
+	if out != nil || err == nil {
+		return out, err
+	}
+	// The caller's context died before the invocation settled, so both the
+	// drain above and the core Output took their cancellation arms and the
+	// result is not stored yet. Wait for it: the runtime is unwinding towards
+	// a failed or aborted output naming the snapshot to resume from, and
+	// returning the bare cancellation would strand that snapshot with no
+	// handle on it.
+	//
+	// The wait is bounded, because an agent function that ignores its context
+	// never settles and the caller needs its escape hatch back. Such a
+	// function has produced no snapshot either, so the grace costs only the
+	// delay: there was never a result to wait for.
+	timer := time.NewTimer(settleGrace)
+	defer timer.Stop()
+	select {
+	case <-c.conn.Done():
+		return c.conn.Output()
+	case <-timer.C:
+		return out, err
+	}
 }
 
 // Done returns a channel closed when the connection completes.

--- a/go/ai/exp/agent.go
+++ b/go/ai/exp/agent.go
@@ -557,10 +557,7 @@ func (s *SessionRunner[State]) snapshotTurnEnd(ctx context.Context, finishReason
 	now := time.Now()
 	snapStatus := SnapshotStatusCompleted
 	if cause != nil {
-		snapStatus = SnapshotStatusFailed
-		if finishReason == AgentFinishReasonAborted {
-			snapStatus = SnapshotStatusAborted
-		}
+		snapStatus = terminalStatus(finishReason)
 	}
 	saved, err := s.store.SaveSnapshot(context.WithoutCancel(ctx), s.turnSnapshotID,
 		func(_ *SessionSnapshot[State]) (*SessionSnapshot[State], error) {
@@ -1442,12 +1439,19 @@ func (rt *agentRuntime[State]) handleTransformFailure(
 	cause error,
 ) (*AgentOutput[State], error) {
 	rt.drainAndWait(cancelWork)
-	// A disconnect that raced the failure keeps error semantics, with the
-	// resume point alongside it (mirrors handleFnDone).
+	return rt.failedOutput(clientCtx, cause), disconnectErr(clientCtx, cause)
+}
+
+// disconnectErr is the error a terminal path returns beside its failed
+// output: the cause when the client is already gone, and nil when it is still
+// there to be handed a graceful failure. Both carry the resume point on the
+// output either way; the error is what tells an in-process caller that the
+// run did not finish on its own terms.
+func disconnectErr(clientCtx context.Context, cause error) error {
 	if clientCtx.Err() != nil {
-		return rt.failedOutput(clientCtx, cause), cause
+		return cause
 	}
-	return rt.failedOutput(clientCtx, cause), nil
+	return nil
 }
 
 // checkDetachCapabilities reports whether the configured store is capable
@@ -1528,21 +1532,14 @@ func (rt *agentRuntime[State]) handleFnDone(
 	// failed regardless of what fn returned, so no completed output leaks the
 	// data it refused to shape.
 	if fatal != nil {
-		if ctx.Err() != nil {
-			return rt.failedOutput(ctx, fatal), fatal
-		}
-		return rt.failedOutput(ctx, fatal), nil
+		return rt.failedOutput(ctx, fatal), disconnectErr(ctx, fatal)
 	}
 
 	if res.err != nil {
-		// A disconnect-driven failure keeps its error semantics, and carries
-		// the resume point alongside it. The clientCtx.Done arm of the run
-		// select handles the common ordering; this guards the race where fn
-		// observes the cancellation first and its result wins the select.
-		if ctx.Err() != nil {
-			return rt.failedOutput(ctx, res.err), res.err
-		}
-		return rt.failedOutput(ctx, res.err), nil
+		// The clientCtx.Done arm of the run select handles the common
+		// disconnect ordering; disconnectErr guards the race where fn observes
+		// the cancellation first and its result wins the select.
+		return rt.failedOutput(ctx, res.err), disconnectErr(ctx, res.err)
 	}
 
 	// The resume point is the last turn-end snapshot (lastSnapshotID), or ""
@@ -1649,11 +1646,21 @@ func terminalReason(ctx context.Context, cause error) AgentFinishReason {
 	return AgentFinishReasonFailed
 }
 
+// terminalStatus is the snapshot status that goes with the reason a turn or
+// invocation ended on, for the rows that ended with an error. Deriving it
+// keeps the two from disagreeing: a row is aborted exactly when it says the
+// caller stopped the run.
+func terminalStatus(reason AgentFinishReason) SnapshotStatus {
+	if reason == AgentFinishReasonAborted {
+		return SnapshotStatusAborted
+	}
+	return SnapshotStatusFailed
+}
+
 // failedOutput assembles the output for an invocation that did not run to
 // completion: [AgentFinishReasonFailed], or [AgentFinishReasonAborted] when
 // the caller stopped it (see callerStopped), the error with its original
-// status,
-// and the resume point: the last turn snapshot's ID when server-managed, or
+// status, and the resume point: the last turn snapshot's ID when server-managed, or
 // the last-good state inline when client-managed. Both hold the state
 // through the last committed turn, which is the failed turn itself when it
 // committed and its predecessor when it did not, since only a committed turn
@@ -1936,10 +1943,7 @@ func (rt *agentRuntime[State]) finalizePendingSnapshot(
 				// this reads the error: a background run that reached a
 				// caller-set limit was stopped, not broken.
 				finishReason = terminalReason(ctx, fnErr)
-				snapStatus = SnapshotStatusFailed
-				if finishReason == AgentFinishReasonAborted {
-					snapStatus = SnapshotStatusAborted
-				}
+				snapStatus = terminalStatus(finishReason)
 				snapErr = convertKeepText(fnErr)
 			}
 
@@ -3270,8 +3274,15 @@ func (c *AgentConnection[State]) Custom() (State, error) {
 // and the last-good state on [AgentOutput.State] (client-managed) or behind
 // [AgentOutput.SnapshotID] (server-managed), so a failure costs only the failed
 // turn, not the session. A detached invocation resolves with the pending
-// snapshot ID. A non-nil error means the invocation never started (a rejected
-// init payload) or could not run to a result (e.g. its context was cancelled).
+// snapshot ID.
+//
+// A run the caller stopped returns both: the error that stopped it, and an
+// [AgentOutput] with [AgentFinishReasonAborted] naming the same resume point,
+// the way [ai.Generate] hands back a partial response beside its error. Check
+// the output even when the error is non-nil, or the work up to the stop is
+// stranded. It is nil when the invocation never started (a rejected init
+// payload), and when an agent function that ignores its context has not
+// settled within settleGrace, since there is nothing yet to report.
 //
 // Do not call Output concurrently with a goroutine iterating Receive; both
 // consume the stream and would split chunks between them. Finish Receive first.
@@ -3295,10 +3306,7 @@ func (c *AgentConnection[State]) Output() (*AgentOutput[State], error) {
 	// returning the bare cancellation would strand that snapshot with no
 	// handle on it.
 	//
-	// The wait is bounded, because an agent function that ignores its context
-	// never settles and the caller needs its escape hatch back. Such a
-	// function has produced no snapshot either, so the grace costs only the
-	// delay: there was never a result to wait for.
+	// Bounded by settleGrace, whose doc carries why.
 	timer := time.NewTimer(settleGrace)
 	defer timer.Stop()
 	select {

--- a/go/ai/exp/agent.go
+++ b/go/ai/exp/agent.go
@@ -84,6 +84,16 @@ func isHeartbeatExpired[State any](snap *SessionSnapshot[State], timeout time.Du
 	return time.Since(*snap.HeartbeatAt) > timeout
 }
 
+// finalizeInFlight reports whether an aborted snapshot carrying no state is
+// still waiting for the write that stamps one on. The abort flips the pending
+// row's status and leaves its heartbeat where the worker left it; only the
+// finalize writes the state, and it clears the heartbeat as it lands. A beat
+// inside timeout therefore says a live worker is between the two writes, and a
+// stale or absent one says it died there.
+func finalizeInFlight[State any](snap *SessionSnapshot[State], timeout time.Duration) bool {
+	return snap.HeartbeatAt != nil && time.Since(*snap.HeartbeatAt) <= timeout
+}
+
 // --- SessionRunner ---
 
 // SessionRunner extends Session with agent-runtime functionality:
@@ -2084,10 +2094,22 @@ func resumeSessionFrom[State any](s *Session[State], snap *SessionSnapshot[State
 		// An aborted row is the one terminal shape written twice: the abort
 		// flips the pending row, which carries no state, and the finalize
 		// that follows stamps the state onto it. A row still between the two
-		// (the process died, or the finalize write failed) holds nothing, and
-		// resuming it would silently hand back an empty session in place of
-		// the conversation the caller asked to continue.
+		// holds nothing, and resuming it would silently hand back an empty
+		// session in place of the conversation the caller asked to continue.
+		//
+		// Which half of that window this is decides what the caller should do
+		// next, and the heartbeat says: the abort leaves it running and the
+		// finalize clears it, so a live beat means the state is one write
+		// away and this same ID is the thing to wait on. Sending that caller
+		// to an earlier snapshot would fork the run away from the work the
+		// finalize is about to commit. Only a quiet beat means the write is
+		// never coming (the process died, or the write failed), and the
+		// earlier snapshot really is the resume point.
 		if snap.State == nil {
+			if finalizeInFlight(snap, defaultHeartbeatTimeout) {
+				return nil, nil, status.Errorf(status.ErrFailedPrecondition,
+					"snapshot %q is still being finalized: its invocation was aborted and has not recorded the state yet; retry this same snapshot ID", snap.SnapshotID)
+			}
 			return nil, nil, status.Errorf(status.ErrFailedPrecondition,
 				"snapshot %q was aborted before its invocation recorded any state; resume from an earlier snapshot", snap.SnapshotID)
 		}

--- a/go/ai/exp/agent.go
+++ b/go/ai/exp/agent.go
@@ -1625,16 +1625,23 @@ func convertKeepText(cause error) *status.Error {
 // detached caller calls the abort companion action, which cancels the work
 // context on the status flip.
 //
-// Or the run reached a limit the caller set, which [ai] reports with an
-// ABORTED status ([ai.ErrMaxTurnsExceeded]). A turn that propagates such an
-// error unchanged is stopped, not broken, and reports so without having to
-// say it in a [TurnResult].
+// Or the run reached a limit the caller set ([ai.ErrMaxTurnsExceeded]). A turn
+// that propagates such an error unchanged is stopped, not broken, and reports
+// so without having to say it in a [TurnResult].
+//
+// Both roads are read from the context and the sentinels, never from the
+// classified status, which is a wider set than the caller's own doing: a
+// service answering 409 or 504 lands on ABORTED or DEADLINE_EXCEEDED through
+// the HTTP mapping in [status]. Persisting that as an aborted row would tell a
+// client the run stopped on request when a provider dropped it, which is the
+// class a retry loop is most likely to leave alone. Same rule as
+// [ai.Generate]'s, so the snapshot status and the partial's finish reason
+// agree on who ended the run.
 func callerStopped(ctx context.Context, cause error) bool {
-	if ctx.Err() != nil {
-		return true
-	}
-	s, ok := status.Classified(cause)
-	return ok && (s == status.Cancelled || s == status.DeadlineExceeded || s == status.Aborted)
+	return ctx.Err() != nil ||
+		errors.Is(cause, context.Canceled) ||
+		errors.Is(cause, context.DeadlineExceeded) ||
+		errors.Is(cause, ai.ErrMaxTurnsExceeded)
 }
 
 // terminalReason is how an invocation or turn that ended with cause reports

--- a/go/ai/exp/agent.go
+++ b/go/ai/exp/agent.go
@@ -156,6 +156,13 @@ type SessionRunner[State any] struct {
 	// for an attached server-managed agent, whose failure path returns the
 	// last turn snapshot instead. See captureLastGood.
 	lastGoodState *SessionState[State]
+
+	// initialState is a deep copy of the state the invocation began with:
+	// fresh, client-provided, or loaded from the snapshot it resumed. It is
+	// the floor committedState falls to when no turn has committed and there
+	// is no snapshot to read one from. Written once by captureInitial and
+	// never mutated after.
+	initialState *SessionState[State]
 }
 
 // suspendSnapshots stops all further turn-end snapshot writes for this
@@ -378,11 +385,77 @@ func (s *SessionRunner[State]) endTurn(ctx context.Context, reason AgentFinishRe
 	s.turnIndex++
 }
 
+// committedState resolves the session state as of the last turn that
+// committed. It is what a run stopping mid-turn must land: the live state
+// holds the unfinished turn's mutations, and an attached turn sheds them by
+// not snapshotting at all.
+//
+// It always resolves, taking the first source that holds an answer:
+//
+//   - the live state, when the last turn committed and there is nothing to
+//     shed;
+//   - the copy captureLastGood took at the last committed turn, which a
+//     client-managed agent always has and a detached one has for every turn
+//     since the detach;
+//   - the last turn-end snapshot, which is where a detached run's turns
+//     before the detach went, since suspending them froze lastSnapshotID
+//     there;
+//   - the state the invocation began with, the answer when nothing has
+//     committed at all.
+//
+// The returned state is the caller's to keep: every branch is a copy or a
+// value nothing mutates afterwards.
+func (s *SessionRunner[State]) committedState(ctx context.Context) *SessionState[State] {
+	if s.lastTurnCommitted {
+		return s.State()
+	}
+	if s.lastGoodState != nil {
+		return s.lastGoodState
+	}
+	if snapped := s.snapshotState(ctx, s.lastSnapshotID); snapped != nil {
+		return snapped
+	}
+	return s.initialState
+}
+
+// snapshotState reads the state off a snapshot this session already wrote.
+// Returns nil when there is no such snapshot, or when it cannot be read or
+// carries no state, which costs committedState this source but never an
+// answer.
+func (s *SessionRunner[State]) snapshotState(ctx context.Context, snapshotID string) *SessionState[State] {
+	if s.store == nil || snapshotID == "" {
+		return nil
+	}
+	snap, err := s.store.GetSnapshot(ctx, snapshotID)
+	if err != nil {
+		logger.Error(ctx, "agent: failed to read snapshot for committed state",
+			"snapshotId", snapshotID, "error", err)
+		return nil
+	}
+	if snap == nil || snap.State == nil {
+		return nil
+	}
+	return jsonClone(snap.State)
+}
+
+// captureInitial deep-copies the state the invocation began with. It is the
+// floor committedState falls to when nothing has committed and no snapshot
+// holds an earlier turn, and, for a client-managed agent, the failure
+// fallback until the first turn commits. One copy serves both: neither is
+// mutated afterwards, only replaced.
+func (s *SessionRunner[State]) captureInitial() {
+	s.mu.RLock()
+	state := s.copyStateLocked()
+	s.mu.RUnlock()
+	s.initialState = &state
+	if s.store == nil {
+		s.lastGoodState = &state
+	}
+}
+
 // captureLastGood deep-copies the committed session state as the failure
 // fallback, excluding the partial mutations of a later turn that failed
-// before committing. Called once at session start (the initial state is the
-// fallback until a turn commits) and after every committed turn, failed or
-// not.
+// before committing. Called after every committed turn, failed or not.
 //
 // It is kept for a client-managed agent, whose failed invocation returns it
 // inline (see failedOutput), and for a detached one, whose finalize has no
@@ -1207,9 +1280,7 @@ func newAgentRuntime[State any](
 		fail:        rt.failTransform,
 	}
 	rt.sess.onStartTurn = rt.patcher.beginTurn
-	// The initial state (fresh, client-provided, or loaded from a snapshot)
-	// is the client-managed failure fallback until a turn completes.
-	rt.sess.captureLastGood()
+	rt.sess.captureInitial()
 
 	return rt, nil
 }
@@ -1814,20 +1885,10 @@ func (rt *agentRuntime[State]) finalizePendingSnapshot(
 	fnErr error,
 	abortedByUser bool,
 ) {
-	// The state the row lands with. The live state is every turn's work when
-	// they all committed; when the last one did not, its partial mutations
-	// have to go, the same rollback an attached turn gets by not snapshotting.
-	// Detach suspended those snapshots, so the fallbacks are the copy
-	// captureLastGood took at the last committed turn, and the parent row when
-	// nothing has committed since the detach.
-	finalState := *rt.session.State()
-	if !rt.sess.lastTurnCommitted {
-		if last := rt.sess.lastGoodState; last != nil {
-			finalState = *last
-		} else if pending.ParentID != "" {
-			finalState = rt.parentState(ctx, pending.ParentID, finalState)
-		}
-	}
+	// The state the row lands with: everything through the last turn that
+	// committed, so an unfinished turn's mutations do not ride onto a row
+	// that is now resumable.
+	finalState := *rt.sess.committedState(ctx)
 	// Captured outside the SaveSnapshot callback (which must stay pure): the
 	// finalizer runs after fn returned, so these are stable. The abort/error
 	// branches below own their reasons and ignore this clean-success default.
@@ -1900,25 +1961,6 @@ func (rt *agentRuntime[State]) finalizePendingSnapshot(
 		logger.Error(ctx, "agent: failed to finalize pending snapshot",
 			"snapshotId", pending.SnapshotID, "error", err)
 	}
-}
-
-// parentState reads the state off the pending row's parent, the last snapshot
-// written before the detach suspended them. It backs the finalize's rollback
-// for a run that aborted or failed before any post-detach turn committed:
-// there is nothing in memory to fall back to, and the parent is the last
-// committed turn. Returns fallback when the parent cannot be read or carries
-// no state, which loses the rollback but never the row.
-func (rt *agentRuntime[State]) parentState(ctx context.Context, parentID string, fallback SessionState[State]) SessionState[State] {
-	parent, err := rt.cfg.store.GetSnapshot(ctx, parentID)
-	if err != nil {
-		logger.Error(ctx, "agent: failed to read parent snapshot for finalize rollback",
-			"parentId", parentID, "error", err)
-		return fallback
-	}
-	if parent == nil || parent.State == nil {
-		return fallback
-	}
-	return *jsonClone(parent.State)
 }
 
 // loadSession constructs a Session from the invocation's init payload,
@@ -2027,6 +2069,17 @@ func resumeSessionFrom[State any](s *Session[State], snap *SessionSnapshot[State
 	case SnapshotStatusPending:
 		return nil, nil, status.Errorf(status.ErrFailedPrecondition,
 			"snapshot %q is still pending: its detached invocation is still running; wait for it to finalize or abort it before resuming", snap.SnapshotID)
+	case SnapshotStatusAborted:
+		// An aborted row is the one terminal shape written twice: the abort
+		// flips the pending row, which carries no state, and the finalize
+		// that follows stamps the state onto it. A row still between the two
+		// (the process died, or the finalize write failed) holds nothing, and
+		// resuming it would silently hand back an empty session in place of
+		// the conversation the caller asked to continue.
+		if snap.State == nil {
+			return nil, nil, status.Errorf(status.ErrFailedPrecondition,
+				"snapshot %q was aborted before its invocation recorded any state; resume from an earlier snapshot", snap.SnapshotID)
+		}
 	}
 	if snap.State != nil {
 		// Stores may return rows sharing memory with their internal
@@ -2945,10 +2998,13 @@ func agentLoop[State any](r api.Registry, prompt ai.Prompt, defaultInput any) Ag
 					return nil, fmt.Errorf("generate: %w", err)
 				}
 				sess.SetMessages(turnSessionMessages(modelResp.History()))
-				// The generate response's reason verbatim, as on the success
-				// arm: a cancelled loop reports "aborted", so the turn's
-				// snapshot lands aborted rather than failed.
-				return &TurnResult{FinishReason: AgentFinishReason(modelResp.FinishReason)}, fmt.Errorf("generate: %w", err)
+				// No reason: the TurnResult here only says the turn committed,
+				// and [SessionRunner.Run] derives the rest from the error it
+				// is handed. The success arm forwards generate's reason
+				// verbatim, but this arm must not, because a response the loop
+				// completed and post-processing then rejected still carries
+				// the model's own "stop".
+				return &TurnResult{}, fmt.Errorf("generate: %w", err)
 			}
 
 			// Replace session messages with the full history minus the

--- a/go/ai/exp/agent_test.go
+++ b/go/ai/exp/agent_test.go
@@ -3961,6 +3961,266 @@ func TestAgent_Detach_AbortStopsFlow(t *testing.T) {
 	}
 }
 
+// abortTestAgent commits a message on its first turn, then blocks on its
+// second so a stop always lands mid-turn with exactly one turn behind it.
+// commit says whether the blocked turn returns a TurnResult beside its error,
+// which is what a prompt-backed agent does whenever the generate call produced
+// a partial response.
+func abortTestAgent(t *testing.T, store SessionStore[testState], name string, commit bool, entered chan<- struct{}) *Agent[testState] {
+	t.Helper()
+	return abortTestAgentGated(t, store, name, commit, entered, nil)
+}
+
+// abortTestAgentGated is abortTestAgent with a signal on the first turn's
+// completion, for a test that has to land a detach between the two turns.
+func abortTestAgentGated(t *testing.T, store SessionStore[testState], name string, commit bool, entered, firstDone chan<- struct{}) *Agent[testState] {
+	t.Helper()
+	turns := 0
+	return DefineCustomAgent(newTestRegistry(t), name,
+		func(ctx context.Context, resp Responder, sess *SessionRunner[testState]) (*AgentResult, error) {
+			return nil, sess.Run(ctx, func(ctx context.Context, input *AgentInput) (*TurnResult, error) {
+				turns++
+				if turns == 1 {
+					sess.AddMessages(ai.NewModelTextMessage("first turn"))
+					return nil, nil
+				}
+				if firstDone != nil {
+					// The first turn has snapshotted by now: this runs after
+					// its turn-end tail.
+					close(firstDone)
+				}
+				sess.AddMessages(ai.NewModelTextMessage("second turn"))
+				select {
+				case entered <- struct{}{}:
+				case <-ctx.Done():
+				}
+				<-ctx.Done()
+				if commit {
+					return &TurnResult{}, ctx.Err()
+				}
+				return nil, ctx.Err()
+			})
+		},
+		WithSessionStore(store),
+	)
+}
+
+// TestAgent_AbortedRunsResume covers the roads to a stopped run. An attached
+// caller cancels the context under it and a detached one calls abort; both
+// land the same aborted snapshot, holding the work through the last turn that
+// finished and resumable like any other.
+func TestAgent_AbortedRunsResume(t *testing.T) {
+	t.Run("an attached cancel returns the resume point with the error", func(t *testing.T) {
+		store := newTestInMemStore[testState]()
+		entered := make(chan struct{})
+		af := abortTestAgent(t, store, "attachedAbort", true, entered)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		conn, err := af.Connect(ctx)
+		if err != nil {
+			t.Fatalf("Connect: %v", err)
+		}
+		drainInBackground(conn)
+		sendText(t, conn, "one")
+		sendText(t, conn, "two")
+		<-entered
+		cancel()
+
+		out, err := conn.Output()
+		// Both, as ai.Generate hands back a partial response beside the error
+		// that ended it. The error alone left nothing to resume from.
+		if err == nil {
+			t.Fatal("Output err is nil, want the cancellation")
+		}
+		if out == nil {
+			t.Fatal("Output is nil, want the resume point alongside the error")
+		}
+		if out.FinishReason != AgentFinishReasonAborted {
+			t.Errorf("FinishReason = %q, want %q", out.FinishReason, AgentFinishReasonAborted)
+		}
+		if out.SnapshotID == "" {
+			t.Fatal("SnapshotID is empty, want the snapshot the run stopped at")
+		}
+		snap := waitForSnapshot(t, store, out.SnapshotID, 2*time.Second, func(s *SessionSnapshot[testState]) bool {
+			return s.Status != SnapshotStatusPending
+		})
+		// The same status a detached run's abort writes: the row does not
+		// record which way the invocation was running when it was stopped.
+		if snap.Status != SnapshotStatusAborted {
+			t.Errorf("snapshot status = %q, want %q", snap.Status, SnapshotStatusAborted)
+		}
+	})
+
+	t.Run("an uncommitted turn rolls back to its predecessor", func(t *testing.T) {
+		store := newTestInMemStore[testState]()
+		entered := make(chan struct{})
+		af := abortTestAgent(t, store, "attachedNoCommit", false, entered)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		conn, err := af.Connect(ctx)
+		if err != nil {
+			t.Fatalf("Connect: %v", err)
+		}
+		drainInBackground(conn)
+		sendText(t, conn, "one")
+		sendText(t, conn, "two")
+		<-entered
+		cancel()
+
+		out, err := conn.Output()
+		if err == nil {
+			t.Fatal("Output err is nil, want the cancellation")
+		}
+		// The stopped turn committed nothing, so it wrote no snapshot and the
+		// resume point stays the turn before it.
+		snap, err := store.GetSnapshot(context.Background(), out.SnapshotID)
+		if err != nil {
+			t.Fatalf("GetSnapshot: %v", err)
+		}
+		if snap.Status != SnapshotStatusCompleted {
+			t.Errorf("snapshot status = %q, want the completed turn before the stop", snap.Status)
+		}
+		for _, m := range snap.State.Messages {
+			if m.Text() == "second turn" {
+				t.Error("resume point holds the turn that did not finish")
+			}
+		}
+	})
+
+	t.Run("a detached abort keeps the work it had done", func(t *testing.T) {
+		store := newTestInMemStore[testState]()
+		entered := make(chan struct{})
+		af := abortTestAgent(t, store, "detachedAbort", false, entered)
+
+		conn, err := af.Connect(context.Background())
+		if err != nil {
+			t.Fatalf("Connect: %v", err)
+		}
+		drainInBackground(conn)
+		// Both inputs are queued before the detach, which the intake reads
+		// while the second turn is still blocked; detach then suspends
+		// per-turn snapshots for the rest of the invocation.
+		sendText(t, conn, "one")
+		sendText(t, conn, "two")
+		<-entered
+		if err := conn.Detach(); err != nil {
+			t.Fatalf("Detach: %v", err)
+		}
+		out, err := conn.Output()
+		if err != nil {
+			t.Fatalf("Output: %v", err)
+		}
+		if _, err := af.Abort(context.Background(), out.SnapshotID); err != nil {
+			t.Fatalf("Abort: %v", err)
+		}
+
+		snap := waitForSnapshot(t, store, out.SnapshotID, 2*time.Second, func(s *SessionSnapshot[testState]) bool {
+			return s.Status == SnapshotStatusAborted && s.FinishReason == AgentFinishReasonAborted
+		})
+		// The row used to carry no state at all: abort only flipped the
+		// pending row's status, and the finalize kept that row verbatim.
+		if snap.State == nil {
+			t.Fatal("aborted snapshot carries no state, so there is nothing to resume from")
+		}
+		var texts []string
+		for _, m := range snap.State.Messages {
+			texts = append(texts, m.Text())
+		}
+		if !slices.Contains(texts, "first turn") {
+			t.Errorf("messages = %q, want the committed turn's reply", texts)
+		}
+		// Detach suspends per-turn snapshots, so the rollback comes off the
+		// pending row's parent rather than a snapshot of its own.
+		if slices.Contains(texts, "second turn") {
+			t.Errorf("messages = %q, want the turn that did not finish rolled back", texts)
+		}
+	})
+
+	t.Run("an aborted snapshot resumes", func(t *testing.T) {
+		store := newTestInMemStore[testState]()
+		entered := make(chan struct{})
+		af := abortTestAgent(t, store, "resumeAborted", true, entered)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		conn, err := af.Connect(ctx)
+		if err != nil {
+			t.Fatalf("Connect: %v", err)
+		}
+		drainInBackground(conn)
+		sendText(t, conn, "one")
+		sendText(t, conn, "two")
+		<-entered
+		cancel()
+		out, _ := conn.Output()
+		waitForSnapshot(t, store, out.SnapshotID, 2*time.Second, func(s *SessionSnapshot[testState]) bool {
+			return s.Status == SnapshotStatusAborted
+		})
+
+		// A fresh agent over the same store, so nothing in memory carries
+		// over: the snapshot is the whole resume point.
+		resumed := DefineCustomAgent(newTestRegistry(t), "resumeAbortedContinuation",
+			func(ctx context.Context, resp Responder, sess *SessionRunner[testState]) (*AgentResult, error) {
+				return nil, sess.Run(ctx, func(ctx context.Context, input *AgentInput) (*TurnResult, error) {
+					sess.AddMessages(ai.NewModelTextMessage("continued"))
+					return nil, nil
+				})
+			},
+			WithSessionStore(store),
+		)
+		cont, err := resumed.RunText(context.Background(), "carry on",
+			WithSnapshotID[testState](out.SnapshotID))
+		if err != nil {
+			t.Fatalf("resuming the aborted snapshot: %v", err)
+		}
+		contSnap, err := store.GetSnapshot(context.Background(), cont.SnapshotID)
+		if err != nil {
+			t.Fatalf("GetSnapshot: %v", err)
+		}
+		if contSnap.State.Messages[len(contSnap.State.Messages)-1].Text() != "continued" {
+			t.Error("the resumed turn's reply is not the conversation's last message")
+		}
+	})
+
+	t.Run("a deadline aborts too, and the error says which", func(t *testing.T) {
+		store := newTestInMemStore[testState]()
+		entered := make(chan struct{})
+		af := abortTestAgent(t, store, "deadlineAborts", true, entered)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+		defer cancel()
+		conn, err := af.Connect(ctx)
+		if err != nil {
+			t.Fatalf("Connect: %v", err)
+		}
+		drainInBackground(conn)
+		sendText(t, conn, "one")
+		sendText(t, conn, "two")
+		<-entered
+
+		out, _ := conn.Output()
+		if out == nil {
+			t.Fatal("Output is nil, want the resume point")
+		}
+		// The caller set the deadline, so it stopped the run as deliberately
+		// as a cancel does, only in advance.
+		if out.FinishReason != AgentFinishReasonAborted {
+			t.Errorf("FinishReason = %q, want %q", out.FinishReason, AgentFinishReasonAborted)
+		}
+		snap := waitForSnapshot(t, store, out.SnapshotID, 2*time.Second, func(s *SessionSnapshot[testState]) bool {
+			return s.Status != SnapshotStatusPending
+		})
+		if snap.Status != SnapshotStatusAborted {
+			t.Errorf("snapshot status = %q, want %q", snap.Status, SnapshotStatusAborted)
+		}
+		// The row does not say which stop it was. The work context is
+		// decoupled from the client's, so the turn only ever sees
+		// context.Canceled and the deadline does not reach the error either.
+		if snap.Error == nil || snap.Error.Status != status.Cancelled {
+			t.Errorf("Error = %+v, want a CANCELLED classification", snap.Error)
+		}
+	})
+}
+
 func TestAgent_Detach_NormalCompletionStillEmitsTurnEnd(t *testing.T) {
 	// Sanity: a non-detached invocation against a store-backed flow still
 	// behaves like a synchronous flow (turn-end snapshots, no pending row).

--- a/go/ai/exp/agent_test.go
+++ b/go/ai/exp/agent_test.go
@@ -4136,6 +4136,62 @@ func TestAgent_AbortedRunsResume(t *testing.T) {
 		}
 	})
 
+	t.Run("a detached abort with nothing committed rolls all the way back", func(t *testing.T) {
+		// The rollback floor. This run detaches on its first input and that
+		// turn never commits, so there is no last-good copy in memory and no
+		// earlier snapshot to read one from: without the invocation's own
+		// initial state as a source, the row keeps the mutations of a turn
+		// that did not finish, on a row this PR makes resumable.
+		store := newTestInMemStore[testState]()
+		entered := make(chan struct{})
+		af := DefineCustomAgent(newTestRegistry(t), "detachedAbortNothingCommitted",
+			func(ctx context.Context, resp Responder, sess *SessionRunner[testState]) (*AgentResult, error) {
+				return nil, sess.Run(ctx, func(ctx context.Context, input *AgentInput) (*TurnResult, error) {
+					sess.AddMessages(ai.NewModelTextMessage("uncommitted turn"))
+					select {
+					case entered <- struct{}{}:
+					case <-ctx.Done():
+					}
+					<-ctx.Done()
+					return nil, ctx.Err()
+				})
+			},
+			WithSessionStore(store),
+		)
+
+		conn, err := af.Connect(context.Background())
+		if err != nil {
+			t.Fatalf("Connect: %v", err)
+		}
+		drainInBackground(conn)
+		sendText(t, conn, "go")
+		<-entered
+		if err := conn.Detach(); err != nil {
+			t.Fatalf("Detach: %v", err)
+		}
+		out, err := outputWithin(t, conn, 10*time.Second)
+		if err != nil {
+			t.Fatalf("Output: %v", err)
+		}
+		if _, err := af.Abort(context.Background(), out.SnapshotID); err != nil {
+			t.Fatalf("Abort: %v", err)
+		}
+
+		snap := waitForSnapshot(t, store, out.SnapshotID, 2*time.Second, func(s *SessionSnapshot[testState]) bool {
+			return s.Status == SnapshotStatusAborted && s.FinishReason == AgentFinishReasonAborted
+		})
+		if snap.State == nil {
+			t.Fatal("aborted snapshot carries no state")
+		}
+		var texts []string
+		for _, m := range snap.State.Messages {
+			texts = append(texts, m.Text())
+		}
+		if len(texts) != 0 {
+			t.Errorf("messages = %q, want none: no turn committed, so there is nothing to keep", texts)
+		}
+	})
+
 	t.Run("an aborted snapshot resumes", func(t *testing.T) {
 		store := newTestInMemStore[testState]()
 		entered := make(chan struct{})
@@ -7962,5 +8018,95 @@ func TestAgent_OutputUnblocksOnCancel(t *testing.T) {
 		}
 	case <-time.After(10 * time.Second):
 		t.Fatal("Output did not return after cancellation; no context escape")
+	}
+}
+
+// TestPromptAgent_FailedTurnReasonIsNotTheModelReason pins the one place the
+// generate loop's finish reason must not be forwarded verbatim. A response
+// the loop completed and post-processing then rejected keeps the model's own
+// reason ("stop") beside its ErrInvalidOutput, so a turn that failed would
+// otherwise report a success on its TurnEnd chunk and on its snapshot row.
+func TestPromptAgent_FailedTurnReasonIsNotTheModelReason(t *testing.T) {
+	ctx := context.Background()
+	reg := newTestRegistry(t)
+	ai.ConfigureFormats(reg)
+	defineTestModel(reg, "test/badjson", nil,
+		func(ctx context.Context, req *ai.ModelRequest, cb ai.ModelStreamCallback) (*ai.ModelResponse, error) {
+			// Not the JSON the output type asks for, and the model itself
+			// finished cleanly: exactly the shape that carries "stop" out of
+			// a failed generate.
+			return &ai.ModelResponse{
+				Request:      req,
+				Message:      ai.NewModelTextMessage("not json"),
+				FinishReason: ai.FinishReasonStop,
+			}, nil
+		})
+	ai.DefineGenerateAction(ctx, reg)
+
+	store := newTestInMemStore[testState]()
+	af := DefineAgent[testState](reg, "invalidOutputAgent", InlinePrompt{
+		ai.WithModelName("test/badjson"),
+		ai.WithOutputType(struct {
+			Name string `json:"name"`
+		}{}),
+	}, WithSessionStore(store))
+
+	out, err := af.RunText(ctx, "hi")
+	if err != nil {
+		t.Fatalf("RunText: %v", err)
+	}
+	if out.FinishReason != AgentFinishReasonFailed {
+		t.Errorf("output FinishReason = %q, want %q", out.FinishReason, AgentFinishReasonFailed)
+	}
+	if out.SnapshotID == "" {
+		t.Fatal("no snapshot: the turn committed the partial, so it must have one")
+	}
+	snap, err := af.GetSnapshot(ctx, out.SnapshotID)
+	if err != nil {
+		t.Fatalf("GetSnapshot: %v", err)
+	}
+	if snap.Status != SnapshotStatusFailed {
+		t.Errorf("snapshot Status = %q, want %q", snap.Status, SnapshotStatusFailed)
+	}
+	if snap.FinishReason != AgentFinishReasonFailed {
+		t.Errorf("snapshot FinishReason = %q, want %q: the model's own reason must not ride onto a failed row",
+			snap.FinishReason, AgentFinishReasonFailed)
+	}
+}
+
+// TestAgent_ResumeRejectsAbortedRowWithNoState covers the window between the
+// two writes an aborted detached row takes: abort flips the status, and the
+// finalize that follows stamps the state. A row still between them holds no
+// conversation, so resuming it must fail rather than hand back an empty
+// session in place of the one the caller asked to continue.
+func TestAgent_ResumeRejectsAbortedRowWithNoState(t *testing.T) {
+	ctx := context.Background()
+	store := newTestInMemStore[testState]()
+	af := DefineCustomAgent(newTestRegistry(t), "abortedNoState",
+		func(ctx context.Context, resp Responder, sess *SessionRunner[testState]) (*AgentResult, error) {
+			return nil, sess.Run(ctx, func(ctx context.Context, input *AgentInput) (*TurnResult, error) {
+				sess.AddMessages(ai.NewModelTextMessage("reply"))
+				return nil, nil
+			})
+		},
+		WithSessionStore(store))
+
+	// The shape abortPendingSnapshot leaves behind before finalizePendingSnapshot
+	// stamps the state: aborted, and carrying nothing.
+	snap, err := store.SaveSnapshot(ctx, "",
+		func(*SessionSnapshot[testState]) (*SessionSnapshot[testState], error) {
+			return &SessionSnapshot[testState]{
+				SessionID: "sess-no-state",
+				Status:    SnapshotStatusAborted,
+			}, nil
+		})
+	if err != nil {
+		t.Fatalf("SaveSnapshot: %v", err)
+	}
+
+	if _, err := af.RunText(ctx, "continue", WithSnapshotID[testState](snap.SnapshotID)); err == nil {
+		t.Fatal("resume from a stateless aborted snapshot succeeded, want FAILED_PRECONDITION")
+	} else if !errors.Is(err, status.ErrFailedPrecondition) {
+		t.Errorf("resume error = %v, want FAILED_PRECONDITION", err)
 	}
 }

--- a/go/ai/exp/agent_test.go
+++ b/go/ai/exp/agent_test.go
@@ -3968,13 +3968,6 @@ func TestAgent_Detach_AbortStopsFlow(t *testing.T) {
 // a partial response.
 func abortTestAgent(t *testing.T, store SessionStore[testState], name string, commit bool, entered chan<- struct{}) *Agent[testState] {
 	t.Helper()
-	return abortTestAgentGated(t, store, name, commit, entered, nil)
-}
-
-// abortTestAgentGated is abortTestAgent with a signal on the first turn's
-// completion, for a test that has to land a detach between the two turns.
-func abortTestAgentGated(t *testing.T, store SessionStore[testState], name string, commit bool, entered, firstDone chan<- struct{}) *Agent[testState] {
-	t.Helper()
 	turns := 0
 	return DefineCustomAgent(newTestRegistry(t), name,
 		func(ctx context.Context, resp Responder, sess *SessionRunner[testState]) (*AgentResult, error) {
@@ -3983,11 +3976,6 @@ func abortTestAgentGated(t *testing.T, store SessionStore[testState], name strin
 				if turns == 1 {
 					sess.AddMessages(ai.NewModelTextMessage("first turn"))
 					return nil, nil
-				}
-				if firstDone != nil {
-					// The first turn has snapshotted by now: this runs after
-					// its turn-end tail.
-					close(firstDone)
 				}
 				sess.AddMessages(ai.NewModelTextMessage("second turn"))
 				select {
@@ -4026,7 +4014,7 @@ func TestAgent_AbortedRunsResume(t *testing.T) {
 		<-entered
 		cancel()
 
-		out, err := conn.Output()
+		out, err := outputWithin(t, conn, 10*time.Second)
 		// Both, as ai.Generate hands back a partial response beside the error
 		// that ended it. The error alone left nothing to resume from.
 		if err == nil {
@@ -4067,7 +4055,7 @@ func TestAgent_AbortedRunsResume(t *testing.T) {
 		<-entered
 		cancel()
 
-		out, err := conn.Output()
+		out, err := outputWithin(t, conn, 10*time.Second)
 		if err == nil {
 			t.Fatal("Output err is nil, want the cancellation")
 		}
@@ -4106,7 +4094,7 @@ func TestAgent_AbortedRunsResume(t *testing.T) {
 		if err := conn.Detach(); err != nil {
 			t.Fatalf("Detach: %v", err)
 		}
-		out, err := conn.Output()
+		out, err := outputWithin(t, conn, 10*time.Second)
 		if err != nil {
 			t.Fatalf("Output: %v", err)
 		}
@@ -4207,7 +4195,7 @@ func TestAgent_AbortedRunsResume(t *testing.T) {
 		sendText(t, conn, "two")
 		<-entered
 		cancel()
-		out, _ := conn.Output()
+		out, _ := outputWithin(t, conn, 10*time.Second)
 		waitForSnapshot(t, store, out.SnapshotID, 2*time.Second, func(s *SessionSnapshot[testState]) bool {
 			return s.Status == SnapshotStatusAborted
 		})
@@ -4253,7 +4241,7 @@ func TestAgent_AbortedRunsResume(t *testing.T) {
 		sendText(t, conn, "two")
 		<-entered
 
-		out, _ := conn.Output()
+		out, _ := outputWithin(t, conn, 10*time.Second)
 		if out == nil {
 			t.Fatal("Output is nil, want the resume point")
 		}

--- a/go/ai/exp/agent_test.go
+++ b/go/ai/exp/agent_test.go
@@ -4059,6 +4059,9 @@ func TestAgent_AbortedRunsResume(t *testing.T) {
 		if err == nil {
 			t.Fatal("Output err is nil, want the cancellation")
 		}
+		if out == nil {
+			t.Fatal("Output is nil, want the resume point beside the error")
+		}
 		// The stopped turn committed nothing, so it wrote no snapshot and the
 		// resume point stays the turn before it.
 		snap, err := store.GetSnapshot(context.Background(), out.SnapshotID)
@@ -4196,6 +4199,9 @@ func TestAgent_AbortedRunsResume(t *testing.T) {
 		<-entered
 		cancel()
 		out, _ := outputWithin(t, conn, 10*time.Second)
+		if out == nil {
+			t.Fatal("Output is nil, want the resume point")
+		}
 		waitForSnapshot(t, store, out.SnapshotID, 2*time.Second, func(s *SessionSnapshot[testState]) bool {
 			return s.Status == SnapshotStatusAborted
 		})

--- a/go/ai/exp/agent_test.go
+++ b/go/ai/exp/agent_test.go
@@ -4225,6 +4225,46 @@ func TestAgent_AbortedRunsResume(t *testing.T) {
 		}
 	})
 
+	t.Run("a service that answers ABORTED is a failure, not an abort", func(t *testing.T) {
+		// The status map turns HTTP 409 into ABORTED and 504 into
+		// DEADLINE_EXCEEDED, so a provider stamping the service's own status
+		// reaches the same names a stopped caller does. Only the caller's
+		// context and the limits it set decide aborted: persisting a dropped
+		// request as aborted would tell a client the run stopped on request,
+		// which is the class a retry loop is most likely to leave alone.
+		ctx := context.Background()
+		store := newTestInMemStore[testState]()
+		af := DefineCustomAgent(newTestRegistry(t), "serviceAborted",
+			func(ctx context.Context, resp Responder, sess *SessionRunner[testState]) (*AgentResult, error) {
+				return nil, sess.Run(ctx, func(ctx context.Context, input *AgentInput) (*TurnResult, error) {
+					sess.AddMessages(ai.NewModelTextMessage("as far as it got"))
+					return &TurnResult{}, status.Errorf(status.ErrAborted, "409 from the service")
+				})
+			},
+			WithSessionStore(store),
+		)
+
+		out, err := af.RunText(ctx, "go")
+		if err != nil {
+			t.Fatalf("RunText: %v", err)
+		}
+		if out.FinishReason != AgentFinishReasonFailed {
+			t.Errorf("FinishReason = %q, want %q", out.FinishReason, AgentFinishReasonFailed)
+		}
+		snap, err := store.GetSnapshot(ctx, out.SnapshotID)
+		if err != nil {
+			t.Fatalf("GetSnapshot: %v", err)
+		}
+		if snap.Status != SnapshotStatusFailed {
+			t.Errorf("snapshot status = %q, want %q", snap.Status, SnapshotStatusFailed)
+		}
+		// The classification itself is untouched: only who ended the run is
+		// this layer's call.
+		if snap.Error == nil || snap.Error.Status != core.ABORTED {
+			t.Errorf("snapshot error = %+v, want the service's ABORTED preserved", snap.Error)
+		}
+	})
+
 	t.Run("a deadline aborts too, and the error says which", func(t *testing.T) {
 		store := newTestInMemStore[testState]()
 		entered := make(chan struct{})

--- a/go/ai/exp/agent_test.go
+++ b/go/ai/exp/agent_test.go
@@ -4265,6 +4265,52 @@ func TestAgent_AbortedRunsResume(t *testing.T) {
 		}
 	})
 
+	t.Run("an aborted row still being finalized points at itself", func(t *testing.T) {
+		// The abort flips the pending row and the finalize stamps the state
+		// on, so a row caught between them carries none. What the caller does
+		// next differs by which half of that window it is, and the heartbeat
+		// the abort left running is what says.
+		ctx := context.Background()
+		store := newTestInMemStore[testState]()
+		af := defineCounterAgent(newTestRegistry(t), "resumeMidFinalize", WithSessionStore(store))
+
+		stateless := func(beat time.Time) string {
+			snap, err := store.SaveSnapshot(ctx, "",
+				func(_ *SessionSnapshot[testState]) (*SessionSnapshot[testState], error) {
+					return &SessionSnapshot[testState]{
+						Status:      SnapshotStatusAborted,
+						HeartbeatAt: &beat,
+					}, nil
+				})
+			if err != nil {
+				t.Fatalf("SaveSnapshot: %v", err)
+			}
+			return snap.SnapshotID
+		}
+
+		for _, tc := range []struct {
+			name string
+			beat time.Time
+			want string
+		}{
+			{"a live heartbeat means the write is coming", time.Now(), "retry this same snapshot ID"},
+			{"a quiet heartbeat means it never will", time.Now().Add(-2 * defaultHeartbeatTimeout), "resume from an earlier snapshot"},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				_, err := af.RunText(ctx, "carry on", WithSnapshotID[testState](stateless(tc.beat)))
+				if err == nil {
+					t.Fatal("resuming a stateless aborted row was accepted")
+				}
+				if !strings.Contains(err.Error(), tc.want) {
+					t.Errorf("error %q does not contain %q", err, tc.want)
+				}
+				if ge := core.AsGenkitError(err); ge.Status != core.FAILED_PRECONDITION {
+					t.Errorf("status = %q, want %q", ge.Status, core.FAILED_PRECONDITION)
+				}
+			})
+		}
+	})
+
 	t.Run("a deadline aborts too, and the error says which", func(t *testing.T) {
 		store := newTestInMemStore[testState]()
 		entered := make(chan struct{})

--- a/go/ai/exp/agents_conformance_test.go
+++ b/go/ai/exp/agents_conformance_test.go
@@ -943,16 +943,6 @@ func executeWaitUntilCompleted(t *testing.T, label string, store *localstore.InM
 		exp.SnapshotStatusFailed:    true,
 		exp.SnapshotStatusAborted:   true,
 	}
-	// An aborted row reaches its status in two writes: the abort flips it, and
-	// the finalize that follows stamps the reason and the state. The reason is
-	// the marker that the second one has landed, so a wait that stopped at the
-	// status alone would read a row still being written.
-	settled := func(snap *exp.SessionSnapshot[customState]) bool {
-		if normalizeStatus(snap.Status) != exp.SnapshotStatusAborted {
-			return true
-		}
-		return snap.FinishReason != ""
-	}
 
 	ctx := context.Background()
 	deadline := time.Now().Add(timeout)
@@ -962,9 +952,16 @@ func executeWaitUntilCompleted(t *testing.T, label string, store *localstore.InM
 		if err != nil {
 			t.Fatalf("%s: getSnapshot while polling: %v", label, err)
 		}
-		if s != nil && terminal[normalizeStatus(s.Status)] && settled(s) {
-			snap = s
-			break
+		// An aborted row reaches its status in two writes: the abort flips it,
+		// and the finalize that follows stamps the reason and the state. The
+		// reason is the marker that the second write landed, so a wait that
+		// stopped at the status alone would read a row still being written.
+		if s != nil {
+			st := normalizeStatus(s.Status)
+			if terminal[st] && (st != exp.SnapshotStatusAborted || s.FinishReason != "") {
+				snap = s
+				break
+			}
 		}
 		time.Sleep(50 * time.Millisecond)
 	}

--- a/go/ai/exp/agents_conformance_test.go
+++ b/go/ai/exp/agents_conformance_test.go
@@ -64,6 +64,7 @@ const specPath = "../../../tests/specs/agent.yaml"
 // typo instead, and fails.
 var supportedRequires = map[string]bool{
 	"resumable-failures": true,
+	"resumable-aborts":   true,
 }
 
 // customState is the single session-state type used by every conformance
@@ -255,6 +256,28 @@ func setupHarness(t *testing.T) *harness {
 			}
 			return &exp.AgentResult{Message: ai.NewModelTextMessage("unblocked")}, nil
 		}, newStore("customAgentBlocking"))
+
+	// customAgentAbortable: server-managed, records the turn and blocks until
+	// its context is cancelled on the turn whose message is "block". Used for
+	// the resumable-abort cases, where the abort has to land with a committed
+	// turn behind it and an unfinished one in front of it.
+	h.agents["customAgentAbortable"] = exp.DefineCustomAgent(reg, "customAgentAbortable",
+		func(ctx context.Context, _ exp.Responder, sess *exp.SessionRunner[customState]) (*exp.AgentResult, error) {
+			if err := sess.Run(ctx, func(ctx context.Context, in *exp.AgentInput) (*exp.TurnResult, error) {
+				sess.AddMessages(in.Message)
+				if in.Message != nil && in.Message.Text() == "block" {
+					<-ctx.Done()
+					// No TurnResult: the turn commits nothing, so the message
+					// it just added rolls back with it.
+					return nil, ctx.Err()
+				}
+				sess.AddMessages(ai.NewModelTextMessage("ack"))
+				return nil, nil
+			}); err != nil {
+				return nil, err
+			}
+			return &exp.AgentResult{Message: ai.NewModelTextMessage("done")}, nil
+		}, newStore("customAgentAbortable"))
 
 	// customAgentFailing: server-managed, fails during processing. Used for
 	// detach + background failure tests.
@@ -920,6 +943,16 @@ func executeWaitUntilCompleted(t *testing.T, label string, store *localstore.InM
 		exp.SnapshotStatusFailed:    true,
 		exp.SnapshotStatusAborted:   true,
 	}
+	// An aborted row reaches its status in two writes: the abort flips it, and
+	// the finalize that follows stamps the reason and the state. The reason is
+	// the marker that the second one has landed, so a wait that stopped at the
+	// status alone would read a row still being written.
+	settled := func(snap *exp.SessionSnapshot[customState]) bool {
+		if normalizeStatus(snap.Status) != exp.SnapshotStatusAborted {
+			return true
+		}
+		return snap.FinishReason != ""
+	}
 
 	ctx := context.Background()
 	deadline := time.Now().Add(timeout)
@@ -929,7 +962,7 @@ func executeWaitUntilCompleted(t *testing.T, label string, store *localstore.InM
 		if err != nil {
 			t.Fatalf("%s: getSnapshot while polling: %v", label, err)
 		}
-		if s != nil && terminal[normalizeStatus(s.Status)] {
+		if s != nil && terminal[normalizeStatus(s.Status)] && settled(s) {
 			snap = s
 			break
 		}

--- a/go/ai/exp/gen.go
+++ b/go/ai/exp/gen.go
@@ -394,15 +394,18 @@ type SessionState[State any] struct {
 
 // SnapshotStatus describes the lifecycle state of a snapshot. A synchronous
 // turn writes [SnapshotStatusCompleted] on success (an empty value is also
-// treated as completed for backwards compatibility) and
-// [SnapshotStatusFailed] when it fails.
+// treated as completed for backwards compatibility), [SnapshotStatusFailed]
+// when something inside it breaks, and [SnapshotStatusAborted] when the caller
+// stopped it instead.
 //
 // When a client sets [AgentInput.Detach], the server writes a single
 // snapshot with [SnapshotStatusPending] (and empty state) and returns its
-// ID immediately. Background processing then either rewrites that snapshot
-// with the cumulative final state and [SnapshotStatusCompleted] /
-// [SnapshotStatusFailed] when the agent finishes, or with
-// [SnapshotStatusAborted] if the client called abort in the meantime.
+// ID immediately. Background processing then rewrites that snapshot with the
+// state through the last committed turn and [SnapshotStatusCompleted] /
+// [SnapshotStatusFailed] when the agent finishes, or [SnapshotStatusAborted]
+// if the client called abort in the meantime. A detached run's rows are
+// therefore shaped like a synchronous one's: the same statuses mean the same
+// things whichever way the invocation ran.
 //
 // [SnapshotStatusExpired] is never persisted: it is computed on read for a
 // pending snapshot whose background worker is presumed dead (its heartbeat
@@ -416,14 +419,24 @@ const (
 	SnapshotStatusPending SnapshotStatus = "pending"
 	// SnapshotStatusCompleted indicates the snapshot captures a settled state.
 	SnapshotStatusCompleted SnapshotStatus = "completed"
-	// SnapshotStatusAborted indicates the snapshot's invocation was aborted
-	// while detached (e.g. via the abort companion action).
+	// SnapshotStatusAborted indicates the caller stopped the invocation rather
+	// than something inside it breaking: it called the abort companion action on a
+	// detached run, it ended the context under an attached one (its own cancel, the
+	// transport closing, a deadline it set expiring), or the run reached a limit it
+	// set such as ai.WithMaxTurns.
+	//
+	// Its state is what the run committed before the stop, trimmed back to the
+	// last turn that finished, so resume is permitted the same way
+	// [SnapshotStatusFailed] permits it. A tool that ran inside the turn that did
+	// not finish has its response discarded with that turn, so re-sending the
+	// conversation runs it again.
 	SnapshotStatusAborted SnapshotStatus = "aborted"
 	// SnapshotStatusFailed indicates a turn ended with an error. The snapshot's
 	// Error field describes the failure, and its state is what the turn
 	// committed before it: the conversation trimmed back to the last completed
 	// tool round. Resume is permitted, so whether the failure is worth another
-	// attempt is the client's call, taken from the error's status.
+	// attempt is the client's call, taken from the error's status. A turn the
+	// caller stopped writes [SnapshotStatusAborted] instead.
 	SnapshotStatusFailed SnapshotStatus = "failed"
 	// SnapshotStatusExpired indicates a pending snapshot whose detached background
 	// worker is presumed dead: its [SessionSnapshot.HeartbeatAt] went stale. It is

--- a/go/ai/exp/gen.go
+++ b/go/ai/exp/gen.go
@@ -101,9 +101,10 @@ type AgentInit[State any] struct {
 	// SessionID identifies the session (conversation) to resume or start. Only
 	// valid when the agent is server-managed (a session store is configured);
 	// mutually exclusive with State. Alone, it resumes the session's latest
-	// snapshot, rejected if that snapshot is an aborted or pending dead end; a
-	// [SnapshotStatusFailed] snapshot resumes with what the failed turn
-	// committed. If the session has no snapshots yet, a fresh conversation
+	// snapshot, rejected only if that snapshot is [SnapshotStatusPending] and so
+	// still being written to. A [SnapshotStatusFailed] or [SnapshotStatusAborted]
+	// snapshot resumes with what the last turn to finish committed. If the session
+	// has no snapshots yet, a fresh conversation
 	// starts under this caller-chosen ID. Combined with SnapshotID, it asserts
 	// the snapshot belongs to that session.
 	SessionID string `json:"sessionId,omitempty"`

--- a/go/ai/exp/option.go
+++ b/go/ai/exp/option.go
@@ -323,11 +323,11 @@ func WithSnapshotID[State any](id string) InvocationOption[State] {
 // state). Combined with [WithSnapshotID], the snapshot picks the resume point
 // and the session ID is validated against it.
 //
-// The resume is rejected if the latest snapshot is an aborted or pending dead
-// end; a pending tip means a detached invocation is still running, so wait for
-// it to finalize or abort it. A failed tip is not a dead end: it resumes with
-// what the failed turn committed, and an input with no payload of its own
-// re-attempts the turn. If history was forked, the most recently created
+// The resume is rejected only if the latest snapshot is pending, meaning a
+// detached invocation is still writing to it: wait for it to finalize, or
+// abort it. A failed or aborted tip resumes with what the last turn to finish
+// committed, and an input with no payload of its own re-attempts from there.
+// If history was forked, the most recently created
 // branch wins; use [WithSnapshotID] for a specific branch. An empty ID is an
 // error, not a no-op.
 func WithSessionID[State any](id string) InvocationOption[State] {

--- a/go/ai/generate.go
+++ b/go/ai/generate.go
@@ -372,14 +372,22 @@ func responseError(cause error) *status.Error {
 	return e
 }
 
-// callerStopped are the statuses that say the caller ended the loop rather
-// than something breaking inside it: it cancelled the context, its deadline
-// expired, or it set a limit the loop reached ([ErrMaxTurnsExceeded] is an
-// ABORTED subtype). They report [FinishReasonAborted].
-var callerStopped = map[status.Name]bool{
-	status.Cancelled:        true,
-	status.DeadlineExceeded: true,
-	status.Aborted:          true,
+// callerStopped reports whether the loop ended because the caller stopped it
+// rather than because something inside it broke: it cancelled the context, its
+// deadline expired, or the loop reached a limit it set ([ErrMaxTurnsExceeded]).
+// Those report [FinishReasonAborted]; everything else reports
+// [FinishReasonFailed].
+//
+// It tests the context and the sentinels, never the classified status. A
+// service that answers 409 or 504 lands on ABORTED or DEADLINE_EXCEEDED
+// through the HTTP mapping in [status], and a provider stopping the request is
+// not the caller stopping the run: reporting it aborted tells a retry client
+// the one thing that is not true of it.
+func callerStopped(ctx context.Context, cause error) bool {
+	return ctx.Err() != nil ||
+		errors.Is(cause, context.Canceled) ||
+		errors.Is(cause, context.DeadlineExceeded) ||
+		errors.Is(cause, ErrMaxTurnsExceeded)
 }
 
 // failurePartial builds the partial [ModelResponse] that accompanies the
@@ -406,14 +414,14 @@ var callerStopped = map[status.Name]bool{
 // classified, so a consumer reading the response as data branches on a status
 // rather than a string. Downstream consumers treat both finishes as abnormal:
 // output parsing is skipped and the typed helpers extract nothing from it.
-func failurePartial(base *ModelResponse, req *ModelRequest, cause error) *ModelResponse {
+func failurePartial(ctx context.Context, base *ModelResponse, req *ModelRequest, cause error) *ModelResponse {
 	p := ModelResponse{}
 	if base != nil {
 		p = *base
 	}
 	p.Message = nil
 	p.FinishReason = FinishReasonFailed
-	if s, ok := status.Classified(cause); ok && callerStopped[s] {
+	if callerStopped(ctx, cause) {
 		p.FinishReason = FinishReasonAborted
 	}
 	p.FinishMessage = cause.Error()
@@ -667,7 +675,7 @@ func generateWithRequest(ctx context.Context, r api.Registry, opts *GenerateActi
 					Role:    RoleTool,
 				}); err != nil {
 					err = fmt.Errorf("streaming callback failed for resumed tool message: %w", err)
-					return failurePartial(nil, &resumeReq, err), err
+					return failurePartial(ctx, nil, &resumeReq, err), err
 				}
 			}
 
@@ -680,7 +688,7 @@ func generateWithRequest(ctx context.Context, r api.Registry, opts *GenerateActi
 			// The model's own output is dropped, complete or not: only the
 			// conversation entering this turn survives. Chunks already
 			// streamed reached the callback, so nothing observable is lost.
-			return failurePartial(resp, req, err), err
+			return failurePartial(ctx, resp, req, err), err
 		}
 
 		// ToolRequests allocates a scan of the message, so only build the
@@ -737,7 +745,7 @@ func generateWithRequest(ctx context.Context, r api.Registry, opts *GenerateActi
 
 		if currentTurn+1 > maxTurns {
 			err := status.Errorf(ErrMaxTurnsExceeded, "exceeded maximum tool call iterations (%d)", maxTurns)
-			return failurePartial(resp, req, err), err
+			return failurePartial(ctx, resp, req, err), err
 		}
 
 		newReq, revisedMsg, err := handleToolRequests(ctx, r, req, resp, wrappedCb, currentIndex, runTool)
@@ -746,7 +754,7 @@ func generateWithRequest(ctx context.Context, r api.Registry, opts *GenerateActi
 			// included: a failed tool leaves its request unanswered, and
 			// [failurePartial] hands back a conversation that can be
 			// re-sent.
-			return failurePartial(resp, req, err), err
+			return failurePartial(ctx, resp, req, err), err
 		}
 		if revisedMsg != nil {
 			logger.Debug(ctx, "generation paused by tool interrupts", "model", opts.Model, "turn", currentTurn)
@@ -844,7 +852,7 @@ func generateWithRequest(ctx context.Context, r api.Registry, opts *GenerateActi
 		if lastPartial != nil {
 			resp = lastPartial
 		} else {
-			resp = failurePartial(nil, lastReq, err)
+			resp = failurePartial(ctx, nil, lastReq, err)
 		}
 	}
 	return resp, err

--- a/go/ai/generate_test.go
+++ b/go/ai/generate_test.go
@@ -3711,6 +3711,40 @@ func TestGeneratePartialResponseOnFailure(t *testing.T) {
 		}
 	})
 
+	t.Run("a service that answers ABORTED reports failed", func(t *testing.T) {
+		// The status map turns HTTP 409 into ABORTED and 504 into
+		// DEADLINE_EXCEEDED, so a provider stamping the service's own status
+		// reaches the same names a stopped caller does. Only the context and
+		// the limits the caller set say aborted: a service dropping the
+		// request broke the run, which is what a retry client reads.
+		r := newTestRegistry(t)
+		defineFakeModel(t, r, fakeModelConfig{
+			name: "test/serviceAborted",
+			handler: func(ctx context.Context, req *ModelRequest, cb ModelStreamCallback) (*ModelResponse, error) {
+				return nil, status.Errorf(status.ErrAborted, "409 from the service")
+			},
+		})
+
+		resp, err := Generate(testCtx, r,
+			WithModelName("test/serviceAborted"),
+			WithPrompt("start"),
+		)
+		if err == nil {
+			t.Fatal("expected the service's error")
+		}
+		if resp == nil {
+			t.Fatal("response is nil, want the loop's partial response")
+		}
+		if resp.FinishReason != FinishReasonFailed {
+			t.Errorf("FinishReason = %q, want %q: the service stopped the request, not the caller", resp.FinishReason, FinishReasonFailed)
+		}
+		// The classification is untouched; only who ended the run is decided
+		// here.
+		if resp.Error == nil || resp.Error.Status != status.Aborted {
+			t.Errorf("Error = %+v, want the service's ABORTED preserved", resp.Error)
+		}
+	})
+
 	t.Run("cancellation inside a tool reports aborted", func(t *testing.T) {
 		r := newTestRegistry(t)
 		defineFakeModel(t, r, fakeModelConfig{

--- a/go/core/schemas.config
+++ b/go/core/schemas.config
@@ -1695,15 +1695,18 @@ SnapshotStatus pkg ai/exp
 SnapshotStatus doc
 SnapshotStatus describes the lifecycle state of a snapshot. A synchronous
 turn writes [SnapshotStatusCompleted] on success (an empty value is also
-treated as completed for backwards compatibility) and
-[SnapshotStatusFailed] when it fails.
+treated as completed for backwards compatibility), [SnapshotStatusFailed]
+when something inside it breaks, and [SnapshotStatusAborted] when the caller
+stopped it instead.
 
 When a client sets [AgentInput.Detach], the server writes a single
 snapshot with [SnapshotStatusPending] (and empty state) and returns its
-ID immediately. Background processing then either rewrites that snapshot
-with the cumulative final state and [SnapshotStatusCompleted] /
-[SnapshotStatusFailed] when the agent finishes, or with
-[SnapshotStatusAborted] if the client called abort in the meantime.
+ID immediately. Background processing then rewrites that snapshot with the
+state through the last committed turn and [SnapshotStatusCompleted] /
+[SnapshotStatusFailed] when the agent finishes, or [SnapshotStatusAborted]
+if the client called abort in the meantime. A detached run's rows are
+therefore shaped like a synchronous one's: the same statuses mean the same
+things whichever way the invocation ran.
 
 [SnapshotStatusExpired] is never persisted: it is computed on read for a
 pending snapshot whose background worker is presumed dead (its heartbeat
@@ -1721,8 +1724,17 @@ SnapshotStatusCompleted indicates the snapshot captures a settled state.
 .
 
 SnapshotStatusAborted doc
-SnapshotStatusAborted indicates the snapshot's invocation was aborted
-while detached (e.g. via the abort companion action).
+SnapshotStatusAborted indicates the caller stopped the invocation rather
+than something inside it breaking: it called the abort companion action on a
+detached run, it ended the context under an attached one (its own cancel, the
+transport closing, a deadline it set expiring), or the run reached a limit it
+set such as ai.WithMaxTurns.
+
+Its state is what the run committed before the stop, trimmed back to the
+last turn that finished, so resume is permitted the same way
+[SnapshotStatusFailed] permits it. A tool that ran inside the turn that did
+not finish has its response discarded with that turn, so re-sending the
+conversation runs it again.
 .
 
 SnapshotStatusFailed doc
@@ -1730,7 +1742,8 @@ SnapshotStatusFailed indicates a turn ended with an error. The snapshot's
 Error field describes the failure, and its state is what the turn
 committed before it: the conversation trimmed back to the last completed
 tool round. Resume is permitted, so whether the failure is worth another
-attempt is the client's call, taken from the error's status.
+attempt is the client's call, taken from the error's status. A turn the
+caller stopped writes [SnapshotStatusAborted] instead.
 .
 
 SnapshotStatusExpired doc

--- a/go/core/schemas.config
+++ b/go/core/schemas.config
@@ -1298,9 +1298,10 @@ AgentInit.sessionId doc
 SessionID identifies the session (conversation) to resume or start. Only
 valid when the agent is server-managed (a session store is configured);
 mutually exclusive with State. Alone, it resumes the session's latest
-snapshot, rejected if that snapshot is an aborted or pending dead end; a
-[SnapshotStatusFailed] snapshot resumes with what the failed turn
-committed. If the session has no snapshots yet, a fresh conversation
+snapshot, rejected only if that snapshot is [SnapshotStatusPending] and so
+still being written to. A [SnapshotStatusFailed] or [SnapshotStatusAborted]
+snapshot resumes with what the last turn to finish committed. If the session
+has no snapshots yet, a fresh conversation
 starts under this caller-chosen ID. Combined with SnapshotID, it asserts
 the snapshot belongs to that session.
 .

--- a/go/samples/basic-agents/cli.go
+++ b/go/samples/basic-agents/cli.go
@@ -378,9 +378,9 @@ func handlePending[State any](ctx context.Context, inputCh <-chan string, a *aix
 			}
 			fmt.Println(style(fmt.Sprintf("Done (%s).", final.Status), ansiGreen))
 			if !resumableStatus(final.Status) {
-				// aborted / pending snapshots are dead ends; the agent
-				// runtime would reject WithSnapshotID on them. Fall
-				// through to a fresh chat instead.
+				// A pending snapshot is still being written to; the agent
+				// runtime would reject WithSnapshotID on it. Fall through
+				// to a fresh chat instead.
 				fmt.Println(style("Cannot resume this snapshot. Starting a new conversation.", ansiYellow))
 				return nil, true
 			}
@@ -399,9 +399,14 @@ func handlePending[State any](ctx context.Context, inputCh <-chan string, a *aix
 
 // resumableStatus reports whether a settled snapshot can be continued from.
 // A failed row qualifies: it holds what its turn committed before the
-// failure, so resuming it picks up there and re-attempts that turn.
+// failure, so resuming it picks up there and re-attempts that turn. So does
+// an aborted one, which holds the turns that finished before the stop.
 func resumableStatus(s aix.SnapshotStatus) bool {
-	return s == aix.SnapshotStatusCompleted || s == aix.SnapshotStatusFailed
+	switch s {
+	case aix.SnapshotStatusCompleted, aix.SnapshotStatusFailed, aix.SnapshotStatusAborted:
+		return true
+	}
+	return false
 }
 
 // pickSession decides which snapshot (if any) to resume from. It only
@@ -421,12 +426,15 @@ func pickSession[State any](ctx context.Context, inputCh <-chan string, a *aix.A
 	fmt.Printf("\nLast %s session: %s\n",
 		style(a.Name(), ansiBold),
 		style(fmt.Sprintf("%s (%s, %d msgs)", shortID(latest.SnapshotID), latest.UpdatedAt.Format(time.RFC822), msgs), ansiDim))
-	if latest.Status == aix.SnapshotStatusFailed {
+	switch latest.Status {
+	case aix.SnapshotStatusFailed:
 		why := "its last turn failed"
 		if latest.Error != nil && latest.Error.Message != "" {
 			why = latest.Error.Message
 		}
 		fmt.Println(style("Resuming re-attempts the failed turn: "+why, ansiYellow))
+	case aix.SnapshotStatusAborted:
+		fmt.Println(style("This session was stopped. Resuming picks up from the last turn that finished.", ansiYellow))
 	}
 	fmt.Println("Resume from it? " + style("[Y/n] (n = start a new conversation)", ansiDim))
 

--- a/go/samples/basic-agents/cli.go
+++ b/go/samples/basic-agents/cli.go
@@ -21,7 +21,8 @@
 //  2. For the picked agent, pick between resuming from the latest
 //     snapshot or starting fresh. If the latest snapshot is still
 //     pending (a detached invocation is still processing in the
-//     background), offer to wait, start fresh, or back out.
+//     background), offer to wait for it, stop it, start fresh, or back
+//     out.
 //  3. Run a small REPL against the agent: stream the model's reply each
 //     turn, accept text input, and offer /detach, /back, and /quit as
 //     control commands.
@@ -31,6 +32,14 @@
 // processing in the background and the caller gets a pending snapshot
 // ID. Re-picking the same agent in step 2 then surfaces the wait/resume
 // flow.
+//
+// A turn that breaks or gets stopped is not a dead end here. Either one
+// leaves a snapshot holding the conversation up to the last turn seam, so
+// step 2 offers it like any other. Whether the turn it left unanswered is
+// worth running again is the user's call: an empty line in step 3 runs a
+// turn on the conversation as it stands, so nothing has to be retyped. The
+// only rows the CLI cannot continue from are the ones the runtime refuses
+// too, and for those it walks back to the snapshot before.
 
 package main
 
@@ -220,18 +229,24 @@ func runCLI(ctx context.Context, agents []agentEntry) error {
 	fmt.Println("Pick an agent below, choose to resume the last conversation")
 	fmt.Println("or start a new one, and chat. Inside a chat:")
 	fmt.Println("  (text)             send a message and stream the reply")
+	fmt.Println("  (empty line)       run a turn on the conversation as it")
+	fmt.Println("                     stands, without adding a message")
 	fmt.Println("  /detach (text...)  send the text (optional) as the final")
 	fmt.Println("                     input, then detach. The agent finishes")
 	fmt.Println("                     in the background and writes a pending")
 	fmt.Println("                     snapshot. Re-pick the agent later to")
-	fmt.Println("                     wait for it and resume from the final")
-	fmt.Println("                     state.")
+	fmt.Println("                     wait for it, or stop it and resume from")
+	fmt.Println("                     the turns it finished.")
 	fmt.Println("  /back              return to the agent list")
 	fmt.Println("  /quit              exit the program")
 	fmt.Println()
 	fmt.Println("Some agents pause mid-turn to ask for input (a tool")
 	fmt.Println("interrupt). When that happens, the CLI prompts you inline and")
 	fmt.Println("resumes the turn with your answer.")
+	fmt.Println()
+	fmt.Println("A turn that breaks, or one you stop, still leaves a snapshot")
+	fmt.Println("you can continue: re-pick the agent, resume from it, and press")
+	fmt.Println("Enter to run the turn it left unanswered again.")
 
 	// lastSession remembers, per agent, the session ID of the most recent
 	// conversation this process ran with it. That is all a client needs to
@@ -309,12 +324,19 @@ func openAgent[State any](ctx context.Context, inputCh <-chan string, a *aix.Age
 	// session (a first visit this run) there is nothing to resume;
 	// otherwise the store resolves the session's latest snapshot, which
 	// also surfaces a still-pending detached invocation.
+	//
+	// Reads go through the agent, not its store: the agent normalizes what a
+	// client should see, which is what turns a detached worker that stopped
+	// beating into an expired row instead of one stuck pending forever. It
+	// reports a missing snapshot as an error where the raw store returns nil,
+	// so an unknown session reads as "nothing to resume".
 	var tip *aix.SessionSnapshot[State]
 	if lastSessionID != "" {
 		var err error
-		tip, err = a.Store().GetLatestSnapshot(ctx, lastSessionID)
-		if err != nil {
-			return lastSessionID, fmt.Errorf("read snapshot for %q: %w", a.Name(), err)
+		tip, err = a.GetLatestSnapshot(ctx, lastSessionID)
+		if err != nil && !errors.Is(err, aix.ErrSnapshotNotFound) {
+			fmt.Fprintf(os.Stderr, "Read snapshot for %q: %v\n", a.Name(), err)
+			return lastSessionID, nil
 		}
 	}
 
@@ -324,9 +346,11 @@ func openAgent[State any](ctx context.Context, inputCh <-chan string, a *aix.Age
 	)
 	if tip != nil && tip.Status == aix.SnapshotStatusPending {
 		// Background invocation still in flight. handlePending makes the
-		// final decision itself (wait & resume, new, or back), so we don't
-		// fall through to pickSession: the user already chose, and asking
-		// again would just be noise.
+		// final decision itself (wait & resume, stop & resume, new, or back),
+		// so we don't fall through to pickSession: the user already chose,
+		// and asking again would just be noise. An expired row is not offered
+		// the wait, since its worker is presumed dead; it goes to pickSession,
+		// which walks back to the last snapshot that can be continued.
 		resume, ok = handlePending(ctx, inputCh, a, tip)
 	} else {
 		resume, ok = pickSession(ctx, inputCh, a, tip)
@@ -341,12 +365,13 @@ func openAgent[State any](ctx context.Context, inputCh <-chan string, a *aix.Age
 // invocation of this agent is still running in the background:
 //
 //  1. wait for it to finalize and resume from it directly,
-//  2. ignore it and start a fresh conversation,
-//  3. go back to the agent list.
+//  2. stop it now and resume from the turns it finished,
+//  3. ignore it and start a fresh conversation,
+//  4. go back to the agent list.
 //
-// Returns the snapshot to resume from (option 1, completed) or nil
-// (option 2, or option 1 when the snapshot terminated non-completed).
-// ok=false means the user chose 3 or the context was canceled.
+// Returns the snapshot to resume from (options 1 and 2) or nil (option 3, or
+// 1 and 2 when nothing in the chain can be continued). ok=false means the
+// user chose 4 or the context was canceled.
 //
 // Crucially, options that imply "use this conversation" return the
 // snapshot directly so the caller can skip the resume / new prompt:
@@ -357,16 +382,32 @@ func handlePending[State any](ctx context.Context, inputCh <-chan string, a *aix
 		fmt.Printf("\nThe last %s session is still running in the background (%s).\n",
 			style(a.Name(), ansiBold), style(shortID(pending.SnapshotID), ansiDim))
 		fmt.Printf("  %s Wait for it to finalize\n", style("1.", ansiCyan))
-		fmt.Printf("  %s Start a new conversation\n", style("2.", ansiCyan))
-		fmt.Printf("  %s Back to agent list\n", style("3.", ansiCyan))
+		fmt.Printf("  %s Stop it now and resume from the turns it finished\n", style("2.", ansiCyan))
+		fmt.Printf("  %s Start a new conversation\n", style("3.", ansiCyan))
+		fmt.Printf("  %s Back to agent list\n", style("4.", ansiCyan))
 
 		line, ok := promptLine(ctx, inputCh, chevron)
 		if !ok {
 			return nil, false
 		}
-		switch strings.TrimSpace(line) {
-		case "1":
-			fmt.Println(style("Waiting for it to finalize...", ansiYellow))
+		choice := strings.TrimSpace(line)
+		switch choice {
+		case "1", "2":
+			if choice == "2" {
+				// Abort flips the pending row, and the runtime observes the
+				// flip and cancels the background work. The flip alone writes
+				// no state: the invocation that owns the row stamps the turns
+				// it finished onto it as it unwinds, which is what the wait
+				// below is for. Stopping and waiting are therefore the same
+				// flow, differing only in who ends the work.
+				if _, err := a.Abort(ctx, pending.SnapshotID); err != nil {
+					fmt.Fprintf(os.Stderr, "Stop error: %v\n", err)
+					return nil, false
+				}
+				fmt.Println(style("Stopping it...", ansiYellow))
+			} else {
+				fmt.Println(style("Waiting for it to finalize...", ansiYellow))
+			}
 			final, err := waitForFinalize(ctx, a, pending.SnapshotID)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "Wait error: %v\n", err)
@@ -376,47 +417,104 @@ func handlePending[State any](ctx context.Context, inputCh <-chan string, a *aix
 				fmt.Println(style("Snapshot disappeared while waiting. Starting a new conversation.", ansiYellow))
 				return nil, true
 			}
-			fmt.Println(style(fmt.Sprintf("Done (%s).", final.Status), ansiGreen))
-			if !resumableStatus(final.Status) {
-				// A pending snapshot is still being written to; the agent
-				// runtime would reject WithSnapshotID on it. Fall through
-				// to a fresh chat instead.
-				fmt.Println(style("Cannot resume this snapshot. Starting a new conversation.", ansiYellow))
+			tone := ansiGreen
+			if final.Status != aix.SnapshotStatusCompleted {
+				tone = ansiYellow
+			}
+			fmt.Println(style(fmt.Sprintf("Settled (%s).", final.Status), tone))
+			// A stopped run holds the turns that finished, so it resumes like
+			// a completed one. Only a row its invocation never finished
+			// writing has nothing to continue from, and resumePoint falls
+			// back to the snapshot before it.
+			resume := resumePoint(ctx, a, final)
+			if resume == nil {
+				fmt.Println(style("Nothing here can be continued. Starting a new conversation.", ansiYellow))
 				return nil, true
 			}
-			return final, true
-		case "2":
+			if resume.SnapshotID != final.SnapshotID {
+				fmt.Println(style("That snapshot holds no state; falling back to the one before it.", ansiYellow))
+			}
+			return resume, true
+		case "3":
 			// Ignore the pending snapshot and start fresh. The background
 			// invocation keeps running; this CLI just stops tracking it.
 			return nil, true
-		case "3":
+		case "4":
 			return nil, false
 		default:
-			fmt.Println("Invalid choice. Type 1, 2, or 3.")
+			fmt.Println("Invalid choice. Type 1, 2, 3, or 4.")
 		}
 	}
 }
 
-// resumableStatus reports whether a settled snapshot can be continued from.
-// A failed row qualifies: it holds what its turn committed before the
-// failure, so resuming it picks up there and re-attempts that turn. So does
-// an aborted one, which holds the turns that finished before the stop.
-func resumableStatus(s aix.SnapshotStatus) bool {
-	switch s {
-	case aix.SnapshotStatusCompleted, aix.SnapshotStatusFailed, aix.SnapshotStatusAborted:
+// resumable reports whether a snapshot can be handed to WithSnapshotID. It
+// mirrors the runtime's own gate. A failed row qualifies: it holds what its
+// turn committed before the failure, so resuming picks up there. So does an
+// aborted one, which holds the turns that finished before the stop.
+//
+// Two shapes do not. A pending row is still being written to by the
+// invocation that owns it (an expired one is a pending row whose worker
+// stopped beating). And an aborted row with no state was flipped by an abort
+// whose invocation never got to stamp the conversation onto it, so it holds
+// nothing to continue from.
+func resumable[State any](snap *aix.SessionSnapshot[State]) bool {
+	switch snap.Status {
+	case aix.SnapshotStatusCompleted, aix.SnapshotStatusFailed:
 		return true
+	case aix.SnapshotStatusAborted:
+		return snap.State != nil
 	}
 	return false
 }
 
+// resumePoint walks back from tip along ParentID to the newest snapshot that
+// can be continued, or nil when the whole chain is dead ends. That is what
+// turns an orphaned tip (a detached worker that died, or an abort nothing
+// finalized) into a conversation the user keeps rather than loses.
+func resumePoint[State any](ctx context.Context, a *aix.Agent[State], tip *aix.SessionSnapshot[State]) *aix.SessionSnapshot[State] {
+	for snap := tip; snap != nil && snap.SnapshotID != ""; {
+		if resumable(snap) {
+			return snap
+		}
+		if snap.ParentID == "" {
+			return nil
+		}
+		parent, err := a.GetSnapshot(ctx, snap.ParentID)
+		if err != nil {
+			return nil
+		}
+		snap = parent
+	}
+	return nil
+}
+
+// endedEarly reports whether a finish reason means the run did not get to
+// finish on its own terms. Both terminals propagate out of the agent's turn
+// loop, so the invocation is over either way and the connection is closing:
+// the REPL has to stop reading rather than send into it. Which of the two it
+// is changes the wording the CLI uses, never the handling.
+func endedEarly(r aix.AgentFinishReason) bool {
+	return r == aix.AgentFinishReasonFailed || r == aix.AgentFinishReasonAborted
+}
+
 // pickSession decides which snapshot (if any) to resume from. It only
-// offers two paths so the demo stays focused: resume from the most
-// recent terminal snapshot (returns the snapshot pointer), or start
+// offers two paths so the demo stays focused: resume from the newest
+// snapshot that can be continued (returns the snapshot pointer), or start
 // fresh (returns nil).
-func pickSession[State any](ctx context.Context, inputCh <-chan string, a *aix.Agent[State], latest *aix.SessionSnapshot[State]) (*aix.SessionSnapshot[State], bool) {
-	if latest == nil || !resumableStatus(latest.Status) {
+func pickSession[State any](ctx context.Context, inputCh <-chan string, a *aix.Agent[State], tip *aix.SessionSnapshot[State]) (*aix.SessionSnapshot[State], bool) {
+	var latest *aix.SessionSnapshot[State]
+	if tip != nil {
+		latest = resumePoint(ctx, a, tip)
+	}
+	if latest == nil {
 		fmt.Printf("\nStarting a new conversation with %s.\n", style(a.Name(), ansiBold))
 		return nil, true
+	}
+	if latest.SnapshotID != tip.SnapshotID {
+		// The tip is orphaned: a detached worker that stopped beating, or an
+		// abort that flipped the row before anything wrote state onto it.
+		// Neither loses the conversation, since its parent still holds it.
+		fmt.Printf("\n%s\n", style(fmt.Sprintf("The last snapshot is %s and holds nothing to continue; using the one before it.", tip.Status), ansiYellow))
 	}
 
 	msgs := 0
@@ -432,9 +530,9 @@ func pickSession[State any](ctx context.Context, inputCh <-chan string, a *aix.A
 		if latest.Error != nil && latest.Error.Message != "" {
 			why = latest.Error.Message
 		}
-		fmt.Println(style("Resuming re-attempts the failed turn: "+why, ansiYellow))
+		fmt.Println(style("This session stopped on an error: "+why, ansiYellow))
 	case aix.SnapshotStatusAborted:
-		fmt.Println(style("This session was stopped. Resuming picks up from the last turn that finished.", ansiYellow))
+		fmt.Println(style("This session was stopped early.", ansiYellow))
 	}
 	fmt.Println("Resume from it? " + style("[Y/n] (n = start a new conversation)", ansiDim))
 
@@ -455,13 +553,14 @@ func pickSession[State any](ctx context.Context, inputCh <-chan string, a *aix.A
 // session is validated against the store first: if it does not resolve
 // to a resumable snapshot (a detached invocation still pending, legacy
 // rows with no session ID, or a store error), fall back to the exact
-// snapshot the user was just shown. Validating up front keeps the chat
-// from opening on a connection whose invocation already failed, which
-// would surface the error only after the user types a message.
+// snapshot the user was just shown, which is also how a walk back past an
+// orphaned tip stays on the snapshot pickSession settled on. Validating up
+// front keeps the chat from opening on a connection whose invocation already
+// failed, which would surface the error only after the user types a message.
 func resumeOption[State any](ctx context.Context, a *aix.Agent[State], resume *aix.SessionSnapshot[State]) aix.InvocationOption[State] {
 	if resume.SessionID != "" {
-		tip, err := a.Store().GetLatestSnapshot(ctx, resume.SessionID)
-		if err == nil && tip != nil && tip.Status != aix.SnapshotStatusPending {
+		tip, err := a.GetLatestSnapshot(ctx, resume.SessionID)
+		if err == nil && tip != nil && resumable(tip) {
 			return aix.WithSessionID[State](resume.SessionID)
 		}
 		fmt.Println(style("(this conversation's session can't be resumed as a whole; continuing from the selected snapshot)", ansiDim))
@@ -485,7 +584,8 @@ func runChat[State any](ctx context.Context, inputCh <-chan string, a *aix.Agent
 	}
 	fmt.Println(style("Commands: /detach [text], /back, /quit", ansiDim))
 
-	if resume != nil && resume.State != nil && len(resume.State.Messages) > 0 {
+	resumed := resume != nil && resume.State != nil && len(resume.State.Messages) > 0
+	if resumed {
 		fmt.Println()
 		fmt.Println(style("(picking up where you left off)", ansiDim))
 		printHistory(resume.State.Messages)
@@ -498,36 +598,35 @@ func runChat[State any](ctx context.Context, inputCh <-chan string, a *aix.Agent
 	}
 	conn, err := a.Connect(ctx, opts...)
 	if err != nil {
-		return prevSessionID, fmt.Errorf("open agent %q: %w", a.Name(), err)
+		// A snapshot the store accepted a moment ago can still be refused
+		// here, so hand the user back to the agent list rather than take the
+		// process down with the connection.
+		fmt.Fprintf(os.Stderr, "Open agent %q: %v\n", a.Name(), err)
+		return prevSessionID, nil
 	}
 
 	var (
-		detached   bool
-		quit       bool
-		failedTurn bool
+		detached bool
+		quit     bool
+		runEnded bool
+		// conversation is whether there is anything for an empty line to run
+		// a turn on. A stray Enter before the first message has nothing, and
+		// the agent rejects an empty input on an empty session.
+		conversation = resumed
 	)
 
-	// A failed snapshot opens on the turn that failed, holding the messages
-	// it committed. An input with no payload runs that turn again on them,
-	// which is the whole re-attempt: nothing the turn already did is redone.
-	if resume != nil && resume.Status == aix.SnapshotStatusFailed {
-		fmt.Println(style("Re-attempting the failed turn...", ansiYellow))
-		fmt.Println()
-		if err := conn.Send(&aix.AgentInput{}); err != nil {
-			fmt.Fprintf(os.Stderr, "Re-attempt error: %v\n", err)
-		} else if end, _, ok := streamReply(conn, hooks, prompter); !ok {
-			failedTurn = true
-		} else if end.FinishReason == aix.AgentFinishReasonFailed {
-			// It failed again, so the invocation is over; Output below
-			// reports the error and the snapshot to pick up from.
-			failedTurn = true
-		}
+	// Whether the turn a stopped run left unanswered is worth running again
+	// is the user's call, not the CLI's, so it is a keystroke rather than an
+	// inference. Saying so here is the only thing the status decides.
+	if resume != nil && (resume.Status == aix.SnapshotStatusFailed || resume.Status == aix.SnapshotStatusAborted) {
+		fmt.Println(style("Its last turn stopped. Press Enter on an empty line to run", ansiYellow))
+		fmt.Println(style("it again on the messages it kept, or just type a new one.", ansiYellow))
 		fmt.Println()
 	}
 
 repl:
 	for {
-		if failedTurn {
+		if runEnded {
 			break
 		}
 		line, ok := promptLine(ctx, inputCh, chevron)
@@ -536,40 +635,51 @@ repl:
 		}
 		text := strings.TrimSpace(line)
 		if text == "" {
-			continue
-		}
-
-		switch {
-		case text == "/back":
-			break repl
-		case text == "/quit" || text == "/exit":
-			quit = true
-			break repl
-		case text == "/detach" || strings.HasPrefix(text, "/detach "):
-			trailing := strings.TrimSpace(strings.TrimPrefix(text, "/detach"))
-			// Send (optional message) + detach in a single wire input so
-			// the trailing text becomes the last buffered message. The
-			// agent will process it in the background after the
-			// connection closes.
-			input := &aix.AgentInput{Detach: true}
-			if trailing != "" {
-				input.Message = ai.NewUserTextMessage(trailing)
+			if !conversation {
+				continue
 			}
-			if err := conn.Send(input); err != nil {
-				fmt.Fprintf(os.Stderr, "Detach error: %v\n", err)
+			// An input with no payload runs a turn on the conversation as it
+			// stands. That is how the turn a stopped run left unanswered is
+			// picked back up: its message is already in the session, so
+			// sending it again would only duplicate it.
+			if err := conn.Send(&aix.AgentInput{}); err != nil {
+				fmt.Fprintf(os.Stderr, "Send error: %v\n", err)
+				break
+			}
+		} else {
+			switch {
+			case text == "/back":
 				break repl
+			case text == "/quit" || text == "/exit":
+				quit = true
+				break repl
+			case text == "/detach" || strings.HasPrefix(text, "/detach "):
+				trailing := strings.TrimSpace(strings.TrimPrefix(text, "/detach"))
+				// Send (optional message) + detach in a single wire input so
+				// the trailing text becomes the last buffered message. The
+				// agent will process it in the background after the
+				// connection closes.
+				input := &aix.AgentInput{Detach: true}
+				if trailing != "" {
+					input.Message = ai.NewUserTextMessage(trailing)
+				}
+				if err := conn.Send(input); err != nil {
+					fmt.Fprintf(os.Stderr, "Detach error: %v\n", err)
+					break repl
+				}
+				detached = true
+				break repl
+			case strings.HasPrefix(text, "/"):
+				fmt.Println("Unknown command. Try /detach, /back, or /quit.")
+				continue
 			}
-			detached = true
-			break repl
-		case strings.HasPrefix(text, "/"):
-			fmt.Println("Unknown command. Try /detach, /back, or /quit.")
-			continue
-		}
 
-		if err := conn.SendText(text); err != nil {
-			fmt.Fprintf(os.Stderr, "Send error: %v\n", err)
-			break
+			if err := conn.SendText(text); err != nil {
+				fmt.Fprintf(os.Stderr, "Send error: %v\n", err)
+				break
+			}
 		}
+		conversation = true
 		fmt.Println()
 		end, wrote, ok := streamReply(conn, hooks, prompter)
 		if !ok {
@@ -600,11 +710,12 @@ repl:
 		}
 		fmt.Println()
 		fmt.Println()
-		if end.FinishReason == aix.AgentFinishReasonFailed {
-			// A failed turn ends the invocation; Output below reports the
-			// error and the last-good snapshot. The footer above already
-			// spaced things off, so flag it to skip the pre-outcome blank.
-			failedTurn = true
+		if endedEarly(end.FinishReason) {
+			// A turn that broke or was stopped ends the invocation; Output
+			// below reports the error and the snapshot to pick up from. The
+			// footer above already spaced things off, so flag it to skip the
+			// pre-outcome blank.
+			runEnded = true
 			break repl
 		}
 	}
@@ -617,7 +728,7 @@ repl:
 	// Set the closing status apart from the last input line (e.g. /back or
 	// /detach) with a blank line. A failed turn already printed its footer
 	// with trailing spacing just above, so skip the extra blank there.
-	if out != nil && !failedTurn {
+	if out != nil && !runEnded {
 		fmt.Println()
 	}
 	switch {
@@ -627,11 +738,15 @@ repl:
 		fmt.Println(style("The agent keeps processing in the background. Pick this", ansiDim))
 		fmt.Println(style("agent again from the list to wait for it to finalize and", ansiDim))
 		fmt.Println(style("resume from the cumulative final state.", ansiDim))
-	case out != nil && out.FinishReason == aix.AgentFinishReasonFailed:
-		// A failed invocation resolves with the error and a last-good
-		// snapshot to resume from.
+	case out != nil && endedEarly(out.FinishReason):
+		// Both terminals resolve with the error and a snapshot to resume
+		// from; which one it is picks the wording, not the handling.
+		what := "Agent failed"
+		if out.FinishReason == aix.AgentFinishReasonAborted {
+			what = "Agent stopped"
+		}
 		if out.Error != nil {
-			fmt.Fprintf(os.Stderr, "%s\n", style(fmt.Sprintf("Agent failed (%s): %s", out.Error.Status, out.Error.Message), ansiYellow))
+			fmt.Fprintf(os.Stderr, "%s\n", style(fmt.Sprintf("%s (%s): %s", what, out.Error.Status, out.Error.Message), ansiYellow))
 			// The output's error carries the status the failure was
 			// classified with, so the client can offer the right next step
 			// without parsing message text.
@@ -642,10 +757,15 @@ repl:
 				fmt.Println(style("The model or a tool rejected the request. Rephrase and try again.", ansiDim))
 			case status.Cancelled, status.DeadlineExceeded:
 				fmt.Println(style("The turn was cut short. Resume from the snapshot below to continue.", ansiDim))
+			case status.Aborted:
+				// A limit the run was given, such as ai.WithMaxTurns. Resuming
+				// re-runs the same turn into the same limit, so say so rather
+				// than invite a retry that burns tokens to fail identically.
+				fmt.Println(style("The run hit a limit it was given. Resuming re-runs the same turn, so it needs a bigger limit or a simpler ask.", ansiDim))
 			}
 		}
 		if out.SnapshotID != "" {
-			// The failed turn's own row when it committed anything, the turn
+			// The stopped turn's own row when it committed anything, the turn
 			// before it otherwise. Either way it is where to pick up.
 			fmt.Printf("%s\n", style(fmt.Sprintf("Resume point: %s. Pick this agent again to continue from it.", shortID(out.SnapshotID)), ansiDim))
 		}
@@ -839,22 +959,24 @@ func resolveInterrupts(hooks agentHooks, p *Prompter, interrupts []*ai.Part) *ai
 // when none has run yet, or the session has no resumable snapshot, so a
 // fresh list shows no clutter.
 //
-// It returns the line already styled: dim metadata, with a still-pending
-// detach highlighted in yellow. Each segment carries its own reset so the
-// yellow status doesn't bleed into the surrounding dim text. A pending
-// snapshot has no finalized messages yet, so its count is omitted.
+// It returns the line already styled: dim metadata, with a detach that is
+// still running (or whose worker died) highlighted in yellow. Each segment
+// carries its own reset so the yellow status doesn't bleed into the
+// surrounding dim text. Neither row has finalized messages yet, so the count
+// is omitted for both.
 func summarizeLatest[State any](ctx context.Context, a *aix.Agent[State], sessionID string) string {
 	if sessionID == "" {
 		return ""
 	}
-	latest, err := a.Store().GetLatestSnapshot(ctx, sessionID)
+	latest, err := a.GetLatestSnapshot(ctx, sessionID)
 	if err != nil || latest == nil {
 		return ""
 	}
 	when := latest.UpdatedAt.Format(time.RFC822)
-	if latest.Status == aix.SnapshotStatusPending {
+	switch latest.Status {
+	case aix.SnapshotStatusPending, aix.SnapshotStatusExpired:
 		return style("last: "+shortID(latest.SnapshotID)+" (", ansiDim) +
-			style("pending", ansiYellow) +
+			style(string(latest.Status), ansiYellow) +
 			style(", "+when+")", ansiDim)
 	}
 	msgs := 0
@@ -865,37 +987,66 @@ func summarizeLatest[State any](ctx context.Context, a *aix.Agent[State], sessio
 		shortID(latest.SnapshotID), latest.Status, msgs, when), ansiDim)
 }
 
+// orphanPoll is how often waitForFinalize re-reads a snapshot it is waiting
+// on. Comfortably under the runtime's heartbeat timeout, so a worker that
+// died is noticed a poll or two after the row goes stale rather than a minute
+// later.
+const orphanPoll = 10 * time.Second
+
 // waitForFinalize subscribes to a snapshot's status and blocks until it
 // transitions out of pending. The returned snapshot is the final one (or
 // nil if it disappeared). OnSnapshotStatusChange yields the current
 // status first, so a snapshot that finalized just before the
 // subscription is observed immediately.
 //
+// The subscription reports the status as stored, which stays pending forever
+// if the background worker died: nothing writes a terminal in its place. So
+// the wait also polls, because a read through the agent surfaces a stale
+// heartbeat as expired and gives the caller something to act on.
+//
 // The status subscription is the optional SnapshotSubscriber capability of
 // the store contract. A store without it cannot stream background progress,
 // so we fall back to reading the snapshot once and returning it as-is.
 func waitForFinalize[State any](ctx context.Context, a *aix.Agent[State], snapshotID string) (*aix.SessionSnapshot[State], error) {
-	store := a.Store()
-	subscriber, ok := store.(aix.SnapshotSubscriber)
+	// A snapshot that vanished under us reads as an error through the agent
+	// where the raw store returns nil; the callers treat both as "gone".
+	read := func() (*aix.SessionSnapshot[State], error) {
+		snap, err := a.GetSnapshot(ctx, snapshotID)
+		if errors.Is(err, aix.ErrSnapshotNotFound) {
+			return nil, nil
+		}
+		return snap, err
+	}
+	subscriber, ok := a.Store().(aix.SnapshotSubscriber)
 	if !ok {
-		return store.GetSnapshot(ctx, snapshotID)
+		return read()
 	}
 	subCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	statusCh := subscriber.OnSnapshotStatusChange(subCtx, snapshotID)
+	ticker := time.NewTicker(orphanPoll)
+	defer ticker.Stop()
 	for {
 		select {
 		case <-ctx.Done():
 			return nil, ctx.Err()
+		case <-ticker.C:
+			// Expired is not a status anything writes, so it arrives only on
+			// a read. Stop waiting on it: the worker is presumed dead and no
+			// terminal is coming.
+			snap, err := read()
+			if err != nil || snap == nil || snap.Status != aix.SnapshotStatusPending {
+				return snap, err
+			}
 		case status, ok := <-statusCh:
 			if !ok {
 				// Subscription closed (e.g. snapshot deleted under us).
-				return store.GetSnapshot(ctx, snapshotID)
+				return read()
 			}
 			if status == aix.SnapshotStatusPending {
 				continue
 			}
-			return store.GetSnapshot(ctx, snapshotID)
+			return read()
 		}
 	}
 }

--- a/go/samples/basic-agents/coder.go
+++ b/go/samples/basic-agents/coder.go
@@ -32,7 +32,9 @@ import (
 // dynamically, or wire up custom tool plumbing).
 //
 // Even with full control over the loop, the framework still owns session
-// state, snapshot writes, and the detach lifecycle.
+// state, snapshot writes, and the detach lifecycle. What a custom loop does
+// own is whether a turn that failed is worth keeping; see the error arm
+// below.
 func defineCustomAgent(g *genkit.Genkit) *aix.Agent[any] {
 	const name = "coder"
 	return genkitx.DefineCustomAgent(g, name,
@@ -44,7 +46,15 @@ func defineCustomAgent(g *genkit.Genkit) *aix.Agent[any] {
 					ai.WithMessages(sess.Messages()...),
 				) {
 					if err != nil {
-						return nil, fmt.Errorf("could not answer the question: %w", err)
+						// Commit the turn rather than discard it: sess.Run
+						// already stored this turn's input, so the session
+						// holds a conversation ending on the user's message,
+						// which is a turn seam. Returning a TurnResult beside
+						// the error is what says so, and it makes the failed
+						// snapshot a resume point that re-runs the turn on
+						// the same message. A bare error would roll the turn
+						// back and the user would have to type it again.
+						return &aix.TurnResult{}, fmt.Errorf("could not answer the question: %w", err)
 					}
 					if chunk.Done {
 						sess.AddMessages(chunk.Response.Message)

--- a/go/samples/basic-agents/main.go
+++ b/go/samples/basic-agents/main.go
@@ -49,7 +49,8 @@
 //	(text)             send a message and stream the reply
 //	/detach (text...)  send the text, then leave it running in the background
 //	                   and return to the agent list. Re-pick the agent to wait
-//	                   for the snapshot and resume from the final state.
+//	                   for the snapshot, or to stop it and resume from the
+//	                   turns it finished.
 //	/back              return to the agent list
 //	/quit              exit
 //

--- a/tests/specs/agent.yaml
+++ b/tests/specs/agent.yaml
@@ -15,6 +15,7 @@
 # fails every harness instead of silently skipping in all of them.
 capabilities:
   - resumable-failures
+  - resumable-aborts
 
 tests:
   # ---------------------------------------------------------------------------
@@ -1741,3 +1742,98 @@ tests:
                   - toolResponse:
                       { name: testTool, ref: r1, output: tool called }
               - { role: model, content: [{ text: all done }] }
+
+  # ---------------------------------------------------------------------------
+  # Resumable aborts (requires: resumable-aborts)
+  # ---------------------------------------------------------------------------
+  # An aborted invocation keeps the turns that finished and resume accepts its
+  # snapshot, the way it accepts a failed one. The snapshot used to carry no
+  # state at all: the pending row was written without any, abort only flipped
+  # its status, and the finalize kept that row verbatim. These cases use
+  # vocabulary gated behind the `resumable-aborts` capability: an `aborted`
+  # snapshot carrying state, and one as a resume target. Their fixture,
+  # customAgentAbortable, records each turn and blocks until its context is
+  # cancelled on the turn whose message is "block".
+
+  - name: an aborted snapshot keeps the finished turns and drops the one in flight
+    requires: [resumable-aborts]
+    description: >
+      A first turn commits, a second blocks, and the client detaches and
+      aborts. The finalize writes the state through the committed turn onto
+      the aborted row: the blocked turn's message is rolled back, because it
+      returned no result to commit and detach had suspended the per-turn
+      snapshot that would otherwise hold it.
+    agent: customAgentAbortable
+    steps:
+      - type: send
+        init: { sessionId: 44444444-4444-4444-8444-444444444444 }
+        inputs:
+          - message: { role: user, content: [{ text: first }] }
+          - message: { role: user, content: [{ text: block }] }
+            detach: true
+        expectOutput:
+          finishReason: detached
+          hasSnapshotId: true
+        captureSnapshotId: snap1
+
+      - type: abort
+        snapshotId: '{{snap1}}'
+        expectPreviousStatus: pending
+
+      # The abort flips the status; the finalize that follows writes the
+      # reason and the state.
+      - type: waitUntilCompleted
+        snapshotId: '{{snap1}}'
+        expectSnapshot:
+          status: aborted
+          finishReason: aborted
+          stateContains:
+            sessionId: 44444444-4444-4444-8444-444444444444
+            messages:
+              - { role: user, content: [{ text: first }] }
+              - { role: model, content: [{ text: ack }] }
+
+  - name: an aborted snapshot is a resume point
+    requires: [resumable-aborts]
+    description: >
+      Resume accepts an aborted snapshot rather than rejecting it as a dead
+      end. The continued turn runs on the conversation the abort left, so the
+      committed turn is still in front of it and the blocked one is not.
+    agent: customAgentAbortable
+    steps:
+      - type: send
+        init: { sessionId: 55555555-5555-4555-8555-555555555555 }
+        inputs:
+          - message: { role: user, content: [{ text: first }] }
+          - message: { role: user, content: [{ text: block }] }
+            detach: true
+        captureSnapshotId: snap1
+
+      - type: abort
+        snapshotId: '{{snap1}}'
+        expectPreviousStatus: pending
+
+      - type: waitUntilCompleted
+        snapshotId: '{{snap1}}'
+        expectSnapshot:
+          status: aborted
+
+      - type: send
+        init: { snapshotId: '{{snap1}}' }
+        inputs:
+          - message: { role: user, content: [{ text: carry on }] }
+        expectOutput:
+          hasSnapshotId: true
+        captureSnapshotId: snap2
+
+      - type: getSnapshotData
+        snapshotId: '{{snap2}}'
+        expectSnapshot:
+          parentId: '{{snap1}}'
+          status: completed
+          stateContains:
+            messages:
+              - { role: user, content: [{ text: first }] }
+              - { role: model, content: [{ text: ack }] }
+              - { role: user, content: [{ text: carry on }] }
+              - { role: model, content: [{ text: ack }] }


### PR DESCRIPTION
Third of the train, on top of [#6173](https://github.com/genkit-ai/genkit/pull/6173) and [#6196](https://github.com/genkit-ai/genkit/pull/6196). Where #6196 made a failed turn a resume point, this does the same for a run the caller stopped.

## One rule: the caller stopped it, or it broke

`aborted` used to mean one thing, a detached run someone called `Abort` on. It now means every way a caller ends a run, and `failed` means every way one breaks. `callerStopped` is the single decision:

```go
func callerStopped(ctx context.Context, cause error) bool {
	if ctx.Err() != nil {
		return true
	}
	s, ok := status.Classified(cause)
	return ok && (s == status.Cancelled || s == status.DeadlineExceeded || s == status.Aborted)
}
```

The context ending covers the caller's own cancel, the transport closing, a deadline it set, and the abort action, which cancels the work context on the status flip. The ABORTED status covers a limit it set: `ai.ErrMaxTurnsExceeded` is an `ErrAborted` subtype, so a turn that propagates a max-turns error unchanged reports stopped without having to say so in a `TurnResult`.

```go
ctx, cancel := context.WithCancel(ctx)
out, err := chatAgent.Run(ctx, &aix.AgentInput{Message: msg})  // cancel() elsewhere
// out.FinishReason == aix.AgentFinishReasonAborted, snapshot status "aborted"
```

It decides all three terminal writers: `Run`'s failure arm, `failedOutput`, and the detach finalize. `terminalStatus` derives the snapshot status from the turn's finish reason rather than re-deriving the rule at each writer, so the two cannot disagree, and the caller stopping wins over a `TurnResult` the way a late abort already wins over the terminal a detached turn was about to land. `Run` derives the reason from the error it is handed, so the prompt loop's `TurnResult` on a generate failure carries none: forwarding generate's own reason would land a `stop` on a failed row whenever post-processing rejected a response the loop completed. The same rule lands in `ai.failurePartial` on #6173, so the generate loop and the agent snapshot agree.

## An aborted snapshot carries the work it kept

`resumeSessionFrom` rejected `aborted`, and lifting that alone would have resumed an empty conversation: the detach handler writes the pending row with no state, and `Agent.Abort` only flips its status. The state has to come from the finalize, which needs the conversation as of the last turn that finished rather than the live one holding an unfinished turn's mutations.

That is a `SessionRunner` property, since the runner owns every source:

```go
func (s *SessionRunner[State]) committedState(ctx context.Context) *SessionState[State] {
	if s.lastTurnCommitted {
		return s.State()
	}
	if s.lastGoodState != nil {
		return s.lastGoodState
	}
	if snapped := s.snapshotState(ctx, s.lastSnapshotID); snapped != nil {
		return snapped
	}
	return s.initialState
}
```

It always resolves, which is what the finalize needs and what a chain of fallbacks does not give. `lastGoodState` covers the turns committed since a detach, and `captureLastGood` now runs once snapshots are suspended to fill it, since detach suspends the per-turn snapshots that would otherwise hold them. The frozen `lastSnapshotID` covers the turns before the detach. `initialState` is the floor: a fresh session that detaches on its first input and never commits has neither of the other two, and without it the row keeps exactly the mutations it exists to shed.

Resume then accepts the row for the reason it accepts a `failed` one: the conversation ends at a turn seam. It still rejects an aborted row carrying no state, which is one caught between the abort's status flip and the finalize that stamps the conversation on.

## A stopped run hands back its resume point

`Run` returned `(nil, err)` on a cancel, so the caller learned nothing about where the run stopped. It now returns both, as `ai.Generate` hands back a partial response beside the error that ended it.

Getting there needed `AgentConnection.Output` to wait: on a cancel, the drain and the core `Output` both take their cancellation arms while the runtime is still unwinding towards the output that names the snapshot. The wait is bounded by `settleGrace`, so an agent function that ignores its context keeps the caller's escape hatch (`TestAgent_OutputUnblocksOnCancel`) and pays only the delay, having produced no snapshot to wait for.

## One behavior a caller could be reading

A turn that ends on a cancelled context, an expired deadline, or a caller-set limit used to write `failed` and now writes `aborted`. Code branching on `SnapshotStatusFailed` to catch those falls through. Everything else is a relaxation: resume accepts a status it used to reject, and `Run` returns an output where it used to return nil. No exported symbol is added, renamed, or removed.

## What this does not do

- **No abort action for an attached run.** `abortPendingSnapshot` only flips a `pending` row, and only detach writes one. A remote client's lever is still closing the transport.
- **Tool side effects inside the discarded turn are not preserved.** The unfinished round goes whole, so a tool that already ran loses its response and runs again on resume. Answering the unfinished requests with an aborted marker would keep the seam and the completed work, but it breaks the partial-response contract #6173 documents, so it is a follow-up.
- **An expired orphan is still a dead end.** Its raw row is `pending`, which resume rejects, and it carries no state for the same reason an aborted one used to carry none. Same problem class, separate change.
- **JS and Python skip the new conformance cases.** They gate behind `resumable-aborts`, alongside `resumable-failures` from #6196.

