### PR TITLE
feat(py): Google AI Interactions HTTP client and converters

### DIFF
--- a/py/packages/genkit-google-genai/pyproject.toml
+++ b/py/packages/genkit-google-genai/pyproject.toml
@@ -45,7 +45,7 @@ classifiers = [
 ]
 dependencies = [
   "genkit",
-  "google-genai>=1.63.0",
+  "google-genai>=2.14.0,<3",
   "google-cloud-aiplatform>=1.77.0",
   "structlog>=25.2.0",
   "strenum>=0.4.15; python_version < '3.11'",

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/_interactions/client.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/_interactions/client.py
@@ -1,0 +1,260 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Raw HTTP helpers for the Google AI Interactions API."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
+from typing import cast
+from urllib.parse import quote
+
+import httpx
+from genkit_google_genai._interactions.options import ClientOptions
+from google.genai.interactions import Interaction
+
+from genkit import GenkitError
+from genkit._core._error import ErrorResponseMetadata, StatusName
+from genkit._core._logger import get_logger
+from genkit.plugin_api import GENKIT_CLIENT_HEADER, get_cached_client
+
+logger = get_logger(__name__)
+
+DEFAULT_API_VERSION = 'v1beta'
+DEFAULT_BASE_URL = 'https://generativelanguage.googleapis.com'
+API_REVISION = '2026-05-20'
+# Creates can run far longer than the shared client's 60s default. No read
+# timeout, but keep a connect budget so a hung handshake doesn't sit forever.
+CACHE_KEY = 'googleai-interactions'
+NO_TIMEOUT = httpx.Timeout(None, connect=10.0)
+RESERVED_HEADERS = ('x-goog-api-key', 'x-goog-api-client')
+
+
+def google_ai_url(
+    resource_path: str,
+    *,
+    client_options: ClientOptions | None = None,
+) -> str:
+    """Build a Google AI REST URL for the given resource path."""
+    opts = client_options or ClientOptions()
+    api_version = opts.api_version or DEFAULT_API_VERSION
+    base_url = (opts.base_url or DEFAULT_BASE_URL).rstrip('/')
+    return f'{base_url}/{api_version}/{resource_path}'
+
+
+def headers(*, api_key: str, client_options: ClientOptions | None) -> dict[str, str]:
+    """Build request headers; api key and Genkit client attribution win over custom.
+
+    Header names are matched case-insensitively so ``X-Goog-Api-Key`` cannot
+    sneak a second key onto the request.
+    """
+    custom = httpx.Headers((client_options or ClientOptions()).custom_headers or {})
+    for name in RESERVED_HEADERS:
+        custom.pop(name, None)
+    custom['Content-Type'] = 'application/json'
+    custom['x-goog-api-client'] = GENKIT_CLIENT_HEADER
+    custom['Api-Revision'] = API_REVISION
+    custom['x-goog-api-key'] = api_key
+    return {key: value for key, value in custom.items()}
+
+
+def timeout_seconds(client_options: ClientOptions | None) -> float | None:
+    """Convert ClientOptions.timeout (milliseconds) to httpx seconds."""
+    opts = client_options or ClientOptions()
+    if opts.timeout is not None and opts.timeout >= 0:
+        return opts.timeout / 1000.0
+    return None
+
+
+def parse_retry_after_ms(value: str | None) -> float | None:
+    """Read a Retry-After header, which may be a delay in seconds or an HTTP date."""
+    if not value or not value.strip():
+        return None
+    try:
+        seconds = float(value)
+    except ValueError:
+        seconds = -1.0
+    if seconds >= 0:
+        return seconds * 1000
+    try:
+        retry_at = parsedate_to_datetime(value)
+    except (TypeError, ValueError, OverflowError):
+        return None
+    if retry_at.tzinfo is None:
+        retry_at = retry_at.replace(tzinfo=timezone.utc)
+    return max(0.0, (retry_at - datetime.now(timezone.utc)).total_seconds() * 1000)
+
+
+def status_for_http_code(status_code: int) -> StatusName:
+    """Map an HTTP status onto the Genkit error status callers switch on."""
+    match status_code:
+        case 429:
+            return 'RESOURCE_EXHAUSTED'
+        case 400:
+            return 'INVALID_ARGUMENT'
+        case 401:
+            return 'UNAUTHENTICATED'
+        case 403:
+            return 'PERMISSION_DENIED'
+        case 404:
+            return 'NOT_FOUND'
+        case 499:
+            return 'CANCELLED'
+        case 500:
+            return 'INTERNAL'
+        case 503:
+            return 'UNAVAILABLE'
+        case _:
+            return 'UNKNOWN'
+
+
+async def create_interaction(
+    api_key: str,
+    body: dict[str, object],
+    client_options: ClientOptions | None = None,
+) -> Interaction:
+    """POST /interactions and return the parsed Interaction."""
+    url = google_ai_url('interactions', client_options=client_options)
+    return await request(
+        method='POST',
+        url=url,
+        api_key=api_key,
+        client_options=client_options,
+        json_body=body,
+    )
+
+
+async def get_interaction(
+    api_key: str,
+    interaction_id: str,
+    client_options: ClientOptions | None = None,
+) -> Interaction:
+    """GET /interactions/{id} and return the parsed Interaction."""
+    url = google_ai_url(f'interactions/{quote(interaction_id, safe="")}', client_options=client_options)
+    return await request(
+        method='GET',
+        url=url,
+        api_key=api_key,
+        client_options=client_options,
+    )
+
+
+async def cancel_interaction(
+    api_key: str,
+    interaction_id: str,
+    client_options: ClientOptions | None = None,
+) -> Interaction:
+    """POST /interactions/{id}/cancel and return a cancelled Interaction."""
+    url = google_ai_url(f'interactions/{quote(interaction_id, safe="")}/cancel', client_options=client_options)
+    try:
+        await request(
+            method='POST',
+            url=url,
+            api_key=api_key,
+            client_options=client_options,
+        )
+        # Successful cancel often surfaces as CANCELLED; normalize both paths.
+        raise GenkitError(status='CANCELLED', message='successfully cancelled')
+    except GenkitError as error:
+        if error.status == 'CANCELLED':
+            return Interaction.model_validate({'id': interaction_id, 'status': 'cancelled'})
+        raise
+
+
+async def request(
+    *,
+    method: str,
+    url: str,
+    api_key: str,
+    client_options: ClientOptions | None,
+    json_body: dict[str, object] | None = None,
+) -> Interaction:
+    """Issue one Interactions HTTP call and parse the Interaction body."""
+    # Auth/key headers are per-request; the loop-local client is just the transport.
+    client = get_cached_client(cache_key=CACHE_KEY, timeout=NO_TIMEOUT)
+    request_headers = headers(api_key=api_key, client_options=client_options)
+    timeout = timeout_seconds(client_options)
+
+    try:
+        if timeout is not None:
+            response = await client.request(
+                method,
+                url,
+                headers=request_headers,
+                json=json_body,
+                timeout=timeout,
+            )
+        else:
+            response = await client.request(
+                method,
+                url,
+                headers=request_headers,
+                json=json_body,
+            )
+    except httpx.TimeoutException as error:
+        raise GenkitError(
+            status='DEADLINE_EXCEEDED',
+            message=f'Request to {url} exceeded the configured timeout: {error}',
+        ) from error
+    except GenkitError:
+        raise
+    except Exception as error:
+        logger.exception('Interactions request failed')
+        raise GenkitError(
+            status='UNKNOWN',
+            message=f'Unable to complete request to {url}: {error}',
+        ) from error
+
+    if response.is_success:
+        if not response.content:
+            raise GenkitError(
+                status='INTERNAL',
+                message=f'Received an empty response from {url}',
+            )
+        try:
+            return Interaction.model_validate(response.json())
+        except Exception as error:
+            raise GenkitError(
+                status='INTERNAL',
+                message=f'Unable to parse Interaction response from {url}: {error}',
+            ) from error
+
+    error_message = response.text
+    error_detail: object | None = None
+    try:
+        payload: object = response.json()
+        error_detail = payload
+        if isinstance(payload, Mapping):
+            api_error = payload.get('error')
+            if isinstance(api_error, Mapping) and api_error.get('message') is not None:
+                error_message = str(api_error['message'])
+    except json.JSONDecodeError:
+        pass
+
+    retry_after_ms = parse_retry_after_ms(response.headers.get('retry-after'))
+    response_metadata: ErrorResponseMetadata | None = None
+    if retry_after_ms is not None:
+        response_metadata = cast(ErrorResponseMetadata, {'retry_after_ms': retry_after_ms})
+
+    raise GenkitError(
+        status=status_for_http_code(response.status_code),
+        message=(f'Request to {url} failed with HTTP {response.status_code} {response.reason_phrase}: {error_message}'),
+        details=error_detail,
+        response_metadata=response_metadata,
+    )

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/_interactions/client.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/_interactions/client.py
@@ -131,13 +131,15 @@ async def create_interaction(
 ) -> Interaction:
     """POST /interactions and return the parsed Interaction."""
     url = google_ai_url('interactions', client_options=client_options)
-    return await request(
+    created = await request(
         method='POST',
         url=url,
         api_key=api_key,
         client_options=client_options,
         json_body=body,
     )
+    assert created is not None
+    return created
 
 
 async def get_interaction(
@@ -147,12 +149,14 @@ async def get_interaction(
 ) -> Interaction:
     """GET /interactions/{id} and return the parsed Interaction."""
     url = google_ai_url(f'interactions/{quote(interaction_id, safe="")}', client_options=client_options)
-    return await request(
+    found = await request(
         method='GET',
         url=url,
         api_key=api_key,
         client_options=client_options,
     )
+    assert found is not None
+    return found
 
 
 async def cancel_interaction(
@@ -163,18 +167,20 @@ async def cancel_interaction(
     """POST /interactions/{id}/cancel and return a cancelled Interaction."""
     url = google_ai_url(f'interactions/{quote(interaction_id, safe="")}/cancel', client_options=client_options)
     try:
-        await request(
+        interaction = await request(
             method='POST',
             url=url,
             api_key=api_key,
             client_options=client_options,
+            allow_empty=True,
         )
-        # Successful cancel often surfaces as CANCELLED; normalize both paths.
-        raise GenkitError(status='CANCELLED', message='successfully cancelled')
     except GenkitError as error:
         if error.status == 'CANCELLED':
             return Interaction.model_validate({'id': interaction_id, 'status': 'cancelled'})
         raise
+    if interaction is None:
+        return Interaction.model_validate({'id': interaction_id, 'status': 'cancelled'})
+    return interaction.model_copy(update={'status': 'cancelled'})
 
 
 async def request(
@@ -184,7 +190,8 @@ async def request(
     api_key: str,
     client_options: ClientOptions | None,
     json_body: dict[str, object] | None = None,
-) -> Interaction:
+    allow_empty: bool = False,
+) -> Interaction | None:
     """Issue one Interactions HTTP call and parse the Interaction body."""
     # Auth/key headers are per-request; the loop-local client is just the transport.
     client = get_cached_client(cache_key=CACHE_KEY, timeout=NO_TIMEOUT)
@@ -223,6 +230,8 @@ async def request(
 
     if response.is_success:
         if not response.content:
+            if allow_empty:
+                return None
             raise GenkitError(
                 status='INTERNAL',
                 message=f'Received an empty response from {url}',

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/_interactions/client.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/_interactions/client.py
@@ -20,8 +20,6 @@ from __future__ import annotations
 
 import json
 from collections.abc import Mapping
-from datetime import datetime, timezone
-from email.utils import parsedate_to_datetime
 from typing import cast
 from urllib.parse import quote
 
@@ -30,9 +28,14 @@ from genkit_google_genai._interactions.options import ClientOptions
 from google.genai.interactions import Interaction
 
 from genkit import GenkitError
-from genkit._core._error import ErrorResponseMetadata, StatusName
+from genkit._core._error import ErrorResponseMetadata
 from genkit._core._logger import get_logger
-from genkit.plugin_api import GENKIT_CLIENT_HEADER, get_cached_client
+from genkit.plugin_api import (
+    GENKIT_CLIENT_HEADER,
+    from_http_code,
+    get_cached_client,
+    parse_retry_after_ms,
+)
 
 logger = get_logger(__name__)
 
@@ -71,7 +74,7 @@ def headers(*, api_key: str, client_options: ClientOptions | None) -> dict[str, 
     custom['x-goog-api-client'] = GENKIT_CLIENT_HEADER
     custom['Api-Revision'] = API_REVISION
     custom['x-goog-api-key'] = api_key
-    return {key: value for key, value in custom.items()}
+    return dict(custom)
 
 
 def timeout_seconds(client_options: ClientOptions | None) -> float | None:
@@ -80,48 +83,6 @@ def timeout_seconds(client_options: ClientOptions | None) -> float | None:
     if opts.timeout is not None and opts.timeout >= 0:
         return opts.timeout / 1000.0
     return None
-
-
-def parse_retry_after_ms(value: str | None) -> float | None:
-    """Read a Retry-After header, which may be a delay in seconds or an HTTP date."""
-    if not value or not value.strip():
-        return None
-    try:
-        seconds = float(value)
-    except ValueError:
-        seconds = -1.0
-    if seconds >= 0:
-        return seconds * 1000
-    try:
-        retry_at = parsedate_to_datetime(value)
-    except (TypeError, ValueError, OverflowError):
-        return None
-    if retry_at.tzinfo is None:
-        retry_at = retry_at.replace(tzinfo=timezone.utc)
-    return max(0.0, (retry_at - datetime.now(timezone.utc)).total_seconds() * 1000)
-
-
-def status_for_http_code(status_code: int) -> StatusName:
-    """Map an HTTP status onto the Genkit error status callers switch on."""
-    match status_code:
-        case 429:
-            return 'RESOURCE_EXHAUSTED'
-        case 400:
-            return 'INVALID_ARGUMENT'
-        case 401:
-            return 'UNAUTHENTICATED'
-        case 403:
-            return 'PERMISSION_DENIED'
-        case 404:
-            return 'NOT_FOUND'
-        case 499:
-            return 'CANCELLED'
-        case 500:
-            return 'INTERNAL'
-        case 503:
-            return 'UNAVAILABLE'
-        case _:
-            return 'UNKNOWN'
 
 
 async def create_interaction(
@@ -256,13 +217,14 @@ async def request(
     except json.JSONDecodeError:
         pass
 
-    retry_after_ms = parse_retry_after_ms(response.headers.get('retry-after'))
+    retry_after_header = response.headers.get('retry-after')
+    retry_after_ms = parse_retry_after_ms(retry_after_header) if retry_after_header else None
     response_metadata: ErrorResponseMetadata | None = None
     if retry_after_ms is not None:
         response_metadata = cast(ErrorResponseMetadata, {'retry_after_ms': retry_after_ms})
 
     raise GenkitError(
-        status=status_for_http_code(response.status_code),
+        status=from_http_code(response.status_code),
         message=(f'Request to {url} failed with HTTP {response.status_code} {response.reason_phrase}: {error_message}'),
         details=error_detail,
         response_metadata=response_metadata,

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/_interactions/converters.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/_interactions/converters.py
@@ -1,0 +1,826 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Converters between Genkit message parts and Interactions API wire shapes."""
+
+from __future__ import annotations
+
+import copy
+import json
+import logging
+from typing import Any, Literal, cast
+
+from genkit_google_genai._interactions.options import ClientOptions
+from google.genai.interactions import (
+    AudioContent,
+    CodeExecutionCallStep,
+    CodeExecutionCallStepParam,
+    CodeExecutionResultStep,
+    CodeExecutionResultStepParam,
+    Content,
+    ContentParam,
+    DocumentContent,
+    FunctionCallStep,
+    FunctionCallStepParam,
+    FunctionParam,
+    FunctionResultStep,
+    FunctionResultStepParam,
+    FunctionResultStepResultUnionParam,
+    GoogleSearchCallStep,
+    GoogleSearchCallStepParam,
+    GoogleSearchResultStep,
+    GoogleSearchResultStepParam,
+    ImageContent,
+    Interaction,
+    ModelOutputStep,
+    ModelOutputStepParam,
+    Step,
+    StepParam,
+    TextContent,
+    TextContentParam,
+    ThoughtStep,
+    ThoughtStepParam,
+    UnknownContent,
+    Usage,
+    UserInputStep,
+    UserInputStepParam,
+    VideoContent,
+)
+from pydantic import BaseModel
+
+from genkit import (
+    CustomPart,
+    GenkitError,
+    Media,
+    MediaPart,
+    Part,
+    ReasoningPart,
+    TextPart,
+    ToolRequest,
+    ToolRequestPart,
+    ToolResponse,
+    ToolResponsePart,
+)
+from genkit.model import Error, FinishReason, Message, ModelResponse, ModelUsage, Operation, ToolDefinition
+
+logger = logging.getLogger(__name__)
+
+InteractionRole = Literal['user', 'model']
+
+# Keys we round-trip through Genkit custom parts and metadata for wire concepts
+# Genkit has no first-class part for. Both directions read them, so a typo in
+# one place would silently break pairing — keep them defined once.
+THOUGHT_SIGNATURE = 'thoughtSignature'
+CALL_ID = 'callId'
+GOOGLE_SEARCH_CALL = 'googleSearchCall'
+GOOGLE_SEARCH_RESULT = 'googleSearchResult'
+EXECUTABLE_CODE = 'executableCode'
+CODE_EXECUTION_RESULT = 'codeExecutionResult'
+UNKNOWN_STEP = 'unknownStep'
+SERVER_FUNCTION_RESULT = 'serverFunctionResult'
+THOUGHT_CUSTOM = 'thought'
+# Wire function_result.content is only text/image blocks, not a JSON array.
+CONTENT_BLOCK_TYPES = frozenset({'text', 'image'})
+# Code execution only ever runs Python, and the wire rejects any other value.
+CODE_LANGUAGE: Literal['python'] = 'python'
+
+FAILED_MESSAGE = 'Interaction failed'
+
+# Interactions splits media into typed content blocks, chosen by mime prefix.
+MEDIA_CONTENT_TYPES: tuple[tuple[str, str], ...] = (
+    ('image/', 'image'),
+    ('audio/', 'audio'),
+    ('video/', 'video'),
+    ('application/pdf', 'document'),
+)
+
+# Turns a Genkit role into the side of the transcript it belongs on. Tool
+# results are part of the user's side; system prompts aren't turns at all.
+INTERACTION_ROLES: dict[str, InteractionRole] = {
+    'user': 'user',
+    'model': 'model',
+    'tool': 'user',
+}
+
+# Terminal statuses that can still carry partial output worth surfacing.
+PARTIAL_TERMINAL_STATUSES: dict[str, tuple[FinishReason, str]] = {
+    'incomplete': (FinishReason.LENGTH, 'Interaction incomplete (truncated output)'),
+    'budget_exceeded': (FinishReason.ABORTED, 'Interaction exceeded its budget'),
+}
+
+
+def interaction_error_message(interaction: Interaction) -> str | None:
+    """Read the failure message a failed Interaction reports on its output step."""
+    for step in interaction.steps or []:
+        if isinstance(step, ModelOutputStep) and step.error is not None and step.error.message:
+            return step.error.message
+    return None
+
+
+def clean_schema(schema: dict[str, Any]) -> dict[str, Any]:
+    """Strip schema keys the Interactions API rejects."""
+    out = copy.deepcopy(schema)
+    for key in list(out):
+        if key in ('$schema', 'additionalProperties'):
+            del out[key]
+            continue
+        value = out[key]
+        if isinstance(value, dict):
+            out[key] = clean_schema(value)
+        elif isinstance(value, list):
+            if key == 'type':
+                out[key] = next((item for item in value if item != 'null'), value[0] if value else value)
+            else:
+                out[key] = [clean_schema(item) if isinstance(item, dict) else item for item in value]
+    return out
+
+
+def ensure_tool_ids(messages: list[Message]) -> list[Message]:
+    """Assign stable tool call IDs so wire payloads stay pairable."""
+    generated_ids: list[str] = []
+    next_id_counter = 0
+
+    new_messages = [message.model_copy(deep=True) for message in messages]
+
+    for message in new_messages:
+        for part in message.content:
+            root = part.root
+            if isinstance(root, ToolRequestPart) and root.tool_request and not root.tool_request.ref:
+                new_id = f'genkit-auto-id-{next_id_counter}'
+                next_id_counter += 1
+                root.tool_request.ref = new_id
+                generated_ids.append(new_id)
+
+    # Responses without refs reuse request IDs in order; unmatched ones get orphan IDs.
+    for message in new_messages:
+        for part in message.content:
+            root = part.root
+            if isinstance(root, ToolResponsePart) and root.tool_response and not root.tool_response.ref:
+                matched_id = generated_ids.pop(0) if generated_ids else None
+                if matched_id:
+                    root.tool_response.ref = matched_id
+                else:
+                    root.tool_response.ref = f'genkit-orphan-id-{next_id_counter}'
+                    next_id_counter += 1
+
+    return new_messages
+
+
+def to_interaction_tool(tool: ToolDefinition) -> FunctionParam:
+    """Convert a Genkit tool definition to an Interactions function tool."""
+    func: FunctionParam = {
+        'type': 'function',
+        'name': tool.name,
+    }
+    if tool.description is not None:
+        func['description'] = tool.description
+    if tool.input_schema is not None:
+        if isinstance(tool.input_schema, dict):
+            func['parameters'] = clean_schema(tool.input_schema)
+        else:
+            func['parameters'] = clean_schema(dict(tool.input_schema))
+    return func
+
+
+def to_interaction_content(part: Part) -> ContentParam | None:
+    """Convert a Genkit part to an Interactions content block."""
+    root = part.root
+    if isinstance(root, TextPart):
+        text: TextContentParam = {'type': 'text', 'text': root.text}
+        return text
+    if isinstance(root, MediaPart) and root.media is not None:
+        return to_interaction_media(root)
+    logger.warning('Unsupported part type for Interaction input: %s', part.model_dump(by_alias=True))
+    return None
+
+
+def to_interaction_media(part: MediaPart) -> ContentParam:
+    """Convert a media part to an Interactions image/audio/video/document block."""
+    if part.media is None:
+        raise ValueError('Media part missing media')
+    content_type = part.media.content_type
+    if not content_type:
+        raise ValueError('Media part missing contentType')
+    block_type = next((name for prefix, name in MEDIA_CONTENT_TYPES if content_type.startswith(prefix)), None)
+    if block_type is None:
+        raise ValueError(f'Unsupported media type: {content_type}')
+
+    block: dict[str, Any] = {'type': block_type, 'mime_type': content_type}
+    # Inline data URLs travel as base64; anything else is a reference the API fetches.
+    url = part.media.url
+    if url.startswith('data:'):
+        if ',' not in url:
+            raise ValueError('Malformed data URL for media part: missing payload separator')
+        block['data'] = url.split(',', 1)[1]
+    else:
+        block['uri'] = url
+    return cast(ContentParam, block)
+
+
+def to_interaction_role(role: str) -> InteractionRole:
+    """Map a Genkit message role to the Interactions API role."""
+    if role == 'system':
+        raise ValueError('System role should be handled as system_instruction, not part of turns.')
+    return INTERACTION_ROLES.get(role, 'user')
+
+
+def split_system_instruction(messages: list[Message]) -> tuple[str | None, list[Message]]:
+    """Lift system turns out of the transcript into the interaction's instruction.
+
+    An interaction carries one system instruction that governs the whole thing
+    rather than a turn in the tape, so however many system messages a prompt
+    has, they fold into a single block of text ahead of the conversation.
+    """
+    instructions: list[str] = []
+    turns: list[Message] = []
+    for message in messages:
+        if message.role != 'system':
+            turns.append(message)
+            continue
+        if any(not isinstance(part.root, TextPart) for part in message.content):
+            logger.warning('Dropping non-text content from a system message; system instructions are text only.')
+        if message.text:
+            instructions.append(message.text)
+    return '\n\n'.join(instructions) or None, turns
+
+
+def with_signature(step: StepParam, metadata: dict[str, Any]) -> StepParam:
+    """Carry a thought signature from part metadata back onto its step."""
+    signature = metadata.get(THOUGHT_SIGNATURE)
+    if signature is not None:
+        cast(dict[str, Any], step)['signature'] = signature
+    return step
+
+
+def to_function_call_step(request: ToolRequest) -> FunctionCallStepParam:
+    """Compile a Genkit tool request into a function_call step.
+
+    Arguments on the wire are a JSON object. A scalar like ``'Paris'`` would
+    silently become ``{}`` and the model would see a different call than the
+    one the caller made.
+    """
+    args = request.input
+    if args is None:
+        args = {}
+    elif not isinstance(args, dict):
+        raise GenkitError(
+            status='INVALID_ARGUMENT',
+            message=(
+                'Tool request input must be a JSON object (got '
+                f'{type(args).__name__}). Wrap scalars as '
+                "{'city': 'Paris'} rather than passing a bare string."
+            ),
+        )
+    return {
+        'type': 'function_call',
+        'name': request.name,
+        'arguments': args,
+        'id': request.ref or '',
+    }
+
+
+def is_content_block_list(value: object) -> bool:
+    """True when value is a non-empty list of text/image content blocks."""
+    if not isinstance(value, list) or not value:
+        return False
+    for item in value:
+        if not isinstance(item, dict):
+            return False
+        block = cast(dict[str, object], item)
+        if block.get('type') not in CONTENT_BLOCK_TYPES:
+            return False
+    return True
+
+
+def metadata_flag(metadata: dict[str, Any] | None, *keys: str) -> object:
+    """Read the first present metadata key (camelCase or snake_case)."""
+    if not metadata:
+        return None
+    for key in keys:
+        if key in metadata:
+            return metadata[key]
+    return None
+
+
+def to_function_result_step(
+    response: ToolResponse,
+    metadata: dict[str, Any] | None = None,
+) -> FunctionResultStepParam:
+    """Compile a Genkit tool response into a function_result step.
+
+    Ordinary JSON arrays (``[1, 2]``) are not multimodal content — they
+    have to be boxed. Only a list of text/image blocks goes on the wire as
+    content. A failed result keeps ``is_error`` so the model sees the miss.
+    """
+    output = response.output
+    if isinstance(output, (str, dict)):
+        result = cast(FunctionResultStepResultUnionParam, output)
+    elif is_content_block_list(output):
+        result = cast(FunctionResultStepResultUnionParam, output)
+    elif output is None:
+        result = cast(FunctionResultStepResultUnionParam, {})
+    else:
+        result = cast(FunctionResultStepResultUnionParam, {'result': output})
+    step: FunctionResultStepParam = {
+        'type': 'function_result',
+        'name': response.name,
+        'result': result,
+        'call_id': response.ref or '',
+    }
+    if metadata_flag(metadata, 'isError', 'is_error'):
+        step['is_error'] = True
+    return step
+
+
+def thought_from_custom(custom: dict[str, Any] | None) -> StepParam | None:
+    """Replay a thought step that was stashed on the part, images and all.
+
+    Rebuilding from ``reasoning`` would drop image summaries and the
+    signature the next turn needs to continue the same thought.
+    """
+    if not custom:
+        return None
+    thought = custom.get(THOUGHT_CUSTOM)
+    if isinstance(thought, dict) and thought.get('type') == 'thought':
+        return cast(StepParam, copy.deepcopy(thought))
+    return None
+
+
+def to_thought_step(part: ReasoningPart) -> StepParam:
+    """Compile a Genkit reasoning part into a thought step."""
+    original = thought_from_custom(part.custom)
+    if original is not None:
+        return original
+    thought: ThoughtStepParam = {
+        'type': 'thought',
+        'summary': [{'type': 'text', 'text': part.reasoning}],
+    }
+    return with_signature(thought, part.metadata or {})
+
+
+def to_server_function_result_step(payload: dict[str, Any]) -> FunctionResultStepParam:
+    """Replay a function_result that was stashed as custom, including is_error."""
+    step: FunctionResultStepParam = {
+        'type': 'function_result',
+        'name': payload.get('name') or '',
+        'result': cast(FunctionResultStepResultUnionParam, payload.get('result')),
+        'call_id': payload.get('call_id') or payload.get('callId') or '',
+    }
+    if payload.get('is_error') or payload.get('isError'):
+        step['is_error'] = True
+    return step
+
+
+def to_server_tool_step(custom: dict[str, Any], metadata: dict[str, Any]) -> StepParam | None:
+    """Compile the custom parts that stand in for Google-side tool activity.
+
+    Search and code execution run on Google's side, so Genkit has no first-class
+    part for them and we round-trip them through custom parts instead.
+    """
+    if GOOGLE_SEARCH_CALL in custom:
+        call = custom[GOOGLE_SEARCH_CALL]
+        search_call: GoogleSearchCallStepParam = {
+            'type': 'google_search_call',
+            'id': call.get('id', ''),
+            'arguments': call.get('arguments'),
+        }
+        return search_call
+    if GOOGLE_SEARCH_RESULT in custom:
+        result = custom[GOOGLE_SEARCH_RESULT]
+        search_result: GoogleSearchResultStepParam = {
+            'type': 'google_search_result',
+            'call_id': result.get(CALL_ID, ''),
+            'result': result.get('result'),
+        }
+        return search_result
+    if EXECUTABLE_CODE in custom:
+        code = custom[EXECUTABLE_CODE]
+        code_call: CodeExecutionCallStepParam = {
+            'type': 'code_execution_call',
+            'id': metadata.get(CALL_ID, ''),
+            'arguments': {'code': code.get('code'), 'language': CODE_LANGUAGE},
+        }
+        return code_call
+    if CODE_EXECUTION_RESULT in custom:
+        code_result: CodeExecutionResultStepParam = {
+            'type': 'code_execution_result',
+            'call_id': metadata.get(CALL_ID, ''),
+            'result': custom[CODE_EXECUTION_RESULT].get('output'),
+        }
+        return code_result
+    return None
+
+
+def to_standalone_step(part: Part) -> StepParam | None:
+    """Return the step a part compiles to on its own, or None if it is inline content."""
+    root = part.root
+    if isinstance(root, ToolRequestPart) and root.tool_request:
+        return to_function_call_step(root.tool_request)
+    if isinstance(root, ToolResponsePart) and root.tool_response:
+        return to_function_result_step(root.tool_response, root.metadata)
+    if isinstance(root, ReasoningPart):
+        return to_thought_step(root)
+    if isinstance(root, CustomPart):
+        custom = root.custom or {}
+        original_thought = thought_from_custom(custom)
+        if original_thought is not None:
+            return original_thought
+        unknown = custom.get(UNKNOWN_STEP)
+        if isinstance(unknown, dict):
+            return cast(StepParam, copy.deepcopy(unknown))
+        server_result = custom.get(SERVER_FUNCTION_RESULT)
+        if isinstance(server_result, dict):
+            return to_server_function_result_step(server_result)
+        metadata = root.metadata or {}
+        step = to_server_tool_step(custom, metadata)
+        return with_signature(step, metadata) if step is not None else None
+    return None
+
+
+def to_content_step(role: InteractionRole, content: list[ContentParam]) -> StepParam:
+    """Wrap a turn's inline content in the step for whoever produced it."""
+    if role == 'model':
+        model_step: ModelOutputStepParam = {'type': 'model_output', 'content': content}
+        return model_step
+    user_step: UserInputStepParam = {'type': 'user_input', 'content': content}
+    return user_step
+
+
+def to_interaction_steps(messages: list[Message]) -> list[StepParam]:
+    """Convert Genkit messages to Interactions API steps.
+
+    Text and media collapse into a content step, but tool calls, thoughts,
+    and Google-side tool activity are steps of their own. Flush any buffered
+    inline content before those so mixed parts stay in message order — a
+    thought sitting between two sentences must not jump the first sentence
+    to the end of the turn.
+    """
+    steps: list[StepParam] = []
+    for message in messages:
+        role = to_interaction_role(message.role)
+        inline: list[ContentParam] = []
+
+        for part in message.content:
+            step = to_standalone_step(part)
+            if step is not None:
+                if inline:
+                    steps.append(to_content_step(role, list(inline)))
+                    inline.clear()
+                steps.append(step)
+                continue
+            content = to_interaction_content(part)
+            if content is not None:
+                inline.append(content)
+        if inline:
+            steps.append(to_content_step(role, inline))
+    return steps
+
+
+def with_metadata(part: Part, key: str, value: object) -> Part:
+    """Return a copy of the part carrying one more metadata entry."""
+    if not value:
+        return part
+    root = part.root
+    updated = root.model_copy(update={'metadata': {**(root.metadata or {}), key: value}})
+    return Part(updated)
+
+
+def plain(value: object) -> object:
+    """Unwrap SDK models into plain data so parts stay JSON-serializable."""
+    if isinstance(value, BaseModel):
+        return value.model_dump(mode='python')
+    if isinstance(value, list):
+        return [plain(item) for item in value]
+    return value
+
+
+def server_tool_part(key: str, payload: dict[str, Any], *, signature: str | None, call_id: str | None = None) -> Part:
+    """Wrap Google-side tool activity in the custom part Genkit round-trips."""
+    part = Part(CustomPart(custom={key: payload}, metadata={CALL_ID: call_id} if call_id else None))
+    return with_metadata(part, THOUGHT_SIGNATURE, signature)
+
+
+def from_google_search_call(step: GoogleSearchCallStep) -> Part:
+    """Convert a google_search_call step to a Genkit custom part."""
+    return server_tool_part(
+        GOOGLE_SEARCH_CALL,
+        {'id': step.id, 'arguments': plain(step.arguments)},
+        signature=step.signature,
+    )
+
+
+def from_google_search_result(step: GoogleSearchResultStep) -> Part:
+    """Convert a google_search_result step to a Genkit custom part."""
+    return server_tool_part(
+        GOOGLE_SEARCH_RESULT,
+        {CALL_ID: step.call_id, 'result': plain(step.result or [])},
+        signature=step.signature,
+    )
+
+
+def from_code_execution_call(step: CodeExecutionCallStep) -> Part:
+    """Convert a code_execution_call step to a Genkit custom part."""
+    arguments = step.arguments
+    return server_tool_part(
+        EXECUTABLE_CODE,
+        {
+            'code': arguments.code if arguments else None,
+            'language': (arguments.language if arguments else None) or CODE_LANGUAGE,
+        },
+        signature=step.signature,
+        call_id=step.id,
+    )
+
+
+def from_code_execution_result(step: CodeExecutionResultStep) -> Part:
+    """Convert a code_execution_result step to a Genkit custom part."""
+    result = step.result
+    return server_tool_part(
+        CODE_EXECUTION_RESULT,
+        {
+            'output': result if isinstance(result, str) else json.dumps(result),
+            'outcome': 'OUTCOME_OK',
+        },
+        signature=step.signature,
+        call_id=step.call_id,
+    )
+
+
+def from_function_call_step(step: FunctionCallStep) -> Part:
+    """Convert a function_call step to a Genkit tool request part.
+
+    Fresh create/get steps with client tool calls are pending work for Genkit's
+    tool loop, so they use ToolRequestPart — not an opaque custom blob.
+    """
+    return Part(
+        ToolRequestPart(
+            tool_request=ToolRequest(
+                name=step.name or '',
+                input=plain(step.arguments) if step.arguments is not None else {},
+                ref=step.id,
+            )
+        )
+    )
+
+
+def from_function_result_step(step: FunctionResultStep) -> Part:
+    """Stash a function_result as custom — never a ToolResponsePart.
+
+    The API echoes the client's own tool result back on the model tape.
+    Putting that on a ToolResponsePart would send it again next turn.
+    """
+    return Part(
+        CustomPart(
+            custom={
+                SERVER_FUNCTION_RESULT: {
+                    'name': step.name or '',
+                    'result': plain(step.result),
+                    'call_id': step.call_id,
+                    'is_error': step.is_error,
+                }
+            }
+        )
+    )
+
+
+def from_media_content(content: ImageContent | AudioContent | DocumentContent | VideoContent) -> MediaPart:
+    """Convert wire media content to a Genkit media part."""
+    url = content.uri
+    if content.data and content.mime_type:
+        url = f'data:{content.mime_type};base64,{content.data}'
+    return MediaPart(media=Media(url=url or '', content_type=content.mime_type))
+
+
+def from_text_content(content: TextContent) -> Part:
+    """Convert wire text content to a Genkit text part."""
+    # Empty annotations still show up in metadata so round-trips stay stable.
+    return Part(
+        TextPart(
+            text=content.text or '',
+            metadata={'annotations': content.annotations},
+        )
+    )
+
+
+def from_visual_content(content: ImageContent | VideoContent) -> Part:
+    """Convert wire image or video content, keeping the resolution it came back at."""
+    return with_metadata(Part(from_media_content(content)), 'resolution', content.resolution)
+
+
+def from_thought_step(step: ThoughtStep) -> Part:
+    """Convert a thought step to a Genkit reasoning part."""
+    summary = step.summary or []
+    reasoning = '\n'.join(item.text or '' if isinstance(item, TextContent) else '[Image]' for item in summary)
+    return Part(
+        ReasoningPart(
+            reasoning=reasoning,
+            metadata={THOUGHT_SIGNATURE: step.signature},
+            custom={THOUGHT_CUSTOM: step.model_dump(mode='python')},
+        )
+    )
+
+
+def from_interaction_content(content: Content) -> Part:
+    """Convert an Interactions content block back to a Genkit part."""
+    if isinstance(content, TextContent):
+        return from_text_content(content)
+    if isinstance(content, (ImageContent, VideoContent)):
+        return from_visual_content(content)
+    if isinstance(content, (AudioContent, DocumentContent)):
+        return Part(from_media_content(content))
+    if isinstance(content, UnknownContent):
+        return Part(CustomPart(custom={'unknownContent': content.model_dump(mode='python')}))
+    return Part(CustomPart(custom={'unknownContent': content}))
+
+
+def from_interaction_step(step: Step) -> list[Part]:
+    """Convert an Interactions step to Genkit parts."""
+    if isinstance(step, ModelOutputStep):
+        return [from_interaction_content(content) for content in (step.content or [])]
+    if isinstance(step, UserInputStep):
+        # The API echoes our prompt back; including it would duplicate the input.
+        return []
+    if isinstance(step, GoogleSearchCallStep):
+        return [from_google_search_call(step)]
+    if isinstance(step, GoogleSearchResultStep):
+        return [from_google_search_result(step)]
+    if isinstance(step, CodeExecutionCallStep):
+        return [from_code_execution_call(step)]
+    if isinstance(step, CodeExecutionResultStep):
+        return [from_code_execution_result(step)]
+    if isinstance(step, ThoughtStep):
+        return [from_thought_step(step)]
+    if isinstance(step, FunctionCallStep):
+        return [from_function_call_step(step)]
+    if isinstance(step, FunctionResultStep):
+        return [from_function_result_step(step)]
+    if isinstance(step, BaseModel):
+        return [Part(CustomPart(custom={UNKNOWN_STEP: step.model_dump(mode='python')}))]
+    return [Part(CustomPart(custom={UNKNOWN_STEP: step}))]
+
+
+def interaction_message_metadata(interaction: Interaction) -> dict[str, Any] | None:
+    """Build message.metadata fields that identify the source Interaction."""
+    metadata: dict[str, Any] = {}
+    if interaction.id:
+        metadata['interactionId'] = interaction.id
+    if interaction.environment_id:
+        metadata['environmentId'] = interaction.environment_id
+    if interaction.status:
+        # Preserve the wire status when finish_reason is a coarser Genkit enum.
+        metadata['interactionStatus'] = interaction.status
+    return metadata or None
+
+
+def usage_from_interaction(usage: Usage) -> ModelUsage:
+    """Map Interactions Usage onto Genkit ModelUsage."""
+    response_usage = ModelUsage(
+        input_tokens=usage.total_input_tokens,
+        output_tokens=usage.total_output_tokens,
+        total_tokens=usage.total_tokens,
+        cached_content_tokens=usage.total_cached_tokens,
+        thoughts_tokens=usage.total_thought_tokens,
+    )
+    for modality_token in usage.input_tokens_by_modality or []:
+        match modality_token.modality:
+            case 'text':
+                response_usage.input_characters = modality_token.tokens
+            case 'image':
+                response_usage.input_images = modality_token.tokens
+            case 'audio':
+                response_usage.input_audio_files = modality_token.tokens
+            case _:
+                pass
+    for modality_token in usage.output_tokens_by_modality or []:
+        match modality_token.modality:
+            case 'text':
+                response_usage.output_characters = modality_token.tokens
+            case 'image':
+                response_usage.output_images = modality_token.tokens
+            case 'audio':
+                response_usage.output_audio_files = modality_token.tokens
+            case _:
+                pass
+    return response_usage
+
+
+def parts_from_steps(steps: list[Step]) -> list[Part]:
+    """Flatten interaction steps into Genkit parts, dropping empty ones."""
+    return [
+        part
+        for part in (item for step in steps for item in from_interaction_step(step))
+        if part.model_dump(exclude_none=True)
+    ]
+
+
+def model_response(
+    interaction: Interaction,
+    *,
+    content: list[Part],
+    finish_reason: FinishReason,
+    finish_message: str | None = None,
+) -> ModelResponse:
+    """Build a ModelResponse that carries the raw interaction alongside its parts."""
+    dumped = interaction.model_dump(mode='python')
+    response = ModelResponse.model_construct(
+        finish_reason=finish_reason,
+        finish_message=finish_message,
+        message=Message(role='model', content=content, metadata=interaction_message_metadata(interaction)),
+        custom=dumped,
+        raw=dumped,
+    )
+    if interaction.usage is not None:
+        response.usage = usage_from_interaction(interaction.usage)
+    return response
+
+
+def cancelled_response(interaction: Interaction) -> ModelResponse:
+    """Build the ModelResponse for a cancelled Interaction."""
+    return model_response(
+        interaction,
+        content=[Part(TextPart(text='Operation cancelled.'))],
+        finish_reason=FinishReason.ABORTED,
+        finish_message='Operation cancelled',
+    )
+
+
+def steps_response(
+    interaction: Interaction,
+    *,
+    finish_reason: FinishReason,
+    finish_message: str | None = None,
+) -> ModelResponse | None:
+    """Build a ModelResponse from interaction steps, or None when there are none."""
+    steps = list(interaction.steps or [])
+    if not steps:
+        return None
+    return model_response(
+        interaction,
+        content=parts_from_steps(steps),
+        finish_reason=finish_reason,
+        finish_message=finish_message,
+    )
+
+
+def completed_response(interaction: Interaction) -> ModelResponse | None:
+    """Build the ModelResponse for a completed Interaction, if it has steps."""
+    return steps_response(interaction, finish_reason=FinishReason.STOP)
+
+
+def from_interaction_sync(interaction: Interaction) -> ModelResponse:
+    """Convert a completed interaction to a synchronous model response."""
+    if interaction.status == 'failed':
+        raise ValueError(interaction_error_message(interaction) or FAILED_MESSAGE)
+    if interaction.status == 'cancelled':
+        return cancelled_response(interaction)
+    return completed_response(interaction) or model_response(interaction, content=[], finish_reason=FinishReason.STOP)
+
+
+def from_interaction(
+    interaction: Interaction,
+    client_options: ClientOptions | None = None,
+) -> Operation:
+    """Convert an interaction poll result to a Genkit operation."""
+    op = Operation.model_construct(id=interaction.id or '')
+    if client_options is not None:
+        dumped = client_options.to_metadata_dict()
+        if dumped:
+            op.metadata = {'clientOptions': dumped}
+
+    status = interaction.status
+    if status in ('in_progress', 'queued'):
+        # Keep polling — still running or waiting on the server.
+        op.done = False
+    elif status == 'cancelled':
+        op.done = True
+        op.output = cancelled_response(interaction)
+    elif status == 'completed':
+        op.done = True
+        op.output = completed_response(interaction)
+    elif partial := PARTIAL_TERMINAL_STATUSES.get(cast(str, status)):
+        # Halted for length or budget. Prefer whatever landed over a bare error.
+        finish_reason, message = partial
+        op.done = True
+        op.output = steps_response(interaction, finish_reason=finish_reason, finish_message=message)
+        if op.output is None:
+            op.error = Error(message=message)
+    elif status == 'failed':
+        # Always exit the poll loop on failure; leaving done unset hangs forever.
+        op.done = True
+        op.error = Error(message=interaction_error_message(interaction) or FAILED_MESSAGE)
+    # requires_action: leave done unset. Resuming that turn is a separate product
+    # decision; we don't invent interrupt/resume here.
+    return op

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/_interactions/converters.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/_interactions/converters.py
@@ -98,6 +98,8 @@ CONTENT_BLOCK_TYPES = frozenset({'text', 'image'})
 CODE_LANGUAGE: Literal['python'] = 'python'
 
 FAILED_MESSAGE = 'Interaction failed'
+# Chat generate can pause for a tool; a background job cannot.
+BACKGROUND_INTERRUPT_UNSUPPORTED = 'Background models do not support interrupts'
 
 # Interactions splits media into typed content blocks, chosen by mime prefix.
 MEDIA_CONTENT_TYPES: tuple[tuple[str, str], ...] = (
@@ -123,7 +125,18 @@ PARTIAL_TERMINAL_STATUSES: dict[str, tuple[FinishReason, str]] = {
 
 
 def interaction_error_message(interaction: Interaction) -> str | None:
-    """Read the failure message a failed Interaction reports on its output step."""
+    """Read the failure message a failed Interaction reports.
+
+    Prefer the top-level errors list when the job died before any output
+    step, then fall back to a step error so callers see the server's reason
+    instead of a generic 'Interaction failed'.
+    """
+    for err in interaction.errors or []:
+        message = getattr(err, 'message', None)
+        if message:
+            return str(message)
+        if isinstance(err, dict) and err.get('message'):
+            return str(err['message'])
     for step in interaction.steps or []:
         if isinstance(step, ModelOutputStep) and step.error is not None and step.error.message:
             return step.error.message
@@ -150,7 +163,7 @@ def clean_schema(schema: dict[str, Any]) -> dict[str, Any]:
 
 def ensure_tool_ids(messages: list[Message]) -> list[Message]:
     """Assign stable tool call IDs so wire payloads stay pairable."""
-    generated_ids: list[str] = []
+    request_ids: list[str] = []
     next_id_counter = 0
 
     new_messages = [message.model_copy(deep=True) for message in messages]
@@ -158,20 +171,30 @@ def ensure_tool_ids(messages: list[Message]) -> list[Message]:
     for message in new_messages:
         for part in message.content:
             root = part.root
-            if isinstance(root, ToolRequestPart) and root.tool_request and not root.tool_request.ref:
-                new_id = f'genkit-auto-id-{next_id_counter}'
-                next_id_counter += 1
-                root.tool_request.ref = new_id
-                generated_ids.append(new_id)
+            if isinstance(root, ToolRequestPart) and root.tool_request:
+                if not root.tool_request.ref:
+                    new_id = f'genkit-auto-id-{next_id_counter}'
+                    next_id_counter += 1
+                    root.tool_request.ref = new_id
+                request_ids.append(root.tool_request.ref)
 
-    # Responses without refs reuse request IDs in order; unmatched ones get orphan IDs.
+    # A response that already named its call isn't in the pairing pool.
+    claimed = {
+        part.root.tool_response.ref
+        for message in new_messages
+        for part in message.content
+        if isinstance(part.root, ToolResponsePart) and part.root.tool_response and part.root.tool_response.ref
+    }
+    available = [ref for ref in request_ids if ref not in claimed]
+
+    # Responses without refs reuse leftover request IDs in order; unmatched
+    # ones get orphan IDs so the wire never sends an empty call_id.
     for message in new_messages:
         for part in message.content:
             root = part.root
             if isinstance(root, ToolResponsePart) and root.tool_response and not root.tool_response.ref:
-                matched_id = generated_ids.pop(0) if generated_ids else None
-                if matched_id:
-                    root.tool_response.ref = matched_id
+                if available:
+                    root.tool_response.ref = available.pop(0)
                 else:
                     root.tool_response.ref = f'genkit-orphan-id-{next_id_counter}'
                     next_id_counter += 1
@@ -272,18 +295,20 @@ def to_function_call_step(request: ToolRequest) -> FunctionCallStepParam:
     silently become ``{}`` and the model would see a different call than the
     one the caller made.
     """
-    args = request.input
-    if args is None:
-        args = {}
-    elif not isinstance(args, dict):
+    dumped = plain(request.input)
+    if dumped is None:
+        args: dict[str, Any] = {}
+    elif not isinstance(dumped, dict):
         raise GenkitError(
             status='INVALID_ARGUMENT',
             message=(
                 'Tool request input must be a JSON object (got '
-                f'{type(args).__name__}). Wrap scalars as '
+                f'{type(dumped).__name__}). Wrap scalars as '
                 "{'city': 'Paris'} rather than passing a bare string."
             ),
         )
+    else:
+        args = cast(dict[str, Any], dumped)
     return {
         'type': 'function_call',
         'name': request.name,
@@ -325,7 +350,7 @@ def to_function_result_step(
     have to be boxed. Only a list of text/image blocks goes on the wire as
     content. A failed result keeps ``is_error`` so the model sees the miss.
     """
-    output = response.output
+    output = plain(response.output)
     if isinstance(output, (str, dict)):
         result = cast(FunctionResultStepResultUnionParam, output)
     elif is_content_block_list(output):
@@ -502,7 +527,9 @@ def plain(value: object) -> object:
     """Unwrap SDK models into plain data so parts stay JSON-serializable."""
     if isinstance(value, BaseModel):
         return value.model_dump(mode='python')
-    if isinstance(value, list):
+    if isinstance(value, dict):
+        return {key: plain(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
         return [plain(item) for item in value]
     return value
 
@@ -610,7 +637,7 @@ def from_text_content(content: TextContent) -> Part:
     return Part(
         TextPart(
             text=content.text or '',
-            metadata={'annotations': content.annotations},
+            metadata={'annotations': plain(content.annotations)},
         )
     )
 
@@ -702,6 +729,8 @@ def usage_from_interaction(usage: Usage) -> ModelUsage:
                 response_usage.input_images = modality_token.tokens
             case 'audio':
                 response_usage.input_audio_files = modality_token.tokens
+            case 'video':
+                response_usage.input_videos = modality_token.tokens
             case _:
                 pass
     for modality_token in usage.output_tokens_by_modality or []:
@@ -712,6 +741,8 @@ def usage_from_interaction(usage: Usage) -> ModelUsage:
                 response_usage.output_images = modality_token.tokens
             case 'audio':
                 response_usage.output_audio_files = modality_token.tokens
+            case 'video':
+                response_usage.output_videos = modality_token.tokens
             case _:
                 pass
     return response_usage
@@ -781,12 +812,30 @@ def completed_response(interaction: Interaction) -> ModelResponse | None:
 
 
 def from_interaction_sync(interaction: Interaction) -> ModelResponse:
-    """Convert a completed interaction to a synchronous model response."""
-    if interaction.status == 'failed':
+    """Convert a finished interaction to a synchronous model response.
+
+    Truncated or over-budget turns keep their real finish reason so a
+    generate that ran out of tokens does not look like a clean stop.
+    In-flight statuses raise — this helper is not a poll loop.
+    """
+    status = interaction.status
+    if status == 'failed':
         raise ValueError(interaction_error_message(interaction) or FAILED_MESSAGE)
-    if interaction.status == 'cancelled':
+    if status == 'cancelled':
         return cancelled_response(interaction)
-    return completed_response(interaction) or model_response(interaction, content=[], finish_reason=FinishReason.STOP)
+    if status in ('in_progress', 'queued', 'requires_action'):
+        raise ValueError(f'Interaction is still running (status={status!r})')
+    if partial := PARTIAL_TERMINAL_STATUSES.get(cast(str, status)):
+        finish_reason, message = partial
+        response = steps_response(interaction, finish_reason=finish_reason, finish_message=message)
+        if response is None:
+            raise ValueError(message)
+        return response
+    if status == 'completed' or status is None:
+        return completed_response(interaction) or model_response(
+            interaction, content=[], finish_reason=FinishReason.STOP
+        )
+    raise ValueError(f'Unknown interaction status: {status!r}')
 
 
 def from_interaction(
@@ -809,7 +858,9 @@ def from_interaction(
         op.output = cancelled_response(interaction)
     elif status == 'completed':
         op.done = True
-        op.output = completed_response(interaction)
+        op.output = completed_response(interaction) or model_response(
+            interaction, content=[], finish_reason=FinishReason.STOP
+        )
     elif partial := PARTIAL_TERMINAL_STATUSES.get(cast(str, status)):
         # Halted for length or budget. Prefer whatever landed over a bare error.
         finish_reason, message = partial
@@ -821,6 +872,14 @@ def from_interaction(
         # Always exit the poll loop on failure; leaving done unset hangs forever.
         op.done = True
         op.error = Error(message=interaction_error_message(interaction) or FAILED_MESSAGE)
-    # requires_action: leave done unset. Resuming that turn is a separate product
-    # decision; we don't invent interrupt/resume here.
+    elif status == 'requires_action':
+        # Chat generate can pause for a tool. A background job cannot — there
+        # is no interrupt/resume on generate_operation — so end the poll
+        # instead of hanging `while not op.done` or inventing a resume handle.
+        op.done = True
+        op.error = Error(message=BACKGROUND_INTERRUPT_UNSUPPORTED)
+    else:
+        # A status we do not map still has to exit `while not op.done`.
+        op.done = True
+        op.error = Error(message=f'Unknown interaction status: {status!r}')
     return op

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/_interactions/converters.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/_interactions/converters.py
@@ -23,7 +23,6 @@ import json
 import logging
 from typing import Any, Literal, cast
 
-from genkit_google_genai._interactions.options import ClientOptions
 from google.genai.interactions import (
     AudioContent,
     CodeExecutionCallStep,
@@ -838,16 +837,9 @@ def from_interaction_sync(interaction: Interaction) -> ModelResponse:
     raise ValueError(f'Unknown interaction status: {status!r}')
 
 
-def from_interaction(
-    interaction: Interaction,
-    client_options: ClientOptions | None = None,
-) -> Operation:
+def from_interaction(interaction: Interaction) -> Operation:
     """Convert an interaction poll result to a Genkit operation."""
     op = Operation.model_construct(id=interaction.id or '')
-    if client_options is not None:
-        dumped = client_options.to_metadata_dict()
-        if dumped:
-            op.metadata = {'clientOptions': dumped}
 
     status = interaction.status
     if status in ('in_progress', 'queued'):

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/_interactions/options.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/_interactions/options.py
@@ -30,10 +30,8 @@ ResponseModality = Literal['text', 'image', 'audio']
 class ClientOptions(BaseModel):
     """HTTP settings for an Interactions call.
 
-    A tenant key never lives here on a ticket. Check/cancel read it again
-    from context.secrets. Tickets may persist timeout, headers, and
-    api_version — not api_key or base_url (those would leak a secret or
-    let a ticket steer the next request at an attacker host).
+    These options belong to one HTTP call. Background operations don't retain
+    them; check/cancel receive the options needed for their own request.
     """
 
     model_config = ConfigDict(alias_generator=to_camel, extra='ignore', populate_by_name=True)
@@ -54,31 +52,3 @@ class ClientOptions(BaseModel):
         # Field names (not aliases) — model_copy(update=...) keys off Python attrs.
         update = overrides.model_dump(exclude_none=True)
         return self.model_copy(update=update) if update else self
-
-    @classmethod
-    def from_metadata(cls, metadata: dict[str, Any] | None) -> Self:
-        """Load transport knobs previously persisted on an Operation.
-
-        Drops api_key and base_url even if an older ticket still has them.
-        The key is re-supplied on the run; a ticket must not pick the host.
-        """
-        raw = (metadata or {}).get('clientOptions')
-        if raw is None:
-            raw = (metadata or {}).get('client_options')
-        parsed: Self
-        if isinstance(raw, cls):
-            parsed = raw
-        elif isinstance(raw, dict):
-            parsed = cls.model_validate(raw)
-        else:
-            return cls()
-        return parsed.model_copy(update={'api_key': None, 'base_url': None})
-
-    def to_metadata_dict(self) -> dict[str, Any]:
-        """Serialize transport knobs for Operation.metadata (no key, no host)."""
-        dumped = self.model_dump(by_alias=True, exclude_none=True)
-        dumped.pop('apiKey', None)
-        dumped.pop('api_key', None)
-        dumped.pop('baseUrl', None)
-        dumped.pop('base_url', None)
-        return dumped

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/_interactions/options.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/_interactions/options.py
@@ -1,0 +1,82 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Small option types for Interactions-backed Google AI models."""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict
+from pydantic.alias_generators import to_camel
+from typing_extensions import Self
+
+ResponseModality = Literal['text', 'image', 'audio']
+
+
+class ClientOptions(BaseModel):
+    """HTTP settings for an Interactions call.
+
+    A tenant key never lives here on a ticket. Check/cancel read it again
+    from context.secrets. Tickets may persist timeout, headers, and
+    api_version — not api_key or base_url (those would leak a secret or
+    let a ticket steer the next request at an attacker host).
+    """
+
+    model_config = ConfigDict(alias_generator=to_camel, extra='ignore', populate_by_name=True)
+
+    api_key: str | None = None
+    api_version: str | None = None
+    base_url: str | None = None
+    custom_headers: dict[str, str] | None = None
+    # Milliseconds — applied to the HTTP call, not the create body.
+    timeout: float | None = None
+
+    def merge(self, overrides: ClientOptions | dict[str, Any] | None) -> Self:
+        """Return a copy with non-null override fields applied."""
+        if not overrides:
+            return self
+        if isinstance(overrides, dict):
+            overrides = ClientOptions.model_validate(overrides)
+        # Field names (not aliases) — model_copy(update=...) keys off Python attrs.
+        update = overrides.model_dump(exclude_none=True)
+        return self.model_copy(update=update) if update else self
+
+    @classmethod
+    def from_metadata(cls, metadata: dict[str, Any] | None) -> Self:
+        """Load transport knobs previously persisted on an Operation.
+
+        Drops api_key and base_url even if an older ticket still has them.
+        The key is re-supplied on the run; a ticket must not pick the host.
+        """
+        raw = (metadata or {}).get('clientOptions')
+        parsed: Self
+        if isinstance(raw, cls):
+            parsed = raw
+        elif isinstance(raw, dict):
+            parsed = cls.model_validate(raw)
+        else:
+            return cls()
+        return parsed.model_copy(update={'api_key': None, 'base_url': None})
+
+    def to_metadata_dict(self) -> dict[str, Any]:
+        """Serialize transport knobs for Operation.metadata (no key, no host)."""
+        dumped = self.model_dump(by_alias=True, exclude_none=True)
+        dumped.pop('apiKey', None)
+        dumped.pop('api_key', None)
+        dumped.pop('baseUrl', None)
+        dumped.pop('base_url', None)
+        return dumped

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/_interactions/options.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/_interactions/options.py
@@ -63,6 +63,8 @@ class ClientOptions(BaseModel):
         The key is re-supplied on the run; a ticket must not pick the host.
         """
         raw = (metadata or {}).get('clientOptions')
+        if raw is None:
+            raw = (metadata or {}).get('client_options')
         parsed: Self
         if isinstance(raw, cls):
             parsed = raw

--- a/py/packages/genkit-google-genai/tests/interactions/interactions_client_test.py
+++ b/py/packages/genkit-google-genai/tests/interactions/interactions_client_test.py
@@ -1,0 +1,262 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the raw HTTP Interactions client."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+from urllib.parse import quote
+
+import httpx
+import pytest
+from genkit_google_genai._interactions import client as interactions_client
+from genkit_google_genai._interactions.client import (
+    API_REVISION,
+    cancel_interaction,
+    create_interaction,
+    get_interaction,
+    google_ai_url,
+    headers,
+    timeout_seconds,
+)
+from genkit_google_genai._interactions.options import ClientOptions
+from google.genai.interactions import Interaction
+
+from genkit import GenkitError
+from genkit.plugin_api import GENKIT_CLIENT_HEADER
+
+
+def test_google_ai_url_defaults() -> None:
+    assert google_ai_url('interactions') == ('https://generativelanguage.googleapis.com/v1beta/interactions')
+
+
+def test_google_ai_url_respects_overrides() -> None:
+    url = google_ai_url(
+        'interactions/abc',
+        client_options=ClientOptions(base_url='https://example.test/', api_version='v1alpha'),
+    )
+    assert url == 'https://example.test/v1alpha/interactions/abc'
+
+
+def test_headers_set_api_revision_and_strip_reserved_custom() -> None:
+    result = headers(
+        api_key='k',
+        client_options=ClientOptions(
+            custom_headers={
+                'x-custom': '1',
+                'x-goog-api-key': 'stolen',
+                'x-goog-api-client': 'wrapper',
+            }
+        ),
+    )
+    built = httpx.Headers(result)
+    assert built['Api-Revision'] == API_REVISION
+    assert built['x-goog-api-key'] == 'k'
+    assert built['x-goog-api-client'] == GENKIT_CLIENT_HEADER
+    assert built['x-custom'] == '1'
+
+
+def test_headers_strip_api_key_case_insensitive() -> None:
+    result = headers(
+        api_key='k',
+        client_options=ClientOptions(custom_headers={'X-Goog-Api-Key': 'stolen'}),
+    )
+    built = httpx.Headers(result)
+    assert built['x-goog-api-key'] == 'k'
+    assert sum(1 for key in result if key.lower() == 'x-goog-api-key') == 1
+
+
+def test_default_timeout_keeps_connect_budget() -> None:
+    timeout = interactions_client.NO_TIMEOUT
+    assert timeout.read is None
+    assert timeout.connect == 10.0
+
+
+def test_timeout_seconds_converts_milliseconds() -> None:
+    assert timeout_seconds(ClientOptions(timeout=1500)) == 1.5
+    assert timeout_seconds(ClientOptions()) is None
+
+
+def mock_response(
+    *,
+    status_code: int = 200,
+    json_body: dict[str, Any] | None = None,
+    text: str = '',
+    headers_map: dict[str, str] | None = None,
+    content: bytes | None = None,
+) -> httpx.Response:
+    if json_body is not None:
+        return httpx.Response(status_code, json=json_body, headers=headers_map or {})
+    if content is not None:
+        return httpx.Response(status_code, content=content, headers=headers_map or {})
+    return httpx.Response(status_code, text=text, headers=headers_map or {})
+
+
+@pytest.fixture
+def http_client() -> MagicMock:
+    client = MagicMock()
+    client.request = AsyncMock()
+    return client
+
+
+@pytest.mark.asyncio
+async def test_create_interaction_posts_body(http_client: MagicMock) -> None:
+    http_client.request.return_value = mock_response(
+        json_body={'id': 'ix-1', 'status': 'in_progress'},
+    )
+    with patch.object(interactions_client, 'get_cached_client', return_value=http_client):
+        result = await create_interaction(
+            'key',
+            {'agent': 'deep-research', 'background': True},
+            ClientOptions(base_url='https://example.test'),
+        )
+
+    assert isinstance(result, Interaction)
+    assert result.id == 'ix-1'
+    method, url = http_client.request.call_args.args[:2]
+    assert method == 'POST'
+    assert url == 'https://example.test/v1beta/interactions'
+    kwargs = http_client.request.call_args.kwargs
+    assert kwargs['json'] == {'agent': 'deep-research', 'background': True}
+    sent = httpx.Headers(kwargs['headers'])
+    assert sent['Api-Revision'] == API_REVISION
+    assert sent['x-goog-api-key'] == 'key'
+
+
+@pytest.mark.asyncio
+async def test_get_interaction_gets_by_id(http_client: MagicMock) -> None:
+    http_client.request.return_value = mock_response(
+        json_body={'id': 'ix-9', 'status': 'completed', 'steps': []},
+    )
+    with patch.object(interactions_client, 'get_cached_client', return_value=http_client):
+        result = await get_interaction('key', 'ix-9')
+
+    assert result.id == 'ix-9'
+    method, url = http_client.request.call_args.args[:2]
+    assert method == 'GET'
+    assert url.endswith('/interactions/ix-9')
+
+
+@pytest.mark.asyncio
+async def test_cancel_interaction_normalizes_http_cancelled(http_client: MagicMock) -> None:
+    http_client.request.return_value = mock_response(
+        status_code=499,
+        json_body={'error': {'message': 'cancelled'}},
+    )
+    with patch.object(interactions_client, 'get_cached_client', return_value=http_client):
+        result = await cancel_interaction('key', 'ix-cancel')
+
+    assert result.id == 'ix-cancel'
+    assert result.status == 'cancelled'
+
+
+@pytest.mark.asyncio
+async def test_cancel_interaction_normalizes_success_as_cancelled(http_client: MagicMock) -> None:
+    http_client.request.return_value = mock_response(
+        json_body={'id': 'ix-cancel', 'status': 'completed'},
+    )
+    with patch.object(interactions_client, 'get_cached_client', return_value=http_client):
+        result = await cancel_interaction('key', 'ix-cancel')
+
+    assert result.status == 'cancelled'
+
+
+@pytest.mark.asyncio
+async def test_cancel_interaction_rethrows_non_cancelled_errors(http_client: MagicMock) -> None:
+    http_client.request.return_value = mock_response(
+        status_code=404,
+        json_body={'error': {'message': 'missing'}},
+    )
+    with patch.object(interactions_client, 'get_cached_client', return_value=http_client):
+        with pytest.raises(GenkitError) as exc_info:
+            await cancel_interaction('key', 'ix-missing')
+    assert exc_info.value.status == 'NOT_FOUND'
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_includes_retry_after_ms(http_client: MagicMock) -> None:
+    http_client.request.return_value = mock_response(
+        status_code=429,
+        json_body={'error': {'message': 'slow down'}},
+        headers_map={'retry-after': '1.5'},
+    )
+    with patch.object(interactions_client, 'get_cached_client', return_value=http_client):
+        with pytest.raises(GenkitError) as exc_info:
+            await create_interaction('key', {'model': 'lyria'})
+    assert exc_info.value.status == 'RESOURCE_EXHAUSTED'
+    assert exc_info.value.response_metadata is not None
+    assert exc_info.value.response_metadata.get('retry_after_ms') == 1500.0
+
+
+@pytest.mark.asyncio
+async def test_empty_success_body_is_internal_error(http_client: MagicMock) -> None:
+    http_client.request.return_value = mock_response(content=b'')
+    with patch.object(interactions_client, 'get_cached_client', return_value=http_client):
+        with pytest.raises(GenkitError, match='empty response') as exc_info:
+            await get_interaction('key', 'ix-1')
+    assert exc_info.value.status == 'INTERNAL'
+
+
+@pytest.mark.asyncio
+async def test_timeout_maps_to_deadline_exceeded(http_client: MagicMock) -> None:
+    http_client.request.side_effect = httpx.TimeoutException('late')
+    with patch.object(interactions_client, 'get_cached_client', return_value=http_client):
+        with pytest.raises(GenkitError) as exc_info:
+            await create_interaction('key', {'model': 'lyria'}, ClientOptions(timeout=1000))
+    assert exc_info.value.status == 'DEADLINE_EXCEEDED'
+
+
+@pytest.mark.asyncio
+async def test_request_timeout_converted_from_ms(http_client: MagicMock) -> None:
+    http_client.request.return_value = mock_response(
+        json_body={'id': 'ix-1', 'status': 'completed', 'steps': []},
+    )
+    with patch.object(interactions_client, 'get_cached_client', return_value=http_client) as cached:
+        await create_interaction('key', {'model': 'lyria'}, ClientOptions(timeout=2500))
+
+    assert cached.call_args.kwargs['timeout'] == interactions_client.NO_TIMEOUT
+    assert http_client.request.call_args.kwargs['timeout'] == 2.5
+
+
+@pytest.mark.asyncio
+async def test_get_interaction_quotes_path_traversal_id(http_client: MagicMock) -> None:
+    http_client.request.return_value = mock_response(
+        json_body={'id': '../evil', 'status': 'completed', 'steps': []},
+    )
+    with patch.object(interactions_client, 'get_cached_client', return_value=http_client):
+        await get_interaction('key', '../evil')
+
+    url = http_client.request.call_args.args[1]
+    encoded = quote('../evil', safe='')
+    assert '../' not in url
+    assert url.endswith(f'/interactions/{encoded}')
+
+
+def test_from_metadata_drops_untrusted_base_url() -> None:
+    loaded = ClientOptions.from_metadata({
+        'clientOptions': {
+            'apiKey': 'ticket-key',
+            'baseUrl': 'https://evil.test',
+            'apiVersion': 'v1alpha',
+            'timeout': 1000,
+        }
+    })
+    assert loaded.api_key is None
+    assert loaded.base_url is None
+    assert loaded.api_version == 'v1alpha'
+    assert loaded.timeout == 1000

--- a/py/packages/genkit-google-genai/tests/interactions/interactions_client_test.py
+++ b/py/packages/genkit-google-genai/tests/interactions/interactions_client_test.py
@@ -251,24 +251,3 @@ async def test_get_interaction_quotes_path_traversal_id(http_client: MagicMock) 
     encoded = quote('../evil', safe='')
     assert '../' not in url
     assert url.endswith(f'/interactions/{encoded}')
-
-
-def test_from_metadata_drops_untrusted_base_url() -> None:
-    loaded = ClientOptions.from_metadata({
-        'clientOptions': {
-            'apiKey': 'ticket-key',
-            'baseUrl': 'https://evil.test',
-            'apiVersion': 'v1alpha',
-            'timeout': 1000,
-        }
-    })
-    assert loaded.api_key is None
-    assert loaded.base_url is None
-    assert loaded.api_version == 'v1alpha'
-    assert loaded.timeout == 1000
-
-
-def test_from_metadata_accepts_snake_case_wrapper() -> None:
-    loaded = ClientOptions.from_metadata({'client_options': {'timeout': 5000, 'api_version': 'v1beta'}})
-    assert loaded.timeout == 5000
-    assert loaded.api_version == 'v1beta'

--- a/py/packages/genkit-google-genai/tests/interactions/interactions_client_test.py
+++ b/py/packages/genkit-google-genai/tests/interactions/interactions_client_test.py
@@ -177,7 +177,13 @@ async def test_cancel_interaction_normalizes_success_as_cancelled(http_client: M
 
 
 @pytest.mark.asyncio
-async def test_cancel_interaction_rethrows_non_cancelled_errors(http_client: MagicMock) -> None:
+async def test_cancel_interaction_empty_success_body_is_cancelled(http_client: MagicMock) -> None:
+    http_client.request.return_value = mock_response(content=b'')
+    with patch.object(interactions_client, 'get_cached_client', return_value=http_client):
+        result = await cancel_interaction('key', 'ix-cancel')
+
+    assert result.id == 'ix-cancel'
+    assert result.status == 'cancelled'
     http_client.request.return_value = mock_response(
         status_code=404,
         json_body={'error': {'message': 'missing'}},
@@ -260,3 +266,9 @@ def test_from_metadata_drops_untrusted_base_url() -> None:
     assert loaded.base_url is None
     assert loaded.api_version == 'v1alpha'
     assert loaded.timeout == 1000
+
+
+def test_from_metadata_accepts_snake_case_wrapper() -> None:
+    loaded = ClientOptions.from_metadata({'client_options': {'timeout': 5000, 'api_version': 'v1beta'}})
+    assert loaded.timeout == 5000
+    assert loaded.api_version == 'v1beta'

--- a/py/packages/genkit-google-genai/tests/interactions/interactions_client_test.py
+++ b/py/packages/genkit-google-genai/tests/interactions/interactions_client_test.py
@@ -251,3 +251,39 @@ async def test_get_interaction_quotes_path_traversal_id(http_client: MagicMock) 
     encoded = quote('../evil', safe='')
     assert '../' not in url
     assert url.endswith(f'/interactions/{encoded}')
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ('status_code', 'expected_status'),
+    [
+        (502, 'INTERNAL'),
+        (504, 'DEADLINE_EXCEEDED'),
+    ],
+)
+async def test_gateway_errors_mapped_to_status(
+    http_client: MagicMock,
+    status_code: int,
+    expected_status: str,
+) -> None:
+    http_client.request.return_value = mock_response(
+        status_code=status_code,
+        text='Gateway error',
+    )
+    with patch.object(interactions_client, 'get_cached_client', return_value=http_client):
+        with pytest.raises(GenkitError) as exc_info:
+            await get_interaction('key', 'ix-1')
+    assert exc_info.value.status == expected_status
+
+
+@pytest.mark.asyncio
+async def test_error_without_retry_after_has_no_response_metadata(http_client: MagicMock) -> None:
+    http_client.request.return_value = mock_response(
+        status_code=429,
+        json_body={'error': {'message': 'slow down'}},
+    )
+    with patch.object(interactions_client, 'get_cached_client', return_value=http_client):
+        with pytest.raises(GenkitError) as exc_info:
+            await create_interaction('key', {'model': 'lyria'})
+    assert exc_info.value.status == 'RESOURCE_EXHAUSTED'
+    assert exc_info.value.response_metadata is None

--- a/py/packages/genkit-google-genai/tests/interactions/interactions_converters_test.py
+++ b/py/packages/genkit-google-genai/tests/interactions/interactions_converters_test.py
@@ -29,13 +29,15 @@ from genkit_google_genai._interactions.converters import (
     from_interaction_sync,
     from_thought_step,
     parts_from_steps,
+    split_system_instruction,
     to_interaction_content,
     to_interaction_role,
     to_interaction_steps,
     to_interaction_tool,
+    usage_from_interaction,
 )
 from genkit_google_genai._interactions.options import ClientOptions
-from google.genai.interactions import Content, Interaction, Step, ThoughtStep
+from google.genai.interactions import Content, Interaction, Step, ThoughtStep, Usage
 from pydantic import BaseModel, TypeAdapter
 
 from genkit import (
@@ -125,6 +127,55 @@ class TestEnsureToolIds:
         result = ensure_tool_ids(messages)
         req1 = result[0].content[0].root.tool_request
         assert req1 and req1.ref == 'existing-id'
+
+    def test_pairs_unreffed_responses_to_existing_request_refs(self) -> None:
+        messages = [
+            Message(
+                role='model',
+                content=[
+                    Part(ToolRequestPart(tool_request=ToolRequest(name='a', input={}, ref='existing'))),
+                    Part(ToolRequestPart(tool_request=ToolRequest(name='b', input={}))),
+                ],
+            ),
+            Message(
+                role='tool',
+                content=[
+                    Part(ToolResponsePart(tool_response=ToolResponse(name='a', output={}))),
+                    Part(ToolResponsePart(tool_response=ToolResponse(name='b', output={}))),
+                ],
+            ),
+        ]
+        result = ensure_tool_ids(messages)
+        req_a = result[0].content[0].root.tool_request
+        req_b = result[0].content[1].root.tool_request
+        res_a = result[1].content[0].root.tool_response
+        res_b = result[1].content[1].root.tool_response
+        assert req_a and req_a.ref == 'existing'
+        assert req_b and req_b.ref and req_b.ref.startswith('genkit-auto-id-')
+        assert res_a and res_a.ref == 'existing'
+        assert res_b and res_b.ref == req_b.ref
+
+    def test_skips_claimed_request_ids_when_pairing(self) -> None:
+        messages = [
+            Message(
+                role='model',
+                content=[
+                    Part(ToolRequestPart(tool_request=ToolRequest(name='a', input={}, ref='existing'))),
+                    Part(ToolRequestPart(tool_request=ToolRequest(name='b', input={}))),
+                ],
+            ),
+            Message(
+                role='tool',
+                content=[
+                    Part(ToolResponsePart(tool_response=ToolResponse(name='a', output={}, ref='existing'))),
+                    Part(ToolResponsePart(tool_response=ToolResponse(name='b', output={}))),
+                ],
+            ),
+        ]
+        result = ensure_tool_ids(messages)
+        req_b = result[0].content[1].root.tool_request
+        res_b = result[1].content[1].root.tool_response
+        assert req_b and res_b and res_b.ref == req_b.ref
 
 
 class TestToInteractionRole:
@@ -458,6 +509,56 @@ class TestToInteractionSteps:
             to_interaction_steps(messages)
         assert exc_info.value.status == 'INVALID_ARGUMENT'
 
+    def test_pydantic_tool_request_input_dumps(self) -> None:
+        class City(BaseModel):
+            city: str = 'Paris'
+
+        messages = [
+            Message(
+                role='model',
+                content=[Part(ToolRequestPart(tool_request=ToolRequest(name='lookup', input=City(), ref='c1')))],
+            )
+        ]
+        assert to_interaction_steps(messages) == [
+            {'type': 'function_call', 'name': 'lookup', 'arguments': {'city': 'Paris'}, 'id': 'c1'}
+        ]
+
+    def test_pydantic_tool_response_output_dumps(self) -> None:
+        class Weather(BaseModel):
+            temp: int = 72
+
+        messages = [
+            Message(
+                role='tool',
+                content=[
+                    Part(ToolResponsePart(tool_response=ToolResponse(name='weather', output=Weather(), ref='r1')))
+                ],
+            )
+        ]
+        assert to_interaction_steps(messages) == [
+            {'type': 'function_result', 'name': 'weather', 'result': {'temp': 72}, 'call_id': 'r1'}
+        ]
+
+    def test_nested_pydantic_tool_output_dumps(self) -> None:
+        class Weather(BaseModel):
+            temp: int = 72
+
+        messages = [
+            Message(
+                role='tool',
+                content=[
+                    Part(
+                        ToolResponsePart(
+                            tool_response=ToolResponse(name='weather', output={'report': Weather()}, ref='r1')
+                        )
+                    )
+                ],
+            )
+        ]
+        assert to_interaction_steps(messages) == [
+            {'type': 'function_result', 'name': 'weather', 'result': {'report': {'temp': 72}}, 'call_id': 'r1'}
+        ]
+
 
 class TestFromInteractionContent:
     def test_text(self) -> None:
@@ -519,6 +620,27 @@ class TestFromInteractionStep:
         assert root.text == 'Hello'
         assert root.metadata is not None
         assert 'annotations' in root.metadata
+
+    def test_text_annotations_are_plain_data(self) -> None:
+        result = from_interaction_step(
+            StepAdapter.validate_python({
+                'type': 'model_output',
+                'content': [
+                    {
+                        'type': 'text',
+                        'text': 'hi',
+                        'annotations': [{'type': 'url_citation', 'url': 'https://x.example'}],
+                    }
+                ],
+            })
+        )
+        root = result[0].root
+        assert isinstance(root, TextPart)
+        anns = (root.metadata or {}).get('annotations')
+        assert isinstance(anns, list) and anns
+        assert isinstance(anns[0], dict)
+        assert anns[0].get('type') == 'url_citation'
+        assert anns[0].get('url') == 'https://x.example'
 
     def test_user_input_dropped(self) -> None:
         result = from_interaction_step(
@@ -795,7 +917,19 @@ class TestFromInteractionStatusMapping:
         assert result.error is not None
         assert result.error.message == 'Interaction failed'
 
-    def test_requires_action_leaves_done_unset(self) -> None:
+    def test_failed_uses_top_level_errors(self) -> None:
+        result = from_interaction(
+            Interaction.model_validate({
+                'id': '123',
+                'status': 'failed',
+                'errors': [{'code': '400', 'message': 'Invalid prompt format'}],
+            })
+        )
+        assert result.done is True
+        assert result.error is not None
+        assert result.error.message == 'Invalid prompt format'
+
+    def test_requires_action_exits_poll_loop(self) -> None:
         interaction = Interaction.model_validate({
             'id': '123',
             'status': 'requires_action',
@@ -803,9 +937,10 @@ class TestFromInteractionStatusMapping:
         })
         result = from_interaction(interaction)
         assert result.id == '123'
-        assert result.done is None
+        assert result.done is True
         assert result.output is None
-        assert not (result.metadata or {}).get('interaction_status')
+        assert result.error is not None
+        assert result.error.message == 'Background models do not support interrupts'
 
     def test_in_progress(self) -> None:
         result = from_interaction(Interaction.model_validate({'id': '123', 'status': 'in_progress'}))
@@ -814,6 +949,22 @@ class TestFromInteractionStatusMapping:
     def test_queued_keeps_polling(self) -> None:
         result = from_interaction(Interaction.model_validate({'id': '123', 'status': 'queued'}))
         assert result.done is False
+
+    def test_completed_empty_steps_still_has_output(self) -> None:
+        result = from_interaction(Interaction.model_validate({'id': '123', 'status': 'completed', 'steps': []}))
+        assert result.done is True
+        assert result.error is None
+        assert result.output is not None
+        assert result.output.finish_reason == 'stop'
+        assert result.output.message is not None
+        assert result.output.message.content == []
+
+    def test_unknown_status_exits_poll_loop(self) -> None:
+        result = from_interaction(Interaction.model_validate({'id': '123', 'status': 'expired'}))
+        assert result.done is True
+        assert result.output is None
+        assert result.error is not None
+        assert 'expired' in (result.error.message or '')
 
     def test_incomplete_surfaces_partial_steps(self) -> None:
         result = from_interaction(
@@ -869,3 +1020,84 @@ class TestFromInteractionSync:
     def test_failed_raises(self) -> None:
         with pytest.raises(ValueError, match='Interaction failed'):
             from_interaction_sync(Interaction.model_validate({'status': 'failed'}))
+
+    def test_cancelled(self) -> None:
+        result = from_interaction_sync(Interaction.model_validate({'id': '123', 'status': 'cancelled'}))
+        assert result.finish_reason == 'aborted'
+        assert result.finish_message == 'Operation cancelled'
+
+    def test_incomplete_surfaces_partial_steps(self) -> None:
+        result = from_interaction_sync(
+            Interaction.model_validate({
+                'id': '123',
+                'status': 'incomplete',
+                'steps': [{'type': 'model_output', 'content': [{'type': 'text', 'text': 'partial'}]}],
+            })
+        )
+        assert result.finish_reason == 'length'
+        assert result.finish_message == 'Interaction incomplete (truncated output)'
+        assert result.message is not None
+        assert result.message.content[0].root.text == 'partial'
+
+    def test_incomplete_without_steps_raises(self) -> None:
+        with pytest.raises(ValueError, match='incomplete'):
+            from_interaction_sync(Interaction.model_validate({'id': '123', 'status': 'incomplete'}))
+
+    def test_budget_exceeded_surfaces_partial_steps(self) -> None:
+        result = from_interaction_sync(
+            Interaction.model_validate({
+                'id': '123',
+                'status': 'budget_exceeded',
+                'steps': [{'type': 'model_output', 'content': [{'type': 'text', 'text': 'draft'}]}],
+            })
+        )
+        assert result.finish_reason == 'aborted'
+        assert result.finish_message == 'Interaction exceeded its budget'
+
+    def test_in_progress_raises(self) -> None:
+        with pytest.raises(ValueError, match='still running'):
+            from_interaction_sync(Interaction.model_validate({'id': '123', 'status': 'in_progress'}))
+
+    def test_unknown_status_raises(self) -> None:
+        with pytest.raises(ValueError, match='Unknown interaction status'):
+            from_interaction_sync(Interaction.model_validate({'id': '123', 'status': 'expired'}))
+
+
+class TestSplitSystemInstruction:
+    def test_lifts_system_turns(self) -> None:
+        instruction, turns = split_system_instruction([
+            Message(role='system', content=[Part(TextPart(text='be terse'))]),
+            Message(role='user', content=[Part(TextPart(text='hi'))]),
+        ])
+        assert instruction == 'be terse'
+        assert len(turns) == 1
+        assert turns[0].role == 'user'
+
+    def test_joins_multiple_system_turns(self) -> None:
+        instruction, turns = split_system_instruction([
+            Message(role='system', content=[Part(TextPart(text='one'))]),
+            Message(role='system', content=[Part(TextPart(text='two'))]),
+        ])
+        assert instruction == 'one\n\ntwo'
+        assert turns == []
+
+
+class TestUsageFromInteraction:
+    def test_maps_totals_and_video_modality(self) -> None:
+        usage = Usage.model_validate({
+            'total_input_tokens': 10,
+            'total_output_tokens': 4,
+            'total_tokens': 14,
+            'total_cached_tokens': 2,
+            'total_thought_tokens': 1,
+            'input_tokens_by_modality': [{'modality': 'video', 'tokens': 3}],
+            'output_tokens_by_modality': [{'modality': 'video', 'tokens': 1}],
+        })
+        mapped = usage_from_interaction(usage)
+        assert mapped.input_tokens == 10
+        assert mapped.output_tokens == 4
+        assert mapped.total_tokens == 14
+        assert mapped.cached_content_tokens == 2
+        assert mapped.thoughts_tokens == 1
+        assert mapped.input_videos == 3
+        assert mapped.output_videos == 1

--- a/py/packages/genkit-google-genai/tests/interactions/interactions_converters_test.py
+++ b/py/packages/genkit-google-genai/tests/interactions/interactions_converters_test.py
@@ -36,7 +36,6 @@ from genkit_google_genai._interactions.converters import (
     to_interaction_tool,
     usage_from_interaction,
 )
-from genkit_google_genai._interactions.options import ClientOptions
 from google.genai.interactions import Content, Interaction, Step, ThoughtStep, Usage
 from pydantic import BaseModel, TypeAdapter
 
@@ -873,21 +872,10 @@ class TestFunctionCallRoundTrip:
         assert root.metadata == {'thoughtSignature': 'sig'}
 
 
-class TestClientOptionsWireFormat:
-    def test_operation_metadata_uses_camel_case_keys(self) -> None:
-        op = from_interaction(
-            Interaction.model_validate({'id': '123', 'status': 'in_progress'}),
-            ClientOptions(api_key='k', base_url='https://example.test', api_version='v1beta', timeout=1500),
-        )
-        assert op.metadata == {
-            'clientOptions': {
-                'apiVersion': 'v1beta',
-                'timeout': 1500.0,
-            }
-        }
-        persisted = (op.metadata or {}).get('clientOptions') or {}
-        assert 'apiKey' not in persisted
-        assert 'baseUrl' not in persisted
+def test_operation_does_not_persist_client_options() -> None:
+    op = from_interaction(Interaction.model_validate({'id': '123', 'status': 'in_progress'}))
+
+    assert not op.metadata
 
 
 class TestFromInteractionStatusMapping:

--- a/py/packages/genkit-google-genai/tests/interactions/interactions_converters_test.py
+++ b/py/packages/genkit-google-genai/tests/interactions/interactions_converters_test.py
@@ -1,0 +1,871 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for Interactions API converters."""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+import pytest
+from genkit_google_genai._interactions.converters import (
+    ensure_tool_ids,
+    from_interaction,
+    from_interaction_content,
+    from_interaction_step,
+    from_interaction_sync,
+    from_thought_step,
+    parts_from_steps,
+    to_interaction_content,
+    to_interaction_role,
+    to_interaction_steps,
+    to_interaction_tool,
+)
+from genkit_google_genai._interactions.options import ClientOptions
+from google.genai.interactions import Content, Interaction, Step, ThoughtStep
+from pydantic import BaseModel, TypeAdapter
+
+from genkit import (
+    CustomPart,
+    GenkitError,
+    Media,
+    MediaPart,
+    Part,
+    ReasoningPart,
+    TextPart,
+    ToolRequest,
+    ToolRequestPart,
+    ToolResponse,
+    ToolResponsePart,
+)
+from genkit.model import Message, ToolDefinition
+
+ContentAdapter: TypeAdapter[Content] = TypeAdapter(Content)
+StepAdapter: TypeAdapter[Step] = TypeAdapter(Step)
+
+
+def part_dict(part: Part) -> dict:
+    return part.root.model_dump(by_alias=True, exclude_none=True)
+
+
+class TestEnsureToolIds:
+    def test_assigns_ids_to_tool_requests_without_refs(self) -> None:
+        messages = [
+            Message(
+                role='model',
+                content=[
+                    Part(ToolRequestPart(tool_request=ToolRequest(name='tool1', input={}))),
+                    Part(ToolRequestPart(tool_request=ToolRequest(name='tool2', input={}))),
+                ],
+            )
+        ]
+        result = ensure_tool_ids(messages)
+        req1 = result[0].content[0].root.tool_request
+        req2 = result[0].content[1].root.tool_request
+        assert req1 is not None and req1.ref and req1.ref.startswith('genkit-auto-id-')
+        assert req2 is not None and req2.ref and req2.ref.startswith('genkit-auto-id-')
+        assert req1.ref != req2.ref
+
+    def test_assigns_matching_ids_to_tool_responses(self) -> None:
+        messages = [
+            Message(
+                role='model',
+                content=[
+                    Part(ToolRequestPart(tool_request=ToolRequest(name='tool1', input={}))),
+                    Part(ToolRequestPart(tool_request=ToolRequest(name='tool2', input={}))),
+                ],
+            ),
+            Message(
+                role='tool',
+                content=[
+                    Part(ToolResponsePart(tool_response=ToolResponse(name='tool1', output={}))),
+                    Part(ToolResponsePart(tool_response=ToolResponse(name='tool2', output={}))),
+                ],
+            ),
+        ]
+        result = ensure_tool_ids(messages)
+        req1 = result[0].content[0].root.tool_request
+        req2 = result[0].content[1].root.tool_request
+        res1 = result[1].content[0].root.tool_response
+        res2 = result[1].content[1].root.tool_response
+        assert req1 and req1.ref and res1 and res1.ref == req1.ref
+        assert req2 and req2.ref and res2 and res2.ref == req2.ref
+
+    def test_assigns_orphan_id_without_matching_request(self) -> None:
+        messages = [
+            Message(
+                role='tool',
+                content=[Part(ToolResponsePart(tool_response=ToolResponse(name='tool1', output={})))],
+            )
+        ]
+        result = ensure_tool_ids(messages)
+        res1 = result[0].content[0].root.tool_response
+        assert res1 and res1.ref and res1.ref.startswith('genkit-orphan-id-')
+
+    def test_preserves_existing_refs(self) -> None:
+        messages = [
+            Message(
+                role='model',
+                content=[Part(ToolRequestPart(tool_request=ToolRequest(name='tool1', input={}, ref='existing-id')))],
+            )
+        ]
+        result = ensure_tool_ids(messages)
+        req1 = result[0].content[0].root.tool_request
+        assert req1 and req1.ref == 'existing-id'
+
+
+class TestToInteractionRole:
+    def test_user(self) -> None:
+        assert to_interaction_role('user') == 'user'
+
+    def test_model(self) -> None:
+        assert to_interaction_role('model') == 'model'
+
+    def test_tool_maps_to_user(self) -> None:
+        assert to_interaction_role('tool') == 'user'
+
+    def test_system_raises(self) -> None:
+        with pytest.raises(ValueError, match='system_instruction'):
+            to_interaction_role('system')
+
+
+class TestToInteractionTool:
+    def test_converts_tool_definition(self) -> None:
+        tool = ToolDefinition(
+            name='myFunc',
+            description='desc',
+            input_schema={'type': 'object', 'properties': {'arg': {'type': 'string'}}},
+        )
+        result = to_interaction_tool(tool)
+        assert result == {
+            'type': 'function',
+            'name': 'myFunc',
+            'description': 'desc',
+            'parameters': {'type': 'object', 'properties': {'arg': {'type': 'string'}}},
+        }
+
+
+class TestToInteractionContent:
+    def test_text(self) -> None:
+        result = to_interaction_content(Part(TextPart(text='Hello')))
+        assert result == {'type': 'text', 'text': 'Hello'}
+
+    def test_image_data(self) -> None:
+        result = to_interaction_content(
+            Part(MediaPart(media=Media(url='data:image/png;base64,DATA', content_type='image/png')))
+        )
+        assert result == {'type': 'image', 'data': 'DATA', 'mime_type': 'image/png'}
+
+    def test_image_data_missing_separator(self) -> None:
+        with pytest.raises(ValueError, match='missing payload separator'):
+            to_interaction_content(
+                Part(MediaPart(media=Media(url='data:image/png;base64GARBAGE', content_type='image/png')))
+            )
+
+    def test_image_uri(self) -> None:
+        result = to_interaction_content(
+            Part(MediaPart(media=Media(url='gs://bucket/image.png', content_type='image/png')))
+        )
+        assert result == {'type': 'image', 'uri': 'gs://bucket/image.png', 'mime_type': 'image/png'}
+
+    def test_audio(self) -> None:
+        result = to_interaction_content(
+            Part(MediaPart(media=Media(url='data:audio/mp3;base64,DATA', content_type='audio/mp3')))
+        )
+        assert result == {'type': 'audio', 'data': 'DATA', 'mime_type': 'audio/mp3'}
+
+    def test_document(self) -> None:
+        result = to_interaction_content(
+            Part(MediaPart(media=Media(url='gs://bucket/doc.pdf', content_type='application/pdf')))
+        )
+        assert result == {'type': 'document', 'uri': 'gs://bucket/doc.pdf', 'mime_type': 'application/pdf'}
+
+    def test_unsupported_media_raises(self) -> None:
+        with pytest.raises(ValueError, match='Unsupported media type'):
+            to_interaction_content(Part(MediaPart(media=Media(url='https://example.com/x', content_type='text/plain'))))
+
+
+class TestToInteractionSteps:
+    def test_tool_request(self) -> None:
+        messages = [
+            Message(
+                role='model',
+                content=[Part(ToolRequestPart(tool_request=ToolRequest(name='func', input={'a': 1}, ref='ref1')))],
+            )
+        ]
+        assert to_interaction_steps(messages) == [
+            {'type': 'function_call', 'name': 'func', 'arguments': {'a': 1}, 'id': 'ref1'}
+        ]
+
+    def test_tool_response(self) -> None:
+        messages = [
+            Message(
+                role='tool',
+                content=[
+                    Part(ToolResponsePart(tool_response=ToolResponse(name='func', output={'result': 'ok'}, ref='ref1')))
+                ],
+            )
+        ]
+        assert to_interaction_steps(messages) == [
+            {'type': 'function_result', 'name': 'func', 'result': {'result': 'ok'}, 'call_id': 'ref1'}
+        ]
+
+    def test_model_output_grouping(self) -> None:
+        messages = [
+            Message(
+                role='model',
+                content=[Part(TextPart(text='Thinking')), Part(TextPart(text='Done'))],
+            )
+        ]
+        assert to_interaction_steps(messages) == [
+            {
+                'type': 'model_output',
+                'content': [{'type': 'text', 'text': 'Thinking'}, {'type': 'text', 'text': 'Done'}],
+            }
+        ]
+
+    def test_system_role_rejected(self) -> None:
+        messages = [Message(role='system', content=[Part(TextPart(text='be terse'))])]
+        with pytest.raises(ValueError, match='system_instruction'):
+            to_interaction_steps(messages)
+
+    def test_code_execution_call_always_sends_python(self) -> None:
+        messages = [
+            Message(
+                role='model',
+                content=[
+                    Part(
+                        CustomPart(
+                            custom={'executableCode': {'code': 'print(1)', 'language': 'PYTHON'}},
+                            metadata={'callId': 'c1'},
+                        )
+                    )
+                ],
+            )
+        ]
+        assert to_interaction_steps(messages) == [
+            {
+                'type': 'code_execution_call',
+                'id': 'c1',
+                'arguments': {'code': 'print(1)', 'language': 'python'},
+            }
+        ]
+
+    def test_google_search_call(self) -> None:
+        messages = [
+            Message(
+                role='model',
+                content=[
+                    Part(
+                        CustomPart(
+                            custom={'googleSearchCall': {'id': 'gs1', 'arguments': {'queries': ['genkit']}}},
+                            metadata={'thoughtSignature': 'sig'},
+                        )
+                    )
+                ],
+            )
+        ]
+        assert to_interaction_steps(messages) == [
+            {
+                'type': 'google_search_call',
+                'id': 'gs1',
+                'arguments': {'queries': ['genkit']},
+                'signature': 'sig',
+            }
+        ]
+
+    def test_thought_becomes_its_own_step(self) -> None:
+        messages = [
+            Message(
+                role='model',
+                content=[
+                    Part(
+                        ReasoningPart(
+                            reasoning='plan the answer',
+                            metadata={'thoughtSignature': 'sig-t'},
+                        )
+                    )
+                ],
+            )
+        ]
+        assert to_interaction_steps(messages) == [
+            {
+                'type': 'thought',
+                'summary': [{'type': 'text', 'text': 'plan the answer'}],
+                'signature': 'sig-t',
+            }
+        ]
+
+    def test_mixed_model_turn_preserves_content_order(self) -> None:
+        """Inline content flushes before a standalone step so order matches the message."""
+        messages = [
+            Message(
+                role='model',
+                content=[
+                    Part(ReasoningPart(reasoning='think', metadata={'thoughtSignature': 's'})),
+                    Part(TextPart(text='calling tool')),
+                    Part(ToolRequestPart(tool_request=ToolRequest(name='lookup', input={'q': 1}, ref='c1'))),
+                    Part(TextPart(text='after')),
+                ],
+            )
+        ]
+        assert to_interaction_steps(messages) == [
+            {
+                'type': 'thought',
+                'summary': [{'type': 'text', 'text': 'think'}],
+                'signature': 's',
+            },
+            {
+                'type': 'model_output',
+                'content': [{'type': 'text', 'text': 'calling tool'}],
+            },
+            {'type': 'function_call', 'name': 'lookup', 'arguments': {'q': 1}, 'id': 'c1'},
+            {
+                'type': 'model_output',
+                'content': [{'type': 'text', 'text': 'after'}],
+            },
+        ]
+
+    def test_unknown_step_round_trips(self) -> None:
+        blob = {'type': 'future_step', 'payload': {'x': 1}}
+        messages = [
+            Message(
+                role='model',
+                content=[Part(CustomPart(custom={'unknownStep': blob}))],
+            )
+        ]
+        assert to_interaction_steps(messages) == [blob]
+
+    def test_unknown_step_inbound_then_outbound(self) -> None:
+        class FutureStep(BaseModel):
+            type: str = 'future_step'
+            payload: dict
+
+        parts = from_interaction_step(cast(Any, FutureStep(payload={'x': 1})))
+        root = parts[0].root
+        assert isinstance(root, CustomPart)
+        assert (root.custom or {})['unknownStep']['type'] == 'future_step'
+        assert to_interaction_steps([Message(role='model', content=parts)]) == [
+            {'type': 'future_step', 'payload': {'x': 1}}
+        ]
+
+    def test_signed_multimodal_thought_replays_original_step(self) -> None:
+        thought_dump = {
+            'type': 'thought',
+            'signature': 'sig-img',
+            'summary': [
+                {'type': 'text', 'text': 'see this'},
+                {'type': 'image', 'uri': 'gs://bucket/thumb.png', 'mime_type': 'image/png'},
+            ],
+        }
+        messages = [
+            Message(
+                role='model',
+                content=[
+                    Part(
+                        ReasoningPart(
+                            reasoning='see this\n[Image]',
+                            metadata={'thoughtSignature': 'sig-img'},
+                            custom={'thought': thought_dump},
+                        )
+                    )
+                ],
+            )
+        ]
+        assert to_interaction_steps(messages) == [thought_dump]
+
+    def test_json_array_function_result_is_boxed(self) -> None:
+        messages = [
+            Message(
+                role='tool',
+                content=[Part(ToolResponsePart(tool_response=ToolResponse(name='fn', output=[1, 2], ref='r1')))],
+            )
+        ]
+        assert to_interaction_steps(messages) == [
+            {
+                'type': 'function_result',
+                'name': 'fn',
+                'result': {'result': [1, 2]},
+                'call_id': 'r1',
+            }
+        ]
+
+    def test_content_block_list_function_result_is_not_boxed(self) -> None:
+        blocks = [
+            {'type': 'text', 'text': 'hello'},
+            {'type': 'image', 'uri': 'gs://x', 'mime_type': 'image/png'},
+        ]
+        messages = [
+            Message(
+                role='tool',
+                content=[Part(ToolResponsePart(tool_response=ToolResponse(name='fn', output=blocks, ref='r1')))],
+            )
+        ]
+        assert to_interaction_steps(messages) == [
+            {
+                'type': 'function_result',
+                'name': 'fn',
+                'result': blocks,
+                'call_id': 'r1',
+            }
+        ]
+
+    def test_failed_tool_result_keeps_is_error(self) -> None:
+        messages = [
+            Message(
+                role='tool',
+                content=[
+                    Part(
+                        ToolResponsePart(
+                            tool_response=ToolResponse(name='fn', output={'e': 'boom'}, ref='r1'),
+                            metadata={'isError': True},
+                        )
+                    )
+                ],
+            )
+        ]
+        assert to_interaction_steps(messages) == [
+            {
+                'type': 'function_result',
+                'name': 'fn',
+                'result': {'e': 'boom'},
+                'call_id': 'r1',
+                'is_error': True,
+            }
+        ]
+
+    def test_scalar_tool_request_input_raises(self) -> None:
+        messages = [
+            Message(
+                role='model',
+                content=[Part(ToolRequestPart(tool_request=ToolRequest(name='lookup', input='Paris', ref='c1')))],
+            )
+        ]
+        with pytest.raises(GenkitError, match='JSON object') as exc_info:
+            to_interaction_steps(messages)
+        assert exc_info.value.status == 'INVALID_ARGUMENT'
+
+
+class TestFromInteractionContent:
+    def test_text(self) -> None:
+        result = from_interaction_content(
+            ContentAdapter.validate_python({
+                'type': 'text',
+                'text': 'Hello world',
+                'annotations': [{'start_index': 0, 'end_index': 5, 'source': 'source'}],
+            })
+        )
+        assert part_dict(result) == {
+            'text': 'Hello world',
+            'metadata': {
+                'annotations': [{'start_index': 0, 'end_index': 5, 'source': 'source', 'type': 'file_citation'}]
+            },
+        }
+
+    def test_image_data(self) -> None:
+        result = from_interaction_content(
+            ContentAdapter.validate_python({'type': 'image', 'data': 'BASE64DATA', 'mime_type': 'image/png'})
+        )
+        assert part_dict(result) == {'media': {'url': 'data:image/png;base64,BASE64DATA', 'contentType': 'image/png'}}
+
+    def test_image_resolution(self) -> None:
+        result = from_interaction_content(
+            ContentAdapter.validate_python({
+                'type': 'image',
+                'uri': 'gs://bucket/image.png',
+                'mime_type': 'image/png',
+                'resolution': 'high',
+            })
+        )
+        assert part_dict(result) == {
+            'media': {'url': 'gs://bucket/image.png', 'contentType': 'image/png'},
+            'metadata': {'resolution': 'high'},
+        }
+
+    def test_thought(self) -> None:
+        step = ThoughtStep.model_validate({
+            'type': 'thought',
+            'signature': 'SIG',
+            'summary': [{'type': 'text', 'text': 'Thinking...'}],
+        })
+        result = from_thought_step(step)
+        assert part_dict(result) == {
+            'reasoning': 'Thinking...',
+            'metadata': {'thoughtSignature': 'SIG'},
+            'custom': {'thought': step.model_dump(mode='python')},
+        }
+
+
+class TestFromInteractionStep:
+    def test_model_output_includes_empty_annotations(self) -> None:
+        result = from_interaction_step(
+            StepAdapter.validate_python({'type': 'model_output', 'content': [{'type': 'text', 'text': 'Hello'}]})
+        )
+        root = result[0].root
+        assert isinstance(root, TextPart)
+        assert root.text == 'Hello'
+        assert root.metadata is not None
+        assert 'annotations' in root.metadata
+
+    def test_user_input_dropped(self) -> None:
+        result = from_interaction_step(
+            StepAdapter.validate_python({'type': 'user_input', 'content': [{'type': 'text', 'text': 'Hello'}]})
+        )
+        assert result == []
+
+    def test_function_call_is_tool_request(self) -> None:
+        result = from_interaction_step(
+            StepAdapter.validate_python({
+                'type': 'function_call',
+                'id': 'c1',
+                'name': 'get_weather',
+                'arguments': {'city': 'Austin'},
+            })
+        )
+        root = result[0].root
+        assert isinstance(root, ToolRequestPart)
+        assert root.tool_request is not None
+        assert root.tool_request.name == 'get_weather'
+        assert root.tool_request.input == {'city': 'Austin'}
+        assert root.tool_request.ref == 'c1'
+
+    def test_function_result_is_custom_stash_not_tool_response(self) -> None:
+        result = from_interaction_step(
+            StepAdapter.validate_python({
+                'type': 'function_result',
+                'call_id': 'c1',
+                'name': 'get_weather',
+                'result': {'temp': 92},
+                'is_error': False,
+            })
+        )
+        root = result[0].root
+        assert isinstance(root, CustomPart)
+        assert not isinstance(root, ToolResponsePart)
+        stash = (root.custom or {})['serverFunctionResult']
+        assert stash['name'] == 'get_weather'
+        assert stash['result'] == {'temp': 92}
+        assert stash['call_id'] == 'c1'
+        assert stash['is_error'] is False
+
+    def test_failed_function_result_keeps_is_error_on_stash(self) -> None:
+        result = from_interaction_step(
+            StepAdapter.validate_python({
+                'type': 'function_result',
+                'call_id': 'c1',
+                'name': 'get_weather',
+                'result': {'e': 'boom'},
+                'is_error': True,
+            })
+        )
+        root = result[0].root
+        assert isinstance(root, CustomPart)
+        stash = (root.custom or {})['serverFunctionResult']
+        assert stash['is_error'] is True
+        again = to_interaction_steps([Message(role='model', content=result)])
+        assert again == [
+            {
+                'type': 'function_result',
+                'name': 'get_weather',
+                'result': {'e': 'boom'},
+                'call_id': 'c1',
+                'is_error': True,
+            }
+        ]
+
+    def test_google_search_call_is_custom_part(self) -> None:
+        result = from_interaction_step(
+            StepAdapter.validate_python({
+                'type': 'google_search_call',
+                'id': 'gs1',
+                'arguments': {'queries': ['genkit']},
+                'signature': 'sig',
+            })
+        )
+        root = result[0].root
+        assert isinstance(root, CustomPart)
+        assert root.custom == {'googleSearchCall': {'id': 'gs1', 'arguments': {'queries': ['genkit']}}}
+        assert root.metadata == {'thoughtSignature': 'sig'}
+
+    def test_code_execution_call_is_custom_part(self) -> None:
+        result = from_interaction_step(
+            StepAdapter.validate_python({
+                'type': 'code_execution_call',
+                'id': 'ce1',
+                'arguments': {'code': 'print(1)', 'language': 'python'},
+            })
+        )
+        root = result[0].root
+        assert isinstance(root, CustomPart)
+        assert root.custom == {'executableCode': {'code': 'print(1)', 'language': 'python'}}
+        assert root.metadata == {'callId': 'ce1'}
+
+
+class TestInboundFlattensToSingleModelMessage:
+    """Every Interaction response becomes one role=model Message of flattened parts."""
+
+    def test_mixed_tape_drops_user_input_and_keeps_order(self) -> None:
+        interaction = Interaction.model_validate({
+            'id': 'ix-1',
+            'status': 'completed',
+            'environment_id': 'env-1',
+            'steps': [
+                {'type': 'user_input', 'content': [{'type': 'text', 'text': 'weather?'}]},
+                {
+                    'type': 'thought',
+                    'signature': 'sig',
+                    'summary': [{'type': 'text', 'text': 'need a tool'}],
+                },
+                {'type': 'model_output', 'content': [{'type': 'text', 'text': 'checking'}]},
+                {
+                    'type': 'function_call',
+                    'id': 'c1',
+                    'name': 'get_weather',
+                    'arguments': {'city': 'Austin'},
+                },
+            ],
+        })
+        op = from_interaction(interaction)
+        assert op.done is True
+        assert op.output is not None
+        message = op.output.message
+        assert message is not None
+        assert message.role == 'model'
+        assert message.metadata == {
+            'interactionId': 'ix-1',
+            'environmentId': 'env-1',
+            'interactionStatus': 'completed',
+        }
+        assert [type(part.root).__name__ for part in message.content] == [
+            'ReasoningPart',
+            'TextPart',
+            'ToolRequestPart',
+        ]
+        assert message.content[0].root.reasoning == 'need a tool'
+        assert message.content[1].root.text == 'checking'
+        assert message.content[2].root.tool_request.ref == 'c1'
+
+    def test_already_resolved_tool_pair_stays_inside_model_message(self) -> None:
+        """A tape that already has function_result still flattens into one model turn."""
+        steps = [
+            StepAdapter.validate_python({
+                'type': 'function_call',
+                'id': 'c1',
+                'name': 'get_weather',
+                'arguments': {'city': 'Austin'},
+            }),
+            StepAdapter.validate_python({
+                'type': 'function_result',
+                'call_id': 'c1',
+                'name': 'get_weather',
+                'result': {'temp': 92},
+            }),
+            StepAdapter.validate_python({
+                'type': 'model_output',
+                'content': [{'type': 'text', 'text': '92F'}],
+            }),
+        ]
+        parts = parts_from_steps(steps)
+        assert [type(part.root).__name__ for part in parts] == [
+            'ToolRequestPart',
+            'CustomPart',
+            'TextPart',
+        ]
+        root = parts[1].root
+        assert isinstance(root, CustomPart)
+        stash = root.custom['serverFunctionResult']
+        assert stash['name'] == 'get_weather'
+        assert stash['result'] == {'temp': 92}
+
+
+class TestFunctionCallRoundTrip:
+    """The bug we hit: function_call must be ToolRequestPart, not CustomPart."""
+
+    def test_outbound_then_inbound_preserves_tool_request(self) -> None:
+        messages = [
+            Message(
+                role='model',
+                content=[
+                    Part(
+                        ToolRequestPart(
+                            tool_request=ToolRequest(name='get_weather', input={'city': 'Austin'}, ref='c1')
+                        )
+                    )
+                ],
+            )
+        ]
+        steps = to_interaction_steps(messages)
+        assert steps == [{'type': 'function_call', 'name': 'get_weather', 'arguments': {'city': 'Austin'}, 'id': 'c1'}]
+        inbound = from_interaction_step(StepAdapter.validate_python(steps[0]))
+        root = inbound[0].root
+        assert isinstance(root, ToolRequestPart)
+        assert root.tool_request is not None
+        assert root.tool_request.name == 'get_weather'
+        assert root.tool_request.input == {'city': 'Austin'}
+        assert root.tool_request.ref == 'c1'
+
+    def test_inbound_then_outbound_preserves_function_call(self) -> None:
+        step = StepAdapter.validate_python({
+            'type': 'function_call',
+            'id': 'c1',
+            'name': 'get_weather',
+            'arguments': {'city': 'Austin'},
+        })
+        part = from_interaction_step(step)[0]
+        assert isinstance(part.root, ToolRequestPart)
+        again = to_interaction_steps([Message(role='model', content=[part])])
+        assert again == [{'type': 'function_call', 'name': 'get_weather', 'arguments': {'city': 'Austin'}, 'id': 'c1'}]
+
+    def test_thought_round_trip_keeps_signature(self) -> None:
+        messages = [
+            Message(
+                role='model',
+                content=[
+                    Part(
+                        ReasoningPart(
+                            reasoning='plan',
+                            metadata={'thoughtSignature': 'sig'},
+                        )
+                    )
+                ],
+            )
+        ]
+        steps = to_interaction_steps(messages)
+        inbound = from_interaction_step(StepAdapter.validate_python(steps[0]))
+        root = inbound[0].root
+        assert isinstance(root, ReasoningPart)
+        assert root.reasoning == 'plan'
+        assert root.metadata == {'thoughtSignature': 'sig'}
+
+
+class TestClientOptionsWireFormat:
+    def test_operation_metadata_uses_camel_case_keys(self) -> None:
+        op = from_interaction(
+            Interaction.model_validate({'id': '123', 'status': 'in_progress'}),
+            ClientOptions(api_key='k', base_url='https://example.test', api_version='v1beta', timeout=1500),
+        )
+        assert op.metadata == {
+            'clientOptions': {
+                'apiVersion': 'v1beta',
+                'timeout': 1500.0,
+            }
+        }
+        persisted = (op.metadata or {}).get('clientOptions') or {}
+        assert 'apiKey' not in persisted
+        assert 'baseUrl' not in persisted
+
+
+class TestFromInteractionStatusMapping:
+    def test_cancelled(self) -> None:
+        result = from_interaction(Interaction.model_validate({'id': '123', 'status': 'cancelled'}))
+        assert result.done is True
+        assert result.output is not None
+        assert result.output.finish_reason == 'aborted'
+        assert result.output.finish_message == 'Operation cancelled'
+        assert part_dict(result.output.message.content[0]) == {'text': 'Operation cancelled.'}
+
+    def test_failed_exits_poll_loop(self) -> None:
+        result = from_interaction(
+            Interaction.model_validate({
+                'id': '123',
+                'status': 'failed',
+                'steps': [{'type': 'model_output', 'error': {'code': 3, 'message': 'boom'}}],
+            })
+        )
+        assert result.done is True
+        assert result.error is not None
+        assert result.error.message == 'boom'
+
+    def test_failed_without_step_error_falls_back(self) -> None:
+        result = from_interaction(Interaction.model_validate({'id': '123', 'status': 'failed'}))
+        assert result.done is True
+        assert result.error is not None
+        assert result.error.message == 'Interaction failed'
+
+    def test_requires_action_leaves_done_unset(self) -> None:
+        interaction = Interaction.model_validate({
+            'id': '123',
+            'status': 'requires_action',
+            'steps': [{'type': 'model_output', 'content': [{'type': 'text', 'text': 'approve plan'}]}],
+        })
+        result = from_interaction(interaction)
+        assert result.id == '123'
+        assert result.done is None
+        assert result.output is None
+        assert not (result.metadata or {}).get('interaction_status')
+
+    def test_in_progress(self) -> None:
+        result = from_interaction(Interaction.model_validate({'id': '123', 'status': 'in_progress'}))
+        assert result.done is False
+
+    def test_queued_keeps_polling(self) -> None:
+        result = from_interaction(Interaction.model_validate({'id': '123', 'status': 'queued'}))
+        assert result.done is False
+
+    def test_incomplete_surfaces_partial_steps(self) -> None:
+        result = from_interaction(
+            Interaction.model_validate({
+                'id': '123',
+                'status': 'incomplete',
+                'steps': [{'type': 'model_output', 'content': [{'type': 'text', 'text': 'partial'}]}],
+            })
+        )
+        assert result.done is True
+        assert result.error is None
+        assert result.output is not None
+        assert result.output.finish_reason == 'length'
+        assert result.output.finish_message == 'Interaction incomplete (truncated output)'
+        assert result.output.message is not None
+        assert result.output.message.content[0].root.text == 'partial'
+        assert result.output.message.metadata is not None
+        assert result.output.message.metadata.get('interactionStatus') == 'incomplete'
+
+    def test_incomplete_without_steps_errors(self) -> None:
+        result = from_interaction(Interaction.model_validate({'id': '123', 'status': 'incomplete'}))
+        assert result.done is True
+        assert result.output is None
+        assert result.error is not None
+
+    def test_budget_exceeded_surfaces_partial_steps(self) -> None:
+        result = from_interaction(
+            Interaction.model_validate({
+                'id': '123',
+                'status': 'budget_exceeded',
+                'steps': [{'type': 'model_output', 'content': [{'type': 'text', 'text': 'draft'}]}],
+            })
+        )
+        assert result.done is True
+        assert result.error is None
+        assert result.output is not None
+        assert result.output.finish_reason == 'aborted'
+        assert result.output.finish_message == 'Interaction exceeded its budget'
+        assert result.output.message is not None
+        assert result.output.message.content[0].root.text == 'draft'
+        assert result.output.message.metadata is not None
+        assert result.output.message.metadata.get('interactionStatus') == 'budget_exceeded'
+
+    def test_budget_exceeded_without_steps_errors(self) -> None:
+        result = from_interaction(Interaction.model_validate({'id': '123', 'status': 'budget_exceeded'}))
+        assert result.done is True
+        assert result.output is None
+        assert result.error is not None
+        assert 'budget' in (result.error.message or '').lower()
+
+
+class TestFromInteractionSync:
+    def test_failed_raises(self) -> None:
+        with pytest.raises(ValueError, match='Interaction failed'):
+            from_interaction_sync(Interaction.model_validate({'status': 'failed'}))

--- a/py/uv.lock
+++ b/py/uv.lock
@@ -1841,7 +1841,7 @@ dependencies = [
 requires-dist = [
     { name = "genkit", editable = "packages/genkit" },
     { name = "google-cloud-aiplatform", specifier = ">=1.77.0" },
-    { name = "google-genai", specifier = ">=1.63.0" },
+    { name = "google-genai", specifier = ">=2.14.0,<3" },
     { name = "strenum", marker = "python_full_version < '3.11'", specifier = ">=0.4.15" },
     { name = "structlog", specifier = ">=25.2.0" },
 ]
@@ -2129,16 +2129,15 @@ grpc = [
 
 [[package]]
 name = "google-auth"
-version = "2.48.0"
+version = "2.57.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
     { name = "pyasn1-modules" },
-    { name = "rsa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0c/41/242044323fbd746615884b1c16639749e73665b718209946ebad7ba8a813/google_auth-2.48.0.tar.gz", hash = "sha256:4f7e706b0cd3208a3d940a19a822c37a476ddba5450156c3e6624a71f7c841ce", size = 326522, upload-time = "2026-01-26T19:22:47.157Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/64/55f316b729f92a552d26e00aa3b1542b2e149d0a5efe2842afff0cac7af7/google_auth-2.57.0.tar.gz", hash = "sha256:9b4f96d6a1feb5f7201231f47cfb3de08d8f176f8a61f9e461555116e95a8789", size = 370794, upload-time = "2026-08-25T19:18:26.419Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/83/1d/d6466de3a5249d35e832a52834115ca9d1d0de6abc22065f049707516d47/google_auth-2.48.0-py3-none-any.whl", hash = "sha256:2e2a537873d449434252a9632c28bfc268b0adb1e53f9fb62afc5333a975903f", size = 236499, upload-time = "2026-01-26T19:22:45.099Z" },
+    { url = "https://files.pythonhosted.org/packages/00/f3/8508a702c094af5f6e89773f4dfdeee74913df0f41a02c21b5e7dc3d75cd/google_auth-2.57.0-py3-none-any.whl", hash = "sha256:180dafe015cfb62193bea26b677500fab5b9fd51a1e825ebf3ad9b182047ae59", size = 259728, upload-time = "2026-08-24T21:55:08.449Z" },
 ]
 
 [package.optional-dependencies]
@@ -2148,15 +2147,17 @@ requests = [
 
 [[package]]
 name = "google-cloud-aiplatform"
-version = "1.137.0"
+version = "2.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "certifi" },
     { name = "docstring-parser" },
     { name = "google-api-core", extra = ["grpc"] },
     { name = "google-auth" },
     { name = "google-cloud-bigquery" },
     { name = "google-cloud-resource-manager" },
-    { name = "google-cloud-storage" },
+    { name = "google-cloud-storage", version = "3.9.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
+    { name = "google-cloud-storage", version = "3.13.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
     { name = "google-genai" },
     { name = "packaging" },
     { name = "proto-plus" },
@@ -2164,9 +2165,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d6/76/0da98f663f5c58239900fa8f99488d01439b1ca7846c9667217a3aee20b1/google_cloud_aiplatform-1.137.0.tar.gz", hash = "sha256:76e66e2c3879936e51039d8bbd82581451510b4c7a840a588daaecee893d7d1e", size = 9947045, upload-time = "2026-02-11T16:23:18.435Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e1/86/d8b154861ab292566d90dbdea276c33ef824b02de4a3fda61f2075d016d7/google_cloud_aiplatform-2.0.1.tar.gz", hash = "sha256:46e051b980baed400c5ea4328c79a8ae25f6f44a034b63bf0041aa5cd248ea84", size = 11325585, upload-time = "2026-08-28T03:41:22.864Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/72/b5/795c410120cb350058b9328f051b57a49a897514ba1bc65677ade0f6c1be/google_cloud_aiplatform-1.137.0-py2.py3-none-any.whl", hash = "sha256:e99dd235c237cbbeb0e73b0fc4b1ca9588b4144ac243a6242b2005b339b40ce8", size = 8204286, upload-time = "2026-02-11T16:23:15.462Z" },
+    { url = "https://files.pythonhosted.org/packages/53/3b/9d7974a7430edf56f009247c8d0d68df1a8fcfc19a27598141bb9e0359a7/google_cloud_aiplatform-2.0.1-py2.py3-none-any.whl", hash = "sha256:a72586889b1eebca0816b34e5914258abe6e76f23fbac40938b47e70103cbeee", size = 9451860, upload-time = "2026-08-28T03:41:19.276Z" },
 ]
 
 [[package]]
@@ -2302,17 +2303,43 @@ wheels = [
 name = "google-cloud-storage"
 version = "3.9.0"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version == '3.12.*'",
+    "python_full_version == '3.11.*'",
+    "python_full_version < '3.11'",
+]
 dependencies = [
-    { name = "google-api-core" },
-    { name = "google-auth" },
-    { name = "google-cloud-core" },
-    { name = "google-crc32c" },
-    { name = "google-resumable-media" },
-    { name = "requests" },
+    { name = "google-api-core", marker = "python_full_version < '3.13'" },
+    { name = "google-auth", marker = "python_full_version < '3.13'" },
+    { name = "google-cloud-core", marker = "python_full_version < '3.13'" },
+    { name = "google-crc32c", marker = "python_full_version < '3.13'" },
+    { name = "google-resumable-media", marker = "python_full_version < '3.13'" },
+    { name = "requests", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f7/b1/4f0798e88285b50dfc60ed3a7de071def538b358db2da468c2e0deecbb40/google_cloud_storage-3.9.0.tar.gz", hash = "sha256:f2d8ca7db2f652be757e92573b2196e10fbc09649b5c016f8b422ad593c641cc", size = 17298544, upload-time = "2026-02-02T13:36:34.119Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/46/0b/816a6ae3c9fd096937d2e5f9670558908811d57d59ddf69dd4b83b326fd1/google_cloud_storage-3.9.0-py3-none-any.whl", hash = "sha256:2dce75a9e8b3387078cbbdad44757d410ecdb916101f8ba308abf202b6968066", size = 321324, upload-time = "2026-02-02T13:36:32.271Z" },
+]
+
+[[package]]
+name = "google-cloud-storage"
+version = "3.13.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14'",
+    "python_full_version == '3.13.*'",
+]
+dependencies = [
+    { name = "google-api-core", marker = "python_full_version >= '3.13'" },
+    { name = "google-auth", marker = "python_full_version >= '3.13'" },
+    { name = "google-cloud-core", marker = "python_full_version >= '3.13'" },
+    { name = "google-crc32c", marker = "python_full_version >= '3.13'" },
+    { name = "google-resumable-media", marker = "python_full_version >= '3.13'" },
+    { name = "requests", marker = "python_full_version >= '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ce/7e/73bb7512df1d1aad6ce3f9aed847cd40e0cd400ba4a85d86ab8eb412e9cc/google_cloud_storage-3.13.1.tar.gz", hash = "sha256:a80bf8cac2794808aa61c50c5f769ecbbe2d10331bacd0d69d30e59b14b346b2", size = 17341051, upload-time = "2026-08-06T06:24:42.229Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/06/6f/d69f0e185e08ddb58c323a0a935af2b492907b5de362bc08933b0a3b5644/google_cloud_storage-3.13.1-py3-none-any.whl", hash = "sha256:98208de6c21e85cecd3eb44551894efff33d98365500e178867d4305854a770a", size = 341486, upload-time = "2026-08-06T06:23:36.548Z" },
 ]
 
 [[package]]
@@ -2368,7 +2395,7 @@ wheels = [
 
 [[package]]
 name = "google-genai"
-version = "1.63.0"
+version = "2.21.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -2382,9 +2409,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/46/d7/07ec5dadd0741f09e89f3ff5f0ce051ce2aa3a76797699d661dc88def077/google_genai-1.63.0.tar.gz", hash = "sha256:dc76cab810932df33cbec6c7ef3ce1538db5bef27aaf78df62ac38666c476294", size = 491970, upload-time = "2026-02-11T23:46:28.472Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/60/a7/a45f64f22ab9302b55fcbeb32acb6f313690a7748629b01e451aad1817a3/google_genai-2.21.0.tar.gz", hash = "sha256:0ecc11c6a5b9f5e3cc58e77ae5fead00c6719f8a1b2b654b803f514a9a6b64c0", size = 677301, upload-time = "2026-08-31T21:49:14.508Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/82/c8/ba32159e553fab787708c612cf0c3a899dafe7aca81115d841766e3bfe69/google_genai-1.63.0-py3-none-any.whl", hash = "sha256:6206c13fc20f332703ca7375bea7c191c82f95d6781c29936c6982d86599b359", size = 724747, upload-time = "2026-02-11T23:46:26.697Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/d7/c2419dd5fedd5803ce09810e4e39561a0a13a960b3f48d2581c12e42af3e/google_genai-2.21.0-py3-none-any.whl", hash = "sha256:36b575034be46a03acd603a852e22a6359f2cdd6b26bb1d65d9b7e0cc7ab3648", size = 1080223, upload-time = "2026-08-31T21:49:12.699Z" },
 ]
 
 [[package]]
@@ -6170,18 +6197,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/13/64/b4d76f227d5c45a7e0b796c674fd81b0a6c4fbd48dc29271857d8219571c/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:dff13836529b921e22f15cb099751209a60009731a68519630a24d61f0b1b30a", size = 573981, upload-time = "2025-11-30T20:24:32.934Z" },
     { url = "https://files.pythonhosted.org/packages/20/91/092bacadeda3edf92bf743cc96a7be133e13a39cdbfd7b5082e7ab638406/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:1b151685b23929ab7beec71080a8889d4d6d9fa9a983d213f07121205d48e2c4", size = 599782, upload-time = "2025-11-30T20:24:35.169Z" },
     { url = "https://files.pythonhosted.org/packages/d1/b7/b95708304cd49b7b6f82fdd039f1748b66ec2b21d6a45180910802f1abf1/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:ac37f9f516c51e5753f27dfdef11a88330f04de2d564be3991384b2f3535d02e", size = 562191, upload-time = "2025-11-30T20:24:36.853Z" },
-]
-
-[[package]]
-name = "rsa"
-version = "4.9.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pyasn1" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/da/8a/22b7beea3ee0d44b1916c0c1cb0ee3af23b700b6da9f04991899d0c555d4/rsa-4.9.1.tar.gz", hash = "sha256:e7bdbfdb5497da4c07dfd35530e1a902659db6ff241e39d9953cad06ebd0ae75", size = 29034, upload-time = "2025-04-16T09:51:18.218Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/64/8d/0133e4eb4beed9e425d9a98ed6e081a55d195481b7632472be1af08d2f6b/rsa-4.9.1-py3-none-any.whl", hash = "sha256:68635866661c6836b8d39430f97a996acbd61bfa49406748ea243539fe239762", size = 34696, upload-time = "2025-04-16T09:51:17.142Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This layer provides the transport foundation for Google AI Interactions-backed models. It converts Genkit messages into Interactions steps, converts an Interaction poll result into a Genkit `Operation`, and provides the raw HTTP create/get/cancel client. Product model registration and higher-level Deep Research, Antigravity, and Lyria support belong in follow-up integration work. The package requires `google-genai>=2.14.0,<3` for the Interactions types.

```python
from genkit import Message, Part, TextPart, ToolRequest, ToolRequestPart
from genkit_google_genai._interactions.converters import (
    from_interaction,
    to_interaction_steps,
)

steps = to_interaction_steps([
    Message(role='user', content=[Part(TextPart(text='weather in Austin?'))]),
    Message(
        role='model',
        content=[
            Part(ToolRequestPart(tool_request=ToolRequest(
                name='get_weather',
                input={'city': 'Austin'},
                ref='c1',
            )))
        ],
    ),
])
# [
#   {'type': 'user_input', 'content': [{'type': 'text', 'text': 'weather in Austin?'}]},
#   {'type': 'function_call', 'name': 'get_weather', 'arguments': {'city': 'Austin'}, 'id': 'c1'},
# ]

operation = from_interaction(interaction)
# Operation(id=..., done=..., output=...)
# HTTP client options are not stored in operation.metadata.
```

The HTTP client talks to `generativelanguage.googleapis.com` through create, get, and cancel requests. Interaction ids in URL paths are quoted. Creates use a 10-second connect timeout with no read timeout so long-running research jobs are not capped by the shared 60-second client.

```python
# Polling never hangs on a terminal or unsupported status.
operation = from_interaction(interaction)  # done=True, with output or error

# Synchronous conversion preserves non-success terminal reasons.
response = from_interaction_sync(interaction)  # LENGTH or ABORTED when applicable
```

**Decisions**
- **HTTP client options are request-scoped.** An `Operation` persists no API key, base URL, timeout, headers, or API version. Create, check, and cancel each receive the options for their own HTTP request, keeping generic L1 operations independent of transport configuration.
- **Quote interaction ids.** Path ids go through `urllib.parse.quote(..., safe="")` so a slash or space in an id cannot change the URL.
- **Connect timeout 10s, no read timeout.** A hung handshake should fail; a long Deep Research create should not.
- **Inbound `function_result` is not a model `ToolResponsePart`.** The API echoes the client's own tool result on the model tape. Storing it as `CustomPart(custom={'serverFunctionResult': ...})` prevents the next turn from sending that result again.
- **Tool request input must be a JSON object.** A scalar such as `'Paris'` would silently become `{}` on the wire, so callers must wrap it, for example `{'city': 'Paris'}`.
- **Mixed parts flush in order.** Text and media buffer into a content step, but a thought or tool call in the middle flushes first so a sentence cannot move past a thought.
- **JSON arrays in tool results are boxed** unless they are a list of text/image content blocks. `[1, 2]` is data, not multimodal content.
- **`is_error` / `isError` round-trips** on `function_result` so the model still sees a failed tool.
- **Reserved headers win case-insensitively.** `X-Goog-Api-Key` in custom headers cannot add a second key to the request.
- **Sync generate shares the poll status table.** A truncated or over-budget turn keeps `LENGTH` / `ABORTED` instead of appearing as a clean `STOP`; an in-flight ticket raises instead of returning empty content.
- **`requires_action` is `done=True` with an unsupported-interrupt error.** Polling must terminate because interrupt/resume is not provided by this transport layer.
- **Tool response refs pair against every request id; already-claimed ids are skipped.** A model-supplied call id and an auto-generated id cannot cross-wire on the next turn.
- **Annotations are stored as plain data.** Metadata remains JSON-serializable when messages are dumped later.
- **Cancel returns cancelled on 200, empty 200, or `CANCELLED`.** Only a real `CANCELLED` error is caught; the successful path returns a cancelled Interaction directly.
- **Pydantic tool input and output are dumped before the wire, including nested values.** Nested models serialize cleanly for the Interactions API.
- **Unknown status means poll done with an error; synchronous conversion raises.** A future API status cannot leave a poll loop spinning forever.
- **Completed with empty steps returns an empty `STOP` `ModelResponse`.** A finished job with no output still produces a well-formed response.
- **Failed jobs prefer top-level interaction errors, then step errors.** The most specific failure surfaces first.
- **Video modality tokens map to `ModelUsage.input_videos` / `output_videos`.** Usage accounting covers video input and output separately.