### PR TITLE
fix(py): honor wrap_generate model swaps by resolving after the hook

### DIFF
--- a/py/packages/genkit/src/genkit/_ai/_generate.py
+++ b/py/packages/genkit/src/genkit/_ai/_generate.py
@@ -776,6 +776,7 @@ class BoxedStart:
     """The ModelResponse start() produced, before wrap_model / wrap_generate."""
 
     response: ModelResponse | None = None
+    name: str = ''
 
 
 def assert_hook_kept_operation(*, boxed: ModelResponse | None, after_hooks: ModelResponse, name: str) -> None:
@@ -811,15 +812,7 @@ async def _generate_action_turn(
 
     model, tools, format_def = await resolve_parameters(registry, raw_request)
     boxed_start = BoxedStart()
-
-    if model.kind == ActionKind.BACKGROUND_MODEL and raw_request.resume is not None:
-        raise GenkitError(
-            status='FAILED_PRECONDITION',
-            message=(
-                f"Cannot resume background model '{model.name}'; "
-                'a background start cannot satisfy an interrupted tool turn'
-            ),
-        )
+    had_resume = raw_request.resume is not None
 
     raw_request, formatter = apply_format(raw_request, format_def)
 
@@ -927,14 +920,22 @@ async def _generate_action_turn(
     ) -> ModelResponse:
         """Execute one turn of the generate loop (model call + optional tool resolution)."""
         chunks.message_index = params.message_index
-        # ``params.options`` picks up whatever wrap_generate middleware changed for
-        # this turn; the model request is rebuilt from it so those edits aren't lost.
+        # ``params.options`` picks up whatever wrap_generate middleware changed
+        # for this turn — including the model name. Re-resolve the action
+        # (and tools) so a reroute is not a silent no-op.
         turn_options = params.options
-        # Re-resolve and re-validate tools per turn to pick up dynamic tool
-        # injections or removals from middleware (e.g. wrap_generate).
+        turn_model = await resolve_model_action(registry, turn_options.model)
+        if turn_model.kind == ActionKind.BACKGROUND_MODEL and had_resume:
+            raise GenkitError(
+                status='FAILED_PRECONDITION',
+                message=(
+                    f"Cannot resume background model '{turn_model.name}'; "
+                    'a background start cannot satisfy an interrupted tool turn'
+                ),
+            )
         turn_tools = await resolve_tools_from_options(registry, turn_options.tools)
         assert_valid_tool_names(turn_tools)
-        request = await action_to_generate_request(turn_options, turn_tools, model)
+        request = await action_to_generate_request(turn_options, turn_tools, turn_model)
         if request.docs:
             request = _augment_with_context(request)
 
@@ -946,22 +947,23 @@ async def _generate_action_turn(
                     turn=current_turn,
                     messages=len(params.request.messages),
                 )
-            result = await model.run(
+            result = await turn_model.run(
                 input=params.request,
                 context=c.custom_context,
                 on_chunk=c.on_chunk,
                 abort_signal=c.abort_signal,
             )
             raw = result.response
-            if model.kind == ActionKind.BACKGROUND_MODEL:
+            if turn_model.kind == ActionKind.BACKGROUND_MODEL:
                 boxed_start.response = box_background_start(
                     raw=raw,
                     request=params.request,
-                    name=model.name,
+                    name=turn_model.name,
                     latency_ms=result.latency_ms,
                 )
+                boxed_start.name = turn_model.name
                 return boxed_start.response
-            return require_model_response(raw=raw, name=model.name)
+            return require_model_response(raw=raw, name=turn_model.name)
 
         with chunks.intercept_model_stream(ctx, role=Role.MODEL):
             model_response = await dispatch_model(
@@ -972,7 +974,7 @@ async def _generate_action_turn(
         assert_hook_kept_operation(
             boxed=boxed_start.response,
             after_hooks=model_response,
-            name=model.name,
+            name=boxed_start.name or turn_model.name,
         )
 
         def message_parser(msg: Message) -> Any:  # noqa: ANN401
@@ -1137,7 +1139,7 @@ async def _generate_action_turn(
     assert_hook_kept_operation(
         boxed=boxed_start.response,
         after_hooks=response,
-        name=model.name,
+        name=boxed_start.name or model.name,
     )
     # The caller's output_schema is what this turn asked for. A wrap_generate
     # that hung its own request on the response is still judged against that,
@@ -1374,21 +1376,26 @@ async def resolve_tools_from_options(
     return actions
 
 
-async def resolve_parameters(
-    registry: Registry, request: GenerateActionOptions
-) -> tuple[Action, list[Action], FormatDef | None]:
-    """Resolve model, tools, and format from registry for a generation request."""
-    model = resolve_model_name(model=request.model, registry=registry)
-
-    model_action = await registry.resolve_model(model)
-    if model_action is None:
-        message = f"Failed to resolve model '{model}'."
-        if isinstance(model, str) and '/' not in model:
+async def resolve_model_action(registry: Registry, model: str | None) -> Action:
+    """Look up the generate or start action for this model name."""
+    name = resolve_model_name(model=model, registry=registry)
+    action = await registry.resolve_model(name)
+    if action is None:
+        message = f"Failed to resolve model '{name}'."
+        if isinstance(name, str) and '/' not in name:
             message += " Ensure the model name includes the plugin namespace (e.g., 'plugin/model')."
         raise GenkitError(
             status='NOT_FOUND',
             message=message,
         )
+    return action
+
+
+async def resolve_parameters(
+    registry: Registry, request: GenerateActionOptions
+) -> tuple[Action, list[Action], FormatDef | None]:
+    """Resolve model, tools, and format from registry for a generation request."""
+    model_action = await resolve_model_action(registry, request.model)
 
     # Resolve tools up front to fail fast on invalid caller-supplied tool names or
     # duplicate short names before running side effects or middleware.

--- a/py/packages/genkit/src/genkit/_ai/_generate.py
+++ b/py/packages/genkit/src/genkit/_ai/_generate.py
@@ -810,39 +810,14 @@ async def _generate_action_turn(
     run_ctx = mw_pipeline.ctx
     raise_if_aborted(run_ctx.abort_signal)
 
-    model, tools, format_def = await resolve_parameters(registry, raw_request)
     boxed_start = BoxedStart()
-    had_resume = raw_request.resume is not None
-
-    raw_request, formatter = apply_format(raw_request, format_def)
-
-    if raw_request.resources:
-        raw_request = await apply_resources(registry, raw_request, run_ctx.abort_signal)
-
-    assert_valid_tool_names(tools)
-
-    (
-        revised_request,
-        interrupted_response,
-        resumed_tool_message,
-    ) = await _resolve_resume_options(
-        registry=registry,
-        raw_request=raw_request,
-        mw_pipeline=mw_pipeline,
-    )
-
-    # NOTE: in the future we should make it possible to interrupt a restart, but
-    # at the moment it's too complicated because it's not clear how to return a
-    # response that amends history but doesn't generate a new message, so we throw
-    if interrupted_response:
-        raise GenkitError(
-            status='FAILED_PRECONDITION',
-            message='One or more tools triggered an interrupt during a restarted execution.',
-            details={'message': interrupted_response.message},
-        )
-    raw_request = revised_request
-
-    chunks = ChunkAccumulator(message_index, formatter)
+    # The caller's output_schema is what this turn asked for. A wrap_generate
+    # that hung its own request on the response is still judged against that,
+    # not whatever leftover output config it copied. apply_format fills in
+    # format/content_type on this same object.
+    formatted_output = raw_request.output
+    formatter: Formatter[Any, Any] | None = None
+    resolved_name = ''
 
     async def dispatch_generate(
         params: GenerateHookParams,
@@ -903,29 +878,17 @@ async def _generate_action_turn(
             runner = cast(Callable[[ModelHookParams, GenerateMiddlewareContext], Awaitable[ModelResponse]], run_next)
         return await runner(params, ctx)
 
-    # if resolving the 'resume' option above generated a tool message, stream it.
-    if resumed_tool_message:
-        chunks.stream_chunk(
-            chunk=ModelResponseChunk(
-                role=resumed_tool_message.role,
-                content=resumed_tool_message.content,
-            ),
-            role=Role.TOOL,
-            ctx=run_ctx,
-        )
-
     async def run_one_iteration(
         params: GenerateHookParams,
         ctx: GenerateMiddlewareContext,
     ) -> ModelResponse:
         """Execute one turn of the generate loop (model call + optional tool resolution)."""
-        chunks.message_index = params.message_index
-        # ``params.options`` picks up whatever wrap_generate middleware changed
-        # for this turn — including the model name. Re-resolve the action
-        # (and tools) so a reroute is not a silent no-op.
+        nonlocal formatter, resolved_name, formatted_output
+        # wrap_generate already ran. The name on options is the action.
         turn_options = params.options
-        turn_model = await resolve_model_action(registry, turn_options.model)
-        if turn_model.kind == ActionKind.BACKGROUND_MODEL and had_resume:
+        turn_model, turn_tools, format_def = await resolve_parameters(registry, turn_options)
+        resolved_name = turn_model.name
+        if turn_model.kind == ActionKind.BACKGROUND_MODEL and turn_options.resume is not None:
             raise GenkitError(
                 status='FAILED_PRECONDITION',
                 message=(
@@ -933,8 +896,43 @@ async def _generate_action_turn(
                     'a background start cannot satisfy an interrupted tool turn'
                 ),
             )
-        turn_tools = await resolve_tools_from_options(registry, turn_options.tools)
+        turn_options, formatter = apply_format(turn_options, format_def)
+        formatted_output = turn_options.output
+        if turn_options.resources:
+            turn_options = await apply_resources(registry, turn_options, run_ctx.abort_signal)
         assert_valid_tool_names(turn_tools)
+
+        (
+            revised_request,
+            interrupted_response,
+            resumed_tool_message,
+        ) = await _resolve_resume_options(
+            registry=registry,
+            raw_request=turn_options,
+            mw_pipeline=mw_pipeline,
+        )
+        # NOTE: in the future we should make it possible to interrupt a restart, but
+        # at the moment it's too complicated because it's not clear how to return a
+        # response that amends history but doesn't generate a new message, so we throw
+        if interrupted_response:
+            raise GenkitError(
+                status='FAILED_PRECONDITION',
+                message='One or more tools triggered an interrupt during a restarted execution.',
+                details={'message': interrupted_response.message},
+            )
+        turn_options = revised_request
+
+        chunks = ChunkAccumulator(params.message_index, formatter)
+        if resumed_tool_message:
+            chunks.stream_chunk(
+                chunk=ModelResponseChunk(
+                    role=resumed_tool_message.role,
+                    content=resumed_tool_message.content,
+                ),
+                role=Role.TOOL,
+                ctx=run_ctx,
+            )
+
         request = await action_to_generate_request(turn_options, turn_tools, turn_model)
         if request.docs:
             request = _augment_with_context(request)
@@ -1133,18 +1131,15 @@ async def _generate_action_turn(
     generate_params = GenerateHookParams(
         options=raw_request,
         iteration=current_turn,
-        message_index=chunks.message_index,
+        message_index=message_index,
     )
     response = await dispatch_generate(generate_params, run_ctx, run_one_iteration)
     assert_hook_kept_operation(
         boxed=boxed_start.response,
         after_hooks=response,
-        name=boxed_start.name or model.name,
+        name=boxed_start.name or resolved_name,
     )
-    # The caller's output_schema is what this turn asked for. A wrap_generate
-    # that hung its own request on the response is still judged against that,
-    # not whatever leftover output config it copied.
-    out = raw_request.output
+    out = formatted_output
     output = OutputConfig(
         format=out.format if out else None,
         # pyrefly: ignore[unexpected-keyword] - populate_by_name accepts the field name
@@ -1160,7 +1155,8 @@ async def _generate_action_turn(
     else:
         response.request = response.request.model_copy(update={'output': output})
     if formatter and response._message_parser is None:
-        response._message_parser = lambda msg: formatter.parse_message(msg)
+        parse = formatter.parse_message
+        response._message_parser = lambda msg: parse(msg)
     if out and out.schema_type:
         response._schema_type = out.schema_type
     response.assert_valid()
@@ -1397,8 +1393,8 @@ async def resolve_parameters(
     """Resolve model, tools, and format from registry for a generation request."""
     model_action = await resolve_model_action(registry, request.model)
 
-    # Resolve tools up front to fail fast on invalid caller-supplied tool names or
-    # duplicate short names before running side effects or middleware.
+    # Resolve tools after wrap_generate so a hook that added names is what we
+    # look up, and fail on a bad name before the model or a resume restart.
     tools = await resolve_tools_from_options(registry, request.tools)
 
     format_def: FormatDef | None = None

--- a/py/packages/genkit/src/genkit/_ai/_generate.py
+++ b/py/packages/genkit/src/genkit/_ai/_generate.py
@@ -72,6 +72,7 @@ from genkit._core._schema import check_output_schema
 from genkit._core._tracing import SpanMetadata, run_in_new_span
 from genkit._core._typing import (
     FinishReason,
+    GenerateActionOutputConfig,
     MiddlewareRef,
     MultipartToolResponse,
     Operation,
@@ -772,11 +773,17 @@ def require_model_response(*, raw: object, name: str) -> ModelResponse:
 
 
 @dataclass
-class BoxedStart:
-    """The ModelResponse start() produced, before wrap_model / wrap_generate."""
+class Turn:
+    """Stamps wrap_generate cannot return — that hook must return ModelResponse.
 
-    response: ModelResponse | None = None
+    Resolve and apply_format run inside the turn. Ticket / schema / parse
+    checks run after the hook returns, so they read this bag.
+    """
+
+    boxed: ModelResponse | None = None
     name: str = ''
+    formatter: Formatter[Any, Any] | None = None
+    output: GenerateActionOutputConfig | None = None
 
 
 def assert_hook_kept_operation(*, boxed: ModelResponse | None, after_hooks: ModelResponse, name: str) -> None:
@@ -810,14 +817,7 @@ async def _generate_action_turn(
     run_ctx = mw_pipeline.ctx
     raise_if_aborted(run_ctx.abort_signal)
 
-    boxed_start = BoxedStart()
-    # The caller's output_schema is what this turn asked for. A wrap_generate
-    # that hung its own request on the response is still judged against that,
-    # not whatever leftover output config it copied. apply_format fills in
-    # format/content_type on this same object.
-    formatted_output = raw_request.output
-    formatter: Formatter[Any, Any] | None = None
-    resolved_name = ''
+    turn = Turn(output=raw_request.output)
 
     async def dispatch_generate(
         params: GenerateHookParams,
@@ -883,11 +883,10 @@ async def _generate_action_turn(
         ctx: GenerateMiddlewareContext,
     ) -> ModelResponse:
         """Execute one turn of the generate loop (model call + optional tool resolution)."""
-        nonlocal formatter, resolved_name, formatted_output
         # wrap_generate already ran. The name on options is the action.
         turn_options = params.options
         turn_model, turn_tools, format_def = await resolve_parameters(registry, turn_options)
-        resolved_name = turn_model.name
+        turn.name = turn_model.name
         if turn_model.kind == ActionKind.BACKGROUND_MODEL and turn_options.resume is not None:
             raise GenkitError(
                 status='FAILED_PRECONDITION',
@@ -896,8 +895,8 @@ async def _generate_action_turn(
                     'a background start cannot satisfy an interrupted tool turn'
                 ),
             )
-        turn_options, formatter = apply_format(turn_options, format_def)
-        formatted_output = turn_options.output
+        turn_options, turn.formatter = apply_format(turn_options, format_def)
+        turn.output = turn_options.output
         if turn_options.resources:
             turn_options = await apply_resources(registry, turn_options, run_ctx.abort_signal)
         assert_valid_tool_names(turn_tools)
@@ -922,7 +921,7 @@ async def _generate_action_turn(
             )
         turn_options = revised_request
 
-        chunks = ChunkAccumulator(params.message_index, formatter)
+        chunks = ChunkAccumulator(params.message_index, turn.formatter)
         if resumed_tool_message:
             chunks.stream_chunk(
                 chunk=ModelResponseChunk(
@@ -953,14 +952,14 @@ async def _generate_action_turn(
             )
             raw = result.response
             if turn_model.kind == ActionKind.BACKGROUND_MODEL:
-                boxed_start.response = box_background_start(
+                turn.boxed = box_background_start(
                     raw=raw,
                     request=params.request,
                     name=turn_model.name,
                     latency_ms=result.latency_ms,
                 )
-                boxed_start.name = turn_model.name
-                return boxed_start.response
+                turn.name = turn_model.name
+                return turn.boxed
             return require_model_response(raw=raw, name=turn_model.name)
 
         with chunks.intercept_model_stream(ctx, role=Role.MODEL):
@@ -970,15 +969,15 @@ async def _generate_action_turn(
                 next_fn,
             )
         assert_hook_kept_operation(
-            boxed=boxed_start.response,
+            boxed=turn.boxed,
             after_hooks=model_response,
-            name=boxed_start.name or turn_model.name,
+            name=turn.name or turn_model.name,
         )
 
         def message_parser(msg: Message) -> Any:  # noqa: ANN401
-            if formatter is None:
+            if turn.formatter is None:
                 return None
-            return formatter.parse_message(msg)
+            return turn.formatter.parse_message(msg)
 
         # Extract schema_type for runtime Pydantic validation
         schema_type = turn_options.output.schema_type if turn_options.output else None
@@ -987,7 +986,7 @@ async def _generate_action_turn(
         # any output format context (message_parser, schema_type) as private attrs.
         response = model_response
         response.request = request
-        if formatter:
+        if turn.formatter:
             response._message_parser = message_parser
         if schema_type:
             response._schema_type = schema_type
@@ -1016,7 +1015,7 @@ async def _generate_action_turn(
             model=turn_options.model,
             finish_reason=response.finish_reason,
             finish_message=response.finish_message,
-            formatter=formatter,
+            formatter=turn.formatter,
             message=generated_msg,
         )
 
@@ -1135,11 +1134,11 @@ async def _generate_action_turn(
     )
     response = await dispatch_generate(generate_params, run_ctx, run_one_iteration)
     assert_hook_kept_operation(
-        boxed=boxed_start.response,
+        boxed=turn.boxed,
         after_hooks=response,
-        name=boxed_start.name or resolved_name,
+        name=turn.name,
     )
-    out = formatted_output
+    out = turn.output
     output = OutputConfig(
         format=out.format if out else None,
         # pyrefly: ignore[unexpected-keyword] - populate_by_name accepts the field name
@@ -1154,8 +1153,8 @@ async def _generate_action_turn(
         )
     else:
         response.request = response.request.model_copy(update={'output': output})
-    if formatter and response._message_parser is None:
-        parse = formatter.parse_message
+    if turn.formatter and response._message_parser is None:
+        parse = turn.formatter.parse_message
         response._message_parser = lambda msg: parse(msg)
     if out and out.schema_type:
         response._schema_type = out.schema_type

--- a/py/packages/genkit/src/genkit/_core/_registry.py
+++ b/py/packages/genkit/src/genkit/_core/_registry.py
@@ -54,6 +54,7 @@ from genkit._core._typing import (
     EmbedResponse,
     EvalRequest,
     EvalResponse,
+    Operation,
 )
 
 logger = get_logger(__name__)
@@ -756,12 +757,15 @@ class Registry:
             return None
         return cast(Action[EmbedRequest, EmbedResponse, Never], action)
 
-    async def resolve_model(self, name: str) -> Action[ModelRequest, ModelResponse, ModelResponseChunk] | None:
+    async def resolve_model(
+        self, name: str
+    ) -> Action[ModelRequest, ModelResponse | Operation, ModelResponseChunk] | None:
         """Resolve a model action by name.
 
         Looks up a normal model first, then a background start action, so a
         name registered only with ``define_background_model`` is findable
-        under the same string callers already pass.
+        under the same string callers already pass. A start returns an
+        Operation, not a ModelResponse.
 
         Args:
             name: The model name (e.g., "gemini-pro" or "plugin/model").
@@ -778,7 +782,7 @@ class Registry:
         if action is None:
             return None
         return cast(
-            Action[ModelRequest, ModelResponse, ModelResponseChunk],
+            Action[ModelRequest, ModelResponse | Operation, ModelResponseChunk],
             action,
         )
 

--- a/py/packages/genkit/tests/genkit/ai/background_generate_test.py
+++ b/py/packages/genkit/tests/genkit/ai/background_generate_test.py
@@ -46,11 +46,21 @@ def ai() -> Genkit:
     return Genkit()
 
 
-def register_bg_model(ai: Genkit, *, op_id: str = 'bg-op-123') -> None:
+def register_bg_model(
+    ai: Genkit,
+    *,
+    op_id: str = 'bg-op-123',
+    starts: list[str] | None = None,
+    checks: list[str] | None = None,
+) -> None:
     async def start(_request: ModelRequest, _ctx: ActionRunContext) -> Operation:
+        if starts is not None:
+            starts.append('start')
         return Operation(id=op_id, done=False)
 
     async def check(op: Operation) -> Operation:
+        if checks is not None:
+            checks.append('check')
         return op
 
     ai.define_background_model(
@@ -96,17 +106,8 @@ async def test_generate_returns_the_job_without_polling(ai: Genkit) -> None:
     ``generate_operation()`` only start; they must not call ``check``
     on the way out, or a long render would block the first call.
     """
-    checks = 0
-
-    async def start(_request: ModelRequest, _ctx: ActionRunContext) -> Operation:
-        return Operation(id='bg-op-123', done=False)
-
-    async def check(op: Operation) -> Operation:
-        nonlocal checks
-        checks += 1
-        return Operation(id=op.id, done=True)
-
-    ai.define_background_model(name='bg-model', start=start, check=check)
+    checks: list[str] = []
+    register_bg_model(ai, checks=checks)
 
     response = await ai.generate(model='bg-model', prompt='a cat surfing')
     operation = await ai.generate_operation(model='bg-model', prompt='a cat surfing')
@@ -114,7 +115,7 @@ async def test_generate_returns_the_job_without_polling(ai: Genkit) -> None:
     assert response.operation is not None
     assert response.operation.done is False
     assert operation.done is False
-    assert checks == 0
+    assert checks == []
 
 
 class ReadsMessage(BaseMiddleware):
@@ -245,17 +246,8 @@ async def test_generate_persists_clean_history_without_injected_docs(ai: Genkit)
 @pytest.mark.asyncio
 async def test_generate_rejects_resume_on_background_model(ai: Genkit) -> None:
     """A video start cannot satisfy an interrupt resume. Don't bill start()."""
-    started = 0
-
-    async def start(_request: ModelRequest, _ctx: ActionRunContext) -> Operation:
-        nonlocal started
-        started += 1
-        return Operation(id='bg-op-123', done=False)
-
-    async def check(op: Operation) -> Operation:
-        return op
-
-    ai.define_background_model(name='bg-model', start=start, check=check)
+    starts: list[str] = []
+    register_bg_model(ai, starts=starts)
 
     with pytest.raises(GenkitError, match='Cannot resume background model') as exc_info:
         await ai.generate(
@@ -273,7 +265,7 @@ async def test_generate_rejects_resume_on_background_model(ai: Genkit) -> None:
         )
 
     assert exc_info.value.status == 'FAILED_PRECONDITION'
-    assert started == 0
+    assert starts == []
 
 
 @pytest.mark.asyncio
@@ -576,23 +568,15 @@ async def test_wrap_generate_reroute_to_background_starts_the_job(ai: Genkit) ->
 @pytest.mark.asyncio
 async def test_wrap_generate_reroute_from_background_runs_plain(ai: Genkit) -> None:
     """The reverse swap must call the chat model and never start()."""
-    started = 0
+    starts: list[str] = []
 
-    async def start(_request: ModelRequest, _ctx: ActionRunContext) -> Operation:
-        nonlocal started
-        started += 1
-        return Operation(id='bg-op-123', done=False)
-
-    async def check(op: Operation, _ctx: ActionRunContext) -> Operation:
-        return op
-
-    ai.define_background_model(name='bg-model', start=start, check=check)
+    register_bg_model(ai, starts=starts)
     register_plain(ai)
 
     response = await ai.generate(model='bg-model', prompt='a cat', use=[Reroute(to='plain')])
 
     assert_chat(response, text='from-plain')
-    assert started == 0
+    assert starts == []
 
 
 @pytest.mark.asyncio
@@ -651,18 +635,10 @@ async def test_wrap_generate_rescues_a_missing_model_name(ai: Genkit) -> None:
 @pytest.mark.asyncio
 async def test_resume_restart_on_video_without_swap_does_not_run_the_tool(ai: Genkit) -> None:
     """Still on Veo after the hook: reject before a resume restart runs the tool."""
-    started = 0
+    starts: list[str] = []
     runs: list[str] = []
 
-    async def start(_request: ModelRequest, _ctx: ActionRunContext) -> Operation:
-        nonlocal started
-        started += 1
-        return Operation(id='bg-op-123', done=False)
-
-    async def check(op: Operation, _ctx: ActionRunContext) -> Operation:
-        return op
-
-    ai.define_background_model(name='bg-model', start=start, check=check)
+    register_bg_model(ai, starts=starts)
     register_ping(ai, runs)
 
     with pytest.raises(GenkitError, match='Cannot resume background model') as raised:
@@ -674,24 +650,16 @@ async def test_resume_restart_on_video_without_swap_does_not_run_the_tool(ai: Ge
         )
 
     assert raised.value.status == 'FAILED_PRECONDITION'
-    assert started == 0
+    assert starts == []
     assert runs == []
 
 
 @pytest.mark.asyncio
 async def test_wrap_generate_resume_respond_on_video_swaps_to_flash_and_continues(ai: Genkit) -> None:
     """Swap off Veo before resolve. Resume stitches, then flash writes the next message."""
-    started = 0
+    starts: list[str] = []
 
-    async def start(_request: ModelRequest, _ctx: ActionRunContext) -> Operation:
-        nonlocal started
-        started += 1
-        return Operation(id='bg-op-123', done=False)
-
-    async def check(op: Operation, _ctx: ActionRunContext) -> Operation:
-        return op
-
-    ai.define_background_model(name='bg-model', start=start, check=check)
+    register_bg_model(ai, starts=starts)
     register_plain(ai)
 
     response = await ai.generate(
@@ -702,24 +670,16 @@ async def test_wrap_generate_resume_respond_on_video_swaps_to_flash_and_continue
     )
 
     assert_chat(response, text='from-plain', roles=[Role.USER, Role.MODEL, Role.TOOL, Role.MODEL])
-    assert started == 0
+    assert starts == []
 
 
 @pytest.mark.asyncio
 async def test_wrap_generate_resume_restart_on_video_swaps_to_flash_runs_the_tool(ai: Genkit) -> None:
     """Swap off Veo, then the restarted tool runs and flash continues."""
-    started = 0
+    starts: list[str] = []
     runs: list[str] = []
 
-    async def start(_request: ModelRequest, _ctx: ActionRunContext) -> Operation:
-        nonlocal started
-        started += 1
-        return Operation(id='bg-op-123', done=False)
-
-    async def check(op: Operation, _ctx: ActionRunContext) -> Operation:
-        return op
-
-    ai.define_background_model(name='bg-model', start=start, check=check)
+    register_bg_model(ai, starts=starts)
     register_plain(ai)
     register_ping(ai, runs)
 
@@ -732,24 +692,16 @@ async def test_wrap_generate_resume_restart_on_video_swaps_to_flash_runs_the_too
     )
 
     assert_chat(response, text='from-plain', roles=[Role.USER, Role.MODEL, Role.TOOL, Role.MODEL])
-    assert started == 0
+    assert starts == []
     assert runs == ['ping']
 
 
 @pytest.mark.asyncio
 async def test_wrap_generate_resume_respond_on_flash_swaps_to_video_raises(ai: Genkit) -> None:
     """A swap onto Veo during resume is still a video start. Don't bill start()."""
-    started = 0
+    starts: list[str] = []
 
-    async def start(_request: ModelRequest, _ctx: ActionRunContext) -> Operation:
-        nonlocal started
-        started += 1
-        return Operation(id='bg-op-123', done=False)
-
-    async def check(op: Operation, _ctx: ActionRunContext) -> Operation:
-        return op
-
-    ai.define_background_model(name='bg-model', start=start, check=check)
+    register_bg_model(ai, starts=starts)
     register_plain(ai)
 
     with pytest.raises(GenkitError, match='Cannot resume background model') as raised:
@@ -761,24 +713,16 @@ async def test_wrap_generate_resume_respond_on_flash_swaps_to_video_raises(ai: G
         )
 
     assert raised.value.status == 'FAILED_PRECONDITION'
-    assert started == 0
+    assert starts == []
 
 
 @pytest.mark.asyncio
 async def test_wrap_generate_resume_restart_on_flash_swaps_to_video_does_not_run_the_tool(ai: Genkit) -> None:
     """Swap onto Veo: reject before the restarted tool runs."""
-    started = 0
+    starts: list[str] = []
     runs: list[str] = []
 
-    async def start(_request: ModelRequest, _ctx: ActionRunContext) -> Operation:
-        nonlocal started
-        started += 1
-        return Operation(id='bg-op-123', done=False)
-
-    async def check(op: Operation, _ctx: ActionRunContext) -> Operation:
-        return op
-
-    ai.define_background_model(name='bg-model', start=start, check=check)
+    register_bg_model(ai, starts=starts)
     register_plain(ai)
     register_ping(ai, runs)
 
@@ -792,7 +736,7 @@ async def test_wrap_generate_resume_restart_on_flash_swaps_to_video_does_not_run
         )
 
     assert raised.value.status == 'FAILED_PRECONDITION'
-    assert started == 0
+    assert starts == []
     assert runs == []
 
 

--- a/py/packages/genkit/tests/genkit/ai/background_generate_test.py
+++ b/py/packages/genkit/tests/genkit/ai/background_generate_test.py
@@ -20,6 +20,7 @@ from collections.abc import Awaitable, Callable
 from typing import Any, cast
 
 import pytest
+from pydantic import BaseModel
 
 from genkit import ActionKind, Document, Genkit, Message
 from genkit._core._action import ActionRunContext
@@ -475,3 +476,85 @@ async def test_started_operation_dump_round_trips_through_check(ai: Genkit) -> N
     assert updated.id == 'bg-op-123'
     assert updated.done is True
     assert updated.action == '/background-model/bg-model'
+
+
+class RerouteConfig(BaseModel):
+    to: str
+
+
+class Reroute(BaseMiddleware[RerouteConfig]):
+    """Swap ``params.options.model`` before the turn runs."""
+
+    async def wrap_generate(
+        self,
+        params: GenerateHookParams,
+        ctx: GenerateMiddlewareContext,
+        next_fn: Callable[[GenerateHookParams, GenerateMiddlewareContext], Awaitable[ModelResponse]],
+    ) -> ModelResponse:
+        options = params.options.model_copy(update={'model': self.config.to})
+        return await next_fn(params.model_copy(update={'options': options}), ctx)
+
+
+def register_plain(ai: Genkit, *, name: str = 'plain', text: str = 'from-plain') -> None:
+    async def model_fn(_request: ModelRequest, _ctx: ActionRunContext) -> ModelResponse:
+        return ModelResponse(message=Message(role=Role.MODEL, content=[Part(root=TextPart(text=text))]))
+
+    ai.define_model(name=name, fn=model_fn)
+
+
+@pytest.mark.asyncio
+async def test_wrap_generate_reroute_to_background_starts_the_job(ai: Genkit) -> None:
+    """A wrap_generate that sets options.model to a Veo id must actually start Veo."""
+    register_bg_model(ai)
+    register_plain(ai)
+
+    response = await ai.generate(model='plain', prompt='a cat', use=[Reroute(to='bg-model')])
+
+    assert response.operation is not None
+    assert response.operation.id == 'bg-op-123'
+    assert response.text == ''
+
+
+@pytest.mark.asyncio
+async def test_wrap_generate_reroute_from_background_runs_plain(ai: Genkit) -> None:
+    """The reverse swap must call the chat model and never start()."""
+    started = 0
+
+    async def start(_request: ModelRequest, _ctx: ActionRunContext) -> Operation:
+        nonlocal started
+        started += 1
+        return Operation(id='bg-op-123', done=False)
+
+    async def check(op: Operation, _ctx: ActionRunContext) -> Operation:
+        return op
+
+    ai.define_background_model(name='bg-model', start=start, check=check)
+    register_plain(ai)
+
+    response = await ai.generate(model='bg-model', prompt='a cat', use=[Reroute(to='plain')])
+
+    assert response.text == 'from-plain'
+    assert response.operation is None
+    assert started == 0
+
+
+@pytest.mark.asyncio
+async def test_wrap_generate_reroute_same_kind_uses_the_new_model(ai: Genkit) -> None:
+    """A flash→pro swap is the same bug without a background model in the mix."""
+    register_plain(ai, name='flash', text='from-flash')
+    register_plain(ai, name='pro', text='from-pro')
+
+    response = await ai.generate(model='flash', prompt='hi', use=[Reroute(to='pro')])
+
+    assert response.text == 'from-pro'
+
+
+@pytest.mark.asyncio
+async def test_wrap_generate_reroute_to_missing_model_is_not_found(ai: Genkit) -> None:
+    """A reroute to a name that is not registered fails at resolve, not silently."""
+    register_plain(ai)
+
+    with pytest.raises(GenkitError) as raised:
+        await ai.generate(model='plain', prompt='hi', use=[Reroute(to='no-such-model')])
+
+    assert raised.value.status == 'NOT_FOUND'

--- a/py/packages/genkit/tests/genkit/ai/background_generate_test.py
+++ b/py/packages/genkit/tests/genkit/ai/background_generate_test.py
@@ -26,7 +26,7 @@ from genkit import ActionKind, Document, Genkit, Message
 from genkit._core._action import ActionRunContext
 from genkit._core._error import GenkitError
 from genkit._core._middleware import BaseMiddleware, GenerateHookParams, GenerateMiddlewareContext, ModelHookParams
-from genkit._core._model import ModelRequest, ModelResponse
+from genkit._core._model import ModelRequest, ModelResponse, ModelResponseChunk
 from genkit._core._typing import (
     Error,
     FinishReason,
@@ -480,10 +480,11 @@ async def test_started_operation_dump_round_trips_through_check(ai: Genkit) -> N
 
 class RerouteConfig(BaseModel):
     to: str
+    turn: int | None = None
 
 
 class Reroute(BaseMiddleware[RerouteConfig]):
-    """Swap ``params.options.model`` before the turn runs."""
+    """Swap ``params.options.model`` before the turn resolves."""
 
     async def wrap_generate(
         self,
@@ -491,15 +492,74 @@ class Reroute(BaseMiddleware[RerouteConfig]):
         ctx: GenerateMiddlewareContext,
         next_fn: Callable[[GenerateHookParams, GenerateMiddlewareContext], Awaitable[ModelResponse]],
     ) -> ModelResponse:
+        if self.config.turn is not None and params.iteration != self.config.turn:
+            return await next_fn(params, ctx)
         options = params.options.model_copy(update={'model': self.config.to})
         return await next_fn(params.model_copy(update={'options': options}), ctx)
 
 
 def register_plain(ai: Genkit, *, name: str = 'plain', text: str = 'from-plain') -> None:
-    async def model_fn(_request: ModelRequest, _ctx: ActionRunContext) -> ModelResponse:
+    async def model_fn(_request: ModelRequest, ctx: ActionRunContext) -> ModelResponse:
+        ctx.send_chunk(ModelResponseChunk(role=Role.MODEL, content=[Part(root=TextPart(text=text))]))
         return ModelResponse(message=Message(role=Role.MODEL, content=[Part(root=TextPart(text=text))]))
 
     ai.define_model(name=name, fn=model_fn)
+
+
+def register_tool_caller(ai: Genkit, *, name: str = 'flash') -> None:
+    async def model_fn(_request: ModelRequest, _ctx: ActionRunContext) -> ModelResponse:
+        return ModelResponse(
+            message=Message(
+                role=Role.MODEL,
+                content=[Part(root=ToolRequestPart(tool_request=ToolRequest(name='ping', input={}, ref='1')))],
+            )
+        )
+
+    ai.define_model(name=name, fn=model_fn)
+
+
+def interrupted_history() -> list[Message]:
+    return [
+        Message(role=Role.USER, content=[Part(root=TextPart(text='hi'))]),
+        Message(
+            role=Role.MODEL,
+            content=[Part(root=ToolRequestPart(tool_request=ToolRequest(name='ping', input={}, ref='1')))],
+        ),
+    ]
+
+
+def respond_ping() -> ToolResponsePart:
+    return ToolResponsePart(tool_response=ToolResponse(name='ping', ref='1', output='ok'))
+
+
+def restart_ping() -> ToolRequestPart:
+    return ToolRequestPart(tool_request=ToolRequest(name='ping', input={}, ref='1'))
+
+
+def register_ping(ai: Genkit, runs: list[str] | None = None) -> None:
+    @ai.tool(name='ping')
+    async def ping() -> str:
+        if runs is not None:
+            runs.append('ping')
+        return 'pong'
+
+
+def assert_chat(response: ModelResponse, *, text: str, roles: list[Role] | None = None) -> None:
+    assert response.operation is None
+    assert response.message is not None
+    assert response.messages[-1] == response.message
+    assert response.text == text
+    if roles is not None:
+        assert [m.role for m in response.messages] == roles
+
+
+def assert_ticket(response: ModelResponse, *, op_id: str = 'bg-op-123') -> None:
+    assert response.operation is not None
+    assert response.operation.id == op_id
+    assert response.operation.done is False
+    assert response.operation.action == '/background-model/bg-model'
+    assert response.message is None
+    assert response.text == ''
 
 
 @pytest.mark.asyncio
@@ -510,9 +570,7 @@ async def test_wrap_generate_reroute_to_background_starts_the_job(ai: Genkit) ->
 
     response = await ai.generate(model='plain', prompt='a cat', use=[Reroute(to='bg-model')])
 
-    assert response.operation is not None
-    assert response.operation.id == 'bg-op-123'
-    assert response.text == ''
+    assert_ticket(response)
 
 
 @pytest.mark.asyncio
@@ -533,8 +591,7 @@ async def test_wrap_generate_reroute_from_background_runs_plain(ai: Genkit) -> N
 
     response = await ai.generate(model='bg-model', prompt='a cat', use=[Reroute(to='plain')])
 
-    assert response.text == 'from-plain'
-    assert response.operation is None
+    assert_chat(response, text='from-plain')
     assert started == 0
 
 
@@ -546,7 +603,7 @@ async def test_wrap_generate_reroute_same_kind_uses_the_new_model(ai: Genkit) ->
 
     response = await ai.generate(model='flash', prompt='hi', use=[Reroute(to='pro')])
 
-    assert response.text == 'from-pro'
+    assert_chat(response, text='from-pro')
 
 
 @pytest.mark.asyncio
@@ -558,3 +615,338 @@ async def test_wrap_generate_reroute_to_missing_model_is_not_found(ai: Genkit) -
         await ai.generate(model='plain', prompt='hi', use=[Reroute(to='no-such-model')])
 
     assert raised.value.status == 'NOT_FOUND'
+
+
+@pytest.mark.asyncio
+async def test_wrap_generate_in_place_model_assignment_runs_the_new_model(ai: Genkit) -> None:
+    """Writing options.model in place is the same swap as model_copy."""
+    register_plain(ai, name='flash', text='from-flash')
+    register_plain(ai, name='pro', text='from-pro')
+
+    class InPlace(BaseMiddleware):
+        async def wrap_generate(
+            self,
+            params: GenerateHookParams,
+            ctx: GenerateMiddlewareContext,
+            next_fn: Callable[[GenerateHookParams, GenerateMiddlewareContext], Awaitable[ModelResponse]],
+        ) -> ModelResponse:
+            params.options.model = 'pro'
+            return await next_fn(params, ctx)
+
+    response = await ai.generate(model='flash', prompt='hi', use=[InPlace()])
+
+    assert_chat(response, text='from-pro')
+
+
+@pytest.mark.asyncio
+async def test_wrap_generate_rescues_a_missing_model_name(ai: Genkit) -> None:
+    """The original name is never resolved. A swap to a real model runs that model."""
+    register_plain(ai)
+
+    response = await ai.generate(model='no-such-model', prompt='hi', use=[Reroute(to='plain')])
+
+    assert_chat(response, text='from-plain')
+
+
+@pytest.mark.asyncio
+async def test_resume_restart_on_video_without_swap_does_not_run_the_tool(ai: Genkit) -> None:
+    """Still on Veo after the hook: reject before a resume restart runs the tool."""
+    started = 0
+    runs: list[str] = []
+
+    async def start(_request: ModelRequest, _ctx: ActionRunContext) -> Operation:
+        nonlocal started
+        started += 1
+        return Operation(id='bg-op-123', done=False)
+
+    async def check(op: Operation, _ctx: ActionRunContext) -> Operation:
+        return op
+
+    ai.define_background_model(name='bg-model', start=start, check=check)
+    register_ping(ai, runs)
+
+    with pytest.raises(GenkitError, match='Cannot resume background model') as raised:
+        await ai.generate(
+            model='bg-model',
+            messages=interrupted_history(),
+            resume_restart=[restart_ping()],
+            tools=['ping'],
+        )
+
+    assert raised.value.status == 'FAILED_PRECONDITION'
+    assert started == 0
+    assert runs == []
+
+
+@pytest.mark.asyncio
+async def test_wrap_generate_resume_respond_on_video_swaps_to_flash_and_continues(ai: Genkit) -> None:
+    """Swap off Veo before resolve. Resume stitches, then flash writes the next message."""
+    started = 0
+
+    async def start(_request: ModelRequest, _ctx: ActionRunContext) -> Operation:
+        nonlocal started
+        started += 1
+        return Operation(id='bg-op-123', done=False)
+
+    async def check(op: Operation, _ctx: ActionRunContext) -> Operation:
+        return op
+
+    ai.define_background_model(name='bg-model', start=start, check=check)
+    register_plain(ai)
+
+    response = await ai.generate(
+        model='bg-model',
+        messages=interrupted_history(),
+        resume_respond=[respond_ping()],
+        use=[Reroute(to='plain')],
+    )
+
+    assert_chat(response, text='from-plain', roles=[Role.USER, Role.MODEL, Role.TOOL, Role.MODEL])
+    assert started == 0
+
+
+@pytest.mark.asyncio
+async def test_wrap_generate_resume_restart_on_video_swaps_to_flash_runs_the_tool(ai: Genkit) -> None:
+    """Swap off Veo, then the restarted tool runs and flash continues."""
+    started = 0
+    runs: list[str] = []
+
+    async def start(_request: ModelRequest, _ctx: ActionRunContext) -> Operation:
+        nonlocal started
+        started += 1
+        return Operation(id='bg-op-123', done=False)
+
+    async def check(op: Operation, _ctx: ActionRunContext) -> Operation:
+        return op
+
+    ai.define_background_model(name='bg-model', start=start, check=check)
+    register_plain(ai)
+    register_ping(ai, runs)
+
+    response = await ai.generate(
+        model='bg-model',
+        messages=interrupted_history(),
+        resume_restart=[restart_ping()],
+        tools=['ping'],
+        use=[Reroute(to='plain')],
+    )
+
+    assert_chat(response, text='from-plain', roles=[Role.USER, Role.MODEL, Role.TOOL, Role.MODEL])
+    assert started == 0
+    assert runs == ['ping']
+
+
+@pytest.mark.asyncio
+async def test_wrap_generate_resume_respond_on_flash_swaps_to_video_raises(ai: Genkit) -> None:
+    """A swap onto Veo during resume is still a video start. Don't bill start()."""
+    started = 0
+
+    async def start(_request: ModelRequest, _ctx: ActionRunContext) -> Operation:
+        nonlocal started
+        started += 1
+        return Operation(id='bg-op-123', done=False)
+
+    async def check(op: Operation, _ctx: ActionRunContext) -> Operation:
+        return op
+
+    ai.define_background_model(name='bg-model', start=start, check=check)
+    register_plain(ai)
+
+    with pytest.raises(GenkitError, match='Cannot resume background model') as raised:
+        await ai.generate(
+            model='plain',
+            messages=interrupted_history(),
+            resume_respond=[respond_ping()],
+            use=[Reroute(to='bg-model')],
+        )
+
+    assert raised.value.status == 'FAILED_PRECONDITION'
+    assert started == 0
+
+
+@pytest.mark.asyncio
+async def test_wrap_generate_resume_restart_on_flash_swaps_to_video_does_not_run_the_tool(ai: Genkit) -> None:
+    """Swap onto Veo: reject before the restarted tool runs."""
+    started = 0
+    runs: list[str] = []
+
+    async def start(_request: ModelRequest, _ctx: ActionRunContext) -> Operation:
+        nonlocal started
+        started += 1
+        return Operation(id='bg-op-123', done=False)
+
+    async def check(op: Operation, _ctx: ActionRunContext) -> Operation:
+        return op
+
+    ai.define_background_model(name='bg-model', start=start, check=check)
+    register_plain(ai)
+    register_ping(ai, runs)
+
+    with pytest.raises(GenkitError, match='Cannot resume background model') as raised:
+        await ai.generate(
+            model='plain',
+            messages=interrupted_history(),
+            resume_restart=[restart_ping()],
+            tools=['ping'],
+            use=[Reroute(to='bg-model')],
+        )
+
+    assert raised.value.status == 'FAILED_PRECONDITION'
+    assert started == 0
+    assert runs == []
+
+
+@pytest.mark.asyncio
+async def test_wrap_generate_swaps_to_pro_on_the_turn_after_a_tool(ai: Genkit) -> None:
+    """After a closed tool round, wrap_generate on that turn picks pro."""
+    register_tool_caller(ai, name='flash')
+    register_plain(ai, name='pro', text='from-pro')
+    register_ping(ai)
+
+    response = await ai.generate(model='flash', prompt='hi', tools=['ping'], use=[Reroute(to='pro', turn=1)])
+
+    assert_chat(response, text='from-pro', roles=[Role.USER, Role.MODEL, Role.TOOL, Role.MODEL])
+
+
+@pytest.mark.asyncio
+async def test_wrap_generate_swaps_to_video_on_the_turn_after_a_tool(ai: Genkit) -> None:
+    """After a closed tool round, a swap to Veo starts the job."""
+    register_tool_caller(ai, name='flash')
+    register_bg_model(ai)
+    register_ping(ai)
+
+    response = await ai.generate(model='flash', prompt='hi', tools=['ping'], use=[Reroute(to='bg-model', turn=1)])
+
+    assert_ticket(response)
+    assert [m.role for m in response.messages] == [Role.USER, Role.MODEL, Role.TOOL]
+
+
+@pytest.mark.asyncio
+async def test_generate_stream_swap_to_pro_streams_pro_text(ai: Genkit) -> None:
+    """generate_stream follows the same swap: chunks and the final reply are pro."""
+    register_plain(ai, name='flash', text='from-flash')
+    register_plain(ai, name='pro', text='from-pro')
+
+    stream = ai.generate_stream(model='flash', prompt='hi', use=[Reroute(to='pro')])
+    texts: list[str] = []
+    async for chunk in stream.stream:
+        texts.append(chunk.text)
+    response = await stream.response
+
+    assert ''.join(texts) == 'from-pro'
+    assert_chat(response, text='from-pro')
+
+
+@pytest.mark.asyncio
+async def test_generate_stream_swap_to_video_returns_a_ticket(ai: Genkit) -> None:
+    """A stream swap to Veo has no token chunks and a ticket on the final response."""
+    register_plain(ai)
+    register_bg_model(ai)
+
+    stream = ai.generate_stream(model='plain', prompt='a cat', use=[Reroute(to='bg-model')])
+    texts: list[str] = []
+    async for chunk in stream.stream:
+        texts.append(chunk.text)
+    response = await stream.response
+
+    assert texts == []
+    assert_ticket(response)
+
+
+@pytest.mark.asyncio
+async def test_check_operation_polls_the_ticket_from_a_swapped_video_start(ai: Genkit) -> None:
+    """The ticket from a flash→Veo swap is what check_operation polls."""
+
+    async def start(_request: ModelRequest, _ctx: ActionRunContext) -> Operation:
+        return Operation(id='bg-op-123', done=False)
+
+    async def check(op: Operation) -> Operation:
+        return Operation(id=op.id, done=True, action=op.action)
+
+    ai.define_background_model(name='bg-model', start=start, check=check)
+    register_plain(ai)
+
+    response = await ai.generate(model='plain', prompt='a cat', use=[Reroute(to='bg-model')])
+    assert_ticket(response)
+
+    updated = await ai.check_operation(response.operation)
+    assert updated.id == 'bg-op-123'
+    assert updated.done is True
+    assert updated.action == '/background-model/bg-model'
+
+
+@pytest.mark.asyncio
+async def test_wrap_generate_on_resume_sees_the_model_message_and_resume(ai: Genkit) -> None:
+    """On a resume turn the hook sees the model message and resume, once."""
+    register_plain(ai)
+    seen: list[dict[str, object]] = []
+
+    class ResumeSpy(BaseMiddleware):
+        async def wrap_generate(
+            self,
+            params: GenerateHookParams,
+            ctx: GenerateMiddlewareContext,
+            next_fn: Callable[[GenerateHookParams, GenerateMiddlewareContext], Awaitable[ModelResponse]],
+        ) -> ModelResponse:
+            messages = params.options.messages
+            seen.append({
+                'iteration': params.iteration,
+                'last_role': messages[-1].role if messages else None,
+                'has_resume': params.options.resume is not None,
+            })
+            return await next_fn(params, ctx)
+
+    response = await ai.generate(
+        model='plain',
+        messages=interrupted_history(),
+        resume_respond=[respond_ping()],
+        use=[ResumeSpy()],
+    )
+
+    assert_chat(response, text='from-plain', roles=[Role.USER, Role.MODEL, Role.TOOL, Role.MODEL])
+    assert seen == [{'iteration': 0, 'last_role': Role.MODEL, 'has_resume': True}]
+
+
+@pytest.mark.asyncio
+async def test_wrap_generate_short_circuit_skips_a_missing_model(ai: Genkit) -> None:
+    """A hook that returns without next never resolves the original name."""
+
+    class ReturnsFlashWithoutNext(BaseMiddleware):
+        async def wrap_generate(
+            self,
+            params: GenerateHookParams,
+            ctx: GenerateMiddlewareContext,
+            next_fn: Callable[[GenerateHookParams, GenerateMiddlewareContext], Awaitable[ModelResponse]],
+        ) -> ModelResponse:
+            return ModelResponse(
+                message=Message(role=Role.MODEL, content=[Part(root=TextPart(text='FLASH'))]),
+                finish_reason=FinishReason.STOP,
+            )
+
+    response = await ai.generate(model='no-such-model', prompt='hi', use=[ReturnsFlashWithoutNext()])
+
+    assert_chat(response, text='FLASH')
+
+
+@pytest.mark.asyncio
+async def test_generate_operation_swap_from_flash_is_not_long_running(ai: Genkit) -> None:
+    """generate_operation gates on the name they passed. A swap to Veo never runs."""
+    register_plain(ai, name='flash', text='from-flash')
+    register_bg_model(ai)
+
+    with pytest.raises(GenkitError, match='does not support long running operations') as raised:
+        await ai.generate_operation(model='flash', prompt='a cat', use=[Reroute(to='bg-model')])
+
+    assert raised.value.status == 'INVALID_ARGUMENT'
+
+
+@pytest.mark.asyncio
+async def test_generate_operation_swap_from_video_to_flash_is_missing_operation(ai: Genkit) -> None:
+    """generate_operation on Veo plus a swap to flash runs flash, then wants a ticket."""
+    register_bg_model(ai)
+    register_plain(ai)
+
+    with pytest.raises(GenkitError, match='did not return an operation') as raised:
+        await ai.generate_operation(model='bg-model', prompt='a cat', use=[Reroute(to='plain')])
+
+    assert raised.value.status == 'FAILED_PRECONDITION'


### PR DESCRIPTION
## Summary

`wrap_generate` can set `params.options.model`. That edit used to be a silent no-op: the model action was bound before the hook ran. Tools already re-resolved from `params.options`; the model did not.

The hook now runs first. Then we resolve that name once. The string middleware wrote is the action that runs.

```python
class Reroute(BaseMiddleware[RerouteConfig]):
    async def wrap_generate(self, params, ctx, next_fn):
        options = params.options.model_copy(update={'model': self.config.to})
        return await next_fn(params.model_copy(update={'options': options}), ctx)

# before: still runs flash; text is 'from-flash'; no ticket
# after: starts Veo; response.operation.id is set; text is ''
await ai.generate(model='flash', prompt='a cat', use=[Reroute(to='veo')])

# before: still calls start(); operation set; text is ''
# after: runs flash; text is 'from-flash'; no ticket
await ai.generate(model='veo', prompt='a cat', use=[Reroute(to='flash')])
```

Same for flash→pro. A swap to an unregistered name is `NOT_FOUND` at resolve. A swap from a missing original name to a real one runs the real model (the original name is never resolved). `params.options.model = 'pro'` in place is the same swap.

`resolve_model` already finds either a chat action (`ModelResponse`) or a background `start()` (`Operation`). The annotation said `ModelResponse` only. It now says `ModelResponse | Operation`.

## Decisions

- **The name middleware wrote is the action that runs.** `wrap_generate` runs, then we resolve `params.options.model` once. There is not a second bind inside the iteration.
- **Resume-on-background is judged on that same action, before resume stitching.** A video start cannot finish an interrupted tool turn. If the hook left the name on Veo, we raise `FAILED_PRECONDITION` and a `resume_restart` tool does not run. If the hook swapped off Veo, we stitch, the tool may run, and the chat model continues.
- **`generate_operation` still gates on the name they passed.** `generate_operation(model='flash', use=[Reroute(to='veo')])` is `INVALID_ARGUMENT` (flash is not long-running). `generate_operation(model='veo', use=[Reroute(to='flash')])` runs flash, then `FAILED_PRECONDITION` (no ticket). The swap is an `ai.generate` / `ai.generate_stream` product.