### PR TITLE
fix(py): stop OpenAI generate from raising when config is omitted

### DIFF
--- a/py/packages/genkit-openai/src/genkit_openai/models/model.py
+++ b/py/packages/genkit-openai/src/genkit_openai/models/model.py
@@ -438,8 +438,11 @@ class OpenAIModel:
             reraise_openai_error(e)
 
     @staticmethod
-    def normalize_config(config: object) -> OpenAIConfig:
+    def normalize_config(config: object | None) -> OpenAIConfig:
         """Ensures the config is an OpenAIConfig instance."""
+        if config is None:
+            return OpenAIConfig()
+
         if isinstance(config, OpenAIConfig):
             return config
 

--- a/py/packages/genkit-openai/tests/openai_model_test.py
+++ b/py/packages/genkit-openai/tests/openai_model_test.py
@@ -264,6 +264,10 @@ async def test_generate_classifies_bad_config_type() -> None:
         ),
         (
             None,
+            OpenAIConfig(),
+        ),
+        (
+            42,
             Exception(),
         ),
     ],


### PR DESCRIPTION
## Why

`ModelRequest.config` defaults to `None` and `normalize_config` had no `None` branch, so it fell through to the final `raise`. `OpenAIModel.generate` and `OpenAIModelHandler.generate` both call it unconditionally, so any generate request that omitted config raised `ValueError` before reaching the API.

## Changes

`normalize_config` returns a default `OpenAIConfig()` when config is `None`, and the annotation widens to `object | None`. This matches the JS plugin and the Anthropic plugin, and the request body is unchanged: `OpenAIConfig()` has no non-None defaults and `_openai_create_kwargs` drops None values, so nothing extra reaches the API.

The `test_normalize_config` case asserting that `None` raises now expects `OpenAIConfig()`; an int case keeps the `ValueError` branch covered.

## Verification

A no-config request through both generate paths now completes with a `{messages, model}` body, the same body built when config is present but empty. Previously both raised.