### PR TITLE
fix(py/plugins/openai): populate token usage and request include_usage for streams

### DIFF
--- a/py/packages/genkit-openai/src/genkit_openai/models/model.py
+++ b/py/packages/genkit-openai/src/genkit_openai/models/model.py
@@ -23,12 +23,15 @@ from typing import Any, cast
 import structlog
 from openai import APIStatusError, AsyncOpenAI
 from openai.lib._pydantic import _ensure_strict_json_schema
+from openai.types import CompletionUsage
+from openai.types.completion_usage import CompletionTokensDetails, PromptTokensDetails
 
 from genkit import (
     Message,
     ModelRequest,
     ModelResponse,
     ModelResponseChunk,
+    ModelUsage,
     Part,
     ReasoningPart,
     Role,
@@ -77,6 +80,71 @@ def _openai_create_kwargs(*, config: OpenAIConfig) -> dict[str, Any]:
     if 'stop' not in body and config.stop_sequences is not None:
         body['stop'] = config.stop_sequences
     return body
+
+
+def _token_count(value: Any) -> float | None:  # noqa: ANN401
+    """A token count as a float, or None when it is absent or not positive.
+
+    Args:
+        value: A count read from a usage field, possibly missing or non-numeric.
+
+    Returns:
+        The count, or None. Zero is dropped: it is indistinguishable from a
+        field the provider did not send.
+    """
+    if isinstance(value, bool) or not isinstance(value, (int, float)) or value <= 0:
+        return None
+    return float(value)
+
+
+def _usage_from_completion(usage: CompletionUsage | None) -> ModelUsage:
+    """Build ModelUsage from a chat completion's usage block.
+
+    Args:
+        usage: The ``usage`` object from a completion or a stream's usage
+            chunk, or None when the response carried none.
+
+    Returns:
+        The token counts, empty when there is no usage to report.
+    """
+    if usage is None:
+        return ModelUsage()
+
+    extras = usage.model_extra or {}
+    prompt = usage.prompt_tokens_details or PromptTokensDetails()
+    completion = usage.completion_tokens_details or CompletionTokensDetails()
+
+    custom: dict[str, Any] = {}
+    for name, value in (
+        ('audioTokens', completion.audio_tokens),
+        ('acceptedPredictionTokens', completion.accepted_prediction_tokens),
+        ('rejectedPredictionTokens', completion.rejected_prediction_tokens),
+        # xAI counts the live-search sources it consulted and breaks image
+        # tokens out of the prompt; neither is in OpenAI's usage shape.
+        ('numSourcesUsed', extras.get('num_sources_used')),
+        ('imageTokens', (prompt.model_extra or {}).get('image_tokens')),
+    ):
+        count = _token_count(value)
+        if count is not None:
+            custom[name] = count
+    # Presence decides for the price a gateway charged, not the value: a
+    # free-tier request is priced at an explicit zero, which is an answer.
+    cost = extras.get('cost')
+    if isinstance(cost, (int, float)) and not isinstance(cost, bool):
+        custom['cost'] = float(cost)
+
+    return ModelUsage(
+        input_tokens=usage.prompt_tokens,
+        output_tokens=usage.completion_tokens,
+        total_tokens=usage.total_tokens,
+        thoughts_tokens=_token_count(completion.reasoning_tokens),
+        # DeepSeek reports cache hits in a usage field of its own and sends no
+        # prompt_tokens_details at all.
+        cached_content_tokens=(
+            _token_count(prompt.cached_tokens) or _token_count(extras.get('prompt_cache_hit_tokens'))
+        ),
+        custom=custom or None,
+    )
 
 
 class OpenAIModel:
@@ -338,6 +406,7 @@ class OpenAIModel:
         result = ModelResponse(
             request=request,
             message=MessageConverter.to_genkit(MessageAdapter(response.choices[0].message)),
+            usage=_usage_from_completion(response.usage),
         )
         return self._clean_json_response(result, request)
 
@@ -355,12 +424,23 @@ class OpenAIModel:
         """
         openai_config = await self._get_openai_request_config(request=request)
         openai_config['stream'] = True
+        openai_config['stream_options'] = {
+            **(openai_config.get('stream_options') or {}),
+            'include_usage': True,
+        }
 
         stream = await self._openai_client.chat.completions.create(**openai_config)
 
         tool_calls: dict[int, Any] = {}
         accumulated_content: list[Part] = []
+        usage: CompletionUsage | None = None
         async for chunk in stream:  # type: ignore
+            # Usage rides on a final chunk that carries no choices.
+            if chunk.usage is not None:
+                usage = chunk.usage
+            if not chunk.choices:
+                continue
+
             delta = chunk.choices[0].delta
 
             # Text content chunk
@@ -415,6 +495,7 @@ class OpenAIModel:
         result = ModelResponse(
             request=request,
             message=Message(role=Role.MODEL, content=accumulated_content),
+            usage=_usage_from_completion(usage),
         )
         return self._clean_json_response(result, request)
 

--- a/py/packages/genkit-openai/tests/openai_model_test.py
+++ b/py/packages/genkit-openai/tests/openai_model_test.py
@@ -17,13 +17,17 @@
 
 """Tests for OpenAI compatible model implementation."""
 
+from collections.abc import AsyncIterator
 from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, PropertyMock
 
 import pytest
 from genkit_openai.models import OpenAIModel
+from genkit_openai.models.model import _usage_from_completion
 from genkit_openai.models.utils import strip_markdown_fences
 from genkit_openai.typing import OpenAIConfig
+from openai.types import CompletionUsage
+from openai.types.chat import ChatCompletionChunk
 from pydantic import BaseModel
 
 from genkit import (
@@ -141,6 +145,7 @@ async def test__generate(sample_request: ModelRequest) -> None:
 
     mock_response = MagicMock()
     mock_response.choices = [MagicMock(message=mock_message)]
+    mock_response.usage = None
 
     mock_client = MagicMock()
     mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
@@ -184,7 +189,7 @@ async def test__generate_stream(sample_request: ModelRequest) -> None:
             choice_mock = MagicMock()
             choice_mock.delta = delta_mock
 
-            return MagicMock(choices=[choice_mock])
+            return MagicMock(choices=[choice_mock], usage=None)
 
     mock_client.chat.completions.create = AsyncMock(return_value=MockStream(['Hello', ', world!']))
 
@@ -197,6 +202,200 @@ async def test__generate_stream(sample_request: ModelRequest) -> None:
     await model._generate_stream(sample_request, callback)
 
     assert collected_chunks == ['Hello', ', world!']
+
+
+_USAGE_PAYLOAD: dict[str, Any] = {
+    'prompt_tokens': 10,
+    'completion_tokens': 7,
+    'total_tokens': 17,
+    'prompt_cache_hit_tokens': 6,
+    'prompt_cache_miss_tokens': 4,
+    'completion_tokens_details': {'reasoning_tokens': 5},
+    'cost': 0.00042,
+}
+
+
+def _assert_usage_payload_reported(usage: Any) -> None:  # noqa: ANN401
+    """Assert every part of _USAGE_PAYLOAD reached the response usage."""
+    assert usage is not None
+    assert usage.input_tokens == 10
+    assert usage.output_tokens == 7
+    assert usage.total_tokens == 17
+    assert usage.thoughts_tokens == 5
+    assert usage.cached_content_tokens == 6
+    assert usage.custom == {'cost': 0.00042}
+
+
+def _text_chunk(text: str) -> ChatCompletionChunk:
+    """A content chunk with no usage, as the API sends mid-stream."""
+    return ChatCompletionChunk.model_validate({
+        'id': '1',
+        'object': 'chat.completion.chunk',
+        'created': 1,
+        'model': 'gpt-4',
+        'choices': [{'index': 0, 'delta': {'role': 'assistant', 'content': text}, 'finish_reason': None}],
+        'usage': None,
+    })
+
+
+def _usage_chunk() -> ChatCompletionChunk:
+    """The final usage chunk, which carries no choices."""
+    return ChatCompletionChunk.model_validate({
+        'id': '1',
+        'object': 'chat.completion.chunk',
+        'created': 1,
+        'model': 'gpt-4',
+        'choices': [],
+        'usage': _USAGE_PAYLOAD,
+    })
+
+
+def _mock_stream(chunks: list[ChatCompletionChunk]) -> AsyncMock:
+    """A create() mock returning chunks from an async iterator."""
+
+    async def iterator() -> AsyncIterator[ChatCompletionChunk]:
+        for chunk in chunks:
+            yield chunk
+
+    return AsyncMock(return_value=iterator())
+
+
+@pytest.mark.asyncio
+async def test__generate_reports_usage(sample_request: ModelRequest) -> None:
+    """A non-streaming response's token usage reaches the ModelResponse."""
+    mock_message = MagicMock()
+    mock_message.content = 'Hello, user!'
+    mock_message.role = 'model'
+    mock_message.tool_calls = None
+    mock_message.reasoning_content = None
+
+    mock_response = MagicMock()
+    mock_response.choices = [MagicMock(message=mock_message)]
+    mock_response.usage = CompletionUsage.model_validate(_USAGE_PAYLOAD)
+
+    mock_client = MagicMock()
+    mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
+
+    model = OpenAIModel(model='gpt-4', client=mock_client)
+    response = await model._generate(sample_request)
+
+    _assert_usage_payload_reported(response.usage)
+    # include_usage is added on the streaming path only.
+    assert 'stream_options' not in mock_client.chat.completions.create.call_args.kwargs
+
+
+@pytest.mark.asyncio
+async def test__generate_reports_extra_token_counts() -> None:
+    """Counts Genkit has no field for land in usage.custom; zeroes are dropped."""
+    mock_message = MagicMock()
+    mock_message.content = 'hi'
+    mock_message.role = 'model'
+    mock_message.tool_calls = None
+    mock_message.reasoning_content = None
+
+    mock_response = MagicMock()
+    mock_response.choices = [MagicMock(message=mock_message)]
+    mock_response.usage = CompletionUsage.model_validate({
+        'prompt_tokens': 3,
+        'completion_tokens': 2,
+        'total_tokens': 5,
+        'prompt_tokens_details': {'cached_tokens': 0, 'image_tokens': 9},
+        'completion_tokens_details': {
+            'audio_tokens': 4,
+            'accepted_prediction_tokens': 0,
+            'rejected_prediction_tokens': 2,
+            'reasoning_tokens': 0,
+        },
+        'num_sources_used': 8,
+    })
+
+    mock_client = MagicMock()
+    mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
+
+    model = OpenAIModel(model='gpt-4', client=mock_client)
+    request = ModelRequest(messages=[Message(role=Role.USER, content=[Part(root=TextPart(text='hi'))])])
+    response = await model._generate(request)
+
+    assert response.usage is not None
+    assert response.usage.custom == {
+        'audioTokens': 4,
+        'rejectedPredictionTokens': 2,
+        'imageTokens': 9,
+        'numSourcesUsed': 8,
+    }
+    assert response.usage.thoughts_tokens is None
+    assert response.usage.cached_content_tokens is None
+
+
+@pytest.mark.parametrize(
+    ('usage_fields', 'expected'),
+    [
+        ({'prompt_tokens_details': {'cached_tokens': 64}}, 64),
+        ({'prompt_cache_hit_tokens': 6}, 6),
+        ({'prompt_tokens_details': {'cached_tokens': 64}, 'prompt_cache_hit_tokens': 6}, 64),
+    ],
+    ids=['prompt_tokens_details', 'top_level_fallback', 'details_take_precedence'],
+)
+def test_cached_content_tokens(usage_fields: dict[str, Any], expected: float) -> None:
+    """cached_content_tokens prefers prompt_tokens_details over the top-level count."""
+    usage = CompletionUsage.model_validate({
+        'prompt_tokens': 10,
+        'completion_tokens': 2,
+        'total_tokens': 12,
+        **usage_fields,
+    })
+
+    assert _usage_from_completion(usage).cached_content_tokens == expected
+
+
+def test_accepted_prediction_tokens() -> None:
+    """A non-zero predicted-outputs count reaches usage.custom."""
+    usage = CompletionUsage.model_validate({
+        'prompt_tokens': 10,
+        'completion_tokens': 4,
+        'total_tokens': 14,
+        'completion_tokens_details': {'accepted_prediction_tokens': 3},
+    })
+
+    assert _usage_from_completion(usage).custom == {'acceptedPredictionTokens': 3}
+
+
+@pytest.mark.asyncio
+async def test__generate_stream_requests_usage(sample_request: ModelRequest) -> None:
+    """A stream asks for its usage, keeping any stream_options the caller set."""
+    config = OpenAIConfig(model='gpt-4', stream_options={'other': 'keep'})
+    sample_request.config = config
+
+    mock_client = MagicMock()
+    mock_client.chat.completions.create = _mock_stream([_text_chunk('Hello')])
+
+    model = OpenAIModel(model='gpt-4', client=mock_client)
+    await model._generate_stream(sample_request, lambda chunk: None)
+
+    assert mock_client.chat.completions.create.call_args.kwargs['stream_options'] == {
+        'other': 'keep',
+        'include_usage': True,
+    }
+    # The caller's config is reused across requests, so it must not be mutated.
+    assert config.stream_options == {'other': 'keep'}
+
+
+@pytest.mark.asyncio
+async def test__generate_stream_reports_usage(sample_request: ModelRequest) -> None:
+    """The choice-less usage chunk is read, not indexed into."""
+    mock_client = MagicMock()
+    mock_client.chat.completions.create = _mock_stream([_text_chunk('Hello'), _usage_chunk()])
+
+    model = OpenAIModel(model='gpt-4', client=mock_client)
+    collected_chunks = []
+
+    def callback(chunk: ModelResponseChunk) -> None:
+        collected_chunks.append(chunk.content[0].root.text)
+
+    response = await model._generate_stream(sample_request, callback)
+
+    assert collected_chunks == ['Hello']
+    _assert_usage_payload_reported(response.usage)
 
 
 @pytest.mark.parametrize(

--- a/py/packages/genkit-openai/tests/tool_calling_test.py
+++ b/py/packages/genkit-openai/tests/tool_calling_test.py
@@ -43,6 +43,7 @@ async def test_generate_with_tool_calls_executes_tools(sample_request: ModelRequ
 
     first_response = MagicMock()
     first_response.choices = [MagicMock(finish_reason='tool_calls', message=first_message)]
+    first_response.usage = None
 
     # Second call is the model response
     second_message = MagicMock()
@@ -53,6 +54,7 @@ async def test_generate_with_tool_calls_executes_tools(sample_request: ModelRequ
 
     second_response = MagicMock()
     second_response.choices = [MagicMock(finish_reason='stop', message=second_message)]
+    second_response.usage = None
 
     mock_client = MagicMock()
     mock_client.chat.completions.create = AsyncMock(
@@ -120,7 +122,7 @@ async def test_generate_stream_with_tool_calls(sample_request: ModelRequest) -> 
             choice_mock = MagicMock()
             choice_mock.delta = delta_mock
 
-            return MagicMock(choices=[choice_mock])
+            return MagicMock(choices=[choice_mock], usage=None)
 
         def __aiter__(self) -> 'MockStream':
             return self


### PR DESCRIPTION
### Why

The plugin never populates token usage. `_generate` ignores `response.usage`, and `_generate_stream` never requests it, so streamed responses report no tokens at all. JS and Go both request and report usage.

Fixes #6188

### Changes

- Read `response.usage` on the non-streaming path and map it to `ModelUsage`: the three top-level counts, `thoughts_tokens`, `cached_content_tokens` (falling back to DeepSeek's top-level `prompt_cache_hit_tokens`), and the counts Genkit has no field for under `usage.custom` (audio, prediction, image tokens, sources used, gateway `cost`), matching Go's breakdown.
- Request `stream_options.include_usage` on streams, merged into any caller-set `stream_options` instead of replacing them.
- Read the usage chunk while streaming and skip chunks that carry no choices. Without the guard, the final usage-only chunk crashes the loop.

### Verification

- New unit tests built from real SDK payloads pin both paths: usage reaches the response, the choice-less final chunk is read rather than indexed into, cached-token precedence, and a caller's `stream_options` keys surviving the merge.