### PR TITLE
fix(py): put leftover generate why on AgentError

### DIFF
--- a/py/packages/genkit/src/genkit/_ai/_agents/_runtime.py
+++ b/py/packages/genkit/src/genkit/_ai/_agents/_runtime.py
@@ -104,6 +104,10 @@ class SessionRunner(Generic[StateT]):
         self.turn_index: int = 0
         self.last_turn_finish_reason: AgentFinishReason | None = None
         self.last_turn_error: GenkitRuntimeError | None = None
+        # Leftover generate() already wrote the why on finish_message. That is
+        # not an exception, so it must not take the last-good recovery path —
+        # but send() still raises and needs the string on AgentOutput.error.
+        self.last_returned_error: GenkitRuntimeError | None = None
         self.last_good_state: SessionState | None = None
         self.last_good_state_version: int | None = None
         self.last_good_finish_reason: AgentFinishReason | None = None
@@ -170,6 +174,7 @@ class SessionRunner(Generic[StateT]):
                     finish_reason = turn_result.finish_reason if turn_result else None
                     self.last_turn_finish_reason = finish_reason
                     self.last_turn_error = None
+                    self.last_returned_error = turn_result.error if turn_result else None
 
                     snapshot_id: str | None = None
                     if self.on_end_turn is not None:
@@ -194,6 +199,7 @@ class SessionRunner(Generic[StateT]):
             except Exception as exc:
                 self.last_turn_finish_reason = AgentFinishReason.FAILED
                 self.last_turn_error = to_error_details(exc)
+                self.last_returned_error = None
 
                 if self.on_end_turn is not None:
                     await self.on_end_turn(AgentFinishReason.FAILED)
@@ -636,7 +642,7 @@ class AgentRuntime:
         snapshot_id = await self.maybe_snapshot(
             finish_reason=finish_reason,
             status=SnapshotStatus.FAILED if is_failed else SnapshotStatus.COMPLETED,
-            error=self.session_runner.last_turn_error,
+            error=self.session_runner.last_turn_error or self.session_runner.last_returned_error,
             force=is_failed,
         )
         # turnEnd is just the boundary marker. The full session rides home on
@@ -999,6 +1005,7 @@ class AgentRuntime:
             message=result.message if result else None,
             artifacts=list(result.artifacts) if result and result.artifacts else [],
             finish_reason=finish_reason,
+            error=self.session_runner.last_returned_error,
         )
         # Client-managed has no store, so the client is the source of truth: ship
         # the whole session and let it copy verbatim. Server-managed returns only
@@ -1063,12 +1070,25 @@ async def generate_prompt_agent_turn(
 
     # Return the turn result wrapping the model finish reason
     finish_reason = to_agent_finish_reason(response.finish_reason) if response.finish_reason is not None else None
-    return TurnResult(finish_reason=finish_reason)
+    return TurnResult(finish_reason=finish_reason, error=leftover_error(response=response))
 
 
 # ---------------------------------------------------------------------------
 # Internal Helper Functions
 # ---------------------------------------------------------------------------
+
+
+def leftover_error(*, response: ModelResponse) -> GenkitRuntimeError | None:
+    # send() raises on failed and reads AgentOutput.error. The leftover why
+    # already lives on finish_message; copy it so the catcher sees that string.
+    if response.finish_reason != FinishReason.FAILED or not response.finish_message:
+        return None
+    status = (
+        'NOT_FOUND'
+        if response.finish_message.startswith('Tool ') and response.finish_message.endswith(' not found')
+        else 'INVALID_ARGUMENT'
+    )
+    return GenkitRuntimeError(status=status, message=response.finish_message)
 
 
 def to_error_details(exc: Exception) -> GenkitRuntimeError:

--- a/py/packages/genkit/tests/genkit/ai/agent_preamble_test.py
+++ b/py/packages/genkit/tests/genkit/ai/agent_preamble_test.py
@@ -322,26 +322,76 @@ async def test_prompt_agent_tool_messages_preserved_verbatim() -> None:
 
 
 @pytest.mark.asyncio
-async def test_prompt_agent_schema_miss_keeps_invalid_argument() -> None:
-    """A leftover Recipe is a failed turn with the generate() status, not UNKNOWN."""
+async def test_prompt_agent_schema_leftover_raises_with_finish_message() -> None:
+    """A leftover Recipe is a failed turn; send() raises with generate()'s why."""
 
     class Recipe(BaseModel):
         title: str
 
     ai = Genkit()
     pm, _ = define_programmable_model(ai)
-    ai.define_prompt(name='cook', model='programmableModel', output_schema=Recipe)
-    agent = ai.define_prompt_agent(name='cook')
-    pm.responses.append(
+    store = InMemorySessionStore()
+    ai.define_prompt(
+        name='cook',
+        model='programmableModel',
+        output_schema=Recipe,
+        output_format='json',
+    )
+    agent = ai.define_prompt_agent(name='cook', store=store)
+    pm.responses.extend([
+        ModelResponse(
+            finish_reason=FinishReason.STOP,
+            message=Message(role=Role.MODEL, content=[Part(TextPart(text='{"title": "Soup"}'))]),
+        ),
         ModelResponse(
             finish_reason=FinishReason.STOP,
             message=Message(role=Role.MODEL, content=[Part(TextPart(text='not json'))]),
+        ),
+    ])
+
+    chat = agent.chat()
+    ok = await chat.send('hello')
+    assert ok.finish_reason == AgentFinishReason.STOP
+    history_before = list(chat.messages)
+
+    with pytest.raises(AgentError) as raised:
+        await chat.send('give me a recipe')
+
+    assert raised.value.status == 'INVALID_ARGUMENT'
+    assert 'not valid JSON' in raised.value.message
+    assert raised.value.response.finish_reason == AgentFinishReason.FAILED
+    assert chat.messages == history_before
+
+
+@pytest.mark.asyncio
+async def test_prompt_agent_wrong_shape_raises_with_schema_mismatch() -> None:
+    """Parsed JSON that is not a Recipe is the same raise, different string."""
+
+    class Recipe(BaseModel):
+        title: str
+
+    ai = Genkit()
+    pm, _ = define_programmable_model(ai)
+    ai.define_prompt(
+        name='cookShape',
+        model='programmableModel',
+        output_schema=Recipe,
+        output_format='json',
+    )
+    agent = ai.define_prompt_agent(name='cookShape')
+    pm.responses.append(
+        ModelResponse(
+            finish_reason=FinishReason.STOP,
+            message=Message(role=Role.MODEL, content=[Part(TextPart(text='{"name": "Soup"}'))]),
         )
     )
 
     with pytest.raises(AgentError) as raised:
         await agent.chat().send('give me a recipe')
-    assert raised.value.status == 'UNKNOWN'
+
+    assert raised.value.status == 'INVALID_ARGUMENT'
+    assert 'title' in raised.value.message
+    assert raised.value.response.finish_reason == AgentFinishReason.FAILED
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
`generate()` already returns when the model replies with something that is not the schema you asked for. The leftover stays on `.text`, and the why is on `finish_message`.

A prompt agent that uses that same schema still raises from `send()`. This change puts the leftover why on that error so you can read it.

```python
# Prompt agent with output_schema=Recipe. Model replies "not json".
try:
  await chat.send('give me a recipe')
except AgentError as e:
  e.message  # leftover why, e.g. "Model output was not valid JSON for the requested schema: not json"
  e.response.finish_reason  # 'failed'
  chat.messages  # last successful turn only; the leftover prompt is not stranded on the chat
```

`generate()` is unchanged:

```python
response = await ai.generate(prompt='give me a recipe', output_schema=Recipe)
if response.output is not None:
  return response.output  # a Recipe

response.finish_reason  # 'failed' — leftover, not a throw
response.text  # 'not json'
response.finish_message  # same leftover why send() now puts on AgentError.message
```

Wrong-shape JSON is the same raise, different string:

```python
# Model replied '{"name": "Soup"}' — parsed, but not a Recipe
except AgentError as e:
  e.message  # schema parse why (e.g. title is required)
  e.response.finish_reason  # 'failed'
```

A matching Recipe is still a normal turn:

```python
turn = await chat.send('give me a recipe')
turn.finish_reason  # 'stop'
# no AgentError
```

## Not in this PR
- `generate()` still returns leftover. It does not grow an `.error` object.
- A failed leftover snapshot is still inspect-only. The next `send()` resumes from the last successful turn, not from the leftover.

## Test plan
- [ ] Prompt agent + `output_schema`, model replies `'not json'` → `AgentError.message` contains the leftover why; `chat.messages` is last-good
- [ ] Same setup, model replies wrong-shape JSON → `AgentError.message` is the schema mismatch string
- [ ] Matching Recipe → `send()` returns, no raise
- [ ] Plain `ai.generate(..., output_schema=Recipe)` leftover still returns (`finish_reason='failed'`, `.text` kept)