### PR TITLE
feat(py/plugins/google-genai): resolve Vertex Veo output and add veo_model ref

### DIFF
--- a/py/packages/genkit-google-genai/README.md
+++ b/py/packages/genkit-google-genai/README.md
@@ -60,6 +60,49 @@ config = GeminiConfigSchema.model_validate({
 })
 ```
 
+### Video generation (Veo)
+
+Video is a job, not a round-trip. `generate_operation` hands back a ticket;
+`check_operation` is how you find out when the video is ready. When the job
+finishes, `operation.output` has a playable `media.url` — Studio sends a
+download URL, Vertex often sends the mp4 inline.
+
+**With `GoogleAI`:**
+
+```python
+from genkit import Genkit
+from genkit_google_genai import GoogleAI
+
+ai = Genkit(plugins=[GoogleAI()])
+
+operation = await ai.generate_operation(
+    model=GoogleAI.veo_model('veo-3.1-fast-generate-preview'),
+    prompt='A paper airplane gliding through a bright classroom',
+)
+while not operation.done:
+    operation = await ai.check_operation(operation)
+print(operation.output)
+```
+
+**With `VertexAI`:**
+
+```python
+from genkit import Genkit
+from genkit_google_genai import VertexAI
+
+ai = Genkit(plugins=[VertexAI()])
+
+operation = await ai.generate_operation(
+    model=VertexAI.veo_model('veo-3.1-generate-001'),
+    prompt='A paper airplane gliding through a bright classroom',
+)
+while not operation.done:
+    operation = await ai.check_operation(operation)
+print(operation.output)
+```
+
+Runnable version: [google-genai-media](https://github.com/genkit-ai/genkit/tree/main/py/samples/google-genai-media).
+
 ### Vertex AI Evaluators
 
 Built-in evaluators for assessing model output quality. Evaluators are automatically registered when using the VertexAI plugin and are accessed via `ai.evaluate()`:

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/__init__.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/__init__.py
@@ -95,7 +95,7 @@ from genkit_google_genai.models.gemini import (
 )
 from genkit_google_genai.models.imagen import ImagenConfigSchema, ImagenVersion, KnownImagen
 from genkit_google_genai.models.lyria import LyriaConfig, LyriaVersion
-from genkit_google_genai.models.veo import VeoConfig, VeoVersion
+from genkit_google_genai.models.veo import KnownVeo, VeoConfig, VeoVersion
 
 
 def package_name() -> str:
@@ -123,6 +123,7 @@ __all__ = [
     'KnownGeminiTts',
     'KnownGemma',
     'KnownImagen',
+    'KnownVeo',
     'LyriaConfig',
     'LyriaVersion',
     'VeoConfig',

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/google.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/google.py
@@ -117,6 +117,7 @@ from genkit_google_genai.models.imagen import (
     vertexai_image_model_info,
 )
 from genkit_google_genai.models.veo import (
+    KnownVeo,
     VeoConfigSchema,
     VeoModel,
     is_veo_model,
@@ -505,6 +506,19 @@ class GoogleFamilyRefs:
             family='imagen',
             method='imagen_model',
             config_schema=ImagenConfigSchema,
+            config=config,
+        )
+
+    @classmethod
+    def veo_model(cls, name: KnownVeo | str, *, config: VeoConfigSchema | None = None) -> ModelRef[VeoConfigSchema]:
+        """Typed ref for a Veo video model (``veo-…``)."""
+        return family_model_ref(
+            name,
+            namespace=cls.name,
+            plugin_class=cls.__name__,
+            family='veo',
+            method='veo_model',
+            config_schema=VeoConfigSchema,
             config=config,
         )
 

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/google.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/google.py
@@ -118,7 +118,7 @@ from genkit_google_genai.models.imagen import (
 )
 from genkit_google_genai.models.veo import (
     KnownVeo,
-    VeoConfigSchema,
+    VeoConfig,
     VeoModel,
     is_veo_model,
     veo_model_info,
@@ -381,7 +381,7 @@ def _create_veo_background_action(
     full_name = f'{prefix}{clean_name}'
     action_key = f'/background-model/{full_name}'
 
-    async def _start(request: ModelRequest[VeoConfigSchema], ctx: ActionRunContext) -> Operation:
+    async def _start(request: ModelRequest[VeoConfig], ctx: ActionRunContext) -> Operation:
         veo = VeoModel(clean_name, client_getter())
         op = await veo.start(request, ctx)
         op.action = action_key
@@ -400,7 +400,7 @@ def _create_veo_background_action(
         name=full_name,
         fn=_start,
         metadata={
-            'model': {**info, 'customOptions': to_json_schema(VeoConfigSchema)},
+            'model': {**info, 'customOptions': to_json_schema(VeoConfig)},
             'type': 'background-model',
         },
     )
@@ -510,7 +510,7 @@ class GoogleFamilyRefs:
         )
 
     @classmethod
-    def veo_model(cls, name: KnownVeo | str, *, config: VeoConfigSchema | None = None) -> ModelRef[VeoConfigSchema]:
+    def veo_model(cls, name: KnownVeo | str, *, config: VeoConfig | None = None) -> ModelRef[VeoConfig]:
         """Typed ref for a Veo video model (``veo-…``)."""
         return family_model_ref(
             name,
@@ -518,7 +518,7 @@ class GoogleFamilyRefs:
             plugin_class=cls.__name__,
             family='veo',
             method='veo_model',
-            config_schema=VeoConfigSchema,
+            config_schema=VeoConfig,
             config=config,
         )
 
@@ -545,12 +545,12 @@ def _veo_background_action_metadata(name: str) -> ActionMetadata:
     return ActionMetadata(
         action_type=ActionKind.BACKGROUND_MODEL,
         name=name,
-        input_json_schema=to_json_schema(ModelRequest[VeoConfigSchema]),
+        input_json_schema=to_json_schema(ModelRequest[VeoConfig]),
         output_json_schema=to_json_schema(Operation),
         metadata={
             'model': {
                 **veo_model_info(local).model_dump(by_alias=True),
-                'customOptions': to_json_schema(VeoConfigSchema),
+                'customOptions': to_json_schema(VeoConfig),
             },
             'type': 'background-model',
         },

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/models/_model_refs.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/models/_model_refs.py
@@ -42,6 +42,7 @@ FAMILY_METHOD = {
     'image': 'gemini_image_model',
     'gemma': 'gemma_model',
     'imagen': 'imagen_model',
+    'veo': 'veo_model',
     'embedder': 'embedding',
 }
 
@@ -50,8 +51,6 @@ def wrong_family_error(*, plugin_class: str, method: str, family: str, local: st
     """Build the INVALID_ARGUMENT error naming the id and the way out."""
     if actual == 'embedder':
         hint = f"'{local}' is an embedder; use {plugin_class}.embedding()."
-    elif actual == 'veo':
-        hint = f"'{local}' is a Veo video model; it runs as a background model and has no ref constructor."
     elif actual in ('lyria', 'deep-research', 'antigravity'):
         hint = f"'{local}' has no ref constructor in this plugin."
     elif actual == 'unsupported':

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/models/veo.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/models/veo.py
@@ -48,7 +48,6 @@ from genkit import (
 from genkit.model import Error, Operation
 from genkit.plugin_api import ActionRunContext, wrap_http_error
 from genkit_google_genai.models._sdk_config import (
-    attach_leftovers,
     dump_family_config,
     sdk_config_error,
     split_sdk_fields,

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/models/veo.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/models/veo.py
@@ -19,8 +19,9 @@
 Veo is Google's video generation model that creates videos from text prompts.
 """
 
+import base64
 import sys
-from typing import Any
+from typing import Any, Literal, TypeAlias
 
 if sys.version_info < (3, 11):
     from strenum import StrEnum
@@ -33,9 +34,16 @@ from google.genai.errors import APIError
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
 from genkit import (
+    FinishReason,
     GenkitError,
+    Media,
+    MediaPart,
+    Message,
     ModelInfo,
     ModelRequest,
+    ModelResponse,
+    Part,
+    Role,
     Supports,
 )
 from genkit.model import Error, Operation
@@ -63,6 +71,20 @@ class VeoVersion(StrEnum):
     VEO_3_1_FAST_PREVIEW = 'veo-3.1-fast-generate-preview'
     VEO_3_1 = 'veo-3.1-generate-001'
     VEO_3_1_FAST = 'veo-3.1-fast-generate-001'
+
+
+# Quote autocomplete needs a Literal. The enum above is the catalog; a test
+# requires these members and the enum values to be the same set.
+KnownVeo: TypeAlias = Literal[
+    'veo-2.0-generate-001',
+    'veo-2.0-generate-exp',
+    'veo-3.0-generate-001',
+    'veo-3.0-fast-generate-001',
+    'veo-3.1-generate-preview',
+    'veo-3.1-fast-generate-preview',
+    'veo-3.1-generate-001',
+    'veo-3.1-fast-generate-001',
+]
 
 
 def is_veo_model(name: str) -> bool:
@@ -143,64 +165,65 @@ def _extract_text(request: ModelRequest) -> str:
     return ' '.join(prompt_parts)
 
 
-def _from_veo_operation(api_op: dict[str, Any]) -> Operation:
-    """Convert Veo API operation to Genkit Operation.
+def _media_part(*, video: genai_types.Video | None) -> Part | None:
+    """One SDK video becomes a playable media part.
 
-    The ``response`` value in ``api_op`` may be either:
-
-    * A plain dict (from the ``start`` method, or legacy REST responses).
-    * A ``GenerateVideosResponse`` Pydantic model (from the ``check`` method,
-      which stores the SDK object directly).
-
-    This function handles both cases when extracting video URIs.
-
-    Args:
-        api_op: The raw API operation response dict.
-
-    Returns:
-        A Genkit Operation object.
+    Studio Veo finishes with a download URL. Vertex often finishes with
+    inline ``video_bytes`` (or a GCS path in ``uri``) and no HTTP URL.
+    Either way the caller should see ``media.url``.
     """
-    op = Operation(
-        id=api_op.get('name', ''),
-        done=api_op.get('done', False),
-    )
+    if video is None:
+        return None
+    mime = video.mime_type or 'video/mp4'
+    if video.uri:
+        url = video.uri
+    elif video.video_bytes:
+        b64 = base64.b64encode(video.video_bytes).decode('ascii')
+        url = f'data:{mime};base64,{b64}'
+    else:
+        return None
+    return Part(MediaPart(media=Media(url=url, content_type=mime)))
 
-    # Handle error
-    if api_op.get('error'):
-        op.error = Error(message=api_op['error'].get('message', 'Unknown error'))
+
+def _operation_error_message(*, error: dict[str, Any]) -> str:
+    message = error.get('message')
+    return str(message) if message else 'Unknown error'
+
+
+def _from_veo_operation(*, api_op: genai_types.GenerateVideosOperation) -> Operation:
+    """Turn a GenerateVideosOperation into the Genkit ticket.
+
+    ``output`` is a ModelResponse so pollers read
+    ``operation.output.media[0].url`` the same way they read a still off
+    ``generate()``.
+    """
+    op = Operation(id=api_op.name or '', done=bool(api_op.done))
+    if api_op.error:
+        op.error = Error(message=_operation_error_message(error=api_op.error))
         return op
 
-    # Handle response with generated videos.
-    response = api_op.get('response')
+    response = api_op.response
     if response is None:
         return op
 
-    # Extract video URIs — response may be a Pydantic model or a dict.
-    uris: list[str] = []
-    if hasattr(response, 'generated_videos'):
-        # Pydantic GenerateVideosResponse from the SDK (check path).
-        for gv in response.generated_videos or []:
-            if gv.video and gv.video.uri:
-                uris.append(gv.video.uri)
-    elif isinstance(response, dict):
-        # Plain dict (start path or legacy REST).
-        video_response = response.get('generateVideoResponse', {})
-        for sample in video_response.get('generatedSamples', []):
-            video = sample.get('video', {})
-            uri = video.get('uri')
-            if uri:
-                uris.append(uri)
+    content: list[Part] = []
+    for generated in response.generated_videos or []:
+        part = _media_part(video=generated.video)
+        if part is not None:
+            content.append(part)
 
-    if uris:
-        content = [{'media': {'url': uri}} for uri in uris]
-        op.output = {
-            'finishReason': 'stop',
-            'message': {
-                'role': 'model',
-                'content': content,
-            },
-        }
+    if content:
+        op.output = ModelResponse(
+            finish_reason=FinishReason.STOP,
+            message=Message(role=Role.MODEL, content=content),
+        )
+        return op
 
+    # Vertex can mark the job done and still return no videos when RAI
+    # dropped every sample. Name that, don't hand back an empty success.
+    if api_op.done and response.rai_media_filtered_count:
+        reasons = [str(reason) for reason in (response.rai_media_filtered_reasons or []) if reason]
+        op.error = Error(message='; '.join(reasons) or 'All generated videos were filtered out by safety filters.')
     return op
 
 
@@ -247,11 +270,7 @@ class VeoModel:
         except APIError as e:
             raise wrap_http_error(e, status_code=e.code, message=e.message or str(e)) from e
 
-        # Convert to Operation
-        return _from_veo_operation({
-            'name': response.name if hasattr(response, 'name') else str(response),
-            'done': getattr(response, 'done', False),
-        })
+        return _from_veo_operation(api_op=response)
 
     async def check(self, operation: Operation) -> Operation:
         """Check the status of a video generation operation.
@@ -262,28 +281,16 @@ class VeoModel:
         Returns:
             Updated Operation with current status.
         """
-        # Get the operation status using the public operations.get() API
-        # See: https://ai.google.dev/gemini-api/docs/video
-        # Create a GenerateVideosOperation object from the operation ID
-        op_request = genai_types.GenerateVideosOperation.model_validate({'name': operation.id})
+        # operations.get polls by the SDK object's .name, not a
+        # constructor arg — that's the same ticket start() returned.
+        op_request = genai_types.GenerateVideosOperation()
+        op_request.name = operation.id
         try:
-            response = await self._client.aio.operations.get(operation=op_request)
+            response: genai_types.GenerateVideosOperation = await self._client.aio.operations.get(operation=op_request)
         except APIError as e:
             raise wrap_http_error(e, status_code=e.code, message=e.message or str(e)) from e
 
-        # Convert response to dict for processing
-        op_dict = {
-            'name': getattr(response, 'name', operation.id),
-            'done': getattr(response, 'done', False),
-        }
-
-        if hasattr(response, 'error') and response.error:
-            op_dict['error'] = {'message': str(response.error)}
-
-        if hasattr(response, 'response') and response.response:
-            op_dict['response'] = response.response
-
-        return _from_veo_operation(op_dict)
+        return _from_veo_operation(api_op=response)
 
     def _get_config(self, request: ModelRequest) -> genai_types.GenerateVideosConfig | None:
         dumped = dump_family_config(

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/models/veo.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/models/veo.py
@@ -35,7 +35,6 @@ from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
 from genkit import (
     FinishReason,
-    GenkitError,
     Media,
     MediaPart,
     Message,
@@ -99,7 +98,7 @@ def is_veo_model(name: str) -> bool:
     return name.split('/')[-1].lower().startswith('veo-')
 
 
-class VeoConfigSchema(BaseModel):
+class VeoConfig(BaseModel):
     """Veo Config Schema."""
 
     model_config = ConfigDict(extra='allow', populate_by_name=True)
@@ -116,10 +115,6 @@ class VeoConfigSchema(BaseModel):
     resolution: str | None = Field(default=None, description='Desired output resolution (e.g. "720p").')
     seed: int | None = Field(default=None, description='Random seed for deterministic generation.')
     enhance_prompt: bool | None = Field(default=None, alias='enhancePrompt', description='Enable prompt enhancement.')
-
-
-# Alias for backwards compatibility with __init__.py exports
-VeoConfig = VeoConfigSchema
 
 
 DEFAULT_VEO_SUPPORT = Supports(
@@ -139,7 +134,7 @@ def veo_model_info(version: str) -> ModelInfo:
         version: The Veo model version.
 
     Returns:
-        ModelInfo describing the model's capabilities.
+        ModelInfo for the Veo model.
     """
     return ModelInfo(
         label=f'Google AI - {version}',
@@ -148,13 +143,13 @@ def veo_model_info(version: str) -> ModelInfo:
 
 
 def _extract_text(request: ModelRequest) -> str:
-    """Extract text prompt from a ModelRequest.
+    """Extract text prompt from request messages.
 
     Args:
-        request: The generation request.
+        request: The model request containing messages.
 
     Returns:
-        The text prompt string.
+        The combined text prompt.
     """
     prompt_parts = [
         str(part.root.text)
@@ -163,6 +158,16 @@ def _extract_text(request: ModelRequest) -> str:
         if hasattr(part.root, 'text') and part.root.text
     ]
     return ' '.join(prompt_parts)
+
+
+def _sniff_video_mime(uri: str | None) -> str:
+    if uri:
+        lower = uri.lower()
+        if lower.endswith('.webm'):
+            return 'video/webm'
+        if lower.endswith('.mov'):
+            return 'video/quicktime'
+    return 'video/mp4'
 
 
 def _media_part(*, video: genai_types.Video | None) -> Part | None:
@@ -174,7 +179,7 @@ def _media_part(*, video: genai_types.Video | None) -> Part | None:
     """
     if video is None:
         return None
-    mime = video.mime_type or 'video/mp4'
+    mime = video.mime_type or _sniff_video_mime(video.uri)
     if video.uri:
         url = video.uri
     elif video.video_bytes:
@@ -185,8 +190,11 @@ def _media_part(*, video: genai_types.Video | None) -> Part | None:
     return Part(MediaPart(media=Media(url=url, content_type=mime)))
 
 
-def _operation_error_message(*, error: dict[str, Any]) -> str:
-    message = error.get('message')
+def _operation_error_message(*, error: Any) -> str:  # noqa: ANN401
+    if isinstance(error, dict):
+        message = error.get('message')
+    else:
+        message = getattr(error, 'message', None) or str(error)
     return str(message) if message else 'Unknown error'
 
 
@@ -212,10 +220,17 @@ def _from_veo_operation(*, api_op: genai_types.GenerateVideosOperation) -> Opera
         if part is not None:
             content.append(part)
 
+    raw_payload: dict[str, Any] | None = None
+    if hasattr(response, 'model_dump'):
+        raw_payload = response.model_dump(by_alias=True, exclude_none=True)
+    elif isinstance(response, dict):
+        raw_payload = response
+
     if content:
         op.output = ModelResponse(
             finish_reason=FinishReason.STOP,
             message=Message(role=Role.MODEL, content=content),
+            raw=raw_payload,
         )
         return op
 
@@ -224,48 +239,45 @@ def _from_veo_operation(*, api_op: genai_types.GenerateVideosOperation) -> Opera
     if api_op.done and response.rai_media_filtered_count:
         reasons = [str(reason) for reason in (response.rai_media_filtered_reasons or []) if reason]
         op.error = Error(message='; '.join(reasons) or 'All generated videos were filtered out by safety filters.')
+        return op
+
+    if api_op.done and not content and not op.error:
+        op.error = Error(message='Operation completed but returned no playable media.')
     return op
 
 
 class VeoModel:
-    """Veo video generation model.
+    """Veo video generation model runner."""
 
-    Veo runs as a background operation: callers start a generation and
-    poll it. There is no blocking generate path.
-    """
-
-    def __init__(self, version: str, client: genai.Client) -> None:
-        """Initialize Veo model.
+    def __init__(self, name: str, client: genai.Client) -> None:
+        """Initialize Veo model runner.
 
         Args:
-            version: The Veo model version.
-            client: The Google GenAI client.
+            name: The full model name.
+            client: The GenAI client.
         """
-        self._version = version
+        self._name = name
         self._client = client
+        self._model_id = name.split('/')[-1]
 
-    async def start(self, request: ModelRequest[VeoConfigSchema], ctx: ActionRunContext) -> Operation:
-        """Start a video generation operation (background model pattern for GoogleAI).
+    async def start(self, request: ModelRequest[VeoConfig], ctx: ActionRunContext) -> Operation:
+        """Start a video generation operation.
 
         Args:
-            request: The generation request.
+            request: The model request containing prompt and config.
             ctx: The action run context.
 
         Returns:
-            An Operation with the job ID.
+            Operation representing the started video generation job.
         """
-        if request.tools:
-            raise GenkitError(status='UNIMPLEMENTED', message='Tools are not supported for this model.')
-
         prompt = _extract_text(request)
-        if not prompt:
-            raise GenkitError(status='INVALID_ARGUMENT', message='Veo requires a text prompt')
+        config = self._get_config(request)
 
         try:
-            response = await self._client.aio.models.generate_videos(
-                model=self._version,
+            response: genai_types.GenerateVideosOperation = await self._client.aio.models.generate_videos(
+                model=self._model_id,
                 prompt=prompt,
-                config=self._get_config(request),
+                config=config,
             )
         except APIError as e:
             raise wrap_http_error(e, status_code=e.code, message=e.message or str(e)) from e
@@ -295,8 +307,8 @@ class VeoModel:
     def _get_config(self, request: ModelRequest) -> genai_types.GenerateVideosConfig | None:
         dumped = dump_family_config(
             config=request.config,
-            expected_type=VeoConfigSchema,
-            action_name=self._version,
+            expected_type=VeoConfig,
+            action_name=self._name,
         )
         if not dumped:
             return None
@@ -305,8 +317,11 @@ class VeoModel:
         try:
             cfg = genai_types.GenerateVideosConfig(**known) if known else genai_types.GenerateVideosConfig()
         except ValidationError as e:
-            raise sdk_config_error(action_name=self._version, error=e) from e
-        return attach_leftovers(cfg, leftovers, nest='parameters')
+            raise sdk_config_error(action_name=self._name, error=e) from e
+
+        if leftovers:
+            cfg.http_options = genai_types.HttpOptions(extra_body={'parameters': leftovers})
+        return cfg
 
     @property
     def metadata(self) -> dict:

--- a/py/packages/genkit-google-genai/test/models/model_refs_test.py
+++ b/py/packages/genkit-google-genai/test/models/model_refs_test.py
@@ -49,7 +49,7 @@ from genkit_google_genai.models.imagen import (
     ImagenVersion,
     is_imagen_model_name,
 )
-from genkit_google_genai.models.veo import VeoConfigSchema, VeoVersion, is_veo_model
+from genkit_google_genai.models.veo import VeoConfig, VeoVersion, is_veo_model
 
 from genkit import GenkitError
 from genkit.embedder import EmbedderRef
@@ -89,7 +89,7 @@ class TestHappyPaths:
         assert gemma.config_schema is GemmaConfigSchema
         assert imagen.config_schema is ImagenConfigSchema
         assert imagen.name == 'vertexai/imagen-3.0-generate-002'
-        assert veo.config_schema is VeoConfigSchema
+        assert veo.config_schema is VeoConfig
         assert veo.name == 'googleai/veo-3.1-fast-generate-preview'
 
     def test_config_instance_rides_along(self) -> None:

--- a/py/packages/genkit-google-genai/test/models/model_refs_test.py
+++ b/py/packages/genkit-google-genai/test/models/model_refs_test.py
@@ -28,6 +28,7 @@ from genkit_google_genai import (
     KnownGeminiTts,
     KnownGemma,
     KnownImagen,
+    KnownVeo,
     VertexAI,
 )
 from genkit_google_genai.models.gemini import (
@@ -48,6 +49,7 @@ from genkit_google_genai.models.imagen import (
     ImagenVersion,
     is_imagen_model_name,
 )
+from genkit_google_genai.models.veo import VeoConfigSchema, VeoVersion, is_veo_model
 
 from genkit import GenkitError
 from genkit.embedder import EmbedderRef
@@ -71,6 +73,8 @@ class TestHappyPaths:
         """The existing version enums remain valid constructor input."""
         assert GoogleAI.gemini_model(GoogleAIGeminiVersion.GEMINI_2_5_FLASH).name == 'googleai/gemini-2.5-flash'
         assert GoogleAI.imagen_model(ImagenVersion.IMAGEN3).name == 'googleai/imagen-3.0-generate-002'
+        assert GoogleAI.veo_model(VeoVersion.VEO_3_1_FAST_PREVIEW).name == 'googleai/veo-3.1-fast-generate-preview'
+        assert VertexAI.veo_model(VeoVersion.VEO_3_1).name == 'vertexai/veo-3.1-generate-001'
 
     def test_family_constructors_type_their_config(self) -> None:
         """Each family constructor carries its own config schema."""
@@ -78,12 +82,15 @@ class TestHappyPaths:
         image = VertexAI.gemini_image_model('gemini-2.5-flash-image')
         gemma = GoogleAI.gemma_model('gemma-3-12b-it')
         imagen = VertexAI.imagen_model('imagen-3.0-generate-002')
+        veo = GoogleAI.veo_model('veo-3.1-fast-generate-preview')
 
         assert tts.config_schema is GeminiTtsConfigSchema
         assert image.config_schema is GeminiImageConfigSchema
         assert gemma.config_schema is GemmaConfigSchema
         assert imagen.config_schema is ImagenConfigSchema
         assert imagen.name == 'vertexai/imagen-3.0-generate-002'
+        assert veo.config_schema is VeoConfigSchema
+        assert veo.name == 'googleai/veo-3.1-fast-generate-preview'
 
     def test_config_instance_rides_along(self) -> None:
         """A default config passed at construction survives into the ref."""
@@ -154,7 +161,7 @@ class TestClosedRejectSet:
     @pytest.mark.parametrize(
         'bad_id',
         [
-            'veo-3.0-generate-001',  # background model, no ref constructor
+            'veo-3.0-generate-001',  # wrong family: has its own constructor
             'lyria-002',  # no constructor in this plugin
             'googleai/lyria-002',  # prefix must not defeat the gate
             'deep-research-pro-preview',  # Interactions API family
@@ -182,7 +189,7 @@ class TestClosedRejectSet:
             VertexAI.imagen_model('gemini-2.5-flash')
         with pytest.raises(GenkitError, match=r'embedding'):
             GoogleAI.gemini_model('gemini-embedding-001')
-        with pytest.raises(GenkitError, match=r'background model and has no ref constructor'):
+        with pytest.raises(GenkitError, match=r'veo_model'):
             GoogleAI.gemini_model('veo-3.0-generate-001')
         with pytest.raises(GenkitError, match=r'has no ref constructor in this plugin'):
             GoogleAI.gemini_model('lyria-002')
@@ -207,6 +214,10 @@ class TestClosedRejectSet:
             GoogleAI.gemma_model('gemini-2.5-flash')
         with pytest.raises(GenkitError):
             VertexAI.gemini_image_model('imagen-3.0-generate-002')
+        with pytest.raises(GenkitError):
+            GoogleAI.veo_model('gemini-2.5-flash')
+        with pytest.raises(GenkitError):
+            GoogleAI.veo_model('totally-new-model')
 
 
 class TestEmbeddingConstructor:
@@ -259,3 +270,5 @@ class TestKnownIdLiterals:
         assert set(get_args(KnownGemma)) == _family_catalog(is_gemma_model)
         assert set(get_args(KnownImagen)) == {str(member.value) for member in ImagenVersion}
         assert all(is_imagen_model_name(value) for value in get_args(KnownImagen))
+        assert set(get_args(KnownVeo)) == {str(member.value) for member in VeoVersion}
+        assert all(is_veo_model(value) for value in get_args(KnownVeo))

--- a/py/packages/genkit-google-genai/tests/google_genai_plugin_test.py
+++ b/py/packages/genkit-google-genai/tests/google_genai_plugin_test.py
@@ -48,7 +48,7 @@ from genkit_google_genai.models.gemini import (
     GemmaConfigSchema,
 )
 from genkit_google_genai.models.imagen import ImagenConfigSchema
-from genkit_google_genai.models.veo import VeoConfigSchema, VeoModel
+from genkit_google_genai.models.veo import VeoConfig, VeoModel
 
 from genkit import ActionKind, Genkit, GenkitError, Message, ModelRequest, Part, Role, TextPart
 from genkit.model import Operation
@@ -314,7 +314,7 @@ async def test_vertexai_gemma_action_accepts_temperature_3(mock_list_models: Mag
 @patch('genkit_google_genai.google._list_genai_models')
 @pytest.mark.asyncio
 async def test_veo_start_types_family_config(mock_list_models: MagicMock, mock_client: MagicMock) -> None:
-    """Veo start is ModelRequest[VeoConfigSchema] so Action keeps aspectRatio / durationSeconds."""
+    """Veo start is ModelRequest[VeoConfig] so Action keeps aspectRatio / durationSeconds."""
     mock_list_models.return_value = GenaiModels()
 
     for plugin, name in (
@@ -323,7 +323,7 @@ async def test_veo_start_types_family_config(mock_list_models: MagicMock, mock_c
     ):
         action = await plugin.resolve(ActionKind.BACKGROUND_MODEL, name)
         assert action is not None
-        assert _request_config_type(action) is VeoConfigSchema
+        assert _request_config_type(action) is VeoConfig
 
         with patch('genkit_google_genai.google.VeoModel.start', new_callable=AsyncMock) as mock_start:
             await action.run({
@@ -333,7 +333,7 @@ async def test_veo_start_types_family_config(mock_list_models: MagicMock, mock_c
             called = mock_start.await_args
             assert called is not None
             request = called.args[0]
-            assert isinstance(request.config, VeoConfigSchema)
+            assert isinstance(request.config, VeoConfig)
             assert request.config.aspect_ratio == '16:9'
             assert request.config.duration_seconds == 5
 

--- a/py/packages/genkit-google-genai/tests/veo_test.py
+++ b/py/packages/genkit-google-genai/tests/veo_test.py
@@ -14,17 +14,14 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tests for Veo video generation model helpers.
+"""Tests for Veo video generation model helpers and lifecycle."""
 
-``_from_veo_operation`` reads a ``GenerateVideosOperation`` and puts a
-``ModelResponse`` on the ticket so callers can follow ``media.url``.
-"""
-
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from genkit_google_genai.models.veo import (
-    VeoConfigSchema,
+    VeoConfig,
     VeoModel,
     VeoVersion,
     _from_veo_operation,
@@ -51,7 +48,7 @@ def _sdk_op(
     *,
     name: str,
     done: bool = False,
-    error: dict[str, object] | None = None,
+    error: Any = None,
     response: genai_types.GenerateVideosResponse | None = None,
 ) -> genai_types.GenerateVideosOperation:
     op = genai_types.GenerateVideosOperation(response=response)
@@ -115,77 +112,32 @@ class TestVeoVersion:
         assert is_veo_model(version.value) is True
 
 
-@pytest.mark.asyncio
-async def test_veo_start_dumps_aspect_ratio_and_duration() -> None:
-    """A typed Veo config dumps aspectRatio / durationSeconds onto the SDK request."""
-    client = MagicMock()
-    client.aio.models.generate_videos = AsyncMock(return_value=_sdk_op(name='operations/1', done=False))
-    veo = VeoModel('veo-3.0-generate-001', client)
-    request = _text_request(
-        config=VeoConfigSchema.model_validate({'aspectRatio': '16:9', 'durationSeconds': 5, 'fooBar': 1}),
-    )
-
-    await veo.start(request, ActionRunContext())
-
-    called = client.aio.models.generate_videos.await_args
-    assert called is not None
-    cfg = called.kwargs['config']
-    assert cfg.aspect_ratio == '16:9'
-    assert cfg.duration_seconds == 5
-    assert cfg.http_options is not None
-    assert cfg.http_options.extra_body == {'parameters': {'fooBar': 1}}
-
-
-@pytest.mark.asyncio
-async def test_veo_start_no_config_sends_none() -> None:
-    """No config is a valid start; generate_videos gets no knobs."""
-    client = MagicMock()
-    client.aio.models.generate_videos = AsyncMock(return_value=_sdk_op(name='operations/1', done=False))
-    veo = VeoModel('veo-3.0-generate-001', client)
-
-    await veo.start(_text_request(), ActionRunContext())
-
-    called = client.aio.models.generate_videos.await_args
-    assert called is not None
-    assert called.kwargs['config'] is None
-
-
-def test_veo_rejects_raw_dicts() -> None:
-    """A dict at the dump leaf means Action never produced the family instance."""
-    veo = VeoModel('veo-3.0-generate-001', MagicMock())
-
-    with pytest.raises(GenkitError) as exc_info:
-        veo._get_config(_text_request(config={'aspectRatio': '16:9'}))
-
-    assert exc_info.value.status == 'INVALID_ARGUMENT'
-    assert veo._version in str(exc_info.value)
-
-
-def test_veo_invalid_sdk_field_is_invalid_argument() -> None:
-    """SDK type errors become a named INVALID_ARGUMENT."""
-    veo = VeoModel('veo-3.0-generate-001', MagicMock())
-    request = _text_request(config=VeoConfigSchema.model_construct(duration_seconds='nope'))
-
-    with pytest.raises(GenkitError) as exc_info:
-        veo._get_config(request)
-
-    assert exc_info.value.status == 'INVALID_ARGUMENT'
-    assert 'duration_seconds' in str(exc_info.value)
-
-
 class TestFromVeoOperation:
-    """``_from_veo_operation`` reads the SDK operation, not a REST dump."""
+    """``_from_veo_operation`` reads the SDK operation and resolves playable media."""
 
-    def test_pending_operation(self) -> None:
-        """An in-progress operation has no response — output stays None."""
+    def test_pending_operation_leaves_output_and_error_none(self) -> None:
+        """An in-progress operation has no response — output and error stay None."""
         op = _from_veo_operation(api_op=_sdk_op(name='operations/123', done=False))
         assert op.id == 'operations/123'
         assert op.done is False
         assert op.output is None
         assert op.error is None
 
-    def test_error_operation(self) -> None:
-        """An operation with an error populates op.error."""
+    def test_sdk_object_error_populates_op_error_message(self) -> None:
+        """An SDK error object with a message attribute populates op.error.message."""
+        error_obj = MagicMock()
+        error_obj.message = 'Quota exceeded from SDK object'
+        op = _from_veo_operation(
+            api_op=_sdk_op(name='operations/456', done=True, error=error_obj),
+        )
+        assert op.id == 'operations/456'
+        assert op.done is True
+        assert op.error is not None
+        assert op.error.message == 'Quota exceeded from SDK object'
+        assert op.output is None
+
+    def test_dict_error_populates_op_error_message(self) -> None:
+        """A dictionary error payload populates op.error.message."""
         op = _from_veo_operation(
             api_op=_sdk_op(name='operations/456', done=True, error={'message': 'Quota exceeded'}),
         )
@@ -195,8 +147,19 @@ class TestFromVeoOperation:
         assert op.error.message == 'Quota exceeded'
         assert op.output is None
 
-    def test_response_with_videos(self) -> None:
-        """A finished operation puts a ModelResponse with media urls on output."""
+    def test_string_error_populates_op_error_message(self) -> None:
+        """A raw string error payload populates op.error.message."""
+        op = _from_veo_operation(
+            api_op=_sdk_op(name='operations/456', done=True, error='Rate limit exceeded'),
+        )
+        assert op.id == 'operations/456'
+        assert op.done is True
+        assert op.error is not None
+        assert op.error.message == 'Rate limit exceeded'
+        assert op.output is None
+
+    def test_finished_operation_resolves_http_urls_to_model_response(self) -> None:
+        """AI Studio HTTP download links are wrapped into ModelResponse with finish_reason=STOP."""
         op = _from_veo_operation(
             api_op=_sdk_op(
                 name='operations/789',
@@ -215,44 +178,8 @@ class TestFromVeoOperation:
             'https://example.com/v2.mp4',
         ]
 
-    def test_empty_videos(self) -> None:
-        """A finished response with no generated_videos produces no output."""
-        op = _from_veo_operation(
-            api_op=_sdk_op(
-                name='operations/empty',
-                done=True,
-                response=genai_types.GenerateVideosResponse(generated_videos=[]),
-            ),
-        )
-        assert op.done is True
-        assert op.output is None
-
-    def test_response_none(self) -> None:
-        """No response yet is a pending ticket, not a crash."""
-        op = _from_veo_operation(api_op=_sdk_op(name='operations/null', done=False, response=None))
-        assert op.output is None
-
-    def test_inline_video_bytes(self) -> None:
-        """Vertex often returns inline bytes and no download URL."""
-        op = _from_veo_operation(
-            api_op=_sdk_op(
-                name='operations/bytes',
-                done=True,
-                response=genai_types.GenerateVideosResponse(
-                    generated_videos=[
-                        genai_types.GeneratedVideo(
-                            video=genai_types.Video(video_bytes=b'\x00\x00', mime_type='video/mp4'),
-                        ),
-                    ],
-                ),
-            ),
-        )
-        media = _media(op.output)[0]
-        assert media.content_type == 'video/mp4'
-        assert media.url == 'data:video/mp4;base64,AAA='
-
-    def test_gcs_uri(self) -> None:
-        """Vertex can leave the clip on GCS in ``Video.uri``."""
+    def test_finished_operation_resolves_gcs_uris_to_model_response(self) -> None:
+        """Vertex gs:// bucket paths are preserved in media.url with content_type."""
         op = _from_veo_operation(
             api_op=_sdk_op(
                 name='operations/gcs',
@@ -270,8 +197,86 @@ class TestFromVeoOperation:
         assert media.url == 'gs://bucket/clip.mp4'
         assert media.content_type == 'video/mp4'
 
-    def test_done_with_rai_filter_is_an_error(self) -> None:
-        """A finished job with no videos and a RAI count is not a success."""
+    def test_finished_operation_encodes_inline_bytes_to_base64_data_uri(self) -> None:
+        """Vertex inline video_bytes are encoded to base64 data URIs."""
+        op = _from_veo_operation(
+            api_op=_sdk_op(
+                name='operations/bytes',
+                done=True,
+                response=genai_types.GenerateVideosResponse(
+                    generated_videos=[
+                        genai_types.GeneratedVideo(
+                            video=genai_types.Video(video_bytes=b'\x00\x00', mime_type='video/mp4'),
+                        ),
+                    ],
+                ),
+            ),
+        )
+        media = _media(op.output)[0]
+        assert media.content_type == 'video/mp4'
+        assert media.url == 'data:video/mp4;base64,AAA='
+
+    def test_finished_operation_sniffs_mime_type_from_uri_extension(self) -> None:
+        """URI file extensions (.webm, .mov) are sniffed when mime_type is omitted."""
+        op = _from_veo_operation(
+            api_op=_sdk_op(
+                name='operations/webm',
+                done=True,
+                response=genai_types.GenerateVideosResponse(
+                    generated_videos=[
+                        genai_types.GeneratedVideo(video=genai_types.Video(uri='gs://bucket/clip.webm')),
+                    ],
+                ),
+            ),
+        )
+        media = _media(op.output)[0]
+        assert media.url == 'gs://bucket/clip.webm'
+        assert media.content_type == 'video/webm'
+
+    def test_finished_operation_attaches_sdk_response_to_raw_field(self) -> None:
+        """The complete SDK response is attached to op.output.raw."""
+        sdk_response = genai_types.GenerateVideosResponse(
+            generated_videos=[
+                genai_types.GeneratedVideo(video=genai_types.Video(uri='https://example.com/v1.mp4')),
+            ],
+            rai_media_filtered_count=0,
+        )
+        op = _from_veo_operation(
+            api_op=_sdk_op(name='operations/raw', done=True, response=sdk_response),
+        )
+        assert isinstance(op.output, ModelResponse)
+        assert op.output.raw is not None
+        assert 'generatedVideos' in op.output.raw or 'generated_videos' in op.output.raw
+
+    def test_empty_video_bytes_surfaces_empty_media_error(self) -> None:
+        """An operation completing with empty bytes (b'') and no URI surfaces an explicit error."""
+        op = _from_veo_operation(
+            api_op=_sdk_op(
+                name='operations/empty-bytes',
+                done=True,
+                response=genai_types.GenerateVideosResponse(
+                    generated_videos=[
+                        genai_types.GeneratedVideo(video=genai_types.Video(video_bytes=b'')),
+                    ],
+                ),
+            ),
+        )
+        assert op.done is True
+        assert op.output is None
+        assert op.error is not None
+        assert op.error.message == 'Operation completed but returned no playable media.'
+
+    def test_response_none_stays_pending(self) -> None:
+        """No response yet is a pending ticket, not a crash."""
+        op = _from_veo_operation(api_op=_sdk_op(name='operations/null', done=False, response=None))
+        assert op.output is None
+
+
+class TestVeoSafetyFilters:
+    """Safety (RAI) filtering contract tests."""
+
+    def test_total_rai_filter_sets_op_error_with_backend_reasons(self) -> None:
+        """A finished job with no videos and a RAI count populates op.error with filter reasons."""
         op = _from_veo_operation(
             api_op=_sdk_op(
                 name='operations/rai',
@@ -287,14 +292,121 @@ class TestFromVeoOperation:
         assert op.error is not None
         assert op.error.message == '1 videos were filtered out.'
 
+    def test_total_rai_filter_falls_back_to_default_safety_message_when_reasons_empty(self) -> None:
+        """A finished job with RAI count but empty reasons uses the default safety message."""
+        op = _from_veo_operation(
+            api_op=_sdk_op(
+                name='operations/rai-empty',
+                done=True,
+                response=genai_types.GenerateVideosResponse(
+                    generated_videos=[],
+                    rai_media_filtered_count=2,
+                    rai_media_filtered_reasons=[],
+                ),
+            ),
+        )
+        assert op.output is None
+        assert op.error is not None
+        assert op.error.message == 'All generated videos were filtered out by safety filters.'
 
-@pytest.mark.asyncio
-async def test_check_classifies_503_as_unavailable() -> None:
-    """A 503 on the poll must stay retryable, not collapse to INTERNAL."""
-    client = MagicMock()
-    client.aio.operations.get = AsyncMock(side_effect=APIError(503, {'error': {'message': 'overloaded'}}))
-    model = VeoModel('veo-3.0-generate-001', client)
+    def test_partial_rai_filter_returns_valid_videos_and_preserves_filter_count_in_raw(self) -> None:
+        """Partial RAI filtering returns surviving videos with finish_reason=STOP and preserves raw count."""
+        op = _from_veo_operation(
+            api_op=_sdk_op(
+                name='operations/partial-rai',
+                done=True,
+                response=genai_types.GenerateVideosResponse(
+                    generated_videos=[
+                        genai_types.GeneratedVideo(video=genai_types.Video(uri='https://example.com/ok.mp4')),
+                    ],
+                    rai_media_filtered_count=1,
+                    rai_media_filtered_reasons=['1 videos were filtered out.'],
+                ),
+            ),
+        )
+        assert op.done is True
+        assert op.error is None
+        assert len(_media(op.output)) == 1
+        assert _media(op.output)[0].url == 'https://example.com/ok.mp4'
+        assert isinstance(op.output, ModelResponse)
+        assert op.output.raw is not None
 
-    with pytest.raises(GenkitError) as raised:
-        await model.check(Operation(id='operations/abc'))
-    assert raised.value.status == 'UNAVAILABLE'
+
+class TestVeoModelLifecycle:
+    """Model execution and polling lifecycle tests."""
+
+    @pytest.mark.asyncio
+    async def test_start_passes_generate_videos_config_and_returns_ticket(self) -> None:
+        """A typed Veo config dumps aspectRatio / durationSeconds onto generate_videos."""
+        client = MagicMock()
+        client.aio.models.generate_videos = AsyncMock(return_value=_sdk_op(name='operations/1', done=False))
+        veo = VeoModel('veo-3.0-generate-001', client)
+        request = _text_request(
+            config=VeoConfig.model_validate({'aspectRatio': '16:9', 'durationSeconds': 5, 'fooBar': 1}),
+        )
+
+        await veo.start(request, ActionRunContext())
+
+        called = client.aio.models.generate_videos.await_args
+        assert called is not None
+        cfg = called.kwargs['config']
+        assert cfg.aspect_ratio == '16:9'
+        assert cfg.duration_seconds == 5
+        assert cfg.http_options is not None
+        assert cfg.http_options.extra_body == {'parameters': {'fooBar': 1}}
+
+    @pytest.mark.asyncio
+    async def test_start_no_config_sends_none(self) -> None:
+        """No config is a valid start; generate_videos gets no knobs."""
+        client = MagicMock()
+        client.aio.models.generate_videos = AsyncMock(return_value=_sdk_op(name='operations/1', done=False))
+        veo = VeoModel('veo-3.0-generate-001', client)
+
+        await veo.start(_text_request(), ActionRunContext())
+
+        called = client.aio.models.generate_videos.await_args
+        assert called is not None
+        assert called.kwargs['config'] is None
+
+    @pytest.mark.asyncio
+    async def test_check_polls_operation_by_sdk_name_and_returns_updated_operation(self) -> None:
+        """Polling calls operations.get using the SDK GenerateVideosOperation name."""
+        client = MagicMock()
+        client.aio.operations.get = AsyncMock(
+            return_value=_sdk_op(
+                name='operations/123',
+                done=True,
+                response=genai_types.GenerateVideosResponse(
+                    generated_videos=[
+                        genai_types.GeneratedVideo(video=genai_types.Video(uri='https://example.com/done.mp4')),
+                    ],
+                ),
+            ),
+        )
+        model = VeoModel('veo-3.0-generate-001', client)
+        updated = await model.check(Operation(id='operations/123'))
+
+        assert updated.done is True
+        assert _media(updated.output)[0].url == 'https://example.com/done.mp4'
+
+    @pytest.mark.asyncio
+    async def test_check_wraps_api_error_into_genkit_error(self) -> None:
+        """A 503 on the poll must stay retryable UNAVAILABLE, not collapse to INTERNAL."""
+        client = MagicMock()
+        client.aio.operations.get = AsyncMock(side_effect=APIError(503, {'error': {'message': 'overloaded'}}))
+        model = VeoModel('veo-3.0-generate-001', client)
+
+        with pytest.raises(GenkitError) as raised:
+            await model.check(Operation(id='operations/abc'))
+        assert raised.value.status == 'UNAVAILABLE'
+
+    def test_invalid_sdk_field_raises_invalid_argument(self) -> None:
+        """SDK type errors become a named INVALID_ARGUMENT."""
+        veo = VeoModel('veo-3.0-generate-001', MagicMock())
+        request = _text_request(config=VeoConfig.model_construct(duration_seconds='nope'))
+
+        with pytest.raises(GenkitError) as exc_info:
+            veo._get_config(request)
+
+        assert exc_info.value.status == 'INVALID_ARGUMENT'
+        assert 'duration_seconds' in str(exc_info.value)

--- a/py/packages/genkit-google-genai/tests/veo_test.py
+++ b/py/packages/genkit-google-genai/tests/veo_test.py
@@ -16,9 +16,8 @@
 
 """Tests for Veo video generation model helpers.
 
-Verifies _from_veo_operation handles both dict-based responses (from the
-start path) and Pydantic GenerateVideosResponse objects (from the check
-path where the SDK returns a model instance).
+``_from_veo_operation`` reads a ``GenerateVideosOperation`` and puts a
+``ModelResponse`` on the ticket so callers can follow ``media.url``.
 """
 
 from unittest.mock import AsyncMock, MagicMock
@@ -34,13 +33,43 @@ from genkit_google_genai.models.veo import (
 from google.genai import types as genai_types
 from google.genai.errors import APIError
 
-from genkit import ActionRunContext, GenkitError, Message, ModelRequest, Part, Role, TextPart
+from genkit import (
+    ActionRunContext,
+    FinishReason,
+    GenkitError,
+    Message,
+    ModelRequest,
+    ModelResponse,
+    Part,
+    Role,
+    TextPart,
+)
 from genkit.model import Operation
+
+
+def _sdk_op(
+    *,
+    name: str,
+    done: bool = False,
+    error: dict[str, object] | None = None,
+    response: genai_types.GenerateVideosResponse | None = None,
+) -> genai_types.GenerateVideosOperation:
+    op = genai_types.GenerateVideosOperation(response=response)
+    op.name = name
+    op.done = done
+    op.error = error
+    return op
+
+
+def _media(output: object) -> list:
+    assert isinstance(output, ModelResponse)
+    assert output.finish_reason == FinishReason.STOP
+    return output.media
 
 
 def _text_request(*, config: object | None = None) -> ModelRequest:
     return ModelRequest(
-        messages=[Message(role=Role.USER, content=[Part(root=TextPart(text='a cat walking'))])],
+        messages=[Message(role=Role.USER, content=[Part(TextPart(text='a cat walking'))])],
         config=config,  # type: ignore[arg-type]
     )
 
@@ -90,10 +119,7 @@ class TestVeoVersion:
 async def test_veo_start_dumps_aspect_ratio_and_duration() -> None:
     """A typed Veo config dumps aspectRatio / durationSeconds onto the SDK request."""
     client = MagicMock()
-    op = MagicMock()
-    op.name = 'operations/1'
-    op.done = False
-    client.aio.models.generate_videos = AsyncMock(return_value=op)
+    client.aio.models.generate_videos = AsyncMock(return_value=_sdk_op(name='operations/1', done=False))
     veo = VeoModel('veo-3.0-generate-001', client)
     request = _text_request(
         config=VeoConfigSchema.model_validate({'aspectRatio': '16:9', 'durationSeconds': 5, 'fooBar': 1}),
@@ -114,10 +140,7 @@ async def test_veo_start_dumps_aspect_ratio_and_duration() -> None:
 async def test_veo_start_no_config_sends_none() -> None:
     """No config is a valid start; generate_videos gets no knobs."""
     client = MagicMock()
-    op = MagicMock()
-    op.name = 'operations/1'
-    op.done = False
-    client.aio.models.generate_videos = AsyncMock(return_value=op)
+    client.aio.models.generate_videos = AsyncMock(return_value=_sdk_op(name='operations/1', done=False))
     veo = VeoModel('veo-3.0-generate-001', client)
 
     await veo.start(_text_request(), ActionRunContext())
@@ -151,25 +174,11 @@ def test_veo_invalid_sdk_field_is_invalid_argument() -> None:
 
 
 class TestFromVeoOperation:
-    """Tests for _from_veo_operation.
-
-    This function must handle two shapes for the 'response' value:
-
-    1. A plain dict — returned by the start() path or legacy REST.
-    2. A GenerateVideosResponse Pydantic model — returned by the check()
-       path where the SDK object is stored directly.
-
-    Regression: before the fix, case 2 raised
-    ``AttributeError: 'GenerateVideosResponse' object has no attribute 'get'``
-    because the code unconditionally called ``.get()`` on the response.
-    """
+    """``_from_veo_operation`` reads the SDK operation, not a REST dump."""
 
     def test_pending_operation(self) -> None:
         """An in-progress operation has no response — output stays None."""
-        op = _from_veo_operation({
-            'name': 'operations/123',
-            'done': False,
-        })
+        op = _from_veo_operation(api_op=_sdk_op(name='operations/123', done=False))
         assert op.id == 'operations/123'
         assert op.done is False
         assert op.output is None
@@ -177,102 +186,106 @@ class TestFromVeoOperation:
 
     def test_error_operation(self) -> None:
         """An operation with an error populates op.error."""
-        op = _from_veo_operation({
-            'name': 'operations/456',
-            'done': True,
-            'error': {'message': 'Quota exceeded'},
-        })
+        op = _from_veo_operation(
+            api_op=_sdk_op(name='operations/456', done=True, error={'message': 'Quota exceeded'}),
+        )
         assert op.id == 'operations/456'
         assert op.done is True
         assert op.error is not None
         assert op.error.message == 'Quota exceeded'
         assert op.output is None
 
-    def test_dict_response_with_videos(self) -> None:
-        """Dict-shaped response extracts video URIs (start path)."""
-        op = _from_veo_operation({
-            'name': 'operations/789',
-            'done': True,
-            'response': {
-                'generateVideoResponse': {
-                    'generatedSamples': [
-                        {'video': {'uri': 'https://example.com/v1.mp4'}},
-                        {'video': {'uri': 'https://example.com/v2.mp4'}},
-                    ]
-                }
-            },
-        })
-        assert op.done is True
-        assert op.output is not None
-        assert op.output['finishReason'] == 'stop'
-        content = op.output['message']['content']
-        assert len(content) == 2
-        assert content[0]['media']['url'] == 'https://example.com/v1.mp4'
-        assert content[1]['media']['url'] == 'https://example.com/v2.mp4'
-
-    def test_pydantic_response_with_videos(self) -> None:
-        """Pydantic GenerateVideosResponse extracts video URIs (check path).
-
-        This is the regression case — previously this raised AttributeError.
-        """
-        pydantic_response = genai_types.GenerateVideosResponse(
-            generated_videos=[
-                genai_types.GeneratedVideo(
-                    video=genai_types.Video(
-                        uri='https://example.com/video_a.mp4',
-                    ),
+    def test_response_with_videos(self) -> None:
+        """A finished operation puts a ModelResponse with media urls on output."""
+        op = _from_veo_operation(
+            api_op=_sdk_op(
+                name='operations/789',
+                done=True,
+                response=genai_types.GenerateVideosResponse(
+                    generated_videos=[
+                        genai_types.GeneratedVideo(video=genai_types.Video(uri='https://example.com/v1.mp4')),
+                        genai_types.GeneratedVideo(video=genai_types.Video(uri='https://example.com/v2.mp4')),
+                    ],
                 ),
-                genai_types.GeneratedVideo(
-                    video=genai_types.Video(
-                        uri='https://example.com/video_b.mp4',
-                    ),
+            ),
+        )
+        assert op.done is True
+        assert [part.url for part in _media(op.output)] == [
+            'https://example.com/v1.mp4',
+            'https://example.com/v2.mp4',
+        ]
+
+    def test_empty_videos(self) -> None:
+        """A finished response with no generated_videos produces no output."""
+        op = _from_veo_operation(
+            api_op=_sdk_op(
+                name='operations/empty',
+                done=True,
+                response=genai_types.GenerateVideosResponse(generated_videos=[]),
+            ),
+        )
+        assert op.done is True
+        assert op.output is None
+
+    def test_response_none(self) -> None:
+        """No response yet is a pending ticket, not a crash."""
+        op = _from_veo_operation(api_op=_sdk_op(name='operations/null', done=False, response=None))
+        assert op.output is None
+
+    def test_inline_video_bytes(self) -> None:
+        """Vertex often returns inline bytes and no download URL."""
+        op = _from_veo_operation(
+            api_op=_sdk_op(
+                name='operations/bytes',
+                done=True,
+                response=genai_types.GenerateVideosResponse(
+                    generated_videos=[
+                        genai_types.GeneratedVideo(
+                            video=genai_types.Video(video_bytes=b'\x00\x00', mime_type='video/mp4'),
+                        ),
+                    ],
                 ),
-            ],
+            ),
         )
-        op = _from_veo_operation({
-            'name': 'models/veo-2.0-generate-001/operations/abc',
-            'done': True,
-            'response': pydantic_response,
-        })
-        assert op.done is True
-        assert op.output is not None
-        assert op.output['finishReason'] == 'stop'
-        content = op.output['message']['content']
-        assert len(content) == 2
-        assert content[0]['media']['url'] == 'https://example.com/video_a.mp4'
-        assert content[1]['media']['url'] == 'https://example.com/video_b.mp4'
+        media = _media(op.output)[0]
+        assert media.content_type == 'video/mp4'
+        assert media.url == 'data:video/mp4;base64,AAA='
 
-    def test_pydantic_response_empty_videos(self) -> None:
-        """Pydantic response with no generated_videos produces no output."""
-        pydantic_response = genai_types.GenerateVideosResponse(
-            generated_videos=[],
+    def test_gcs_uri(self) -> None:
+        """Vertex can leave the clip on GCS in ``Video.uri``."""
+        op = _from_veo_operation(
+            api_op=_sdk_op(
+                name='operations/gcs',
+                done=True,
+                response=genai_types.GenerateVideosResponse(
+                    generated_videos=[
+                        genai_types.GeneratedVideo(
+                            video=genai_types.Video(uri='gs://bucket/clip.mp4', mime_type='video/mp4'),
+                        ),
+                    ],
+                ),
+            ),
         )
-        op = _from_veo_operation({
-            'name': 'operations/empty',
-            'done': True,
-            'response': pydantic_response,
-        })
-        assert op.done is True
-        assert op.output is None
+        media = _media(op.output)[0]
+        assert media.url == 'gs://bucket/clip.mp4'
+        assert media.content_type == 'video/mp4'
 
-    def test_response_none_explicit(self) -> None:
-        """Explicit None response is handled (no crash)."""
-        op = _from_veo_operation({
-            'name': 'operations/null',
-            'done': False,
-            'response': None,
-        })
+    def test_done_with_rai_filter_is_an_error(self) -> None:
+        """A finished job with no videos and a RAI count is not a success."""
+        op = _from_veo_operation(
+            api_op=_sdk_op(
+                name='operations/rai',
+                done=True,
+                response=genai_types.GenerateVideosResponse(
+                    generated_videos=[],
+                    rai_media_filtered_count=1,
+                    rai_media_filtered_reasons=['1 videos were filtered out.'],
+                ),
+            ),
+        )
         assert op.output is None
-
-    def test_dict_response_no_videos(self) -> None:
-        """Dict response with empty generatedSamples produces no output."""
-        op = _from_veo_operation({
-            'name': 'operations/empty-dict',
-            'done': True,
-            'response': {'generateVideoResponse': {'generatedSamples': []}},
-        })
-        assert op.done is True
-        assert op.output is None
+        assert op.error is not None
+        assert op.error.message == '1 videos were filtered out.'
 
 
 @pytest.mark.asyncio

--- a/py/samples/google-genai-media/README.md
+++ b/py/samples/google-genai-media/README.md
@@ -1,13 +1,12 @@
 # Speech, image, video
 
 Same `generate()` for speech and images. Video is
-`generate_operation` plus `check_operation`.
+`generate_operation` plus `check_operation`. Speech and image use
+Google AI Studio; video uses Vertex (`VertexAI.veo_model`).
 
 ```bash
 export GEMINI_API_KEY=your-api-key
+gcloud auth application-default login
 uv sync
 uv run src/main.py
 ```
-
-That does voice and a poster. The Veo poll is commented at the bottom
-of `src/main.py` — it takes a couple of minutes.

--- a/py/samples/google-genai-media/src/main.py
+++ b/py/samples/google-genai-media/src/main.py
@@ -9,18 +9,20 @@
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
+# See the License for the specific language governing
 # limitations under the License.
 #
 # SPDX-License-Identifier: Apache-2.0
 
 """Speech and image are generate(). Video is generate_operation + poll."""
 
-from genkit_google_genai import GoogleAI
+import asyncio
+
+from genkit_google_genai import GoogleAI, VertexAI
 
 from genkit import Genkit
 
-ai = Genkit(plugins=[GoogleAI()])
+ai = Genkit(plugins=[GoogleAI(), VertexAI()])
 
 
 async def main() -> None:
@@ -39,18 +41,17 @@ async def main() -> None:
     )
     print(poster.media[0].url if poster.media else 'no image')
 
-    # Video is a job, not a round-trip. Uncomment to wait on Veo
-    # (a couple of minutes):
-    #
-    # import asyncio
-    # operation = await ai.generate_operation(
-    #     model='googleai/veo-3.1-generate-preview',
-    #     prompt='A paper airplane gliding through a bright classroom',
-    # )
-    # while not operation.done:
-    #     await asyncio.sleep(3)
-    #     operation = await ai.check_operation(operation)
-    # print(operation.output)
+    # Video is a job, not a round-trip. generate_operation hands back a
+    # ticket; check_operation is how you find out when the video is ready.
+    # Vertex often returns the mp4 inline; operation.output still has a url.
+    operation = await ai.generate_operation(
+        model=VertexAI.veo_model('veo-3.1-generate-001'),
+        prompt='A paper airplane gliding through a bright classroom',
+    )
+    while not operation.done:
+        await asyncio.sleep(3)
+        operation = await ai.check_operation(operation)
+    print(operation.output)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

- Unpacks `uri` / `gcs` / inline bytes from Vertex Veo operations into a playable `media.url`.
- Names RAI-empty finishes properly when the operation completes.
- Adds `veo_model` helper so `VertexAI.veo_model('veo-3.1-generate-001')` works.
- Updates media sample and plugin README.