### PR TITLE
fix(py/plugins/openai): classify embedder and list_actions API errors

### DIFF
--- a/py/packages/genkit-openai/src/genkit_openai/openai_plugin.py
+++ b/py/packages/genkit-openai/src/genkit_openai/openai_plugin.py
@@ -455,26 +455,33 @@ class OpenAI(Plugin):
 
         async def embed_fn(request: EmbedRequest) -> EmbedResponse:
             """Embedder function that calls OpenAI embeddings API."""
-            try:
-                # Extract text from document content
-                texts = []
-                for doc in request.input:
-                    doc_text = ''.join(  # type: ignore[arg-type]
-                        part.root.text for part in doc.content if hasattr(part.root, 'text') and part.root.text
-                    )
-                    texts.append(doc_text)
+            # Extract text from document content
+            texts = []
+            for doc in request.input:
+                doc_text = ''.join(  # type: ignore[arg-type]
+                    part.root.text for part in doc.content if hasattr(part.root, 'text') and part.root.text
+                )
+                texts.append(doc_text)
 
-                # Get optional parameters (omit when None; OpenAI create() uses Omit, not None)
-                dimensions: int | None = None
-                encoding_format: Literal['base64', 'float'] | None = None
-                if request.options:
-                    if dim_val := request.options.get('dimensions'):
+            # Get optional parameters (omit when None; OpenAI create() uses Omit, not None)
+            dimensions: int | None = None
+            encoding_format: Literal['base64', 'float'] | None = None
+            if request.options:
+                if dim_val := request.options.get('dimensions'):
+                    try:
                         dimensions = int(dim_val)
-                    enc_val = request.options.get('encodingFormat')
-                    if enc_val in ('float', 'base64'):
-                        encoding_format = cast(Literal['base64', 'float'], enc_val)
+                    except (TypeError, ValueError) as e:
+                        raise GenkitError(
+                            status='INVALID_ARGUMENT',
+                            message=f'dimensions must be an int, got {dim_val!r}',
+                            cause=e,
+                        ) from e
+                enc_val = request.options.get('encodingFormat')
+                if enc_val in ('float', 'base64'):
+                    encoding_format = cast(Literal['base64', 'float'], enc_val)
 
-                # Call with only non-None optional params to satisfy strict typings
+            # Call with only non-None optional params to satisfy strict typings
+            try:
                 if dimensions is not None and encoding_format is not None:
                     response = await self._runtime_client().embeddings.create(
                         model=clean_name,
@@ -499,12 +506,12 @@ class OpenAI(Plugin):
                         model=clean_name,
                         input=texts,
                     )
-
-                # Convert OpenAI response to Genkit format
-                embeddings = [Embedding(embedding=item.embedding) for item in response.data]
-                return EmbedResponse(embeddings=embeddings)
-            except (APIStatusError, ValueError) as e:
+            except APIStatusError as e:
                 reraise_openai_error(e)
+
+            # Convert OpenAI response to Genkit format
+            embeddings = [Embedding(embedding=item.embedding) for item in response.data]
+            return EmbedResponse(embeddings=embeddings)
 
         return embedder(
             name,

--- a/py/packages/genkit-openai/src/genkit_openai/openai_plugin.py
+++ b/py/packages/genkit-openai/src/genkit_openai/openai_plugin.py
@@ -20,7 +20,7 @@
 import enum
 from typing import Any, Literal, TypeAlias, cast
 
-from openai import AsyncOpenAI
+from openai import APIStatusError, AsyncOpenAI
 from openai.types import Model
 
 from genkit import Embedding, EmbedRequest, EmbedResponse, GenkitError, ModelInfo, ModelRequest, ModelResponse, Supports
@@ -49,6 +49,7 @@ from genkit_openai.models import (
     OpenAITTSModel,
 )
 from genkit_openai.models.model_info import KnownGpt, get_default_openai_model_info
+from genkit_openai.models.utils import reraise_openai_error
 from genkit_openai.typing import OpenAIConfig
 
 
@@ -454,53 +455,56 @@ class OpenAI(Plugin):
 
         async def embed_fn(request: EmbedRequest) -> EmbedResponse:
             """Embedder function that calls OpenAI embeddings API."""
-            # Extract text from document content
-            texts = []
-            for doc in request.input:
-                doc_text = ''.join(  # type: ignore[arg-type]
-                    part.root.text for part in doc.content if hasattr(part.root, 'text') and part.root.text
-                )
-                texts.append(doc_text)
+            try:
+                # Extract text from document content
+                texts = []
+                for doc in request.input:
+                    doc_text = ''.join(  # type: ignore[arg-type]
+                        part.root.text for part in doc.content if hasattr(part.root, 'text') and part.root.text
+                    )
+                    texts.append(doc_text)
 
-            # Get optional parameters (omit when None; OpenAI create() uses Omit, not None)
-            dimensions: int | None = None
-            encoding_format: Literal['base64', 'float'] | None = None
-            if request.options:
-                if dim_val := request.options.get('dimensions'):
-                    dimensions = int(dim_val)
-                enc_val = request.options.get('encodingFormat')
-                if enc_val in ('float', 'base64'):
-                    encoding_format = cast(Literal['base64', 'float'], enc_val)
+                # Get optional parameters (omit when None; OpenAI create() uses Omit, not None)
+                dimensions: int | None = None
+                encoding_format: Literal['base64', 'float'] | None = None
+                if request.options:
+                    if dim_val := request.options.get('dimensions'):
+                        dimensions = int(dim_val)
+                    enc_val = request.options.get('encodingFormat')
+                    if enc_val in ('float', 'base64'):
+                        encoding_format = cast(Literal['base64', 'float'], enc_val)
 
-            # Call with only non-None optional params to satisfy strict typings
-            if dimensions is not None and encoding_format is not None:
-                response = await self._runtime_client().embeddings.create(
-                    model=clean_name,
-                    input=texts,
-                    dimensions=dimensions,
-                    encoding_format=encoding_format,
-                )
-            elif dimensions is not None:
-                response = await self._runtime_client().embeddings.create(
-                    model=clean_name,
-                    input=texts,
-                    dimensions=dimensions,
-                )
-            elif encoding_format is not None:
-                response = await self._runtime_client().embeddings.create(
-                    model=clean_name,
-                    input=texts,
-                    encoding_format=encoding_format,
-                )
-            else:
-                response = await self._runtime_client().embeddings.create(
-                    model=clean_name,
-                    input=texts,
-                )
+                # Call with only non-None optional params to satisfy strict typings
+                if dimensions is not None and encoding_format is not None:
+                    response = await self._runtime_client().embeddings.create(
+                        model=clean_name,
+                        input=texts,
+                        dimensions=dimensions,
+                        encoding_format=encoding_format,
+                    )
+                elif dimensions is not None:
+                    response = await self._runtime_client().embeddings.create(
+                        model=clean_name,
+                        input=texts,
+                        dimensions=dimensions,
+                    )
+                elif encoding_format is not None:
+                    response = await self._runtime_client().embeddings.create(
+                        model=clean_name,
+                        input=texts,
+                        encoding_format=encoding_format,
+                    )
+                else:
+                    response = await self._runtime_client().embeddings.create(
+                        model=clean_name,
+                        input=texts,
+                    )
 
-            # Convert OpenAI response to Genkit format
-            embeddings = [Embedding(embedding=item.embedding) for item in response.data]
-            return EmbedResponse(embeddings=embeddings)
+                # Convert OpenAI response to Genkit format
+                embeddings = [Embedding(embedding=item.embedding) for item in response.data]
+                return EmbedResponse(embeddings=embeddings)
+            except (APIStatusError, ValueError) as e:
+                reraise_openai_error(e)
 
         return embedder(
             name,
@@ -528,7 +532,10 @@ class OpenAI(Plugin):
             return self._list_actions_cache
 
         actions: list[ActionMetadata] = []
-        models_ = await self._runtime_client().models.list()
+        try:
+            models_ = await self._runtime_client().models.list()
+        except APIStatusError as e:
+            reraise_openai_error(e)
         models: list[Model] = models_.data
         for model in models:
             name = model.id

--- a/py/packages/genkit-openai/src/genkit_openai/openai_plugin.py
+++ b/py/packages/genkit-openai/src/genkit_openai/openai_plugin.py
@@ -467,15 +467,15 @@ class OpenAI(Plugin):
             dimensions: int | None = None
             encoding_format: Literal['base64', 'float'] | None = None
             if request.options:
-                if dim_val := request.options.get('dimensions'):
-                    try:
-                        dimensions = int(dim_val)
-                    except (TypeError, ValueError) as e:
+                dim_val = request.options.get('dimensions')
+                if dim_val is not None:
+                    # bool is an int subclass, so True would otherwise pass as 1.
+                    if not isinstance(dim_val, int) or isinstance(dim_val, bool):
                         raise GenkitError(
                             status='INVALID_ARGUMENT',
                             message=f'dimensions must be an int, got {dim_val!r}',
-                            cause=e,
-                        ) from e
+                        )
+                    dimensions = dim_val
                 enc_val = request.options.get('encodingFormat')
                 if enc_val in ('float', 'base64'):
                     encoding_format = cast(Literal['base64', 'float'], enc_val)

--- a/py/packages/genkit-openai/tests/openai_plugin_test.py
+++ b/py/packages/genkit-openai/tests/openai_plugin_test.py
@@ -274,6 +274,17 @@ def _embedder_client(error: Exception) -> MagicMock:
     return client
 
 
+def _embedding_client() -> MagicMock:
+    """Create a stub client whose embeddings call returns one vector."""
+    client = MagicMock()
+    item = MagicMock()
+    item.embedding = [0.1, 0.2]
+    result = MagicMock()
+    result.data = [item]
+    client.embeddings.create = AsyncMock(return_value=result)
+    return client
+
+
 async def _run_embedder(client: MagicMock, options: dict[str, Any] | None = None) -> None:
     """Run the embedder action function against a stub client."""
     action = _plugin_with(client)._create_embedder_action('openai/text-embedding-3-small')
@@ -316,7 +327,11 @@ async def test_embedder_carries_retry_after_metadata() -> None:
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize('dimensions', ['lots', [256]], ids=['non-numeric', 'wrong-type'])
+@pytest.mark.parametrize(
+    'dimensions',
+    ['lots', '256', 256.9, True, [256]],
+    ids=['non-numeric-str', 'numeric-str', 'float', 'bool', 'list'],
+)
 async def test_embedder_classifies_bad_dimensions_option(dimensions: Any) -> None:
     """A dimensions option that is not an int is INVALID_ARGUMENT, before any API call."""
     client = MagicMock()
@@ -328,6 +343,16 @@ async def test_embedder_classifies_bad_dimensions_option(dimensions: Any) -> Non
     assert exc_info.value.status == 'INVALID_ARGUMENT'
     assert 'dimensions' in str(exc_info.value)
     client.embeddings.create.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_embedder_forwards_zero_dimensions() -> None:
+    """A dimensions of 0 reaches the API rather than being dropped as falsy."""
+    client = _embedding_client()
+
+    await _run_embedder(client, options={'dimensions': 0})
+
+    assert client.embeddings.create.await_args.kwargs['dimensions'] == 0
 
 
 @pytest.mark.asyncio

--- a/py/packages/genkit-openai/tests/openai_plugin_test.py
+++ b/py/packages/genkit-openai/tests/openai_plugin_test.py
@@ -23,13 +23,15 @@ import threading
 from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock
 
+import httpx
 import pytest
 from genkit_openai.models.model_info import SUPPORTED_OPENAI_MODELS
 from genkit_openai.openai_plugin import OpenAI, openai_model
 from genkit_openai.typing import SupportedOutputFormat
+from openai import APIStatusError, APITimeoutError
 from openai.types import Model
 
-from genkit import Supports
+from genkit import Document, EmbedRequest, GenkitError, Supports
 from genkit.plugin_api import ActionKind, ActionMetadata, loop_local_client
 
 
@@ -241,3 +243,151 @@ async def test_openai_plugin_resolve_action_not_found(kind: ActionKind, name: st
 def test_openai_model_function() -> None:
     """Test openai_model function."""
     assert openai_model('gpt-4') == 'openai/gpt-4'
+
+
+_ERROR_MESSAGE = 'OpenAI request failed'
+
+
+def _http_request() -> httpx.Request:
+    """Create the request required by OpenAI SDK errors."""
+    return httpx.Request('POST', 'https://api.openai.com/v1/embeddings')
+
+
+def _status_error(status_code: int, retry_after: str | None = None) -> APIStatusError:
+    """Create a real OpenAI status error."""
+    headers = {'retry-after': retry_after} if retry_after is not None else None
+    response = httpx.Response(status_code, request=_http_request(), headers=headers)
+    return APIStatusError(_ERROR_MESSAGE, response=response, body={'error': {'message': _ERROR_MESSAGE}})
+
+
+def _plugin_with(client: MagicMock) -> OpenAI:
+    """Create a plugin bound to a stub client."""
+    plugin = OpenAI(api_key='test-key')
+    plugin._runtime_client = lambda: client
+    return plugin
+
+
+def _embedder_client(error: Exception) -> MagicMock:
+    """Create a stub client whose embeddings call raises an error."""
+    client = MagicMock()
+    client.embeddings.create = AsyncMock(side_effect=error)
+    return client
+
+
+async def _run_embedder(client: MagicMock, options: dict[str, Any] | None = None) -> None:
+    """Run the embedder action function against a stub client."""
+    action = _plugin_with(client)._create_embedder_action('openai/text-embedding-3-small')
+    await action._fn(EmbedRequest(input=[Document.from_text('hello')], options=options))
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    'options',
+    [
+        None,
+        {'dimensions': 256},
+        {'encodingFormat': 'float'},
+        {'dimensions': 256, 'encodingFormat': 'base64'},
+    ],
+    ids=['no-options', 'dimensions', 'encoding-format', 'both'],
+)
+async def test_embedder_maps_status_errors_for_every_option_shape(options: dict[str, Any] | None) -> None:
+    """Each embeddings call variant maps its failures."""
+    api_error = _status_error(401)
+
+    with pytest.raises(GenkitError) as exc_info:
+        await _run_embedder(_embedder_client(api_error), options=options)
+
+    assert exc_info.value.status == 'UNAUTHENTICATED'
+    assert exc_info.value.__cause__ is api_error
+
+
+@pytest.mark.asyncio
+async def test_embedder_carries_retry_after_metadata() -> None:
+    """A rate-limited embed reports RESOURCE_EXHAUSTED with the parsed delay."""
+    api_error = _status_error(429, retry_after='2.5')
+
+    with pytest.raises(GenkitError) as exc_info:
+        await _run_embedder(_embedder_client(api_error))
+
+    assert exc_info.value.status == 'RESOURCE_EXHAUSTED'
+    assert exc_info.value.__cause__ is api_error
+    assert exc_info.value.response_metadata == {'retry_after_ms': 2500.0}
+
+
+@pytest.mark.asyncio
+async def test_embedder_classifies_bad_dimensions_option() -> None:
+    """A non-numeric dimensions option is INVALID_ARGUMENT, before any API call."""
+    client = MagicMock()
+    client.embeddings.create = AsyncMock()
+
+    with pytest.raises(GenkitError) as exc_info:
+        await _run_embedder(client, options={'dimensions': 'lots'})
+
+    assert exc_info.value.status == 'INVALID_ARGUMENT'
+    client.embeddings.create.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    'error',
+    [
+        APITimeoutError(request=_http_request()),
+        RuntimeError('unexpected failure'),
+    ],
+    ids=['timeout', 'runtime-error'],
+)
+async def test_embedder_propagates_unclassified_errors(error: Exception) -> None:
+    """An error without a failing HTTP status escapes the embedder unchanged."""
+    with pytest.raises(Exception) as exc_info:
+        await _run_embedder(_embedder_client(error))
+
+    assert exc_info.value is error
+    assert not isinstance(exc_info.value, GenkitError)
+
+
+def _list_client(*results: Any) -> MagicMock:
+    """Create a stub client whose model listing yields the given results in order."""
+    client = MagicMock()
+    client.models.list = AsyncMock(side_effect=list(results))
+    return client
+
+
+@pytest.mark.asyncio
+async def test_list_actions_maps_status_errors() -> None:
+    """A failed model listing reports the status the HTTP response carried."""
+    api_error = _status_error(503)
+
+    with pytest.raises(GenkitError) as exc_info:
+        await _plugin_with(_list_client(api_error)).list_actions()
+
+    assert exc_info.value.status == 'UNAVAILABLE'
+    assert exc_info.value.__cause__ is api_error
+
+
+@pytest.mark.asyncio
+async def test_list_actions_error_is_not_cached() -> None:
+    """A failed model listing is retried on the next call, not cached."""
+    ok_result = MagicMock()
+    ok_result.data = [Model(id='gpt-4', created=1687882411, object='model', owned_by='openai')]
+    client = _list_client(_status_error(503), ok_result)
+    plugin = _plugin_with(client)
+
+    with pytest.raises(GenkitError):
+        await plugin.list_actions()
+
+    actions = await plugin.list_actions()
+    assert [a.name for a in actions] == ['openai/gpt-4']
+    assert client.models.list.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_list_actions_propagates_unclassified_errors() -> None:
+    """An error without a failing HTTP status escapes list_actions unchanged."""
+    error = APITimeoutError(request=_http_request())
+
+    with pytest.raises(APITimeoutError) as exc_info:
+        await _plugin_with(_list_client(error)).list_actions()
+
+    assert exc_info.value is error
+    assert not isinstance(exc_info.value, GenkitError)

--- a/py/packages/genkit-openai/tests/openai_plugin_test.py
+++ b/py/packages/genkit-openai/tests/openai_plugin_test.py
@@ -316,15 +316,17 @@ async def test_embedder_carries_retry_after_metadata() -> None:
 
 
 @pytest.mark.asyncio
-async def test_embedder_classifies_bad_dimensions_option() -> None:
-    """A non-numeric dimensions option is INVALID_ARGUMENT, before any API call."""
+@pytest.mark.parametrize('dimensions', ['lots', [256]], ids=['non-numeric', 'wrong-type'])
+async def test_embedder_classifies_bad_dimensions_option(dimensions: Any) -> None:
+    """A dimensions option that is not an int is INVALID_ARGUMENT, before any API call."""
     client = MagicMock()
     client.embeddings.create = AsyncMock()
 
     with pytest.raises(GenkitError) as exc_info:
-        await _run_embedder(client, options={'dimensions': 'lots'})
+        await _run_embedder(client, options={'dimensions': dimensions})
 
     assert exc_info.value.status == 'INVALID_ARGUMENT'
+    assert 'dimensions' in str(exc_info.value)
     client.embeddings.create.assert_not_called()
 
 
@@ -333,12 +335,16 @@ async def test_embedder_classifies_bad_dimensions_option() -> None:
     'error',
     [
         APITimeoutError(request=_http_request()),
+        ValueError('No embedding data received'),
         RuntimeError('unexpected failure'),
     ],
-    ids=['timeout', 'runtime-error'],
+    ids=['timeout', 'sdk-value-error', 'runtime-error'],
 )
 async def test_embedder_propagates_unclassified_errors(error: Exception) -> None:
-    """An error without a failing HTTP status escapes the embedder unchanged."""
+    """An error without a failing HTTP status escapes the embedder unchanged.
+
+    A ValueError from the SDK is a provider-side failure, not caller input,
+    so it must not be reported as INVALID_ARGUMENT."""
     with pytest.raises(Exception) as exc_info:
         await _run_embedder(_embedder_client(error))
 


### PR DESCRIPTION
Resolves #6189

## Why

#6098 routed chat, streaming, image, TTS, and STT through reraise_openai_error, but the embedder and dynamic model listing still leak raw SDK exceptions. Callers cannot branch on a Genkit status for those paths, and a failed model listing surfaces as a raw openai error rather than a GenkitError like every other action.

## Changes

- embed_fn wraps only the embeddings.create call in except APIStatusError. A dimensions option that is not an int raises INVALID_ARGUMENT before the call; ValueErrors from the SDK or from response conversion propagate unchanged so they are not mistaken for bad caller input.
- list_actions wraps only the models.list() call and catches APIStatusError alone, since no caller input reaches it. The action cache is assigned on success only, so a failed listing is retried rather than served from cache; a test pins that.
- Connection failures and timeouts still propagate unchanged.