### PR TITLE
refactor(a2ui): add A2uiServerEnvelope type and filter action envelopes

### DIFF
--- a/js/plugins/a2ui/src/client.ts
+++ b/js/plugins/a2ui/src/client.ts
@@ -27,7 +27,7 @@
 
 import { remoteAgent } from 'genkit/beta/client';
 import { a2uiEnvelopesFromParts, a2uiPart } from './part.js';
-import type { A2uiClientAction, A2uiEnvelope } from './types.js';
+import type { A2uiClientAction, A2uiServerEnvelope } from './types.js';
 
 export { a2uiEnvelopesFromParts, a2uiPart, isA2uiPart } from './part.js';
 export {
@@ -38,12 +38,14 @@ export {
   type A2uiComponent,
   type A2uiEnvelope,
   type A2uiPart,
+  type A2uiServerEnvelope,
+  type ActionEnvelope,
 } from './types.js';
 
 /** A single event yielded while streaming an A2UI agent turn. */
 export type A2uiStreamEvent =
   | { type: 'text'; text: string }
-  | { type: 'envelopes'; envelopes: A2uiEnvelope[] };
+  | { type: 'envelopes'; envelopes: A2uiServerEnvelope[] };
 
 /** Options for {@link streamA2uiAgent}. */
 export interface StreamA2uiAgentOptions {
@@ -62,7 +64,9 @@ export interface StreamA2uiAgentOptions {
 /** Normalizes a string message into a Genkit user message. */
 function toMessage(message: string | Record<string, unknown>) {
   if (typeof message === 'string') {
-    return { role: 'user', content: [{ text: message }] };
+    // `as const` keeps `role` as the literal `'user'` rather than widening to
+    // `string`, so the result is assignable to an agent input `message`.
+    return { role: 'user' as const, content: [{ text: message }] };
   }
   return message;
 }
@@ -134,7 +138,9 @@ export function actionToMessage(action: A2uiClientAction) {
       : '') +
     '.';
   return {
-    role: 'user',
+    // `as const` keeps `role` as the literal `'user'` rather than widening to
+    // `string`, so the result is assignable to an agent input `message`.
+    role: 'user' as const,
     content: [{ text: summary }, a2uiPart([{ action }])],
   };
 }

--- a/js/plugins/a2ui/src/index.ts
+++ b/js/plugins/a2ui/src/index.ts
@@ -51,6 +51,8 @@ export {
   type A2uiComponent,
   type A2uiEnvelope,
   type A2uiPart,
+  type A2uiServerEnvelope,
+  type ActionEnvelope,
   type CreateSurfaceEnvelope,
   type DeleteSurfaceEnvelope,
   type UpdateComponentsEnvelope,

--- a/js/plugins/a2ui/src/part.ts
+++ b/js/plugins/a2ui/src/part.ts
@@ -28,7 +28,12 @@
  */
 
 import { type Part } from 'genkit';
-import { A2UI_MIME_TYPE, type A2uiEnvelope, type A2uiPart } from './types.js';
+import {
+  A2UI_MIME_TYPE,
+  type A2uiEnvelope,
+  type A2uiPart,
+  type A2uiServerEnvelope,
+} from './types.js';
 
 /** A minimal structural view of a Genkit part for these helpers. */
 interface PartLike {
@@ -76,14 +81,36 @@ export function isA2uiPart(part: unknown): part is A2uiPart {
  * be `undefined`); a nullish list is treated as empty.
  *
  * Returns `[]` for content that carries no a2ui parts (e.g. plain prose).
+ *
+ * The result is typed as {@link A2uiServerEnvelope}[] — the surfaces the agent
+ * renders — because that is all a render stream carries. Any inbound
+ * {@link ActionEnvelope} (a user action echoed in history) is filtered out, so
+ * the returned envelopes can be handed straight to a renderer's message
+ * processor without a cast.
  */
 export function a2uiEnvelopesFromParts(
   parts: readonly Part[] | null | undefined
-): A2uiEnvelope[] {
+): A2uiServerEnvelope[] {
   if (!Array.isArray(parts)) return [];
-  const out: A2uiEnvelope[] = [];
+  const out: A2uiServerEnvelope[] = [];
   for (const part of parts) {
-    if (isA2uiPart(part)) out.push(...part.data.envelopes);
+    if (!isA2uiPart(part)) continue;
+    for (const env of part.data.envelopes) {
+      // Keep only server → client surface envelopes. Inbound action envelopes
+      // (a user action echoed in history) are dropped, and any null /
+      // non-object garbage from malformed model output is skipped so the
+      // `A2uiServerEnvelope[]` return type stays honest.
+      if (!env || typeof env !== 'object') continue;
+      if (isActionEnvelope(env)) continue;
+      out.push(env);
+    }
   }
   return out;
+}
+
+/** Narrows an envelope to a client → server action envelope. */
+function isActionEnvelope(
+  env: A2uiEnvelope
+): env is Extract<A2uiEnvelope, { action: unknown }> {
+  return 'action' in env;
 }

--- a/js/plugins/a2ui/src/part.ts
+++ b/js/plugins/a2ui/src/part.ts
@@ -99,8 +99,9 @@ export function a2uiEnvelopesFromParts(
       // Keep only server → client surface envelopes. Inbound action envelopes
       // (a user action echoed in history) are dropped, and any null /
       // non-object garbage from malformed model output is skipped so the
-      // `A2uiServerEnvelope[]` return type stays honest.
-      if (!env || typeof env !== 'object') continue;
+      // `A2uiServerEnvelope[]` return type stays honest. Arrays are excluded
+      // explicitly since `typeof [] === 'object'`.
+      if (!env || typeof env !== 'object' || Array.isArray(env)) continue;
       if (isActionEnvelope(env)) continue;
       out.push(env);
     }

--- a/js/plugins/a2ui/src/part.ts
+++ b/js/plugins/a2ui/src/part.ts
@@ -96,22 +96,31 @@ export function a2uiEnvelopesFromParts(
   for (const part of parts) {
     if (!isA2uiPart(part)) continue;
     for (const env of part.data.envelopes) {
-      // Keep only server → client surface envelopes. Inbound action envelopes
-      // (a user action echoed in history) are dropped, and any null /
-      // non-object garbage from malformed model output is skipped so the
-      // `A2uiServerEnvelope[]` return type stays honest. Arrays are excluded
-      // explicitly since `typeof [] === 'object'`.
-      if (!env || typeof env !== 'object' || Array.isArray(env)) continue;
-      if (isActionEnvelope(env)) continue;
-      out.push(env);
+      // Keep only server → client surface envelopes. This is a positive check,
+      // so inbound action envelopes (a user action echoed in history) and any
+      // null / non-object / array / arbitrary-object garbage from malformed
+      // model output are all excluded, keeping the `A2uiServerEnvelope[]`
+      // return type honest.
+      if (isServerEnvelope(env)) out.push(env);
     }
   }
   return out;
 }
 
-/** Narrows an envelope to a client → server action envelope. */
-function isActionEnvelope(
-  env: A2uiEnvelope
-): env is Extract<A2uiEnvelope, { action: unknown }> {
-  return 'action' in env;
+/** The discriminant keys of the server → client surface envelopes. */
+const SERVER_ENVELOPE_KEYS = [
+  'createSurface',
+  'updateComponents',
+  'updateDataModel',
+  'deleteSurface',
+] as const;
+
+/**
+ * Narrows a value to a server → client surface envelope by checking for one of
+ * the known surface discriminant keys. Arrays are excluded explicitly since
+ * `typeof [] === 'object'`.
+ */
+function isServerEnvelope(env: unknown): env is A2uiServerEnvelope {
+  if (!env || typeof env !== 'object' || Array.isArray(env)) return false;
+  return SERVER_ENVELOPE_KEYS.some((key) => key in env);
 }

--- a/js/plugins/a2ui/src/part.ts
+++ b/js/plugins/a2ui/src/part.ts
@@ -15,7 +15,7 @@
  */
 
 /**
- * Helpers for working with the canonical "a2ui part" — a Genkit `data` part
+ * Helpers for working with the canonical "a2ui part" - a Genkit `data` part
  * whose `data` is an object `{ envelopes }` wrapping an array of A2UI envelopes,
  * tagged with {@link A2UI_MIME_TYPE}.
  *
@@ -33,6 +33,10 @@ import {
   type A2uiEnvelope,
   type A2uiPart,
   type A2uiServerEnvelope,
+  type CreateSurfaceEnvelope,
+  type DeleteSurfaceEnvelope,
+  type UpdateComponentsEnvelope,
+  type UpdateDataModelEnvelope,
 } from './types.js';
 
 /** A minimal structural view of a Genkit part for these helpers. */
@@ -82,8 +86,8 @@ export function isA2uiPart(part: unknown): part is A2uiPart {
  *
  * Returns `[]` for content that carries no a2ui parts (e.g. plain prose).
  *
- * The result is typed as {@link A2uiServerEnvelope}[] — the surfaces the agent
- * renders — because that is all a render stream carries. Any inbound
+ * The result is typed as {@link A2uiServerEnvelope}[] - the surfaces the agent
+ * renders - because that is all a render stream carries. Any inbound
  * {@link ActionEnvelope} (a user action echoed in history) is filtered out, so
  * the returned envelopes can be handed straight to a renderer's message
  * processor without a cast.
@@ -96,7 +100,7 @@ export function a2uiEnvelopesFromParts(
   for (const part of parts) {
     if (!isA2uiPart(part)) continue;
     for (const env of part.data.envelopes) {
-      // Keep only server → client surface envelopes. This is a positive check,
+      // Keep only server-to-client surface envelopes. This is a positive check,
       // so inbound action envelopes (a user action echoed in history) and any
       // null / non-object / array / arbitrary-object garbage from malformed
       // model output are all excluded, keeping the `A2uiServerEnvelope[]`
@@ -107,16 +111,32 @@ export function a2uiEnvelopesFromParts(
   return out;
 }
 
-/** The discriminant keys of the server → client surface envelopes. */
+/**
+ * The discriminant key each server-to-client surface envelope carries (every
+ * variant is `{ version } & { <key>: ... }`). Deriving this from the union keeps
+ * {@link SERVER_ENVELOPE_KEYS} honest: a typo or a stale key stops compiling.
+ */
+type ServerEnvelopeKey =
+  | Exclude<keyof CreateSurfaceEnvelope, 'version'>
+  | Exclude<keyof UpdateComponentsEnvelope, 'version'>
+  | Exclude<keyof UpdateDataModelEnvelope, 'version'>
+  | Exclude<keyof DeleteSurfaceEnvelope, 'version'>;
+
+/**
+ * The discriminant keys of the server-to-client surface envelopes. The
+ * `satisfies` guard validates every entry against {@link ServerEnvelopeKey}, so
+ * an invalid or misspelled key is a compile error rather than a silently dropped
+ * envelope at runtime.
+ */
 const SERVER_ENVELOPE_KEYS = [
   'createSurface',
   'updateComponents',
   'updateDataModel',
   'deleteSurface',
-] as const;
+] as const satisfies readonly ServerEnvelopeKey[];
 
 /**
- * Narrows a value to a server → client surface envelope by checking for one of
+ * Narrows a value to a server-to-client surface envelope by checking for one of
  * the known surface discriminant keys. Arrays are excluded explicitly since
  * `typeof [] === 'object'`.
  */

--- a/js/plugins/a2ui/src/types.ts
+++ b/js/plugins/a2ui/src/types.ts
@@ -125,6 +125,21 @@ export interface ActionEnvelope {
 }
 
 /**
+ * The server → client A2UI envelopes: the surfaces an agent renders. These are
+ * what a renderer consumes, so {@link a2uiEnvelopesFromParts} yields exactly
+ * this type (an {@link ActionEnvelope} never rides a render stream).
+ *
+ * This union is structurally compatible with the message unions of the renderer
+ * packages (e.g. `@a2ui/web_core`'s `A2uiMessage`), so envelopes read off a
+ * chunk can be handed straight to a renderer without a cast.
+ */
+export type A2uiServerEnvelope =
+  | CreateSurfaceEnvelope
+  | UpdateComponentsEnvelope
+  | UpdateDataModelEnvelope
+  | DeleteSurfaceEnvelope;
+
+/**
  * A single A2UI envelope message.
  *
  * Most variants flow server → client (surfaces the agent renders); the
@@ -132,12 +147,7 @@ export interface ActionEnvelope {
  * back as the next turn). Keeping both directions in one union lets
  * {@link a2uiPart} be the single constructor for every a2ui part.
  */
-export type A2uiEnvelope =
-  | CreateSurfaceEnvelope
-  | UpdateComponentsEnvelope
-  | UpdateDataModelEnvelope
-  | DeleteSurfaceEnvelope
-  | ActionEnvelope;
+export type A2uiEnvelope = A2uiServerEnvelope | ActionEnvelope;
 
 /**
  * The canonical "a2ui part": a Genkit `data` part whose `data` is an object

--- a/js/plugins/a2ui/tests/part_test.ts
+++ b/js/plugins/a2ui/tests/part_test.ts
@@ -135,11 +135,12 @@ describe('a2uiEnvelopesFromParts', () => {
     assert.deepStrictEqual(a2uiEnvelopesFromParts(content), []);
   });
 
-  it('tolerates null / non-object envelope elements without throwing', () => {
-    // Malformed model output: envelopes should never be nullish, but the guard
-    // must not throw if they are.
+  it('drops null / non-object / array envelope elements without throwing', () => {
+    // Malformed model output: envelopes should never contain these, but the
+    // guard must not throw and must not leak non-envelopes into the result
+    // (arrays are `typeof 'object'`, so they get an explicit check).
     const part = {
-      data: { envelopes: [null, 'nope', sampleEnvelope] },
+      data: { envelopes: [null, 'nope', [], sampleEnvelope] },
       metadata: { mimeType: A2UI_MIME_TYPE },
     };
     assert.deepStrictEqual(a2uiEnvelopesFromParts([part]), [sampleEnvelope]);

--- a/js/plugins/a2ui/tests/part_test.ts
+++ b/js/plugins/a2ui/tests/part_test.ts
@@ -135,12 +135,13 @@ describe('a2uiEnvelopesFromParts', () => {
     assert.deepStrictEqual(a2uiEnvelopesFromParts(content), []);
   });
 
-  it('drops null / non-object / array envelope elements without throwing', () => {
+  it('drops null / non-object / array / non-envelope elements without throwing', () => {
     // Malformed model output: envelopes should never contain these, but the
-    // guard must not throw and must not leak non-envelopes into the result
-    // (arrays are `typeof 'object'`, so they get an explicit check).
+    // positive server-envelope check must not throw and must keep only real
+    // surface envelopes. Arrays are `typeof 'object'`, and a stray object like
+    // `{ foo: 1 }` carries no surface discriminant, so both are dropped.
     const part = {
-      data: { envelopes: [null, 'nope', [], sampleEnvelope] },
+      data: { envelopes: [null, 'nope', [], { foo: 1 }, sampleEnvelope] },
       metadata: { mimeType: A2UI_MIME_TYPE },
     };
     assert.deepStrictEqual(a2uiEnvelopesFromParts([part]), [sampleEnvelope]);

--- a/js/plugins/a2ui/tests/part_test.ts
+++ b/js/plugins/a2ui/tests/part_test.ts
@@ -17,11 +17,25 @@
 import assert from 'node:assert';
 import { describe, it } from 'node:test';
 import { a2uiEnvelopesFromParts, a2uiPart, isA2uiPart } from '../src/part.js';
-import { A2UI_MIME_TYPE, type A2uiEnvelope } from '../src/types.js';
+import {
+  A2UI_MIME_TYPE,
+  type A2uiEnvelope,
+  type ActionEnvelope,
+} from '../src/types.js';
 
 const sampleEnvelope: A2uiEnvelope = {
   createSurface: { surfaceId: 's1', catalogId: 'c1' },
   version: 'v0.9',
+};
+
+const sampleActionEnvelope: ActionEnvelope = {
+  action: {
+    name: 'submit',
+    surfaceId: 's1',
+    sourceComponentId: 'btn',
+    timestamp: '2026-01-01T00:00:00.000Z',
+    context: {},
+  },
 };
 
 describe('a2uiPart', () => {
@@ -107,5 +121,27 @@ describe('a2uiEnvelopesFromParts', () => {
   it('returns [] for a nullish parts list', () => {
     assert.deepStrictEqual(a2uiEnvelopesFromParts(null), []);
     assert.deepStrictEqual(a2uiEnvelopesFromParts(undefined), []);
+  });
+
+  it('filters out inbound action envelopes, keeping only server envelopes', () => {
+    const content = [
+      a2uiPart([sampleActionEnvelope, sampleEnvelope, sampleActionEnvelope]),
+    ];
+    assert.deepStrictEqual(a2uiEnvelopesFromParts(content), [sampleEnvelope]);
+  });
+
+  it('returns [] for a part carrying only action envelopes', () => {
+    const content = [a2uiPart([sampleActionEnvelope])];
+    assert.deepStrictEqual(a2uiEnvelopesFromParts(content), []);
+  });
+
+  it('tolerates null / non-object envelope elements without throwing', () => {
+    // Malformed model output: envelopes should never be nullish, but the guard
+    // must not throw if they are.
+    const part = {
+      data: { envelopes: [null, 'nope', sampleEnvelope] },
+      metadata: { mimeType: A2UI_MIME_TYPE },
+    };
+    assert.deepStrictEqual(a2uiEnvelopesFromParts([part]), [sampleEnvelope]);
   });
 });

--- a/js/testapps/a2ui/web/src/main.ts
+++ b/js/testapps/a2ui/web/src/main.ts
@@ -27,20 +27,34 @@
  * to the agent as the next turn.
  */
 
-import { basicCatalog, Context } from '@a2ui/lit/v0_9';
+import { A2uiSurface, basicCatalog, Context } from '@a2ui/lit/v0_9';
 // Importing the v0_9 entry registers <a2ui-surface> and all basic components.
 import '@a2ui/lit/v0_9';
 import { renderMarkdown } from '@a2ui/markdown-it';
-import { MessageProcessor } from '@a2ui/web_core/v0_9';
+import { MessageProcessor, type A2uiMessage } from '@a2ui/web_core/v0_9';
 import { injectBasicCatalogStyles } from '@a2ui/web_core/v0_9/basic_catalog';
 import {
   a2uiEnvelopesFromParts,
   actionToMessage,
   type A2uiClientAction,
+  type A2uiServerEnvelope,
 } from '@genkit-ai/a2ui/client';
 import { ContextProvider } from '@lit/context';
-import { remoteAgent, type AgentChat } from 'genkit/beta/client';
+import {
+  remoteAgent,
+  type AgentChat,
+  type AgentInput,
+} from 'genkit/beta/client';
 import './style.css';
+
+// Compile-time guard: the plugin's `A2uiServerEnvelope` (what
+// `a2uiEnvelopesFromParts` returns) must stay assignable to web_core's
+// `A2uiMessage`, so envelopes can be handed to `processor.processMessages`
+// without a cast. This holds only while the plugin's `SUPPORTED_VERSIONS`
+// matches web_core's version enum; if they diverge, this line fails the build
+// (rather than silently forcing consumers back to `as any`).
+const _a2uiMessageCompat: A2uiMessage = null as unknown as A2uiServerEnvelope;
+void _a2uiMessageCompat;
 
 // Inject the basic catalog's default styles into the document.
 injectBasicCatalogStyles();
@@ -55,12 +69,10 @@ injectBasicCatalogStyles();
 // stray selectable blank line *and* inflates the Text box, which throws off the
 // `align-items: center` vertical alignment of icons next to titles/labels in
 // Rows and Buttons. Trim the output so every Text is exactly its visible size.
-const renderMarkdownTrimmed = ((value: string, options: unknown) =>
-  renderMarkdown(value, options as any).then((html) =>
-    html.trim()
-  )) as typeof renderMarkdown;
+const renderMarkdownTrimmed: typeof renderMarkdown = (value, options) =>
+  renderMarkdown(value, options).then((html) => html.trim());
 
-new ContextProvider(document.body as any, {
+new ContextProvider(document.body, {
   context: Context.markdown,
   initialValue: renderMarkdownTrimmed,
 });
@@ -96,16 +108,19 @@ const sendBtn = document.getElementById('send') as HTMLButtonElement;
 
 /** Shared message processor + a place to route surface actions back to the agent. */
 const processor = new MessageProcessor([basicCatalog], (action) => {
-  onSurfaceAction(action as unknown as A2uiClientAction);
+  onSurfaceAction(action);
 });
 
 // When a surface is (re)created, drop its renderer into the newest agent bubble.
 let pendingSurfaceSlot: HTMLDivElement | null = null;
-processor.onSurfaceCreated((surface: any) => {
+processor.onSurfaceCreated((surface) => {
   const slot = pendingSurfaceSlot ?? newAgentBubble();
   pendingSurfaceSlot = null;
   slot.querySelector('a2ui-surface')?.remove();
-  const el = document.createElement('a2ui-surface') as any;
+  // `createElement` returns a plain `HTMLElement` (the v0_9 tag isn't in the
+  // DOM's `HTMLElementTagNameMap`), so narrow to the renderer's element class
+  // to get a typed `surface` property.
+  const el = document.createElement('a2ui-surface') as A2uiSurface;
   el.surface = surface;
   slot.appendChild(el);
   scrollToBottom();
@@ -140,7 +155,7 @@ async function send(text: string) {
 }
 
 /** Runs a single agent turn, streaming prose + surfaces into the log. */
-async function runTurn(message: string | Record<string, unknown>) {
+async function runTurn(message: string | AgentInput) {
   const agentBubble = newAgentBubble();
   const prose = document.createElement('div');
   prose.className = 'prose';
@@ -149,7 +164,7 @@ async function runTurn(message: string | Record<string, unknown>) {
   pendingSurfaceSlot = agentBubble;
 
   try {
-    const turn = chat.sendStream(message as any);
+    const turn = chat.sendStream(message);
     for await (const chunk of turn.stream) {
       if (chunk.text) {
         prose.textContent += chunk.text;
@@ -176,10 +191,7 @@ async function onSurfaceAction(action: A2uiClientAction) {
   label.textContent = `▶ ${action.name}`;
   setBusy(true);
   // Wrap the action's message as an AgentInput (`{ message }`).
-  await runTurn({ message: actionToMessage(action) } as Record<
-    string,
-    unknown
-  >);
+  await runTurn({ message: actionToMessage(action) });
   setBusy(false);
 }
 

--- a/js/testapps/a2ui/web/src/style.css
+++ b/js/testapps/a2ui/web/src/style.css
@@ -139,6 +139,15 @@ a2ui-surface {
   display: block;
   margin-top: 10px;
   padding: 18px;
+
+  /* `white-space` is inherited, and `.bubble` sets `pre-wrap` for chat prose.
+     Left alone it bleeds into the surface's shadow DOM, where the catalog's Lit
+     templates carry literal newlines/indentation between nodes (e.g. Column's
+     `${map(...)}` and CheckBox's `<label>` block). Under `pre-wrap` those render
+     as real line breaks, producing huge vertical gaps and knocking labels off
+     their checkbox baseline. Reset it so the surface controls its own layout. */
+  white-space: normal;
+
   --a2ui-color-background: #ffffff;
   --a2ui-color-on-background: #1b2030;
   --a2ui-color-surface: #ffffff;


### PR DESCRIPTION
Introduce A2uiServerEnvelope to represent server → client render surfaces and export it alongside ActionEnvelope. Update a2uiEnvelopesFromParts to return A2uiServerEnvelope[], dropping inbound action envelopes and malformed entries so results can be passed directly to a renderer without casting. Also use `as const` for message roles to preserve literal types.
