### PR TITLE
fix(py): remove Responses-API-only models from the OpenAI chat catalog and listing

### DIFF
--- a/py/packages/genkit-openai/src/genkit_openai/models/model_info.py
+++ b/py/packages/genkit-openai/src/genkit_openai/models/model_info.py
@@ -119,25 +119,22 @@ KnownGpt: TypeAlias = Literal[
     'o1',
     'o3',
     'o3-mini',
-    'o3-pro',
     'o4-mini',
     'gpt-5',
     'gpt-5-mini',
     'gpt-5-nano',
     'gpt-5-chat-latest',
     'gpt-5.1',
-    'gpt-5.1-codex',
-    'gpt-5.1-codex-max',
     'gpt-5.2',
     'gpt-5.2-chat',
-    'gpt-5.2-pro',
-    'gpt-5.3-codex',
     'gpt-oss-120b',
     'gpt-oss-20b',
 ]
 
 
 # Source: https://platform.openai.com/docs/models
+# Codex and -pro ids (gpt-5.x-codex, o3-pro, gpt-5.x-pro) are served only by
+# the Responses API; this plugin speaks Chat Completions, so they are absent.
 SUPPORTED_OPENAI_MODELS: dict[KnownGpt, ModelInfo] = {
     # --- GPT-4o series ---
     'gpt-4o': ModelInfo(label='OpenAI - gpt-4o', supports=MULTIMODAL_MODEL_SUPPORTS),
@@ -172,7 +169,6 @@ SUPPORTED_OPENAI_MODELS: dict[KnownGpt, ModelInfo] = {
             output=[SupportedOutputFormat.JSON_MODE, SupportedOutputFormat.TEXT],
         ),
     ),
-    'o3-pro': ModelInfo(label='OpenAI - o3-pro', supports=O_SERIES_MODEL_SUPPORTS),
     'o4-mini': ModelInfo(label='OpenAI - o4-mini', supports=O_SERIES_MODEL_SUPPORTS),
     # --- GPT-5 series ---
     'gpt-5': ModelInfo(label='OpenAI - gpt-5', supports=GPT_5_MODEL_SUPPORTS),
@@ -189,12 +185,8 @@ SUPPORTED_OPENAI_MODELS: dict[KnownGpt, ModelInfo] = {
         ),
     ),
     'gpt-5.1': ModelInfo(label='OpenAI - gpt-5.1', supports=GPT_5_MODEL_SUPPORTS),
-    'gpt-5.1-codex': ModelInfo(label='OpenAI - gpt-5.1-codex', supports=GPT_5_MODEL_SUPPORTS),
-    'gpt-5.1-codex-max': ModelInfo(label='OpenAI - gpt-5.1-codex-max', supports=GPT_5_MODEL_SUPPORTS),
     'gpt-5.2': ModelInfo(label='OpenAI - gpt-5.2', supports=GPT_5_MODEL_SUPPORTS),
     'gpt-5.2-chat': ModelInfo(label='OpenAI - gpt-5.2-chat', supports=GPT_5_MODEL_SUPPORTS),
-    'gpt-5.2-pro': ModelInfo(label='OpenAI - gpt-5.2-pro', supports=GPT_5_MODEL_SUPPORTS),
-    'gpt-5.3-codex': ModelInfo(label='OpenAI - gpt-5.3-codex', supports=GPT_5_MODEL_SUPPORTS),
     # --- OSS models (hosted) ---
     'gpt-oss-120b': ModelInfo(label='OpenAI - gpt-oss-120b', supports=GPT_OSS_MODEL_SUPPORTS),
     'gpt-oss-20b': ModelInfo(label='OpenAI - gpt-oss-20b', supports=GPT_OSS_MODEL_SUPPORTS),

--- a/py/packages/genkit-openai/src/genkit_openai/openai_plugin.py
+++ b/py/packages/genkit-openai/src/genkit_openai/openai_plugin.py
@@ -116,7 +116,7 @@ def _classify_model(name: str) -> _ModelType:
     return _ModelType.CHAT
 
 
-_UNSUPPORTED_MODEL_MATCHERS = ('babbage', 'davinci', 'codex')
+_UNSUPPORTED_MODEL_MATCHERS = ('babbage', 'davinci', 'codex', '-pro')
 
 
 def _is_known_unsupported(name: str) -> bool:

--- a/py/packages/genkit-openai/src/genkit_openai/openai_plugin.py
+++ b/py/packages/genkit-openai/src/genkit_openai/openai_plugin.py
@@ -116,6 +116,14 @@ def _classify_model(name: str) -> _ModelType:
     return _ModelType.CHAT
 
 
+_UNSUPPORTED_MODEL_MATCHERS = ('babbage', 'davinci', 'codex')
+
+
+def _is_known_unsupported(name: str) -> bool:
+    """Report whether a model id is in a family Chat Completions does not serve."""
+    return any(matcher in name for matcher in _UNSUPPORTED_MODEL_MATCHERS)
+
+
 # Default Supports for each multimodal model type, used as fallback when
 # a model is not found in the registry.
 _DEFAULT_SUPPORTS: dict[_ModelType, Supports] = {
@@ -518,6 +526,8 @@ class OpenAI(Plugin):
         models: list[Model] = models_.data
         for model in models:
             name = model.id
+            if _is_known_unsupported(name):
+                continue
             model_type = _classify_model(name)
             if model_type == _ModelType.EMBEDDER:
                 actions.append(

--- a/py/packages/genkit-openai/tests/openai_plugin_test.py
+++ b/py/packages/genkit-openai/tests/openai_plugin_test.py
@@ -52,7 +52,11 @@ async def test_openai_plugin_init() -> None:
 
 @pytest.mark.parametrize(
     'kind, name',
-    [(ActionKind.MODEL, 'gpt-3.5-turbo')],
+    [
+        (ActionKind.MODEL, 'gpt-3.5-turbo'),
+        # Unlisted ids still resolve when asked for by name.
+        (ActionKind.MODEL, 'codex-mini-latest'),
+    ],
 )
 @pytest.mark.asyncio
 async def test_openai_plugin_resolve_action(kind: ActionKind, name: str) -> None:
@@ -75,6 +79,8 @@ async def test_openai_plugin_list_actions() -> None:
         Model(id='gpt-3.5-turbo', created=1677610602, object='model', owned_by='openai'),
         Model(id='o4-mini-deep-research-2025-06-26', created=1750866121, object='model', owned_by='system'),
         Model(id='codex-mini-latest', created=1746673257, object='model', owned_by='system'),
+        Model(id='babbage-002', created=1692634615, object='model', owned_by='system'),
+        Model(id='davinci-002', created=1692634301, object='model', owned_by='system'),
         Model(id='text-embedding-ada-002', created=1671217299, object='model', owned_by='openai-internal'),
     ]
     plugin = OpenAI(api_key='test-key')
@@ -92,7 +98,12 @@ async def test_openai_plugin_list_actions() -> None:
     # list_actions is cached after the first API fetch.
     assert mock_client.models.list.call_count == 1
 
-    assert len(actions) == len(entries)
+    # Ids Chat Completions does not serve are dropped from the listing.
+    listed = {action.name for action in actions}
+    assert 'openai/codex-mini-latest' not in listed
+    assert 'openai/babbage-002' not in listed
+    assert 'openai/davinci-002' not in listed
+    assert len(actions) == len(entries) - 3
     assert actions[0].name == 'openai/gpt-4-0613'
     assert actions[-1].name == 'openai/text-embedding-ada-002'
 

--- a/py/packages/genkit-openai/tests/openai_plugin_test.py
+++ b/py/packages/genkit-openai/tests/openai_plugin_test.py
@@ -81,6 +81,7 @@ async def test_openai_plugin_list_actions() -> None:
         Model(id='codex-mini-latest', created=1746673257, object='model', owned_by='system'),
         Model(id='babbage-002', created=1692634615, object='model', owned_by='system'),
         Model(id='davinci-002', created=1692634301, object='model', owned_by='system'),
+        Model(id='o3-pro', created=1748475948, object='model', owned_by='system'),
         Model(id='text-embedding-ada-002', created=1671217299, object='model', owned_by='openai-internal'),
     ]
     plugin = OpenAI(api_key='test-key')
@@ -103,7 +104,8 @@ async def test_openai_plugin_list_actions() -> None:
     assert 'openai/codex-mini-latest' not in listed
     assert 'openai/babbage-002' not in listed
     assert 'openai/davinci-002' not in listed
-    assert len(actions) == len(entries) - 3
+    assert 'openai/o3-pro' not in listed
+    assert len(actions) == len(entries) - 4
     assert actions[0].name == 'openai/gpt-4-0613'
     assert actions[-1].name == 'openai/text-embedding-ada-002'
 


### PR DESCRIPTION
## Why

The compat-oai plugin speaks only the Chat Completions API, but the chat catalog curated five ids OpenAI serves only through the Responses API: gpt-5.1-codex, gpt-5.1-codex-max, gpt-5.3-codex, o3-pro, gpt-5.2-pro. Selecting any of them from the catalog fails at request time. Dynamic listing had the same defect: list_actions() surfaced every id models.list() returns, including codex ids and the legacy babbage/davinci completions models, none of which this plugin can serve.

Fixes #6156. Part of #5903.

## Changes

- Remove the five Responses-only ids from KnownGpt and SUPPORTED_OPENAI_MODELS, and note above the catalog why codex and -pro ids are absent.
- Filter the babbage, davinci, and codex id families out of list_actions(), the same denylist the JS plugin applies to its listing. Resolution by explicit name is unchanged as uncurated ids still resolve dynamically.

## Verification

- openai_plugin_test.py pins the new listing behavior (codex-mini-latest, babbage-002, and davinci-002 are absent from list_actions() output) and that codex-mini-latest still resolves when named explicitly.