### PR TITLE
fix(js/plugins/a2ui): handle candidates shape and stitch split text parts

### DIFF
--- a/js/plugins/a2ui/src/middleware.ts
+++ b/js/plugins/a2ui/src/middleware.ts
@@ -331,26 +331,69 @@ function transformResponse(
     surfaceId: () => string;
   }
 ): GenerateResponseData {
-  const message = response.message;
+  // Real models (e.g. google-genai) return the candidates shape, not a
+  // top-level `message`; only the GenerateResponse constructor later collapses
+  // `message ?? candidates[0].message`. Read from whichever the model used so
+  // the transform runs on the real path, not just when a caller hands us a
+  // pre-collapsed `message`.
+  const message = response.message ?? response.candidates?.[0]?.message;
   if (!message?.content) return response;
 
   const parser = new A2uiStreamParser(opts);
+
   const newContent: Part[] = [];
+
+  // Drains whatever the parser is still holding (a withheld prose tail, or an
+  // unterminated trailing block) and appends it. Called at every non-text
+  // boundary and once at the end.
+  const flushHeld = () => {
+    const tail = parser.flush();
+    newContent.push(...partsFromParse(tail));
+  };
+
   for (const part of message.content) {
-    if (isTextPart(part)) {
-      // Combine the streamed-push and final-flush segments so ordering (prose
-      // before/after a block) is preserved in the aggregated message too.
-      const pushed = parser.push(part.text);
-      const flushed = parser.flush();
-      const segments = [...pushed.segments, ...flushed.segments];
-      newContent.push(...partsFromParse({ segments } as ParseResult));
+    if (isTextPart(part) && part.text !== '') {
+      // Push WITHOUT flushing between consecutive text parts so an a2ui block
+      // that spans several adjacent text parts is stitched back together. The
+      // model's final message is not guaranteed to coalesce adjacent text: the
+      // Gemini plugin, for instance, aggregates a turn into many separate text
+      // parts (fence, JSON body split many ways, close fence, then a trailing
+      // empty-text part carrying the thought signature), so a per-part flush
+      // would reset the parser mid-block and leak the whole surface back out as
+      // raw prose. This mirrors the streaming path, which shares one parser
+      // across all chunks and flushes only once at the end.
+      newContent.push(...partsFromParse(parser.push(part.text)));
     } else {
+      // A non-text part (e.g. a toolRequest) or an empty-text part (e.g. the
+      // trailing thought-signature carrier) is a boundary: flush any held tail
+      // so it lands before this part, preserving order. This is what a
+      // tool-calling turn [text("Checking the weather."), toolRequest] relies
+      // on so the prose is not reordered behind the toolRequest. Then carry the
+      // part through untouched so its metadata survives.
+      flushHeld();
       newContent.push(part);
     }
   }
+  flushHeld();
+
+  const newMessage = { ...message, content: newContent };
+
+  // Write the transformed message back to the same shape the model used. A
+  // model that returned a top-level `message` gets it back there; one that
+  // returned the candidates shape (e.g. google-genai) gets candidate[0]
+  // rewritten, so consumers reading `candidates` (not just the collapsed
+  // GenerateResponse.message getter) see the a2ui parts too. Only candidate 0
+  // is transformed: the framework collapses to `candidates[0].message` and
+  // candidateCount defaults to 1, and each candidate would otherwise consume
+  // the shared surface-id replay state.
+  if (response.message) {
+    return { ...response, message: newMessage };
+  }
   return {
     ...response,
-    message: { ...message, content: newContent },
+    candidates: response.candidates!.map((c, i) =>
+      i === 0 ? { ...c, message: newMessage } : c
+    ),
   };
 }
 

--- a/js/plugins/a2ui/src/middleware.ts
+++ b/js/plugins/a2ui/src/middleware.ts
@@ -378,23 +378,25 @@ function transformResponse(
 
   const newMessage = { ...message, content: newContent };
 
-  // Write the transformed message back to the same shape the model used. A
-  // model that returned a top-level `message` gets it back there; one that
-  // returned the candidates shape (e.g. google-genai) gets candidate[0]
-  // rewritten, so consumers reading `candidates` (not just the collapsed
-  // GenerateResponse.message getter) see the a2ui parts too. Only candidate 0
-  // is transformed: the framework collapses to `candidates[0].message` and
-  // candidateCount defaults to 1, and each candidate would otherwise consume
-  // the shared surface-id replay state.
-  if (response.message) {
-    return { ...response, message: newMessage };
+  // Write the transformed message back to WHICHEVER shape(s) the response
+  // carries, so no consumer sees the raw prose. Real providers (e.g.
+  // google-genai) use the candidates shape, but a response could carry a
+  // top-level `message` and a `candidates` array at once (e.g. a prior
+  // middleware pre-populated `message` while keeping `candidates`); updating
+  // only one would leave the other holding the untransformed fence text. Only
+  // candidate 0 is transformed: the framework collapses to
+  // `candidates[0].message` and candidateCount defaults to 1, and each
+  // candidate would otherwise consume the shared surface-id replay state.
+  const result = { ...response };
+  if (result.message) {
+    result.message = newMessage;
   }
-  return {
-    ...response,
-    candidates: response.candidates!.map((c, i) =>
+  if (result.candidates?.[0]) {
+    result.candidates = result.candidates.map((c, i) =>
       i === 0 ? { ...c, message: newMessage } : c
-    ),
-  };
+    );
+  }
+  return result;
 }
 
 /**

--- a/js/plugins/a2ui/tests/middleware_test.ts
+++ b/js/plugins/a2ui/tests/middleware_test.ts
@@ -184,6 +184,67 @@ describe('a2ui() middleware', () => {
     assert.strictEqual((envelopes[0] as any).createSurface.surfaceId, 'sfc');
   });
 
+  it('stitches a block split across many final-message text parts', async () => {
+    // The aggregated final message is not guaranteed to coalesce adjacent text:
+    // the Gemini plugin splits a turn into many text parts (fence, JSON body
+    // split many ways, close fence, then a trailing empty-text part carrying
+    // the thought signature). transformResponse must stitch a block spanning
+    // several parts into a single a2ui data part rather than flushing per part
+    // and leaking the whole surface back out as raw prose.
+    const mw = modelHook({ surfaceId: 'sfc' });
+
+    const content = [
+      { text: 'Here is the weather:\n\n``' },
+      { text: `\`a2ui\n[{"createSurface":{"surfaceId":"SURFACE_ID",` },
+      { text: `"catalogId":"${basicCatalog.id}"}},` },
+      { text: `{"updateComponents":{"surfaceId":"SURFACE_ID",` },
+      { text: `"components":[{"id":"root","component":"Text",` },
+      { text: `"text":"hi"}]}}]\n\`\`` },
+      { text: '`' },
+      // A trailing empty-text part that only carries a thought signature.
+      { text: '', metadata: { signature: 'thought-sig-xyz' } },
+    ];
+
+    // Return the *candidates* shape that real models (e.g. google-genai) emit,
+    // not a pre-collapsed top-level `message`. The middleware must transform
+    // candidates[0].message, otherwise it silently passes the raw fence text
+    // through (the bug this guards against).
+    const res = await mw(req('sys'), undefined, async () => ({
+      candidates: [
+        { index: 0, finishReason: 'stop', message: { role: 'model', content } },
+      ],
+    }));
+    const out = (res as any).candidates[0].message.content;
+
+    // The block spread over many parts is stitched into exactly two envelopes
+    // on a single a2ui data part.
+    const envelopes = a2uiEnvelopesFromParts(out);
+    assert.strictEqual(envelopes.length, 2);
+    assert.strictEqual((envelopes[0] as any).createSurface.surfaceId, 'sfc');
+
+    // No text part should still contain the raw fence: the JSON must have been
+    // parsed out, not leaked back as prose.
+    assert.ok(
+      !out.some(
+        (p: any) => typeof p.text === 'string' && p.text.includes('a2ui')
+      )
+    );
+
+    // The leading prose survives, and the trailing signature part is carried
+    // through untouched.
+    assert.ok(
+      out.some(
+        (p: any) =>
+          typeof p.text === 'string' && p.text.includes('Here is the weather')
+      ),
+      'expected the leading prose to be preserved'
+    );
+    assert.ok(
+      out.some((p: any) => p.metadata?.signature === 'thought-sig-xyz'),
+      'expected the trailing thought-signature part to survive'
+    );
+  });
+
   it('leaves plain prose responses untouched (no a2ui parts)', async () => {
     const mw = modelHook({});
     const res = await mw(req('sys'), undefined, async () => ({
@@ -674,5 +735,57 @@ describe('a2ui() end-to-end via ai.generate', () => {
     const envelopes = a2uiEnvelopesFromParts(res.message!.content);
     assert.strictEqual(envelopes.length, 2);
     assert.strictEqual((envelopes[0] as any).createSurface.surfaceId, 'sfc');
+  });
+
+  it('rewrites a candidates-shaped model response (real provider shape)', async () => {
+    // Real providers (e.g. google-genai) return the `candidates` shape, not a
+    // pre-collapsed top-level `message`, and split the block across many text
+    // parts. This exercises the full ai.generate path end-to-end, catching the
+    // regression where transformResponse only read `response.message` and thus
+    // left the raw fence text in the persisted message.
+    const ai = genkit({});
+    const model = ai.defineModel({ name: 'echo-candidates' }, async () => {
+      return {
+        candidates: [
+          {
+            index: 0,
+            finishReason: 'stop',
+            message: {
+              role: 'model',
+              content: [
+                { text: 'Here is the weather:\n\n``' },
+                {
+                  text: `\`a2ui\n[{"createSurface":{"surfaceId":"SURFACE_ID",`,
+                },
+                { text: `"catalogId":"${basicCatalog.id}"}},` },
+                { text: `{"updateComponents":{"surfaceId":"SURFACE_ID",` },
+                { text: `"components":[{"id":"root","component":"Text",` },
+                { text: `"text":"hi"}]}}]\n\`\`` },
+                { text: '`' },
+              ],
+            },
+          },
+        ],
+        finishReason: 'stop',
+      };
+    });
+
+    const res = await ai.generate({
+      model,
+      prompt: 'weather please',
+      use: [a2ui({ surfaceId: 'sfc' })],
+    });
+
+    // The final (collapsed) message carries the parsed a2ui data part, not raw
+    // fence text.
+    const envelopes = a2uiEnvelopesFromParts(res.message!.content);
+    assert.strictEqual(envelopes.length, 2);
+    assert.strictEqual((envelopes[0] as any).createSurface.surfaceId, 'sfc');
+    assert.ok(
+      !res
+        .message!.content.filter((p: any) => typeof p.text === 'string')
+        .some((p: any) => p.text.includes('a2ui')),
+      'raw a2ui fence must not leak into prose'
+    );
   });
 });

--- a/js/plugins/a2ui/tests/middleware_test.ts
+++ b/js/plugins/a2ui/tests/middleware_test.ts
@@ -245,6 +245,39 @@ describe('a2ui() middleware', () => {
     );
   });
 
+  it('transforms both message and candidates[0] when a response carries both', async () => {
+    // A response could carry a top-level `message` AND a `candidates` array at
+    // once (e.g. a prior middleware pre-populated `message` while keeping
+    // `candidates`). Both must be transformed so a consumer reading either sees
+    // the parsed a2ui part, never the raw fence text.
+    const mw = modelHook({ surfaceId: 'sfc' });
+    const res = await mw(req('sys'), undefined, async () => ({
+      message: { role: 'model', content: [{ text: SAMPLE_TEXT }] },
+      candidates: [
+        {
+          index: 0,
+          finishReason: 'stop',
+          message: { role: 'model', content: [{ text: SAMPLE_TEXT }] },
+        },
+      ],
+    }));
+
+    for (const content of [
+      (res as any).message.content,
+      (res as any).candidates[0].message.content,
+    ]) {
+      const envelopes = a2uiEnvelopesFromParts(content);
+      assert.strictEqual(envelopes.length, 2);
+      assert.strictEqual((envelopes[0] as any).createSurface.surfaceId, 'sfc');
+      assert.ok(
+        !content.some(
+          (p: any) => typeof p.text === 'string' && p.text.includes('```')
+        ),
+        'raw fence must not leak into either shape'
+      );
+    }
+  });
+
   it('leaves plain prose responses untouched (no a2ui parts)', async () => {
     const mw = modelHook({});
     const res = await mw(req('sys'), undefined, async () => ({


### PR DESCRIPTION
Read message from candidates shape (used by real models like google-genai) in addition to top-level message, and write transformed content back to the same shape. Push consecutive text parts without flushing between them so a2ui blocks spanning multiple adjacent text parts are stitched back together, mirroring the streaming path and preventing surfaces from leaking as raw prose.
