### PR TITLE
fix(genkit-tools): support java for analytics and fallback to unknown

### DIFF
--- a/genkit-tools/common/src/manager/types.ts
+++ b/genkit-tools/common/src/manager/types.ts
@@ -16,7 +16,7 @@
 
 import type { GenkitError } from '../types/error';
 
-export type Runtime = 'nodejs' | 'go' | 'python' | 'dart' | undefined;
+export type Runtime = 'nodejs' | 'go' | 'python' | 'dart' | 'java' | undefined;
 
 export class GenkitToolsError extends Error {
   public data?: GenkitError;

--- a/genkit-tools/common/src/server/server.ts
+++ b/genkit-tools/common/src/server/server.ts
@@ -143,7 +143,7 @@ export function startServer(
   port: number,
   host: string = DEFAULT_HOST
 ) {
-  const projectRuntime = detectRuntimeSync(manager.projectRoot);
+  const projectRuntime = detectRuntimeSync(manager.projectRoot) || 'unknown';
   let server: Server;
   const app = express();
 

--- a/genkit-tools/common/src/utils/analytics.ts
+++ b/genkit-tools/common/src/utils/analytics.ts
@@ -100,7 +100,7 @@ export class RunCommandEvent extends GAEvent {
     this.stickyParameters = {
       command,
       runtime_type,
-      ...(project_runtime && { project_runtime }),
+      project_runtime: project_runtime || 'unknown',
     };
   }
 }

--- a/genkit-tools/common/src/utils/utils.ts
+++ b/genkit-tools/common/src/utils/utils.ts
@@ -41,6 +41,7 @@ export async function findProjectRoot(): Promise<string> {
     'requirements.txt',
     'pom.xml',
     'build.gradle',
+    'build.gradle.kts',
     'pubspec.yaml',
   ];
 
@@ -135,6 +136,13 @@ function matchRuntimeMarker(file: string, isFile: boolean): Runtime {
   }
   if (file === 'pubspec.yaml') {
     return 'dart';
+  }
+  if (
+    file === 'pom.xml' ||
+    file === 'build.gradle' ||
+    file === 'build.gradle.kts'
+  ) {
+    return 'java';
   }
   return undefined;
 }

--- a/genkit-tools/common/tests/utils/utils_test.ts
+++ b/genkit-tools/common/tests/utils/utils_test.ts
@@ -26,6 +26,8 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import {
+  detectRuntime,
+  detectRuntimeSync,
   findProjectRoot,
   projectNameFromGenkitFilePath,
 } from '../../src/utils';
@@ -51,20 +53,34 @@ describe('utils', () => {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     });
 
-    it('returns the directory containing a pubspec.yaml', async () => {
-      const projectDir = path.join(tmpDir, 'dart-app');
-      const nestedDir = path.join(projectDir, 'lib', 'src');
-      fs.mkdirSync(nestedDir, { recursive: true });
-      fs.writeFileSync(path.join(projectDir, 'pubspec.yaml'), 'name: dart_app');
+    const projectMarkers = [
+      'package.json',
+      'go.mod',
+      'pyproject.toml',
+      'requirements.txt',
+      'pom.xml',
+      'build.gradle',
+      'build.gradle.kts',
+      'pubspec.yaml',
+    ];
 
-      const cwdSpy = jest.spyOn(process, 'cwd').mockReturnValue(nestedDir);
+    it.each(projectMarkers)(
+      'returns the directory containing %s when called from a nested subdirectory',
+      async (markerFile) => {
+        const projectDir = path.join(tmpDir, `project-${markerFile}`);
+        const nestedDir = path.join(projectDir, 'src', 'nested');
+        fs.mkdirSync(nestedDir, { recursive: true });
+        fs.writeFileSync(path.join(projectDir, markerFile), '');
 
-      try {
-        expect(await findProjectRoot()).toEqual(projectDir);
-      } finally {
-        cwdSpy.mockRestore();
+        const cwdSpy = jest.spyOn(process, 'cwd').mockReturnValue(nestedDir);
+
+        try {
+          expect(await findProjectRoot()).toEqual(projectDir);
+        } finally {
+          cwdSpy.mockRestore();
+        }
       }
-    });
+    );
 
     it('returns the nearest project root when a Dart project is nested under a package.json', async () => {
       // Mirrors a Dart project living inside a JS workspace or monorepo. The
@@ -83,6 +99,60 @@ describe('utils', () => {
       } finally {
         cwdSpy.mockRestore();
       }
+    });
+  });
+
+  describe('detectRuntime / detectRuntimeSync', () => {
+    let tmpDir: string;
+
+    beforeEach(() => {
+      tmpDir = fs.realpathSync(
+        fs.mkdtempSync(path.join(os.tmpdir(), 'genkit-detect-runtime-'))
+      );
+    });
+
+    afterEach(() => {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    const runtimeMarkerCases: { file: string; expected: string }[] = [
+      { file: 'pom.xml', expected: 'java' },
+      { file: 'build.gradle', expected: 'java' },
+      { file: 'build.gradle.kts', expected: 'java' },
+      { file: 'go.mod', expected: 'go' },
+      { file: 'main.go', expected: 'go' },
+      { file: 'pyproject.toml', expected: 'python' },
+      { file: 'requirements.txt', expected: 'python' },
+      { file: 'pubspec.yaml', expected: 'dart' },
+      { file: 'package.json', expected: 'nodejs' },
+    ];
+
+    it.each(runtimeMarkerCases)(
+      'detects "$expected" for marker file "$file"',
+      async ({ file, expected }) => {
+        const appDir = path.join(tmpDir, `app-${file}`);
+        fs.mkdirSync(appDir, { recursive: true });
+        fs.writeFileSync(path.join(appDir, file), '');
+
+        expect(await detectRuntime(appDir)).toBe(expected);
+        expect(detectRuntimeSync(appDir)).toBe(expected);
+      }
+    );
+
+    it('returns undefined when no marker files exist in the directory', async () => {
+      const emptyDir = path.join(tmpDir, 'empty-app');
+      fs.mkdirSync(emptyDir, { recursive: true });
+
+      expect(await detectRuntime(emptyDir)).toBeUndefined();
+      expect(detectRuntimeSync(emptyDir)).toBeUndefined();
+    });
+
+    it('returns undefined when a marker is a directory rather than a file', async () => {
+      const dirMarkerApp = path.join(tmpDir, 'dir-marker-app');
+      fs.mkdirSync(path.join(dirMarkerApp, 'go.mod'), { recursive: true });
+
+      expect(await detectRuntime(dirMarkerApp)).toBeUndefined();
+      expect(detectRuntimeSync(dirMarkerApp)).toBeUndefined();
     });
   });
 


### PR DESCRIPTION
Improves our metrics coverage for java and adds a reasonable fallback instead of "" to `project_runtime`.