### PR TITLE
fix(py): honor wrap_generate model swaps (#6199, #6200)

### DIFF
--- a/py/packages/genkit/src/genkit/_ai/_generate.py
+++ b/py/packages/genkit/src/genkit/_ai/_generate.py
@@ -776,6 +776,7 @@ class BoxedStart:
     """The ModelResponse start() produced, before wrap_model / wrap_generate."""
 
     response: ModelResponse | None = None
+    name: str = ''
 
 
 def assert_hook_kept_operation(*, boxed: ModelResponse | None, after_hooks: ModelResponse, name: str) -> None:
@@ -811,15 +812,7 @@ async def _generate_action_turn(
 
     model, tools, format_def = await resolve_parameters(registry, raw_request)
     boxed_start = BoxedStart()
-
-    if model.kind == ActionKind.BACKGROUND_MODEL and raw_request.resume is not None:
-        raise GenkitError(
-            status='FAILED_PRECONDITION',
-            message=(
-                f"Cannot resume background model '{model.name}'; "
-                'a background start cannot satisfy an interrupted tool turn'
-            ),
-        )
+    had_resume = raw_request.resume is not None
 
     raw_request, formatter = apply_format(raw_request, format_def)
 
@@ -927,14 +920,22 @@ async def _generate_action_turn(
     ) -> ModelResponse:
         """Execute one turn of the generate loop (model call + optional tool resolution)."""
         chunks.message_index = params.message_index
-        # ``params.options`` picks up whatever wrap_generate middleware changed for
-        # this turn; the model request is rebuilt from it so those edits aren't lost.
+        # ``params.options`` picks up whatever wrap_generate middleware changed
+        # for this turn — including the model name. Re-resolve the action
+        # (and tools) so a reroute is not a silent no-op.
         turn_options = params.options
-        # Re-resolve and re-validate tools per turn to pick up dynamic tool
-        # injections or removals from middleware (e.g. wrap_generate).
+        turn_model = await resolve_model_action(registry, turn_options.model)
+        if turn_model.kind == ActionKind.BACKGROUND_MODEL and had_resume:
+            raise GenkitError(
+                status='FAILED_PRECONDITION',
+                message=(
+                    f"Cannot resume background model '{turn_model.name}'; "
+                    'a background start cannot satisfy an interrupted tool turn'
+                ),
+            )
         turn_tools = await resolve_tools_from_options(registry, turn_options.tools)
         assert_valid_tool_names(turn_tools)
-        request = await action_to_generate_request(turn_options, turn_tools, model)
+        request = await action_to_generate_request(turn_options, turn_tools, turn_model)
         if request.docs:
             request = _augment_with_context(request)
 
@@ -946,22 +947,23 @@ async def _generate_action_turn(
                     turn=current_turn,
                     messages=len(params.request.messages),
                 )
-            result = await model.run(
+            result = await turn_model.run(
                 input=params.request,
                 context=c.custom_context,
                 on_chunk=c.on_chunk,
                 abort_signal=c.abort_signal,
             )
             raw = result.response
-            if model.kind == ActionKind.BACKGROUND_MODEL:
+            if turn_model.kind == ActionKind.BACKGROUND_MODEL:
                 boxed_start.response = box_background_start(
                     raw=raw,
                     request=params.request,
-                    name=model.name,
+                    name=turn_model.name,
                     latency_ms=result.latency_ms,
                 )
+                boxed_start.name = turn_model.name
                 return boxed_start.response
-            return require_model_response(raw=raw, name=model.name)
+            return require_model_response(raw=raw, name=turn_model.name)
 
         with chunks.intercept_model_stream(ctx, role=Role.MODEL):
             model_response = await dispatch_model(
@@ -972,7 +974,7 @@ async def _generate_action_turn(
         assert_hook_kept_operation(
             boxed=boxed_start.response,
             after_hooks=model_response,
-            name=model.name,
+            name=boxed_start.name or turn_model.name,
         )
 
         def message_parser(msg: Message) -> Any:  # noqa: ANN401
@@ -1137,7 +1139,7 @@ async def _generate_action_turn(
     assert_hook_kept_operation(
         boxed=boxed_start.response,
         after_hooks=response,
-        name=model.name,
+        name=boxed_start.name or model.name,
     )
     # The caller's output_schema is what this turn asked for. A wrap_generate
     # that hung its own request on the response is still judged against that,
@@ -1374,21 +1376,26 @@ async def resolve_tools_from_options(
     return actions
 
 
-async def resolve_parameters(
-    registry: Registry, request: GenerateActionOptions
-) -> tuple[Action, list[Action], FormatDef | None]:
-    """Resolve model, tools, and format from registry for a generation request."""
-    model = resolve_model_name(model=request.model, registry=registry)
-
-    model_action = await registry.resolve_model(model)
-    if model_action is None:
-        message = f"Failed to resolve model '{model}'."
-        if isinstance(model, str) and '/' not in model:
+async def resolve_model_action(registry: Registry, model: str | None) -> Action:
+    """Look up the generate or start action for this model name."""
+    name = resolve_model_name(model=model, registry=registry)
+    action = await registry.resolve_model(name)
+    if action is None:
+        message = f"Failed to resolve model '{name}'."
+        if isinstance(name, str) and '/' not in name:
             message += " Ensure the model name includes the plugin namespace (e.g., 'plugin/model')."
         raise GenkitError(
             status='NOT_FOUND',
             message=message,
         )
+    return action
+
+
+async def resolve_parameters(
+    registry: Registry, request: GenerateActionOptions
+) -> tuple[Action, list[Action], FormatDef | None]:
+    """Resolve model, tools, and format from registry for a generation request."""
+    model_action = await resolve_model_action(registry, request.model)
 
     # Resolve tools up front to fail fast on invalid caller-supplied tool names or
     # duplicate short names before running side effects or middleware.

--- a/py/packages/genkit/src/genkit/_core/_registry.py
+++ b/py/packages/genkit/src/genkit/_core/_registry.py
@@ -54,6 +54,7 @@ from genkit._core._typing import (
     EmbedResponse,
     EvalRequest,
     EvalResponse,
+    Operation,
 )
 
 logger = get_logger(__name__)
@@ -756,12 +757,15 @@ class Registry:
             return None
         return cast(Action[EmbedRequest, EmbedResponse, Never], action)
 
-    async def resolve_model(self, name: str) -> Action[ModelRequest, ModelResponse, ModelResponseChunk] | None:
+    async def resolve_model(
+        self, name: str
+    ) -> Action[ModelRequest, ModelResponse | Operation, ModelResponseChunk] | None:
         """Resolve a model action by name.
 
         Looks up a normal model first, then a background start action, so a
         name registered only with ``define_background_model`` is findable
-        under the same string callers already pass.
+        under the same string callers already pass. A start returns an
+        Operation, not a ModelResponse.
 
         Args:
             name: The model name (e.g., "gemini-pro" or "plugin/model").
@@ -775,12 +779,7 @@ class Registry:
             # kind. Callers still pass the same name they would for a normal
             # model.
             action = await self.resolve_action(ActionKind.BACKGROUND_MODEL, name)
-        if action is None:
-            return None
-        return cast(
-            Action[ModelRequest, ModelResponse, ModelResponseChunk],
-            action,
-        )
+        return action
 
     async def resolve_evaluator(self, name: str) -> Action[EvalRequest, EvalResponse, Never] | None:
         """Resolve an evaluator action by name with full type information.

--- a/py/packages/genkit/tests/genkit/ai/background_generate_test.py
+++ b/py/packages/genkit/tests/genkit/ai/background_generate_test.py
@@ -20,6 +20,7 @@ from collections.abc import Awaitable, Callable
 from typing import Any, cast
 
 import pytest
+from pydantic import BaseModel
 
 from genkit import ActionKind, Document, Genkit, Message
 from genkit._core._action import ActionRunContext
@@ -475,3 +476,85 @@ async def test_started_operation_dump_round_trips_through_check(ai: Genkit) -> N
     assert updated.id == 'bg-op-123'
     assert updated.done is True
     assert updated.action == '/background-model/bg-model'
+
+
+class RerouteConfig(BaseModel):
+    to: str
+
+
+class Reroute(BaseMiddleware[RerouteConfig]):
+    """Swap ``params.options.model`` before the turn runs."""
+
+    async def wrap_generate(
+        self,
+        params: GenerateHookParams,
+        ctx: GenerateMiddlewareContext,
+        next_fn: Callable[[GenerateHookParams, GenerateMiddlewareContext], Awaitable[ModelResponse]],
+    ) -> ModelResponse:
+        options = params.options.model_copy(update={'model': self.config.to})
+        return await next_fn(params.model_copy(update={'options': options}), ctx)
+
+
+def register_plain(ai: Genkit, *, name: str = 'plain', text: str = 'from-plain') -> None:
+    async def model_fn(_request: ModelRequest, _ctx: ActionRunContext) -> ModelResponse:
+        return ModelResponse(message=Message(role=Role.MODEL, content=[Part(root=TextPart(text=text))]))
+
+    ai.define_model(name=name, fn=model_fn)
+
+
+@pytest.mark.asyncio
+async def test_wrap_generate_reroute_to_background_starts_the_job(ai: Genkit) -> None:
+    """A wrap_generate that sets options.model to a Veo id must actually start Veo."""
+    register_bg_model(ai)
+    register_plain(ai)
+
+    response = await ai.generate(model='plain', prompt='a cat', use=[Reroute(to='bg-model')])
+
+    assert response.operation is not None
+    assert response.operation.id == 'bg-op-123'
+    assert response.text == ''
+
+
+@pytest.mark.asyncio
+async def test_wrap_generate_reroute_from_background_runs_plain(ai: Genkit) -> None:
+    """The reverse swap must call the chat model and never start()."""
+    started = 0
+
+    async def start(_request: ModelRequest, _ctx: ActionRunContext) -> Operation:
+        nonlocal started
+        started += 1
+        return Operation(id='bg-op-123', done=False)
+
+    async def check(op: Operation, _ctx: ActionRunContext) -> Operation:
+        return op
+
+    ai.define_background_model(name='bg-model', start=start, check=check)
+    register_plain(ai)
+
+    response = await ai.generate(model='bg-model', prompt='a cat', use=[Reroute(to='plain')])
+
+    assert response.text == 'from-plain'
+    assert response.operation is None
+    assert started == 0
+
+
+@pytest.mark.asyncio
+async def test_wrap_generate_reroute_same_kind_uses_the_new_model(ai: Genkit) -> None:
+    """A flash→pro swap is the same bug without a background model in the mix."""
+    register_plain(ai, name='flash', text='from-flash')
+    register_plain(ai, name='pro', text='from-pro')
+
+    response = await ai.generate(model='flash', prompt='hi', use=[Reroute(to='pro')])
+
+    assert response.text == 'from-pro'
+
+
+@pytest.mark.asyncio
+async def test_wrap_generate_reroute_to_missing_model_is_not_found(ai: Genkit) -> None:
+    """A reroute to a name that is not registered fails at resolve, not silently."""
+    register_plain(ai)
+
+    with pytest.raises(GenkitError) as raised:
+        await ai.generate(model='plain', prompt='hi', use=[Reroute(to='no-such-model')])
+
+    assert raised.value.status == 'NOT_FOUND'


### PR DESCRIPTION
## Summary
- Type `resolve_model` as `ModelResponse | Operation` and drop the lying `cast`. A background start is allowed to return a ticket.
- Re-resolve the model in `run_one_iteration` from `params.options.model`, the same way tools already re-resolve, so a `wrap_generate` reroute actually runs that action.
- Judge resume-on-background on the model that runs this turn, so a reroute away from Veo can still resume.

Fixes https://github.com/genkit-ai/genkit/issues/6199
Fixes https://github.com/genkit-ai/genkit/issues/6200

## Test plan
- [x] `wrap_generate` flash→Veo starts the job
- [x] `wrap_generate` Veo→flash never calls `start()`
- [x] same-kind flash→pro swap uses the new model
- [x] reroute to a missing name is `NOT_FOUND`
- [x] resume on a background model still raises before `start()`
- [ ] CI green