### PR TITLE
feat(py): add Deep Research, Antigravity, and Lyria via Google AI Interactions

### DIFF
--- a/py/packages/genkit-google-genai/src/genkit_google_genai/__init__.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/__init__.py
@@ -76,6 +76,8 @@ from genkit_google_genai.google import (
     GoogleAI,
     VertexAI,
 )
+from genkit_google_genai.models.antigravity import AntigravityConfig
+from genkit_google_genai.models.deep_research import DeepResearchConfig
 from genkit_google_genai.models.embedder import (
     EmbeddingTaskType,
     GeminiEmbeddingModels,
@@ -114,6 +116,8 @@ __all__ = [
     'GeminiImageConfigSchema',
     'GeminiTtsConfigSchema',
     'GemmaConfigSchema',
+    'AntigravityConfig',
+    'DeepResearchConfig',
     'GoogleAI',
     'GoogleAIGeminiVersion',
     'ImagenConfigSchema',

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/__init__.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/__init__.py
@@ -96,7 +96,8 @@ from genkit_google_genai.models.gemini import (
     VertexAIGeminiVersion,
 )
 from genkit_google_genai.models.imagen import ImagenConfigSchema, ImagenVersion, KnownImagen
-from genkit_google_genai.models.lyria import LyriaConfig, LyriaVersion
+from genkit_google_genai.models.interactions_lyria import LyriaConfig
+from genkit_google_genai.models.interactions_registry import LyriaVersion
 from genkit_google_genai.models.veo import KnownVeo, VeoConfig, VeoVersion
 
 

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/google.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/google.py
@@ -66,7 +66,15 @@ from genkit._core._action import ActionRunContext
 from genkit._core._model import ModelRequest, ModelResponse
 from genkit.embedder import EmbedderRef, embedder, embedder_action_metadata
 from genkit.evaluator import EvalFnResponse, EvalRequest
-from genkit.model import BackgroundAction, ModelRef, Operation, background_model, model, model_action_metadata
+from genkit.model import (
+    BackgroundAction,
+    ModelRef,
+    Operation,
+    background_model,
+    model,
+    model_action_metadata,
+    model_ref,
+)
 from genkit.plugin_api import (
     GENKIT_CLIENT_HEADER,
     Action,
@@ -76,6 +84,7 @@ from genkit.plugin_api import (
     loop_local_client,
     to_json_schema,
 )
+from genkit_google_genai._interactions.options import ClientOptions
 from genkit_google_genai.evaluators import (
     VertexAIEvaluationMetricType,
     create_vertex_evaluators,
@@ -83,8 +92,15 @@ from genkit_google_genai.evaluators import (
 from genkit_google_genai.models._model_refs import (
     family_embedder_ref,
     family_model_ref,
+    wrong_family_error,
 )
-from genkit_google_genai.models._routing import is_unroutable_model_id
+from genkit_google_genai.models._routing import classify_family, is_unroutable_model_id, strip_ref_prefixes
+from genkit_google_genai.models.antigravity import AntigravityConfig, create_antigravity_action
+from genkit_google_genai.models.deep_research import (
+    DeepResearchConfig,
+    create_deep_research_background_action,
+    deep_research_model,
+)
 from genkit_google_genai.models.embedder import (
     VERTEX_KNOWN_EMBEDDERS,
     Embedder,
@@ -116,6 +132,21 @@ from genkit_google_genai.models.imagen import (
     is_imagen_model_name,
     is_unsupported_image_model_name,
     vertexai_image_model_info,
+)
+from genkit_google_genai.models.interactions_lyria import (
+    LyriaConfig as InteractionsLyriaConfig,
+    create_lyria_action,
+)
+from genkit_google_genai.models.interactions_registry import (
+    antigravity_model_info,
+    deep_research_model_info,
+    is_antigravity_model_name,
+    is_deep_research_model_name,
+    is_lyria_model_name,
+    list_known_antigravity_models,
+    list_known_deep_research_models,
+    list_known_lyria_models,
+    lyria_model_info,
 )
 from genkit_google_genai.models.veo import (
     KnownVeo,
@@ -572,6 +603,67 @@ class GoogleAI(GoogleFamilyRefs, Plugin):
     name = GOOGLEAI_PLUGIN_NAME
     _vertexai = False
 
+    @classmethod
+    def deep_research_model(
+        cls, name: str, *, config: DeepResearchConfig | None = None
+    ) -> ModelRef[DeepResearchConfig]:
+        """Typed ref for a Deep Research agent. Pass to generate_operation()."""
+        local = strip_ref_prefixes(name) if isinstance(name, str) else name
+        if not isinstance(name, str) or not local:
+            raise wrong_family_error(
+                plugin_class=cls.__name__,
+                method='deep_research_model',
+                family='deep-research',
+                local=str(name),
+                actual='unknown',
+            )
+        if classify_family(local) != 'deep-research':
+            raise wrong_family_error(
+                plugin_class=cls.__name__,
+                method='deep_research_model',
+                family='deep-research',
+                local=local,
+                actual=classify_family(local),
+            )
+        ref = deep_research_model(local)
+        if config is None:
+            return ref
+        return model_ref(
+            local,
+            namespace=cls.name,
+            info=ref.info,
+            config_schema=DeepResearchConfig,
+            config=config,
+        )
+
+    @classmethod
+    def antigravity_model(cls, name: str, *, config: AntigravityConfig | None = None) -> ModelRef[AntigravityConfig]:
+        """Typed ref for an Antigravity agent."""
+        return family_model_ref(
+            name,
+            namespace=cls.name,
+            plugin_class=cls.__name__,
+            family='antigravity',
+            method='antigravity_model',
+            config_schema=AntigravityConfig,
+            config=config,
+        )
+
+    @classmethod
+    def lyria_model(
+        cls, name: str, *, config: InteractionsLyriaConfig | None = None
+    ) -> ModelRef[InteractionsLyriaConfig]:
+        """Typed ref for Google AI Interactions Lyria (lyria-3-clip-preview, …)."""
+        return family_model_ref(
+            name,
+            namespace=cls.name,
+            plugin_class=cls.__name__,
+            family='lyria',
+            method='lyria_model',
+            config_schema=InteractionsLyriaConfig,
+            config=config,
+        )
+
     def __init__(
         self,
         api_key: str | None = None,
@@ -624,6 +716,26 @@ class GoogleAI(GoogleFamilyRefs, Plugin):
         self._runtime_client = loop_local_client(lambda: genai.client.Client(**self._client_kwargs))
         self._list_actions_cache: list[ActionMetadata] | None = None
 
+    def _interactions_client_options(self) -> ClientOptions:
+        """Plugin-level transport knobs for Interactions models.
+
+        Per-request config can still override timeout/headers/api_version.
+        A ticket never supplies the host.
+        """
+        http_options: HttpOptions | None = self._client_kwargs.get('http_options')
+        if http_options is None:
+            return ClientOptions()
+        return ClientOptions(
+            api_version=http_options.api_version,
+            base_url=http_options.base_url,
+            custom_headers=dict(http_options.headers) if http_options.headers else None,
+            timeout=float(http_options.timeout) if http_options.timeout is not None else None,
+        )
+
+    def _plugin_api_key(self) -> str | None:
+        raw = self._client_kwargs.get('api_key')
+        return raw if isinstance(raw, str) else None
+
     async def init(self) -> list[Action]:
         """Initialize the plugin.
 
@@ -648,6 +760,31 @@ class GoogleAI(GoogleFamilyRefs, Plugin):
             bg_action = self._resolve_veo_model(googleai_name(name))
             actions.append(bg_action.start_action)
             actions.append(bg_action.check_action)
+
+        client_options = self._interactions_client_options()
+        plugin_api_key = self._plugin_api_key()
+        for name in list_known_deep_research_models():
+            bg_action = self._resolve_deep_research_model(googleai_name(name), client_options, plugin_api_key)
+            actions.append(bg_action.start_action)
+            actions.append(bg_action.check_action)
+            if bg_action.cancel_action is not None:
+                actions.append(bg_action.cancel_action)
+        for name in list_known_antigravity_models():
+            actions.append(
+                create_antigravity_action(
+                    googleai_name(name),
+                    plugin_api_key=plugin_api_key,
+                    client_options=client_options,
+                )
+            )
+        for name in list_known_lyria_models():
+            actions.append(
+                create_lyria_action(
+                    googleai_name(name),
+                    plugin_api_key=plugin_api_key,
+                    client_options=client_options,
+                )
+            )
 
         # Embedders
         for name in genai_models.embedders:
@@ -702,27 +839,59 @@ class GoogleAI(GoogleFamilyRefs, Plugin):
         if action_type == ActionKind.MODEL:
             return self._resolve_model(name)
         elif action_type == ActionKind.BACKGROUND_MODEL:
-            # For Veo models, return the start action
             prefix = GOOGLEAI_PLUGIN_NAME + '/'
             clean_name = name.replace(prefix, '') if name.startswith(prefix) else name
             if is_veo_model(clean_name):
-                bg_action = self._resolve_veo_model(name)
-                return bg_action.start_action
+                return self._resolve_veo_model(name).start_action
+            if is_deep_research_model_name(clean_name):
+                return self._resolve_deep_research_model(
+                    deep_research_model(name),
+                    self._interactions_client_options(),
+                    self._plugin_api_key(),
+                ).start_action
             return None
         elif action_type == ActionKind.CHECK_OPERATION:
-            # Check action names are in format {model_name}/check
-            # Extract the model name and resolve if it's a Veo model
             if name.endswith('/check'):
-                model_name = name[:-6]  # Remove '/check' suffix
+                model_name = name[:-6]
                 prefix = GOOGLEAI_PLUGIN_NAME + '/'
                 clean_name = model_name.replace(prefix, '') if model_name.startswith(prefix) else model_name
                 if is_veo_model(clean_name):
-                    bg_action = self._resolve_veo_model(model_name)
-                    return bg_action.check_action
+                    return self._resolve_veo_model(model_name).check_action
+                if is_deep_research_model_name(clean_name):
+                    return self._resolve_deep_research_model(
+                        deep_research_model(model_name),
+                        self._interactions_client_options(),
+                        self._plugin_api_key(),
+                    ).check_action
+            return None
+        elif action_type == ActionKind.CANCEL_OPERATION:
+            if name.endswith('/cancel'):
+                model_name = name[:-7]
+                prefix = GOOGLEAI_PLUGIN_NAME + '/'
+                clean_name = model_name.replace(prefix, '') if model_name.startswith(prefix) else model_name
+                if is_deep_research_model_name(clean_name):
+                    return self._resolve_deep_research_model(
+                        deep_research_model(model_name),
+                        self._interactions_client_options(),
+                        self._plugin_api_key(),
+                    ).cancel_action
             return None
         elif action_type == ActionKind.EMBEDDER:
             return self._resolve_embedder(name)
         return None
+
+    def _resolve_deep_research_model(
+        self,
+        target: str | ModelRef,
+        client_options: ClientOptions,
+        plugin_api_key: str | None,
+    ) -> BackgroundAction:
+        """Create a BackgroundAction for a Deep Research model."""
+        return create_deep_research_background_action(
+            target,
+            plugin_api_key=plugin_api_key,
+            client_options=client_options,
+        )
 
     def _resolve_veo_model(self, name: str) -> BackgroundAction:
         """Create a BackgroundAction for a Veo video generation model.
@@ -749,6 +918,23 @@ class GoogleAI(GoogleFamilyRefs, Plugin):
         """
         # Extract local name (remove plugin prefix)
         clean_name = name.replace(GOOGLEAI_PLUGIN_NAME + '/', '') if name.startswith(GOOGLEAI_PLUGIN_NAME) else name
+
+        # Interactions families before the shared fail-closed table so Vertex
+        # can keep them unroutable while Google AI actually serves them.
+        if is_deep_research_model_name(clean_name):
+            return None
+        if is_antigravity_model_name(clean_name):
+            return create_antigravity_action(
+                name,
+                plugin_api_key=self._plugin_api_key(),
+                client_options=self._interactions_client_options(),
+            )
+        if is_lyria_model_name(clean_name):
+            return create_lyria_action(
+                name,
+                plugin_api_key=self._plugin_api_key(),
+                client_options=self._interactions_client_options(),
+            )
 
         if is_unroutable_model_id(clean_name):
             return None
@@ -840,6 +1026,39 @@ class GoogleAI(GoogleFamilyRefs, Plugin):
 
         for name in genai_models.veo:
             actions_list.append(_veo_background_action_metadata(googleai_name(name)))
+
+        for name in list_known_deep_research_models():
+            actions_list.append(
+                ActionMetadata(
+                    action_type=ActionKind.BACKGROUND_MODEL,
+                    name=googleai_name(name),
+                    input_json_schema=to_json_schema(ModelRequest[DeepResearchConfig]),
+                    output_json_schema=to_json_schema(Operation),
+                    metadata={
+                        'model': {
+                            **deep_research_model_info(name).model_dump(by_alias=True),
+                            'customOptions': to_json_schema(DeepResearchConfig),
+                        },
+                        'type': 'background-model',
+                    },
+                )
+            )
+        for name in list_known_antigravity_models():
+            actions_list.append(
+                model_action_metadata(
+                    name=googleai_name(name),
+                    info=antigravity_model_info(name).model_dump(by_alias=True),
+                    config_schema=AntigravityConfig,
+                )
+            )
+        for name in list_known_lyria_models():
+            actions_list.append(
+                model_action_metadata(
+                    name=googleai_name(name),
+                    info=lyria_model_info(name).model_dump(by_alias=True),
+                    config_schema=InteractionsLyriaConfig,
+                )
+            )
 
         for name in genai_models.embedders:
             actions_list.append(

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/google.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/google.py
@@ -352,7 +352,7 @@ def _create_embedder_action(
     Returns:
         Action object for the embedder.
     """
-    clean_name = name.replace(f'{plugin_name}/', '') if name.startswith(plugin_name) else name
+    clean_name = name.removeprefix(f'{plugin_name}/')
     full_name = f'{plugin_name}/{clean_name}'
     label = f'{PLUGIN_DISPLAY_NAME[plugin_name]} - {clean_name}'
     embed_info = get_embedder_info(
@@ -415,6 +415,14 @@ def _create_veo_background_action(
         info=veo_model_info(clean_name),
         metadata={'type': 'background-model'},
     )
+
+
+def _background_actions(bg: BackgroundAction) -> list[Action]:
+    """Unpack a BackgroundAction into its constituent Action objects."""
+    actions = [bg.start_action, bg.check_action]
+    if bg.cancel_action is not None:
+        actions.append(bg.cancel_action)
+    return actions
 
 
 class GoogleFamilyRefs:
@@ -739,18 +747,20 @@ class GoogleAI(GoogleFamilyRefs, Plugin):
 
         # Veo Models (background models)
         for name in genai_models.veo:
-            bg_action = self._resolve_veo_model(googleai_name(name))
-            actions.append(bg_action.start_action)
-            actions.append(bg_action.check_action)
+            actions.extend(_background_actions(self._resolve_veo_model(googleai_name(name))))
 
         client_options = self._interactions_client_options()
         plugin_api_key = self._plugin_api_key()
         for name in list_known_deep_research_models():
-            bg_action = self._resolve_deep_research_model(googleai_name(name), client_options, plugin_api_key)
-            actions.append(bg_action.start_action)
-            actions.append(bg_action.check_action)
-            if bg_action.cancel_action is not None:
-                actions.append(bg_action.cancel_action)
+            actions.extend(
+                _background_actions(
+                    create_deep_research_background_action(
+                        googleai_name(name),
+                        plugin_api_key=plugin_api_key,
+                        client_options=client_options,
+                    )
+                )
+            )
         for name in list_known_antigravity_models():
             actions.append(
                 create_antigravity_action(
@@ -795,9 +805,7 @@ class GoogleAI(GoogleFamilyRefs, Plugin):
         genai_models = _list_genai_models(self._runtime_client(), is_vertex=False)
         actions = []
         for name in genai_models.veo:
-            bg_action = self._resolve_veo_model(googleai_name(name))
-            actions.append(bg_action.start_action)
-            actions.append(bg_action.check_action)
+            actions.extend(_background_actions(self._resolve_veo_model(googleai_name(name))))
         return actions
 
     def _list_known_embedders(self) -> list[Action]:
@@ -839,25 +847,12 @@ class GoogleAI(GoogleFamilyRefs, Plugin):
         if is_veo_model(clean):
             return self._resolve_veo_model(name)
         if is_deep_research_model_name(clean):
-            return self._resolve_deep_research_model(
+            return create_deep_research_background_action(
                 deep_research_model(name),
-                self._interactions_client_options(),
-                self._plugin_api_key(),
+                plugin_api_key=self._plugin_api_key(),
+                client_options=self._interactions_client_options(),
             )
         return None
-
-    def _resolve_deep_research_model(
-        self,
-        target: str | ModelRef,
-        client_options: ClientOptions,
-        plugin_api_key: str | None,
-    ) -> BackgroundAction:
-        """Create a BackgroundAction for a Deep Research model."""
-        return create_deep_research_background_action(
-            target,
-            plugin_api_key=plugin_api_key,
-            client_options=client_options,
-        )
 
     def _resolve_veo_model(self, name: str) -> BackgroundAction:
         """Create a BackgroundAction for a Veo video generation model.
@@ -883,7 +878,7 @@ class GoogleAI(GoogleFamilyRefs, Plugin):
             instead of defaulting to Gemini).
         """
         # Extract local name (remove plugin prefix)
-        clean_name = name.replace(GOOGLEAI_PLUGIN_NAME + '/', '') if name.startswith(GOOGLEAI_PLUGIN_NAME) else name
+        clean_name = name.removeprefix(f'{GOOGLEAI_PLUGIN_NAME}/')
 
         # Interactions families before the shared fail-closed table so Vertex
         # can keep them unroutable while Google AI actually serves them.

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/google.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/google.py
@@ -61,7 +61,7 @@ from google.genai.types import HttpOptions, HttpOptionsDict
 from pydantic import BaseModel
 
 import genkit_google_genai.constants as const
-from genkit import ModelInfo
+from genkit import GenkitError, ModelInfo
 from genkit._core._action import ActionRunContext
 from genkit._core._model import ModelRequest, ModelResponse
 from genkit.embedder import EmbedderRef, embedder, embedder_action_metadata
@@ -608,14 +608,16 @@ class GoogleAI(GoogleFamilyRefs, Plugin):
         cls, name: str, *, config: DeepResearchConfig | None = None
     ) -> ModelRef[DeepResearchConfig]:
         """Typed ref for a Deep Research agent. Pass to generate_operation()."""
-        local = strip_ref_prefixes(name) if isinstance(name, str) else name
-        if not isinstance(name, str) or not local:
-            raise wrong_family_error(
-                plugin_class=cls.__name__,
-                method='deep_research_model',
-                family='deep-research',
-                local=str(name),
-                actual='unknown',
+        if not isinstance(name, str):
+            raise GenkitError(
+                status='INVALID_ARGUMENT',
+                message=f'{cls.__name__}.deep_research_model: model name must be a string.',
+            )
+        local = strip_ref_prefixes(name)
+        if not local:
+            raise GenkitError(
+                status='INVALID_ARGUMENT',
+                message=f'{cls.__name__}.deep_research_model: model name is required.',
             )
         if classify_family(local) != 'deep-research':
             raise wrong_family_error(

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/google.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/google.py
@@ -61,7 +61,7 @@ from google.genai.types import HttpOptions, HttpOptionsDict
 from pydantic import BaseModel
 
 import genkit_google_genai.constants as const
-from genkit import GenkitError, ModelInfo
+from genkit import ModelInfo
 from genkit._core._action import ActionRunContext
 from genkit._core._model import ModelRequest, ModelResponse
 from genkit.embedder import EmbedderRef, embedder, embedder_action_metadata
@@ -73,7 +73,6 @@ from genkit.model import (
     background_model,
     model,
     model_action_metadata,
-    model_ref,
 )
 from genkit.plugin_api import (
     GENKIT_CLIENT_HEADER,
@@ -92,9 +91,8 @@ from genkit_google_genai.evaluators import (
 from genkit_google_genai.models._model_refs import (
     family_embedder_ref,
     family_model_ref,
-    wrong_family_error,
 )
-from genkit_google_genai.models._routing import classify_family, is_unroutable_model_id, strip_ref_prefixes
+from genkit_google_genai.models._routing import is_unroutable_model_id, strip_ref_prefixes
 from genkit_google_genai.models.antigravity import AntigravityConfig, create_antigravity_action
 from genkit_google_genai.models.deep_research import (
     DeepResearchConfig,
@@ -608,34 +606,16 @@ class GoogleAI(GoogleFamilyRefs, Plugin):
         cls, name: str, *, config: DeepResearchConfig | None = None
     ) -> ModelRef[DeepResearchConfig]:
         """Typed ref for a Deep Research agent. Pass to generate_operation()."""
-        if not isinstance(name, str):
-            raise GenkitError(
-                status='INVALID_ARGUMENT',
-                message=f'{cls.__name__}.deep_research_model: model name must be a string.',
-            )
-        local = strip_ref_prefixes(name)
-        if not local:
-            raise GenkitError(
-                status='INVALID_ARGUMENT',
-                message=f'{cls.__name__}.deep_research_model: model name is required.',
-            )
-        if classify_family(local) != 'deep-research':
-            raise wrong_family_error(
-                plugin_class=cls.__name__,
-                method='deep_research_model',
-                family='deep-research',
-                local=local,
-                actual=classify_family(local),
-            )
-        ref = deep_research_model(local)
-        if config is None:
-            return ref
-        return model_ref(
-            local,
+        clean = strip_ref_prefixes(name) if isinstance(name, str) else ''
+        return family_model_ref(
+            name,
             namespace=cls.name,
-            info=ref.info,
+            plugin_class=cls.__name__,
+            family='deep-research',
+            method='deep_research_model',
             config_schema=DeepResearchConfig,
             config=config,
+            info=deep_research_model_info(clean) if clean else None,
         )
 
     @classmethod
@@ -840,46 +820,30 @@ class GoogleAI(GoogleFamilyRefs, Plugin):
         """
         if action_type == ActionKind.MODEL:
             return self._resolve_model(name)
-        elif action_type == ActionKind.BACKGROUND_MODEL:
-            prefix = GOOGLEAI_PLUGIN_NAME + '/'
-            clean_name = name.replace(prefix, '') if name.startswith(prefix) else name
-            if is_veo_model(clean_name):
-                return self._resolve_veo_model(name).start_action
-            if is_deep_research_model_name(clean_name):
-                return self._resolve_deep_research_model(
-                    deep_research_model(name),
-                    self._interactions_client_options(),
-                    self._plugin_api_key(),
-                ).start_action
-            return None
-        elif action_type == ActionKind.CHECK_OPERATION:
-            if name.endswith('/check'):
-                model_name = name[:-6]
-                prefix = GOOGLEAI_PLUGIN_NAME + '/'
-                clean_name = model_name.replace(prefix, '') if model_name.startswith(prefix) else model_name
-                if is_veo_model(clean_name):
-                    return self._resolve_veo_model(model_name).check_action
-                if is_deep_research_model_name(clean_name):
-                    return self._resolve_deep_research_model(
-                        deep_research_model(model_name),
-                        self._interactions_client_options(),
-                        self._plugin_api_key(),
-                    ).check_action
-            return None
-        elif action_type == ActionKind.CANCEL_OPERATION:
-            if name.endswith('/cancel'):
-                model_name = name[:-7]
-                prefix = GOOGLEAI_PLUGIN_NAME + '/'
-                clean_name = model_name.replace(prefix, '') if model_name.startswith(prefix) else model_name
-                if is_deep_research_model_name(clean_name):
-                    return self._resolve_deep_research_model(
-                        deep_research_model(model_name),
-                        self._interactions_client_options(),
-                        self._plugin_api_key(),
-                    ).cancel_action
-            return None
-        elif action_type == ActionKind.EMBEDDER:
+        if action_type == ActionKind.BACKGROUND_MODEL:
+            bg = self._resolve_background_action(name)
+            return bg.start_action if bg else None
+        if action_type == ActionKind.CHECK_OPERATION and name.endswith('/check'):
+            bg = self._resolve_background_action(name.removesuffix('/check'))
+            return bg.check_action if bg else None
+        if action_type == ActionKind.CANCEL_OPERATION and name.endswith('/cancel'):
+            bg = self._resolve_background_action(name.removesuffix('/cancel'))
+            return bg.cancel_action if bg else None
+        if action_type == ActionKind.EMBEDDER:
             return self._resolve_embedder(name)
+        return None
+
+    def _resolve_background_action(self, name: str) -> BackgroundAction | None:
+        """Resolve a background action for Veo or Deep Research."""
+        clean = name.removeprefix(f'{GOOGLEAI_PLUGIN_NAME}/')
+        if is_veo_model(clean):
+            return self._resolve_veo_model(name)
+        if is_deep_research_model_name(clean):
+            return self._resolve_deep_research_model(
+                deep_research_model(name),
+                self._interactions_client_options(),
+                self._plugin_api_key(),
+            )
         return None
 
     def _resolve_deep_research_model(

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/models/_model_refs.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/models/_model_refs.py
@@ -51,8 +51,24 @@ def wrong_family_error(*, plugin_class: str, method: str, family: str, local: st
     """Build the INVALID_ARGUMENT error naming the id and the way out."""
     if actual == 'embedder':
         hint = f"'{local}' is an embedder; use {plugin_class}.embedding()."
-    elif actual in ('lyria', 'deep-research', 'antigravity'):
-        hint = f"'{local}' has no ref constructor in this plugin."
+    elif actual == 'deep-research':
+        hint = (
+            f"'{local}' is a Deep Research model; use {plugin_class}.deep_research_model()."
+            if plugin_class == 'GoogleAI'
+            else f"'{local}' has no ref constructor in this plugin."
+        )
+    elif actual == 'antigravity':
+        hint = (
+            f"'{local}' is an Antigravity model; use {plugin_class}.antigravity_model()."
+            if plugin_class == 'GoogleAI'
+            else f"'{local}' has no ref constructor in this plugin."
+        )
+    elif actual == 'lyria':
+        hint = (
+            f"'{local}' is a Lyria model; use {plugin_class}.lyria_model()."
+            if plugin_class == 'GoogleAI'
+            else f"'{local}' has no ref constructor in this plugin."
+        )
     elif actual == 'unsupported':
         hint = f"'{local}' is not a supported model."
     elif actual in FAMILY_METHOD:

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/models/_model_refs.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/models/_model_refs.py
@@ -28,15 +28,15 @@ from typing import TypeVar
 
 from pydantic import BaseModel
 
-from genkit import GenkitError
+from genkit import GenkitError, ModelInfo
 from genkit.embedder import EmbedderRef
 from genkit.model import ModelRef, model_ref
 from genkit_google_genai.models._routing import classify_family, strip_ref_prefixes
 
 ConfigT = TypeVar('ConfigT', bound=BaseModel)
 
-# Families with a constructor, for "use X instead" error hints.
-FAMILY_METHOD = {
+# Map known families onto their GoogleAI/VertexAI method name.
+FAMILY_METHOD: dict[str, str] = {
     'gemini': 'gemini_model',
     'tts': 'gemini_tts_model',
     'image': 'gemini_image_model',
@@ -46,26 +46,21 @@ FAMILY_METHOD = {
     'embedder': 'embedding',
 }
 
+INTERACTIONS_FAMILY_METHODS: dict[str, tuple[str, str]] = {
+    'deep-research': ('Deep Research', 'deep_research_model'),
+    'antigravity': ('Antigravity', 'antigravity_model'),
+    'lyria': ('Lyria', 'lyria_model'),
+}
+
 
 def wrong_family_error(*, plugin_class: str, method: str, family: str, local: str, actual: str) -> GenkitError:
     """Build the INVALID_ARGUMENT error naming the id and the way out."""
     if actual == 'embedder':
         hint = f"'{local}' is an embedder; use {plugin_class}.embedding()."
-    elif actual == 'deep-research':
+    elif actual in INTERACTIONS_FAMILY_METHODS:
+        display, method_name = INTERACTIONS_FAMILY_METHODS[actual]
         hint = (
-            f"'{local}' is a Deep Research model; use {plugin_class}.deep_research_model()."
-            if plugin_class == 'GoogleAI'
-            else f"'{local}' has no ref constructor in this plugin."
-        )
-    elif actual == 'antigravity':
-        hint = (
-            f"'{local}' is an Antigravity model; use {plugin_class}.antigravity_model()."
-            if plugin_class == 'GoogleAI'
-            else f"'{local}' has no ref constructor in this plugin."
-        )
-    elif actual == 'lyria':
-        hint = (
-            f"'{local}' is a Lyria model; use {plugin_class}.lyria_model()."
+            f"'{local}' is a {display} model; use {plugin_class}.{method_name}()."
             if plugin_class == 'GoogleAI'
             else f"'{local}' has no ref constructor in this plugin."
         )
@@ -87,6 +82,7 @@ def family_model_ref(
     method: str,
     config_schema: type[ConfigT],
     config: ConfigT | None,
+    info: ModelInfo | None = None,
 ) -> ModelRef[ConfigT]:
     """Strip, gate against the closed family set, then stamp this plugin's namespace."""
     # str(None) is 'None', and gemini_model allows unknown ids, so a
@@ -103,7 +99,7 @@ def family_model_ref(
     allowed = actual == family or (family == 'gemini' and actual == 'unknown')
     if not allowed:
         raise wrong_family_error(plugin_class=plugin_class, method=method, family=family, local=local, actual=actual)
-    return model_ref(local, config_schema=config_schema, namespace=namespace, config=config)
+    return model_ref(local, config_schema=config_schema, namespace=namespace, config=config, info=info)
 
 
 def family_embedder_ref(

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/models/_routing.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/models/_routing.py
@@ -18,8 +18,9 @@
 
 Families with no generate path here resolve to nothing: Veo is
 background-only, embedders are a different action kind, and retired or
-unimplemented image ids must not fall through. Lyria, Deep Research, and
-Antigravity fail closed until those families have a generate action here.
+unimplemented image ids must not fall through. Vertex keeps Lyria, Deep
+Research, and Antigravity closed; Google AI routes those families through
+Interactions.
 """
 
 from genkit_google_genai.models.gemini import (

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/models/antigravity.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/models/antigravity.py
@@ -1,0 +1,140 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Google AI Interactions Antigravity model action."""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, field_validator
+from pydantic.alias_generators import to_camel
+from typing_extensions import Never
+
+from genkit import ModelRequest, ModelResponse
+from genkit.plugin_api import Action, ActionKind, ActionRunContext, model_action_metadata
+from genkit_google_genai._interactions.client import create_interaction
+from genkit_google_genai._interactions.converters import (
+    ensure_tool_ids,
+    from_interaction_sync,
+    split_system_instruction,
+    to_interaction_steps,
+)
+from genkit_google_genai._interactions.options import ClientOptions
+from genkit_google_genai.models._secrets import reject_request_config_api_key
+from genkit_google_genai.models.interactions_registry import antigravity_model_info
+from genkit_google_genai.models.interactions_utils import (
+    api_key_for_context,
+    client_overrides_from_config,
+    extract_version,
+    lowercase_choice_list,
+    partition_keys,
+    remove_client_option_overrides,
+    require_interaction_steps,
+)
+
+DEFAULT_ENVIRONMENT: dict[str, str] = {'type': 'remote'}
+
+CREATE_OPTION_KEYS = (
+    'previous_interaction_id',
+    'store',
+    'environment',
+    'response_modalities',
+)
+
+
+class AntigravityConfig(BaseModel):
+    """Antigravity model configuration."""
+
+    model_config = ConfigDict(extra='allow', populate_by_name=True, alias_generator=to_camel)
+    base_url: str | None = None
+    api_version: str | None = None
+    # Milliseconds — applied to the HTTP call, not the create body.
+    timeout: float | None = None
+    custom_headers: dict[str, str] | None = None
+    previous_interaction_id: str | None = None
+    store: bool | None = None
+    environment: str | dict[str, Any] | None = None
+    response_modalities: list[Literal['text', 'image']] | None = None
+
+    @field_validator('response_modalities', mode='before')
+    @classmethod
+    def fold_modalities_case(cls, value: object) -> object:
+        """Accept TEXT/IMAGE the same as lowercase wire values."""
+        return lowercase_choice_list(value)
+
+
+def create_antigravity_action(
+    name: str,
+    *,
+    plugin_api_key: str | None,
+    client_options: ClientOptions,
+) -> Action[ModelRequest[AntigravityConfig], ModelResponse, Never]:
+    """Build a foreground model action for Antigravity."""
+    version = extract_version(name)
+    info = antigravity_model_info(version)
+
+    async def run(request: ModelRequest[AntigravityConfig], ctx: ActionRunContext) -> ModelResponse:
+        reject_request_config_api_key(request.config)
+        config = request.config or AntigravityConfig()
+        api_key = api_key_for_context(ctx.context, plugin_api_key)
+        merged_options = client_options.merge(
+            client_overrides_from_config(
+                base_url=config.base_url,
+                api_version=config.api_version,
+                timeout=config.timeout,
+                custom_headers=config.custom_headers,
+            )
+        )
+
+        # Known create kwargs vs undocumented passthrough — non-mutating split.
+        dumped = remove_client_option_overrides(config.model_dump(exclude_none=True))
+        create_options, passthrough = partition_keys(dumped, CREATE_OPTION_KEYS)
+        # Antigravity doesn't take system_instruction; fold system text into the
+        # leading user turn so guidance still reaches the model.
+        system_instruction, turns = split_system_instruction(request.messages or [])
+        steps = to_interaction_steps(ensure_tool_ids(turns))
+        if system_instruction:
+            steps.insert(
+                0,
+                {
+                    'type': 'user_input',
+                    'content': [{'type': 'text', 'text': system_instruction}],
+                },
+            )
+        require_interaction_steps(steps)
+        create_kwargs: dict[str, Any] = {
+            'agent': version,
+            'input': steps,
+            **create_options,
+            **passthrough,
+        }
+        # Default missing environment to remote; the API rejects unsupported values.
+        create_kwargs.setdefault('environment', DEFAULT_ENVIRONMENT)
+
+        created = await create_interaction(api_key, create_kwargs, merged_options)
+        return from_interaction_sync(created)
+
+    return Action(
+        kind=ActionKind.MODEL,
+        name=name,
+        fn=run,
+        metadata=model_action_metadata(
+            name=name,
+            info=info.model_dump(by_alias=True),
+            config_schema=AntigravityConfig,
+        ).metadata,
+    )

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/models/antigravity.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/models/antigravity.py
@@ -27,12 +27,7 @@ from typing_extensions import Never
 from genkit import ModelRequest, ModelResponse
 from genkit.plugin_api import Action, ActionKind, ActionRunContext, model_action_metadata
 from genkit_google_genai._interactions.client import create_interaction
-from genkit_google_genai._interactions.converters import (
-    ensure_tool_ids,
-    from_interaction_sync,
-    split_system_instruction,
-    to_interaction_steps,
-)
+from genkit_google_genai._interactions.converters import from_interaction_sync
 from genkit_google_genai._interactions.options import ClientOptions
 from genkit_google_genai.models._secrets import reject_request_config_api_key
 from genkit_google_genai.models.interactions_registry import antigravity_model_info
@@ -43,7 +38,7 @@ from genkit_google_genai.models.interactions_utils import (
     lowercase_choice_list,
     partition_keys,
     remove_client_option_overrides,
-    require_interaction_steps,
+    steps_with_folded_system_instruction,
 )
 
 DEFAULT_ENVIRONMENT: dict[str, str] = {'type': 'remote'}
@@ -91,34 +86,14 @@ def create_antigravity_action(
         reject_request_config_api_key(request.config)
         config = request.config or AntigravityConfig()
         api_key = api_key_for_context(ctx.context, plugin_api_key)
-        merged_options = client_options.merge(
-            client_overrides_from_config(
-                base_url=config.base_url,
-                api_version=config.api_version,
-                timeout=config.timeout,
-                custom_headers=config.custom_headers,
-            )
-        )
+        merged_options = client_options.merge(client_overrides_from_config(config))
 
         # Known create kwargs vs undocumented passthrough — non-mutating split.
         dumped = remove_client_option_overrides(config.model_dump(exclude_none=True))
         create_options, passthrough = partition_keys(dumped, CREATE_OPTION_KEYS)
-        # Antigravity doesn't take system_instruction; fold system text into the
-        # leading user turn so guidance still reaches the model.
-        system_instruction, turns = split_system_instruction(request.messages or [])
-        steps = to_interaction_steps(ensure_tool_ids(turns))
-        if system_instruction:
-            steps.insert(
-                0,
-                {
-                    'type': 'user_input',
-                    'content': [{'type': 'text', 'text': system_instruction}],
-                },
-            )
-        require_interaction_steps(steps)
         create_kwargs: dict[str, Any] = {
             'agent': version,
-            'input': steps,
+            'input': steps_with_folded_system_instruction(request.messages),
             **create_options,
             **passthrough,
         }

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/models/deep_research.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/models/deep_research.py
@@ -44,7 +44,6 @@ from genkit_google_genai.models._secrets import reject_request_config_api_key
 from genkit_google_genai.models.interactions_registry import deep_research_model_info
 from genkit_google_genai.models.interactions_utils import (
     api_key_for_context,
-    client_options_for_operation,
     client_overrides_from_config,
     extract_version,
     lowercase_choice,
@@ -239,21 +238,21 @@ def create_deep_research_background_action(
             create_kwargs['response_format'] = response_format
 
         interaction = await create_interaction(api_key, create_kwargs, options)
-        return persist(from_interaction(interaction, client_options_for_operation(options)))
+        return persist(from_interaction(interaction))
 
     async def check(operation: Operation, ctx: ActionRunContext) -> Operation:
-        stored = ClientOptions.from_metadata(operation.metadata)
-        options = client_options.merge(stored)
+        call_config = ctx.context.get('config')
+        options = client_options.merge(call_config if isinstance(call_config, dict) else None)
         api_key = api_key_for_context(ctx.context, plugin_api_key)
         interaction = await get_interaction(api_key, operation.id, options)
-        return persist(from_interaction(interaction, client_options_for_operation(options)))
+        return persist(from_interaction(interaction))
 
     async def cancel(operation: Operation, ctx: ActionRunContext) -> Operation:
-        stored = ClientOptions.from_metadata(operation.metadata)
-        options = client_options.merge(stored)
+        call_config = ctx.context.get('config')
+        options = client_options.merge(call_config if isinstance(call_config, dict) else None)
         api_key = api_key_for_context(ctx.context, plugin_api_key)
         interaction = await cancel_interaction(api_key, operation.id, options)
-        return persist(from_interaction(interaction, client_options_for_operation(options)))
+        return persist(from_interaction(interaction))
 
     start_action = Action(
         kind=ActionKind.BACKGROUND_MODEL,

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/models/deep_research.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/models/deep_research.py
@@ -1,0 +1,283 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Google AI Interactions Deep Research background model action."""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, field_validator
+from pydantic.alias_generators import to_camel
+
+from genkit import ModelRequest
+from genkit.model import BackgroundAction, ModelRef, Operation, model_ref
+from genkit.plugin_api import Action, ActionKind, ActionRunContext, to_json_schema
+from genkit_google_genai._interactions.client import (
+    cancel_interaction,
+    create_interaction,
+    get_interaction,
+)
+from genkit_google_genai._interactions.converters import (
+    clean_schema,
+    ensure_tool_ids,
+    from_interaction,
+    split_system_instruction,
+    to_interaction_steps,
+    to_interaction_tool,
+)
+from genkit_google_genai._interactions.options import ClientOptions
+from genkit_google_genai.models._secrets import reject_request_config_api_key
+from genkit_google_genai.models.interactions_registry import deep_research_model_info
+from genkit_google_genai.models.interactions_utils import (
+    api_key_for_context,
+    client_options_for_operation,
+    client_overrides_from_config,
+    extract_version,
+    lowercase_choice,
+    lowercase_choice_list,
+    partition_keys,
+    remove_client_option_overrides,
+    require_interaction_steps,
+)
+
+AGENT_CONFIG_KEYS = (
+    'thinking_summaries',
+    'visualization',
+    'collaborative_planning',
+)
+TOOL_CONFIG_KEYS = (
+    'google_search',
+    'url_context',
+    'code_execution',
+    'file_search',
+    'mcp_servers',
+)
+CREATE_OPTION_KEYS = (
+    'previous_interaction_id',
+    'store',
+    'response_modalities',
+)
+
+
+class McpServerConfig(BaseModel):
+    """MCP server configuration for Deep Research."""
+
+    model_config = ConfigDict(extra='allow', populate_by_name=True, alias_generator=to_camel)
+    name: str | None = None
+    url: str | None = None
+    headers: dict[str, str] | None = None
+    allowed_tools: list[str] | None = None
+
+
+class FileSearchConfig(BaseModel):
+    """File search store configuration for Deep Research."""
+
+    model_config = ConfigDict(extra='allow', populate_by_name=True, alias_generator=to_camel)
+    file_search_store_names: list[str]
+
+
+class DeepResearchConfig(BaseModel):
+    """Deep Research model configuration."""
+
+    model_config = ConfigDict(extra='allow', populate_by_name=True, alias_generator=to_camel)
+    base_url: str | None = None
+    api_version: str | None = None
+    # Milliseconds — applied to the HTTP call, not the create body.
+    timeout: float | None = None
+    custom_headers: dict[str, str] | None = None
+    thinking_summaries: Literal['auto', 'none'] | None = None
+    previous_interaction_id: str | None = None
+    store: bool | None = None
+    response_modalities: list[Literal['text', 'image', 'audio']] | None = None
+    visualization: Literal['auto', 'off'] | None = None
+    collaborative_planning: bool | None = None
+    google_search: bool | None = None
+    url_context: bool | None = None
+    code_execution: bool | None = None
+    file_search: FileSearchConfig | None = None
+    mcp_servers: list[McpServerConfig] | None = None
+
+    @field_validator('thinking_summaries', 'visualization', mode='before')
+    @classmethod
+    def fold_choice_case(cls, value: object) -> object:
+        """Accept AUTO/NONE the same as auto/none."""
+        return lowercase_choice(value)
+
+    @field_validator('response_modalities', mode='before')
+    @classmethod
+    def fold_modalities_case(cls, value: object) -> object:
+        """Accept TEXT/IMAGE/AUDIO the same as lowercase wire values."""
+        return lowercase_choice_list(value)
+
+
+def deep_research_model(version: str) -> ModelRef:
+    """Return a ModelRef for a Deep Research version (namespaced or bare)."""
+    clean = extract_version(version)
+    return model_ref(
+        name=clean,
+        namespace='googleai',
+        info=deep_research_model_info(clean),
+        config_schema=DeepResearchConfig,
+    )
+
+
+def build_tools(request: ModelRequest[DeepResearchConfig], config: DeepResearchConfig) -> list[dict[str, Any]]:
+    """Build Interactions API tool configurations for Deep Research."""
+    tools: list[dict[str, Any]] = []
+    if request.tools:
+        tools.extend(dict(to_interaction_tool(tool_def)) for tool_def in request.tools)
+
+    if config.google_search:
+        tools.append({'type': 'google_search'})
+    if config.url_context:
+        tools.append({'type': 'url_context'})
+    if config.code_execution:
+        tools.append({'type': 'code_execution'})
+    if config.file_search is not None:
+        # Create body is snake_case. Dumping by alias would send
+        # fileSearchStoreNames and the stores would never attach.
+        tools.append({'type': 'file_search', **config.file_search.model_dump(exclude_none=True)})
+    for mcp_server in config.mcp_servers or []:
+        tools.append({'type': 'mcp_server', **mcp_server.model_dump(exclude_none=True)})
+
+    return tools
+
+
+def response_format_from_request(
+    request: ModelRequest[DeepResearchConfig],
+) -> dict[str, Any] | None:
+    """Build response_format when the caller asked for JSON output."""
+    if request.output_format != 'json' and request.output_content_type != 'application/json':
+        return None
+    response_format: dict[str, Any] = {'type': 'text', 'mime_type': 'application/json'}
+    if request.output_schema:
+        # output_schema is already a JSON Schema dict. Dumping a model
+        # by alias here would rename properties the constraint expects.
+        response_format['schema'] = clean_schema(request.output_schema)
+    return response_format
+
+
+def create_deep_research_background_action(
+    target: str | ModelRef,
+    *,
+    plugin_api_key: str | None,
+    client_options: ClientOptions,
+) -> BackgroundAction:
+    """Wire Deep Research start/check/cancel as Actions that re-read secrets."""
+    name = target.name if isinstance(target, ModelRef) else target
+    version = extract_version(name)
+    info = deep_research_model_info(version)
+    full_name = name if '/' in name else f'googleai/{name}'
+    action_key = f'/background-model/{full_name}'
+
+    def persist(operation: Operation) -> Operation:
+        operation.action = action_key
+        return operation
+
+    async def start(request: ModelRequest[DeepResearchConfig], ctx: ActionRunContext) -> Operation:
+        reject_request_config_api_key(request.config)
+        config = request.config or DeepResearchConfig()
+        api_key = api_key_for_context(ctx.context, plugin_api_key)
+        options = client_options.merge(
+            client_overrides_from_config(
+                base_url=config.base_url,
+                api_version=config.api_version,
+                timeout=config.timeout,
+                custom_headers=config.custom_headers,
+            )
+        )
+
+        dumped = remove_client_option_overrides(config.model_dump(exclude_none=True))
+        agent_fields, _tool_fields, create_options, passthrough = partition_keys(
+            dumped,
+            AGENT_CONFIG_KEYS,
+            TOOL_CONFIG_KEYS,
+            CREATE_OPTION_KEYS,
+        )
+        agent_config: dict[str, Any] = {'type': 'deep-research', **agent_fields}
+
+        tools = build_tools(request, config)
+        response_format = response_format_from_request(request)
+        # Deep Research rejects system_instruction and asks for guidance in the
+        # input prompt instead, so system turns become a leading user_input step.
+        system_instruction, turns = split_system_instruction(request.messages or [])
+        steps = to_interaction_steps(ensure_tool_ids(turns))
+        if system_instruction:
+            steps.insert(
+                0,
+                {
+                    'type': 'user_input',
+                    'content': [{'type': 'text', 'text': system_instruction}],
+                },
+            )
+        require_interaction_steps(steps)
+        create_kwargs: dict[str, Any] = {
+            'agent': version,
+            'input': steps,
+            'background': True,
+            'agent_config': agent_config,
+            **create_options,
+            **passthrough,
+        }
+        if tools:
+            create_kwargs['tools'] = tools
+        if response_format is not None:
+            create_kwargs['response_format'] = response_format
+
+        interaction = await create_interaction(api_key, create_kwargs, options)
+        return persist(from_interaction(interaction, client_options_for_operation(options)))
+
+    async def check(operation: Operation, ctx: ActionRunContext) -> Operation:
+        stored = ClientOptions.from_metadata(operation.metadata)
+        options = client_options.merge(stored)
+        api_key = api_key_for_context(ctx.context, plugin_api_key)
+        interaction = await get_interaction(api_key, operation.id, options)
+        return persist(from_interaction(interaction, client_options_for_operation(options)))
+
+    async def cancel(operation: Operation, ctx: ActionRunContext) -> Operation:
+        stored = ClientOptions.from_metadata(operation.metadata)
+        options = client_options.merge(stored)
+        api_key = api_key_for_context(ctx.context, plugin_api_key)
+        interaction = await cancel_interaction(api_key, operation.id, options)
+        return persist(from_interaction(interaction, client_options_for_operation(options)))
+
+    start_action = Action(
+        kind=ActionKind.BACKGROUND_MODEL,
+        name=full_name,
+        fn=start,
+        metadata={
+            'model': {**info.model_dump(by_alias=True), 'customOptions': to_json_schema(DeepResearchConfig)},
+            'type': 'background-model',
+        },
+    )
+    check_action = Action(
+        kind=ActionKind.CHECK_OPERATION,
+        name=f'{full_name}/check',
+        fn=check,
+        metadata={'type': 'check-operation'},
+    )
+    cancel_action = Action(
+        kind=ActionKind.CANCEL_OPERATION,
+        name=f'{full_name}/cancel',
+        fn=cancel,
+        metadata={'type': 'cancel-operation'},
+    )
+    return BackgroundAction(
+        start_action=start_action,
+        check_action=check_action,
+        cancel_action=cancel_action,
+    )

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/models/deep_research.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/models/deep_research.py
@@ -137,12 +137,9 @@ def build_tools(request: ModelRequest[DeepResearchConfig], config: DeepResearchC
     if request.tools:
         tools.extend(dict(to_interaction_tool(tool_def)) for tool_def in request.tools)
 
-    if config.google_search:
-        tools.append({'type': 'google_search'})
-    if config.url_context:
-        tools.append({'type': 'url_context'})
-    if config.code_execution:
-        tools.append({'type': 'code_execution'})
+    for tool_type in ('google_search', 'url_context', 'code_execution'):
+        if getattr(config, tool_type, None):
+            tools.append({'type': tool_type})
     if config.file_search is not None:
         # Create body is snake_case. Dumping by alias would send
         # fileSearchStoreNames and the stores would never attach.
@@ -217,17 +214,18 @@ def create_deep_research_background_action(
         interaction = await create_interaction(api_key, create_kwargs, options)
         return persist(from_interaction(interaction))
 
-    async def check(operation: Operation, ctx: ActionRunContext) -> Operation:
+    def _op_key_and_options(ctx: ActionRunContext) -> tuple[str, ClientOptions]:
         call_config = ctx.context.get('config')
         options = client_options.merge(call_config if isinstance(call_config, dict) else None)
-        api_key = api_key_for_context(ctx.context, plugin_api_key)
+        return api_key_for_context(ctx.context, plugin_api_key), options
+
+    async def check(operation: Operation, ctx: ActionRunContext) -> Operation:
+        api_key, options = _op_key_and_options(ctx)
         interaction = await get_interaction(api_key, operation.id, options)
         return persist(from_interaction(interaction))
 
     async def cancel(operation: Operation, ctx: ActionRunContext) -> Operation:
-        call_config = ctx.context.get('config')
-        options = client_options.merge(call_config if isinstance(call_config, dict) else None)
-        api_key = api_key_for_context(ctx.context, plugin_api_key)
+        api_key, options = _op_key_and_options(ctx)
         interaction = await cancel_interaction(api_key, operation.id, options)
         return persist(from_interaction(interaction))
 

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/models/deep_research.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/models/deep_research.py
@@ -33,10 +33,7 @@ from genkit_google_genai._interactions.client import (
 )
 from genkit_google_genai._interactions.converters import (
     clean_schema,
-    ensure_tool_ids,
     from_interaction,
-    split_system_instruction,
-    to_interaction_steps,
     to_interaction_tool,
 )
 from genkit_google_genai._interactions.options import ClientOptions
@@ -50,7 +47,7 @@ from genkit_google_genai.models.interactions_utils import (
     lowercase_choice_list,
     partition_keys,
     remove_client_option_overrides,
-    require_interaction_steps,
+    steps_with_folded_system_instruction,
 )
 
 AGENT_CONFIG_KEYS = (
@@ -191,14 +188,7 @@ def create_deep_research_background_action(
         reject_request_config_api_key(request.config)
         config = request.config or DeepResearchConfig()
         api_key = api_key_for_context(ctx.context, plugin_api_key)
-        options = client_options.merge(
-            client_overrides_from_config(
-                base_url=config.base_url,
-                api_version=config.api_version,
-                timeout=config.timeout,
-                custom_headers=config.custom_headers,
-            )
-        )
+        options = client_options.merge(client_overrides_from_config(config))
 
         dumped = remove_client_option_overrides(config.model_dump(exclude_none=True))
         agent_fields, _tool_fields, create_options, passthrough = partition_keys(
@@ -211,22 +201,9 @@ def create_deep_research_background_action(
 
         tools = build_tools(request, config)
         response_format = response_format_from_request(request)
-        # Deep Research rejects system_instruction and asks for guidance in the
-        # input prompt instead, so system turns become a leading user_input step.
-        system_instruction, turns = split_system_instruction(request.messages or [])
-        steps = to_interaction_steps(ensure_tool_ids(turns))
-        if system_instruction:
-            steps.insert(
-                0,
-                {
-                    'type': 'user_input',
-                    'content': [{'type': 'text', 'text': system_instruction}],
-                },
-            )
-        require_interaction_steps(steps)
         create_kwargs: dict[str, Any] = {
             'agent': version,
-            'input': steps,
+            'input': steps_with_folded_system_instruction(request.messages),
             'background': True,
             'agent_config': agent_config,
             **create_options,

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/models/interactions_lyria.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/models/interactions_lyria.py
@@ -1,0 +1,122 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Google AI Interactions Lyria audio model action."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, field_validator
+from pydantic.alias_generators import to_camel
+from typing_extensions import Never
+
+from genkit import ModelRequest, ModelResponse
+from genkit.plugin_api import Action, ActionKind, ActionRunContext, model_action_metadata
+from genkit_google_genai._interactions.client import create_interaction
+from genkit_google_genai._interactions.converters import (
+    ensure_tool_ids,
+    from_interaction_sync,
+    split_system_instruction,
+    to_interaction_steps,
+)
+from genkit_google_genai._interactions.options import ClientOptions, ResponseModality
+from genkit_google_genai.models._secrets import reject_request_config_api_key
+from genkit_google_genai.models.interactions_registry import lyria_model_info
+from genkit_google_genai.models.interactions_utils import (
+    api_key_for_context,
+    client_overrides_from_config,
+    extract_version,
+    lowercase_choice_list,
+    partition_keys,
+    remove_client_option_overrides,
+    require_interaction_steps,
+)
+
+CREATE_OPTION_KEYS = ('response_modalities',)
+
+
+class LyriaConfig(BaseModel):
+    """Google AI Interactions Lyria model configuration."""
+
+    model_config = ConfigDict(extra='allow', populate_by_name=True, alias_generator=to_camel)
+    base_url: str | None = None
+    api_version: str | None = None
+    # Milliseconds — applied to the HTTP call, not the create body.
+    timeout: float | None = None
+    custom_headers: dict[str, str] | None = None
+    response_modalities: list[ResponseModality] | None = None
+
+    @field_validator('response_modalities', mode='before')
+    @classmethod
+    def fold_modalities_case(cls, value: object) -> object:
+        """Accept TEXT/AUDIO the same as lowercase wire values."""
+        return lowercase_choice_list(value)
+
+
+def create_lyria_action(
+    name: str,
+    *,
+    plugin_api_key: str | None,
+    client_options: ClientOptions,
+) -> Action[ModelRequest[LyriaConfig], ModelResponse, Never]:
+    """Build a foreground model action for Interactions Lyria."""
+    version = extract_version(name)
+    info = lyria_model_info(version)
+
+    async def run(request: ModelRequest[LyriaConfig], ctx: ActionRunContext) -> ModelResponse:
+        reject_request_config_api_key(request.config)
+        config = request.config or LyriaConfig()
+        api_key = api_key_for_context(ctx.context, plugin_api_key)
+        merged_options = client_options.merge(
+            client_overrides_from_config(
+                base_url=config.base_url,
+                api_version=config.api_version,
+                timeout=config.timeout,
+                custom_headers=config.custom_headers,
+            )
+        )
+        dumped = remove_client_option_overrides(config.model_dump(exclude_none=True))
+        create_options, passthrough = partition_keys(dumped, CREATE_OPTION_KEYS)
+        modalities = create_options.get('response_modalities') or ['audio', 'text']
+        system_instruction, turns = split_system_instruction(request.messages or [])
+        steps = to_interaction_steps(ensure_tool_ids(turns))
+        create_kwargs: dict[str, Any] = {
+            'model': version,
+            'input': steps,
+            'response_modalities': modalities,
+            **passthrough,
+        }
+        if system_instruction:
+            create_kwargs['system_instruction'] = system_instruction
+        # A system prompt is enough to start a clip — empty user turns
+        # should not fail the call when instruction is already set.
+        if not system_instruction:
+            require_interaction_steps(steps)
+
+        created = await create_interaction(api_key, create_kwargs, merged_options)
+        return from_interaction_sync(created)
+
+    return Action(
+        kind=ActionKind.MODEL,
+        name=name,
+        fn=run,
+        metadata=model_action_metadata(
+            name=name,
+            info=info.model_dump(by_alias=True),
+            config_schema=LyriaConfig,
+        ).metadata,
+    )

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/models/interactions_lyria.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/models/interactions_lyria.py
@@ -81,14 +81,7 @@ def create_lyria_action(
         reject_request_config_api_key(request.config)
         config = request.config or LyriaConfig()
         api_key = api_key_for_context(ctx.context, plugin_api_key)
-        merged_options = client_options.merge(
-            client_overrides_from_config(
-                base_url=config.base_url,
-                api_version=config.api_version,
-                timeout=config.timeout,
-                custom_headers=config.custom_headers,
-            )
-        )
+        merged_options = client_options.merge(client_overrides_from_config(config))
         dumped = remove_client_option_overrides(config.model_dump(exclude_none=True))
         create_options, passthrough = partition_keys(dumped, CREATE_OPTION_KEYS)
         modalities = create_options.get('response_modalities') or ['audio', 'text']

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/models/interactions_registry.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/models/interactions_registry.py
@@ -1,0 +1,174 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Curated catalogs of Google AI Interactions models.
+
+When Google ships a new Interactions model version, add it here — not in the
+individual action modules. Plugin registration, list_actions, and resolve all
+read from this file.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from genkit import ModelInfo, Supports
+from genkit._core._compat import StrEnum
+from genkit_google_genai.models.interactions_utils import extract_version
+
+
+def model_info(
+    version: str,
+    *,
+    fallback: ModelInfo,
+    known: Mapping[str, ModelInfo] | None = None,
+) -> ModelInfo:
+    """Build ModelInfo with a Google AI label and family (or per-version) supports."""
+    clean = extract_version(version)
+    entry = known.get(clean) if known else None
+    return ModelInfo(label=f'Google AI - {clean}', supports=(entry or fallback).supports)
+
+
+# ---------------------------------------------------------------------------
+# Lyria
+# ---------------------------------------------------------------------------
+
+LYRIA_INFO = ModelInfo(
+    label='Google AI - Lyria',
+    supports=Supports(
+        multiturn=False,
+        media=True,
+        tools=False,
+        tool_choice=False,
+        system_role=False,
+        output=['media', 'text'],
+    ),
+)
+
+
+class LyriaVersion(StrEnum):
+    """Lyria model version identifiers."""
+
+    LYRIA_3_CLIP = 'lyria-3-clip-preview'
+    LYRIA_3_PRO = 'lyria-3-pro-preview'
+
+
+KNOWN_LYRIA_MODELS: tuple[LyriaVersion, ...] = (
+    LyriaVersion.LYRIA_3_CLIP,
+    LyriaVersion.LYRIA_3_PRO,
+)
+
+
+def is_lyria_model_name(name: str | None) -> bool:
+    """Return True when the model name belongs to the Lyria family."""
+    return bool(name and name.startswith('lyria-'))
+
+
+def lyria_model_info(version: str) -> ModelInfo:
+    """Return capability metadata for an Interactions Lyria model."""
+    return model_info(version, fallback=LYRIA_INFO)
+
+
+def list_known_lyria_models() -> list[str]:
+    """Return statically known Interactions Lyria model names."""
+    return [str(version) for version in KNOWN_LYRIA_MODELS]
+
+
+# ---------------------------------------------------------------------------
+# Antigravity
+# ---------------------------------------------------------------------------
+
+ANTIGRAVITY_INFO = ModelInfo(
+    label='Google AI - Antigravity',
+    supports=Supports(
+        multiturn=True,
+        media=True,
+        tools=False,
+        tool_choice=False,
+        system_role=False,
+        output=['text'],
+    ),
+)
+
+KNOWN_ANTIGRAVITY_MODELS: dict[str, ModelInfo] = {
+    'antigravity-preview-05-2026': ANTIGRAVITY_INFO,
+}
+
+
+def is_antigravity_model_name(name: str | None) -> bool:
+    """Return True when the model name belongs to the Antigravity family."""
+    return bool(name and name.startswith('antigravity-'))
+
+
+def antigravity_model_info(version: str) -> ModelInfo:
+    """Return capability metadata for an Antigravity model."""
+    return model_info(version, known=KNOWN_ANTIGRAVITY_MODELS, fallback=ANTIGRAVITY_INFO)
+
+
+def list_known_antigravity_models() -> list[str]:
+    """Return statically known Antigravity model names."""
+    return list(KNOWN_ANTIGRAVITY_MODELS.keys())
+
+
+# ---------------------------------------------------------------------------
+# Deep Research
+# ---------------------------------------------------------------------------
+
+DEEP_RESEARCH_INFO = ModelInfo(
+    label='Google AI - Deep Research',
+    supports=Supports(
+        multiturn=True,
+        media=False,
+        tools=False,
+        tool_choice=False,
+        system_role=False,
+        output=['text'],
+        long_running=True,
+    ),
+)
+
+ADVANCED_DEEP_RESEARCH_INFO = ModelInfo(
+    supports=Supports(
+        multiturn=True,
+        media=True,
+        tools=True,
+        tool_choice=False,
+        system_role=False,
+        output=['text', 'media'],
+        long_running=True,
+    ),
+)
+
+KNOWN_DEEP_RESEARCH_MODELS: dict[str, ModelInfo] = {
+    'deep-research-pro-preview-12-2025': DEEP_RESEARCH_INFO,
+    'deep-research-preview-04-2026': ADVANCED_DEEP_RESEARCH_INFO,
+    'deep-research-max-preview-04-2026': ADVANCED_DEEP_RESEARCH_INFO,
+}
+
+
+def is_deep_research_model_name(name: str | None) -> bool:
+    """Return True when the model name belongs to the Deep Research family."""
+    return bool(name and name.startswith('deep-research-'))
+
+
+def deep_research_model_info(version: str) -> ModelInfo:
+    """Return capability metadata for a Deep Research model."""
+    return model_info(version, known=KNOWN_DEEP_RESEARCH_MODELS, fallback=DEEP_RESEARCH_INFO)
+
+
+def list_known_deep_research_models() -> list[str]:
+    """Return statically known Deep Research model names."""
+    return list(KNOWN_DEEP_RESEARCH_MODELS.keys())

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/models/interactions_registry.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/models/interactions_registry.py
@@ -73,8 +73,8 @@ KNOWN_LYRIA_MODELS: tuple[LyriaVersion, ...] = (
 
 
 def is_lyria_model_name(name: str | None) -> bool:
-    """Return True when the model name belongs to the Lyria family."""
-    return bool(name and name.startswith('lyria-'))
+    """True for any lyria-* id so a version we have not catalogued still routes here."""
+    return bool(name and name.rsplit('/', 1)[-1].startswith('lyria-'))
 
 
 def lyria_model_info(version: str) -> ModelInfo:

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/models/interactions_registry.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/models/interactions_registry.py
@@ -74,7 +74,7 @@ KNOWN_LYRIA_MODELS: tuple[LyriaVersion, ...] = (
 
 def is_lyria_model_name(name: str | None) -> bool:
     """True for any lyria-* id so a version we have not catalogued still routes here."""
-    return bool(name and name.rsplit('/', 1)[-1].startswith('lyria-'))
+    return bool(name and extract_version(name).startswith('lyria-'))
 
 
 def lyria_model_info(version: str) -> ModelInfo:
@@ -110,7 +110,7 @@ KNOWN_ANTIGRAVITY_MODELS: dict[str, ModelInfo] = {
 
 def is_antigravity_model_name(name: str | None) -> bool:
     """Return True when the model name belongs to the Antigravity family."""
-    return bool(name and name.startswith('antigravity-'))
+    return bool(name and extract_version(name).startswith('antigravity-'))
 
 
 def antigravity_model_info(version: str) -> ModelInfo:
@@ -161,7 +161,7 @@ KNOWN_DEEP_RESEARCH_MODELS: dict[str, ModelInfo] = {
 
 def is_deep_research_model_name(name: str | None) -> bool:
     """Return True when the model name belongs to the Deep Research family."""
-    return bool(name and name.startswith('deep-research-'))
+    return bool(name and extract_version(name).startswith('deep-research-'))
 
 
 def deep_research_model_info(version: str) -> ModelInfo:

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/models/interactions_utils.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/models/interactions_utils.py
@@ -1,0 +1,241 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared helpers for Google AI Interactions-backed models."""
+
+from __future__ import annotations
+
+import os
+from typing import Any, cast
+
+from google.genai.errors import APIError
+
+from genkit import GenkitError
+from genkit._core._error import ErrorResponseMetadata, StatusName
+from genkit_google_genai._interactions.client import parse_retry_after_ms, status_for_http_code
+from genkit_google_genai._interactions.options import ClientOptions
+from genkit_google_genai.models._secrets import context_api_key
+
+# Snake_case: callers dump config with by_alias=False before we strip these.
+CLIENT_OPTION_KEYS = frozenset({
+    'api_key',
+    'base_url',
+    'api_version',
+    'custom_headers',
+    'timeout',
+    'experimental_debug_traces',
+})
+
+
+def get_api_key_from_env() -> str | None:
+    """Read a Gemini API key from common environment variables."""
+    return os.getenv('GEMINI_API_KEY') or os.getenv('GOOGLE_API_KEY') or os.getenv('GOOGLE_GENAI_API_KEY')
+
+
+def calculate_api_key(
+    plugin_api_key: str | None,
+    request_api_key: str | None,
+) -> str:
+    """Resolve the plugin/env API key when context.secrets did not supply one."""
+    api_key = request_api_key or plugin_api_key or get_api_key_from_env()
+    if not api_key:
+        raise GenkitError(
+            status='FAILED_PRECONDITION',
+            message=(
+                'Please pass in the API key or set the GEMINI_API_KEY or GOOGLE_API_KEY environment variable.\n'
+                'For more details see https://genkit.dev/docs/plugins/google-genai/'
+            ),
+        )
+    return api_key
+
+
+def api_key_for_context(context: dict[str, Any], plugin_api_key: str | None) -> str:
+    """Tenant key from context.secrets, else the plugin/env key."""
+    return context_api_key(context) or calculate_api_key(plugin_api_key, None)
+
+
+def extract_version(model_name: str) -> str:
+    """Return the bare model version from a namespaced model name."""
+    if '/' in model_name:
+        return model_name.split('/', 1)[1]
+    return model_name
+
+
+def remove_client_option_overrides(config: dict[str, Any]) -> dict[str, Any]:
+    """Drop client-only config keys before passthrough to the wire payload."""
+    return {key: value for key, value in config.items() if key not in CLIENT_OPTION_KEYS}
+
+
+def client_overrides_from_config(
+    *,
+    base_url: str | None = None,
+    api_version: str | None = None,
+    timeout: float | None = None,
+    custom_headers: dict[str, str] | None = None,
+) -> ClientOptions:
+    """Lift per-request transport knobs out of a model config into ClientOptions."""
+    return ClientOptions(
+        base_url=base_url,
+        api_version=api_version,
+        timeout=timeout,
+        custom_headers=custom_headers,
+    )
+
+
+def partition_keys(
+    payload: dict[str, Any],
+    *groups: tuple[str, ...],
+) -> tuple[dict[str, Any], ...]:
+    """Split payload into one dict per key group, then a remainder of leftovers.
+
+    Does not mutate payload. Keys listed in any group are claimed for that group
+    (or dropped from the remainder even when absent), so callers can peel a
+    dumped model config into agent_config / create options / tool fields /
+    passthrough extras without colliding.
+    """
+    claimed: set[str] = set()
+    for keys in groups:
+        claimed.update(keys)
+    parts = tuple({key: payload[key] for key in keys if key in payload} for keys in groups)
+    remainder = {key: value for key, value in payload.items() if key not in claimed}
+    return (*parts, remainder)
+
+
+def require_interaction_steps(steps: list[Any]) -> list[Any]:
+    """Reject an empty Interactions input before we pay for a round trip."""
+    if not steps:
+        raise GenkitError(
+            status='INVALID_ARGUMENT',
+            message='Missing input.',
+        )
+    return steps
+
+
+def http_status_code_from_exception(exc: BaseException) -> int | None:
+    """Read an HTTP status from SDK errors that aren't google.genai.errors.APIError.
+
+    Interactions (gaos) raises its own BadRequestError hierarchy with
+    status_code, which doesn't subclass google.genai.errors.APIError.
+    """
+    for attr in ('status_code', 'code'):
+        raw = getattr(exc, attr, None)
+        if raw is None:
+            continue
+        try:
+            code = int(raw)
+        except (TypeError, ValueError):
+            continue
+        if code > 0:
+            return code
+    return None
+
+
+def client_options_for_operation(client_options: ClientOptions) -> ClientOptions:
+    """Transport knobs that may ride on a ticket. Never the key or the host.
+
+    A ticket is shared; a tenant key and an attacker-chosen base_url
+    must not travel with it. Check/cancel re-read secrets on the run
+    and keep the plugin's own host.
+    """
+    return ClientOptions(
+        api_version=client_options.api_version,
+        timeout=client_options.timeout,
+        custom_headers=client_options.custom_headers,
+    )
+
+
+def lowercase_choice(value: object) -> object:
+    """Accept AUTO/NONE-style labels the same as auto/none."""
+    return value.lower() if isinstance(value, str) else value
+
+
+def lowercase_choice_list(value: object) -> object:
+    """Lowercase each string in a response_modalities list."""
+    if not isinstance(value, list):
+        return value
+    return [item.lower() if isinstance(item, str) else item for item in value]
+
+
+def status_from_api_error(error: APIError) -> StatusName:
+    """Pick the Genkit error status for an SDK error, preferring the status it names."""
+    raw_status = error.status
+    if isinstance(raw_status, str):
+        candidate = raw_status.upper()
+        # API sometimes returns gRPC status names directly.
+        valid: set[str] = {
+            'OK',
+            'CANCELLED',
+            'UNKNOWN',
+            'INVALID_ARGUMENT',
+            'DEADLINE_EXCEEDED',
+            'NOT_FOUND',
+            'ALREADY_EXISTS',
+            'PERMISSION_DENIED',
+            'UNAUTHENTICATED',
+            'RESOURCE_EXHAUSTED',
+            'FAILED_PRECONDITION',
+            'ABORTED',
+            'OUT_OF_RANGE',
+            'UNIMPLEMENTED',
+            'INTERNAL',
+            'UNAVAILABLE',
+            'DATA_LOSS',
+        }
+        if candidate in valid:
+            return cast(StatusName, candidate)
+    # APIError.code comes straight from response JSON, so it may not be numeric.
+    try:
+        code = int(error.code or 0)
+    except (TypeError, ValueError):
+        code = 0
+    return status_for_http_code(code)
+
+
+def map_genai_error(exc: BaseException) -> GenkitError:
+    """Map a google-genai SDK error onto GenkitError for callers/poll backoff."""
+    if isinstance(exc, GenkitError):
+        return exc
+    if isinstance(exc, APIError):
+        retry_after_ms: float | None = None
+        headers: dict[str, str] = {}
+        response = getattr(exc, 'response', None)
+        raw_headers = getattr(response, 'headers', None)
+        if raw_headers is not None:
+            try:
+                headers = {str(key).lower(): str(value) for key, value in raw_headers.items()}
+            except Exception:  # noqa: BLE001 - headers shape varies by transport
+                headers = {}
+            retry_after_ms = parse_retry_after_ms(headers.get('retry-after'))
+        response_metadata: ErrorResponseMetadata | None = None
+        if retry_after_ms is not None or headers:
+            meta: ErrorResponseMetadata = {}
+            if retry_after_ms is not None:
+                meta['retry_after_ms'] = retry_after_ms
+            if headers:
+                meta['headers'] = headers
+            response_metadata = meta
+        return GenkitError(
+            status=status_from_api_error(exc),
+            message=exc.message or str(exc),
+            details=getattr(exc, 'details', None),
+            response_metadata=response_metadata,
+        )
+    # Interactions path: gaos BadRequestError etc. carry status_code but aren't APIError.
+    status_code = http_status_code_from_exception(exc)
+    if status_code is not None:
+        message = getattr(exc, 'message', None) or str(exc)
+        return GenkitError(status=status_for_http_code(status_code), message=message)
+    return GenkitError(status='UNKNOWN', message=str(exc))

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/models/interactions_utils.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/models/interactions_utils.py
@@ -119,20 +119,6 @@ def require_interaction_steps(steps: list[Any]) -> list[Any]:
     return steps
 
 
-def client_options_for_operation(client_options: ClientOptions) -> ClientOptions:
-    """Transport knobs that may ride on a ticket. Never the key or the host.
-
-    A ticket is shared; a tenant key and an attacker-chosen base_url
-    must not travel with it. Check/cancel re-read secrets on the run
-    and keep the plugin's own host.
-    """
-    return ClientOptions(
-        api_version=client_options.api_version,
-        timeout=client_options.timeout,
-        custom_headers=client_options.custom_headers,
-    )
-
-
 def lowercase_choice(value: object) -> object:
     """Accept AUTO/NONE-style labels the same as auto/none."""
     return value.lower() if isinstance(value, str) else value

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/models/interactions_utils.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/models/interactions_utils.py
@@ -19,14 +19,11 @@
 from __future__ import annotations
 
 import os
-from typing import Any, cast
-
-from google.genai.errors import APIError
+from typing import Any
 
 from genkit import GenkitError
-from genkit._core._error import ErrorResponseMetadata, StatusName
-from genkit_google_genai._interactions.client import parse_retry_after_ms, status_for_http_code
 from genkit_google_genai._interactions.options import ClientOptions
+from genkit_google_genai.models._routing import strip_ref_prefixes
 from genkit_google_genai.models._secrets import context_api_key
 
 # Snake_case: callers dump config with by_alias=False before we strip these.
@@ -68,10 +65,8 @@ def api_key_for_context(context: dict[str, Any], plugin_api_key: str | None) -> 
 
 
 def extract_version(model_name: str) -> str:
-    """Return the bare model version from a namespaced model name."""
-    if '/' in model_name:
-        return model_name.split('/', 1)[1]
-    return model_name
+    """Bare model id for the wire. Pasted action keys still have models/googleai/ on them."""
+    return strip_ref_prefixes(model_name)
 
 
 def remove_client_option_overrides(config: dict[str, Any]) -> dict[str, Any]:
@@ -124,25 +119,6 @@ def require_interaction_steps(steps: list[Any]) -> list[Any]:
     return steps
 
 
-def http_status_code_from_exception(exc: BaseException) -> int | None:
-    """Read an HTTP status from SDK errors that aren't google.genai.errors.APIError.
-
-    Interactions (gaos) raises its own BadRequestError hierarchy with
-    status_code, which doesn't subclass google.genai.errors.APIError.
-    """
-    for attr in ('status_code', 'code'):
-        raw = getattr(exc, attr, None)
-        if raw is None:
-            continue
-        try:
-            code = int(raw)
-        except (TypeError, ValueError):
-            continue
-        if code > 0:
-            return code
-    return None
-
-
 def client_options_for_operation(client_options: ClientOptions) -> ClientOptions:
     """Transport knobs that may ride on a ticket. Never the key or the host.
 
@@ -167,75 +143,3 @@ def lowercase_choice_list(value: object) -> object:
     if not isinstance(value, list):
         return value
     return [item.lower() if isinstance(item, str) else item for item in value]
-
-
-def status_from_api_error(error: APIError) -> StatusName:
-    """Pick the Genkit error status for an SDK error, preferring the status it names."""
-    raw_status = error.status
-    if isinstance(raw_status, str):
-        candidate = raw_status.upper()
-        # API sometimes returns gRPC status names directly.
-        valid: set[str] = {
-            'OK',
-            'CANCELLED',
-            'UNKNOWN',
-            'INVALID_ARGUMENT',
-            'DEADLINE_EXCEEDED',
-            'NOT_FOUND',
-            'ALREADY_EXISTS',
-            'PERMISSION_DENIED',
-            'UNAUTHENTICATED',
-            'RESOURCE_EXHAUSTED',
-            'FAILED_PRECONDITION',
-            'ABORTED',
-            'OUT_OF_RANGE',
-            'UNIMPLEMENTED',
-            'INTERNAL',
-            'UNAVAILABLE',
-            'DATA_LOSS',
-        }
-        if candidate in valid:
-            return cast(StatusName, candidate)
-    # APIError.code comes straight from response JSON, so it may not be numeric.
-    try:
-        code = int(error.code or 0)
-    except (TypeError, ValueError):
-        code = 0
-    return status_for_http_code(code)
-
-
-def map_genai_error(exc: BaseException) -> GenkitError:
-    """Map a google-genai SDK error onto GenkitError for callers/poll backoff."""
-    if isinstance(exc, GenkitError):
-        return exc
-    if isinstance(exc, APIError):
-        retry_after_ms: float | None = None
-        headers: dict[str, str] = {}
-        response = getattr(exc, 'response', None)
-        raw_headers = getattr(response, 'headers', None)
-        if raw_headers is not None:
-            try:
-                headers = {str(key).lower(): str(value) for key, value in raw_headers.items()}
-            except Exception:  # noqa: BLE001 - headers shape varies by transport
-                headers = {}
-            retry_after_ms = parse_retry_after_ms(headers.get('retry-after'))
-        response_metadata: ErrorResponseMetadata | None = None
-        if retry_after_ms is not None or headers:
-            meta: ErrorResponseMetadata = {}
-            if retry_after_ms is not None:
-                meta['retry_after_ms'] = retry_after_ms
-            if headers:
-                meta['headers'] = headers
-            response_metadata = meta
-        return GenkitError(
-            status=status_from_api_error(exc),
-            message=exc.message or str(exc),
-            details=getattr(exc, 'details', None),
-            response_metadata=response_metadata,
-        )
-    # Interactions path: gaos BadRequestError etc. carry status_code but aren't APIError.
-    status_code = http_status_code_from_exception(exc)
-    if status_code is not None:
-        message = getattr(exc, 'message', None) or str(exc)
-        return GenkitError(status=status_for_http_code(status_code), message=message)
-    return GenkitError(status='UNKNOWN', message=str(exc))

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/models/interactions_utils.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/models/interactions_utils.py
@@ -21,7 +21,12 @@ from __future__ import annotations
 import os
 from typing import Any
 
-from genkit import GenkitError
+from genkit import GenkitError, Message
+from genkit_google_genai._interactions.converters import (
+    ensure_tool_ids,
+    split_system_instruction,
+    to_interaction_steps,
+)
 from genkit_google_genai._interactions.options import ClientOptions
 from genkit_google_genai.models._routing import strip_ref_prefixes
 from genkit_google_genai.models._secrets import context_api_key
@@ -42,12 +47,9 @@ def get_api_key_from_env() -> str | None:
     return os.getenv('GEMINI_API_KEY') or os.getenv('GOOGLE_API_KEY') or os.getenv('GOOGLE_GENAI_API_KEY')
 
 
-def calculate_api_key(
-    plugin_api_key: str | None,
-    request_api_key: str | None,
-) -> str:
-    """Resolve the plugin/env API key when context.secrets did not supply one."""
-    api_key = request_api_key or plugin_api_key or get_api_key_from_env()
+def api_key_for_context(context: dict[str, Any], plugin_api_key: str | None) -> str:
+    """Tenant key from context.secrets, else the plugin or env key."""
+    api_key = context_api_key(context) or plugin_api_key or get_api_key_from_env()
     if not api_key:
         raise GenkitError(
             status='FAILED_PRECONDITION',
@@ -57,11 +59,6 @@ def calculate_api_key(
             ),
         )
     return api_key
-
-
-def api_key_for_context(context: dict[str, Any], plugin_api_key: str | None) -> str:
-    """Tenant key from context.secrets, else the plugin/env key."""
-    return context_api_key(context) or calculate_api_key(plugin_api_key, None)
 
 
 def extract_version(model_name: str) -> str:
@@ -75,6 +72,7 @@ def remove_client_option_overrides(config: dict[str, Any]) -> dict[str, Any]:
 
 
 def client_overrides_from_config(
+    config: object = None,
     *,
     base_url: str | None = None,
     api_version: str | None = None,
@@ -83,10 +81,10 @@ def client_overrides_from_config(
 ) -> ClientOptions:
     """Lift per-request transport knobs out of a model config into ClientOptions."""
     return ClientOptions(
-        base_url=base_url,
-        api_version=api_version,
-        timeout=timeout,
-        custom_headers=custom_headers,
+        base_url=getattr(config, 'base_url', base_url),
+        api_version=getattr(config, 'api_version', api_version),
+        timeout=getattr(config, 'timeout', timeout),
+        custom_headers=getattr(config, 'custom_headers', custom_headers),
     )
 
 
@@ -117,6 +115,21 @@ def require_interaction_steps(steps: list[Any]) -> list[Any]:
             message='Missing input.',
         )
     return steps
+
+
+def steps_with_folded_system_instruction(messages: list[Message] | None) -> list[dict[str, Any]]:
+    """Convert messages to interaction steps, folding system prompt into a leading user turn."""
+    system_instruction, turns = split_system_instruction(messages or [])
+    steps = to_interaction_steps(ensure_tool_ids(turns))
+    if system_instruction:
+        steps.insert(
+            0,
+            {
+                'type': 'user_input',
+                'content': [{'type': 'text', 'text': system_instruction}],
+            },
+        )
+    return require_interaction_steps(steps)
 
 
 def lowercase_choice(value: object) -> object:

--- a/py/packages/genkit-google-genai/test/models/model_refs_test.py
+++ b/py/packages/genkit-google-genai/test/models/model_refs_test.py
@@ -191,12 +191,16 @@ class TestClosedRejectSet:
             GoogleAI.gemini_model('gemini-embedding-001')
         with pytest.raises(GenkitError, match=r'veo_model'):
             GoogleAI.gemini_model('veo-3.0-generate-001')
-        with pytest.raises(GenkitError, match=r'has no ref constructor in this plugin'):
+        with pytest.raises(GenkitError, match=r'lyria_model'):
             GoogleAI.gemini_model('lyria-002')
-        with pytest.raises(GenkitError, match=r'has no ref constructor in this plugin'):
+        with pytest.raises(GenkitError, match=r'deep_research_model'):
             GoogleAI.gemini_model('deep-research-pro-preview')
-        with pytest.raises(GenkitError, match=r'has no ref constructor in this plugin'):
+        with pytest.raises(GenkitError, match=r'antigravity_model'):
             GoogleAI.gemini_model('antigravity-code-1')
+        with pytest.raises(GenkitError, match=r'has no ref constructor in this plugin'):
+            VertexAI.gemini_model('lyria-002')
+        with pytest.raises(GenkitError, match=r'has no ref constructor in this plugin'):
+            VertexAI.gemini_model('deep-research-pro-preview')
         with pytest.raises(GenkitError, match=r'is not a supported model'):
             GoogleAI.gemini_model('imagegeneration@006')
         with pytest.raises(GenkitError, match=r'is not a supported model'):

--- a/py/packages/genkit-google-genai/test/models/model_refs_test.py
+++ b/py/packages/genkit-google-genai/test/models/model_refs_test.py
@@ -222,6 +222,8 @@ class TestClosedRejectSet:
             GoogleAI.veo_model('gemini-2.5-flash')
         with pytest.raises(GenkitError):
             GoogleAI.veo_model('totally-new-model')
+        with pytest.raises(GenkitError, match=r'model name must be a string'):
+            GoogleAI.deep_research_model(None)  # type: ignore[arg-type]
 
 
 class TestEmbeddingConstructor:

--- a/py/packages/genkit-google-genai/tests/google_genai_plugin_test.py
+++ b/py/packages/genkit-google-genai/tests/google_genai_plugin_test.py
@@ -531,7 +531,6 @@ async def test_vertexai_unroutable_ids_fail_closed(
         'virtual-try-on-001',
         'imagegeneration@006',
         'imagetext@001',
-        'lyria-002',
         'deep-research-pro-preview',
         'gemini-embedding-001',
         'models/deep-research-pro-preview',

--- a/py/packages/genkit-google-genai/tests/interactions/interactions_models_test.py
+++ b/py/packages/genkit-google-genai/tests/interactions/interactions_models_test.py
@@ -33,7 +33,7 @@ from genkit_google_genai.models.deep_research import (
     response_format_from_request,
 )
 from genkit_google_genai.models.interactions_lyria import LyriaConfig, create_lyria_action
-from genkit_google_genai.models.interactions_registry import deep_research_model_info
+from genkit_google_genai.models.interactions_registry import deep_research_model_info, lyria_model_info
 from google.genai.interactions import Interaction
 
 from genkit import ActionKind, GenkitError, Message, ModelRequest, Part, Role, TextPart
@@ -420,6 +420,32 @@ async def test_antigravity_generate_folds_system_and_uses_agent() -> None:
     assert response.response.message.content[0].root.text == 'hello'
 
 
+@pytest.mark.asyncio
+async def test_antigravity_keeps_custom_environment() -> None:
+    patcher, create_calls, _, _ = patch_interactions(
+        'genkit_google_genai.models.antigravity',
+        create_result={
+            'id': 'ag-env',
+            'status': 'completed',
+            'steps': [{'type': 'model_output', 'content': [{'type': 'text', 'text': 'ok'}]}],
+        },
+    )
+    action = create_antigravity_action(
+        'antigravity-preview-05-2026',
+        plugin_api_key='key',
+        client_options=ClientOptions(),
+    )
+    with patcher:
+        await action.run(
+            ModelRequest(
+                messages=[Message(role=Role.USER, content=[Part(TextPart(text='build'))])],
+                config=AntigravityConfig(environment={'type': 'custom', 'name': 'custom-env'}),
+            )
+        )
+
+    assert create_calls[0]['environment'] == {'type': 'custom', 'name': 'custom-env'}
+
+
 def test_bare_model_request_accepts_lyria_config_instance() -> None:
     """Bare ModelRequest(config=LyriaConfig(...)) should not reject the plugin schema."""
     request = ModelRequest(
@@ -511,6 +537,28 @@ def test_googleai_family_constructors() -> None:
     ly = GoogleAI.lyria_model('lyria-3-clip-preview')
     assert ly.name == 'googleai/lyria-3-clip-preview'
     assert ly.config_schema is LyriaConfig
+    ly_supports = lyria_model_info('lyria-3-clip-preview').supports
+    assert ly_supports is not None
+    assert ly_supports.system_role is False
+    assert GoogleAI.lyria_model('lyria-002').name == 'googleai/lyria-002'
+
+    with_config = GoogleAI.deep_research_model(
+        'deep-research-preview-04-2026',
+        config=DeepResearchConfig(thinking_summaries='auto'),
+    )
+    assert isinstance(with_config.config, DeepResearchConfig)
+    assert with_config.config.thinking_summaries == 'auto'
+
+
+def test_package_root_lyria_config_is_interactions() -> None:
+    from genkit_google_genai import LyriaConfig as RootLyriaConfig
+
+    ref = GoogleAI.lyria_model(
+        'lyria-3-clip-preview',
+        config=RootLyriaConfig(response_modalities=['audio']),
+    )
+    assert ref.config_schema is LyriaConfig
+    assert isinstance(ref.config, RootLyriaConfig)
 
 
 @pytest.mark.asyncio
@@ -603,10 +651,11 @@ async def test_googleai_resolve_routes_interactions_models() -> None:
     ly = await plugin.resolve(ActionKind.MODEL, googleai_name('lyria-3-pro-preview'))
     assert ly is not None
 
-    # Legacy Vertex name must not fall through to Gemini capabilities metadata.
-    ly_legacy = await plugin.resolve(ActionKind.MODEL, googleai_name('lyria-002'))
-    assert ly_legacy is not None
-    model_meta = (ly_legacy.metadata or {}).get('model')
+    # Unknown lyria-* ids still resolve here so a version we have not
+    # catalogued is not minted as Gemini.
+    ly_passthrough = await plugin.resolve(ActionKind.MODEL, googleai_name('lyria-002'))
+    assert ly_passthrough is not None
+    model_meta = (ly_passthrough.metadata or {}).get('model')
     assert isinstance(model_meta, dict)
     supports = model_meta.get('supports')
     assert isinstance(supports, dict)
@@ -722,6 +771,55 @@ async def test_lyria_system_only_is_enough() -> None:
 
     assert create_calls[0]['system_instruction'] == 'play jazz'
     assert create_calls[0]['input'] == []
+
+
+@pytest.mark.asyncio
+async def test_lyria_rejects_empty_messages_without_system() -> None:
+    patcher, create_calls, _, _ = patch_interactions(
+        'genkit_google_genai.models.interactions_lyria',
+        create_result={'id': 'ly-empty', 'status': 'completed', 'steps': []},
+    )
+    action = create_lyria_action(
+        'lyria-3-clip-preview',
+        plugin_api_key='key',
+        client_options=ClientOptions(),
+    )
+    with patcher:
+        with pytest.raises(GenkitError, match='Missing input') as exc_info:
+            await action.run(ModelRequest(messages=[]))
+    assert exc_info.value.status == 'INVALID_ARGUMENT'
+    assert create_calls == []
+
+
+@pytest.mark.asyncio
+async def test_lyria_keeps_system_instruction_and_user_input() -> None:
+    patcher, create_calls, _, _ = patch_interactions(
+        'genkit_google_genai.models.interactions_lyria',
+        create_result={
+            'id': 'ly-both',
+            'status': 'completed',
+            'steps': [{'type': 'model_output', 'content': [{'type': 'text', 'text': 'ok'}]}],
+        },
+    )
+    action = create_lyria_action(
+        'lyria-3-clip-preview',
+        plugin_api_key='key',
+        client_options=ClientOptions(),
+    )
+    with patcher:
+        await action.run(
+            ModelRequest(
+                messages=[
+                    Message(role=Role.SYSTEM, content=[Part(TextPart(text='cinematic'))]),
+                    Message(role=Role.USER, content=[Part(TextPart(text='short sting'))]),
+                ]
+            )
+        )
+
+    assert create_calls[0]['system_instruction'] == 'cinematic'
+    assert create_calls[0]['input'] == [
+        {'type': 'user_input', 'content': [{'type': 'text', 'text': 'short sting'}]},
+    ]
 
 
 @pytest.mark.asyncio

--- a/py/packages/genkit-google-genai/tests/interactions/interactions_models_test.py
+++ b/py/packages/genkit-google-genai/tests/interactions/interactions_models_test.py
@@ -24,7 +24,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from genkit_google_genai._interactions.converters import split_system_instruction
 from genkit_google_genai._interactions.options import ClientOptions
-from genkit_google_genai.google import GoogleAI, VertexAI, googleai_name
+from genkit_google_genai.google import GenaiModels, GoogleAI, VertexAI, googleai_name
 from genkit_google_genai.models.antigravity import AntigravityConfig, create_antigravity_action
 from genkit_google_genai.models.deep_research import (
     DeepResearchConfig,
@@ -36,7 +36,7 @@ from genkit_google_genai.models.interactions_lyria import LyriaConfig, create_ly
 from genkit_google_genai.models.interactions_registry import deep_research_model_info, lyria_model_info
 from google.genai.interactions import Interaction
 
-from genkit import ActionKind, GenkitError, Message, ModelRequest, Part, Role, TextPart
+from genkit import ActionKind, Genkit, GenkitError, Message, ModelRequest, Part, Role, TextPart
 from genkit.model import Operation
 
 
@@ -134,14 +134,26 @@ async def test_deep_research_start_sends_background_request() -> None:
     action = create_deep_research_background_action(
         'deep-research-preview-04-2026',
         plugin_api_key='plugin-key',
-        client_options=ClientOptions(),
+        client_options=ClientOptions(
+            base_url='https://plugin.example',
+            api_version='v1',
+            timeout=1000,
+            custom_headers={'x-request-id': 'plugin'},
+        ),
     )
     request = ModelRequest(
         messages=[
             Message(role=Role.SYSTEM, content=[Part(TextPart(text='sys'))]),
             Message(role=Role.USER, content=[Part(TextPart(text='research this'))]),
         ],
-        config={'thinking_summaries': 'auto', 'google_search': True},
+        config={
+            'thinking_summaries': 'auto',
+            'google_search': True,
+            'base_url': 'https://start.example',
+            'api_version': 'v1',
+            'timeout': 1500,
+            'custom_headers': {'x-request-id': 'start'},
+        },
     )
     with patcher:
         operation = await action.start(request)
@@ -162,9 +174,16 @@ async def test_deep_research_start_sends_background_request() -> None:
     ]
     assert operation.id == 'dr-1'
     assert operation.done is False
-    persisted = (operation.metadata or {}).get('clientOptions') or {}
-    assert 'apiKey' not in persisted
-    assert 'baseUrl' not in persisted
+    assert not operation.metadata
+    options = captured['client_options']
+    assert options.base_url == 'https://start.example'
+    assert options.api_version == 'v1'
+    assert options.timeout == 1500
+    assert options.custom_headers == {'x-request-id': 'start'}
+    assert 'base_url' not in body
+    assert 'api_version' not in body
+    assert 'timeout' not in body
+    assert 'custom_headers' not in body
 
 
 @pytest.mark.asyncio
@@ -182,18 +201,39 @@ async def test_deep_research_check_reads_secrets_not_ticket() -> None:
     action = create_deep_research_background_action(
         'deep-research-preview-04-2026',
         plugin_api_key='plugin-key',
-        client_options=ClientOptions(),
+        client_options=ClientOptions(
+            base_url='https://plugin.example',
+            api_version='v1',
+            timeout=1000,
+            custom_headers={'x-request-id': 'plugin'},
+        ),
     )
     operation = Operation.model_construct(
         id='dr-1',
         metadata={'clientOptions': {'baseUrl': 'https://evil.test', 'apiKey': 'ticket-key'}},
     )
     with patcher:
-        updated = await action.check(operation, context={'secrets': {'api_key': 'tenant-key'}})
+        updated = await action.check(
+            operation,
+            context={
+                'secrets': {'api_key': 'tenant-key'},
+                'config': {
+                    'base_url': 'https://poll.example',
+                    'api_version': 'v1beta',
+                    'timeout': 2000,
+                    'custom_headers': {'x-request-id': 'check'},
+                },
+            },
+        )
 
     assert captured['api_key'] == 'tenant-key'
-    assert captured['client_options'].base_url is None
+    options = captured['client_options']
+    assert options.base_url == 'https://poll.example'
+    assert options.api_version == 'v1beta'
+    assert options.timeout == 2000
+    assert options.custom_headers == {'x-request-id': 'check'}
     assert get_calls == ['dr-1']
+    assert not updated.metadata
     assert updated.done is True
     assert updated.output is not None
     assert updated.output.message is not None
@@ -220,13 +260,29 @@ async def test_deep_research_cancel_reads_secrets_not_ticket() -> None:
         metadata={'clientOptions': {'baseUrl': 'https://evil.test', 'apiKey': 'ticket-key'}},
     )
     with patcher:
-        updated = await action.cancel(operation, context={'secrets': {'api_key': 'tenant-key'}})
+        updated = await action.cancel(
+            operation,
+            context={
+                'secrets': {'api_key': 'tenant-key'},
+                'config': {
+                    'base_url': 'https://cancel.example',
+                    'api_version': 'v1alpha',
+                    'timeout': 2500,
+                    'custom_headers': {'x-request-id': 'cancel'},
+                },
+            },
+        )
 
     assert captured['api_key'] == 'tenant-key'
-    assert captured['client_options'].base_url is None
+    options = captured['client_options']
+    assert options.base_url == 'https://cancel.example'
+    assert options.api_version == 'v1alpha'
+    assert options.timeout == 2500
+    assert options.custom_headers == {'x-request-id': 'cancel'}
     assert cancel_calls == ['dr-1']
     assert updated.done is True
     assert updated.id == 'dr-1'
+    assert not updated.metadata
 
 
 @pytest.mark.asyncio
@@ -864,3 +920,241 @@ async def test_lyria_rejects_config_api_key() -> None:
                 )
             )
     assert create_calls == []
+
+
+@pytest.mark.asyncio
+async def test_antigravity_generate_uses_context_secrets() -> None:
+    captured: dict[str, Any] = {}
+    patcher, create_calls, _, _ = patch_interactions(
+        'genkit_google_genai.models.antigravity',
+        create_result={
+            'id': 'ag-secret',
+            'status': 'completed',
+            'steps': [{'type': 'model_output', 'content': [{'type': 'text', 'text': 'ok'}]}],
+        },
+        captured=captured,
+    )
+    action = create_antigravity_action(
+        'antigravity-preview-05-2026',
+        plugin_api_key='plugin-key',
+        client_options=ClientOptions(),
+    )
+    with patcher:
+        await action.run(
+            ModelRequest(messages=[Message(role=Role.USER, content=[Part(TextPart(text='plan'))])]),
+            context={'secrets': {'api_key': 'tenant-key'}},
+        )
+
+    assert captured['api_key'] == 'tenant-key'
+    assert create_calls[0]['agent'] == 'antigravity-preview-05-2026'
+
+
+@pytest.mark.asyncio
+async def test_lyria_generate_uses_context_secrets() -> None:
+    captured: dict[str, Any] = {}
+    patcher, create_calls, _, _ = patch_interactions(
+        'genkit_google_genai.models.interactions_lyria',
+        create_result={'id': 'ly-secret', 'status': 'completed', 'steps': []},
+        captured=captured,
+    )
+    action = create_lyria_action(
+        'lyria-3-clip-preview',
+        plugin_api_key='plugin-key',
+        client_options=ClientOptions(),
+    )
+    with patcher:
+        await action.run(
+            ModelRequest(messages=[Message(role=Role.USER, content=[Part(TextPart(text='sting'))])]),
+            context={'secrets': {'api_key': 'tenant-key'}},
+        )
+
+    assert captured['api_key'] == 'tenant-key'
+    assert create_calls[0]['model'] == 'lyria-3-clip-preview'
+
+
+@pytest.mark.asyncio
+async def test_lyria_002_hits_interactions_wire() -> None:
+    patcher, create_calls, _, _ = patch_interactions(
+        'genkit_google_genai.models.interactions_lyria',
+        create_result={'id': 'ly-002', 'status': 'completed', 'steps': []},
+    )
+    action = create_lyria_action(
+        'lyria-002',
+        plugin_api_key='plugin-key',
+        client_options=ClientOptions(),
+    )
+    with patcher:
+        await action.run(ModelRequest(messages=[Message(role=Role.USER, content=[Part(TextPart(text='sting'))])]))
+
+    assert create_calls[0]['model'] == 'lyria-002'
+
+
+@patch('genkit_google_genai.google.genai.client.Client')
+@patch('genkit_google_genai.google._list_genai_models')
+@pytest.mark.asyncio
+async def test_ai_generate_operation_deep_research_uses_context_secrets(
+    mock_list_models: MagicMock, mock_client: MagicMock
+) -> None:
+    mock_list_models.return_value = GenaiModels()
+    captured: dict[str, Any] = {}
+    patcher, create_calls, get_calls, cancel_calls = patch_interactions(
+        'genkit_google_genai.models.deep_research',
+        create_result={'id': 'dr-ai-1', 'status': 'in_progress'},
+        get_result={
+            'id': 'dr-ai-1',
+            'status': 'completed',
+            'steps': [{'type': 'model_output', 'content': [{'type': 'text', 'text': 'report'}]}],
+        },
+        cancel_result={'id': 'dr-ai-1', 'status': 'cancelled'},
+        captured=captured,
+    )
+    ai = Genkit(plugins=[GoogleAI(api_key='plugin-key')])
+    tenant = {'secrets': {'api_key': 'tenant-key'}}
+    with patcher:
+        operation = await ai.generate_operation(
+            model=GoogleAI.deep_research_model('deep-research-preview-04-2026'),
+            prompt='Summarize recent advances in quantum error correction.',
+            config={
+                'base_url': 'https://start.example',
+                'api_version': 'v1',
+                'timeout': 1500,
+                'custom_headers': {'x-request-id': 'start'},
+            },
+            context=tenant,
+        )
+        assert captured['api_key'] == 'tenant-key'
+        assert captured['client_options'] == ClientOptions(
+            base_url='https://start.example',
+            api_version='v1',
+            timeout=1500,
+            custom_headers={'x-request-id': 'start'},
+        )
+        assert create_calls[0]['background'] is True
+        assert operation.id == 'dr-ai-1'
+        assert operation.done is False
+        assert not operation.metadata
+
+        updated = await ai.check_operation(
+            operation,
+            context=tenant,
+            config={
+                'base_url': 'https://poll.example',
+                'api_version': 'v1beta',
+                'timeout': 2000,
+                'custom_headers': {'x-request-id': 'check'},
+            },
+        )
+        assert captured['client_options'] == ClientOptions(
+            base_url='https://poll.example',
+            api_version='v1beta',
+            timeout=2000,
+            custom_headers={'x-request-id': 'check'},
+        )
+
+        cancelled = await ai.cancel_operation(
+            operation,
+            context=tenant,
+            config={
+                'base_url': 'https://cancel.example',
+                'api_version': 'v1alpha',
+                'timeout': 2500,
+                'custom_headers': {'x-request-id': 'cancel'},
+            },
+        )
+
+    assert captured['api_key'] == 'tenant-key'
+    assert captured['client_options'] == ClientOptions(
+        base_url='https://cancel.example',
+        api_version='v1alpha',
+        timeout=2500,
+        custom_headers={'x-request-id': 'cancel'},
+    )
+    assert get_calls == ['dr-ai-1']
+    assert cancel_calls == ['dr-ai-1']
+    assert updated.done is True
+    assert cancelled.done is True
+    assert not updated.metadata
+    assert not cancelled.metadata
+    assert updated.output is not None
+    assert updated.output.message is not None
+    assert updated.output.message.content[0].root.text == 'report'
+
+
+@patch('genkit_google_genai.google.genai.client.Client')
+@patch('genkit_google_genai.google._list_genai_models')
+@pytest.mark.asyncio
+async def test_ai_generate_antigravity_uses_context_secrets(
+    mock_list_models: MagicMock, mock_client: MagicMock
+) -> None:
+    mock_list_models.return_value = GenaiModels()
+    captured: dict[str, Any] = {}
+    patcher, create_calls, _, _ = patch_interactions(
+        'genkit_google_genai.models.antigravity',
+        create_result={
+            'id': 'ag-ai-1',
+            'status': 'completed',
+            'steps': [{'type': 'model_output', 'content': [{'type': 'text', 'text': 'hello'}]}],
+        },
+        captured=captured,
+    )
+    ai = Genkit(plugins=[GoogleAI(api_key='plugin-key')])
+    with patcher:
+        response = await ai.generate(
+            model=GoogleAI.antigravity_model('antigravity-preview-05-2026'),
+            prompt='Plan a three-day itinerary',
+            config={
+                'base_url': 'https://antigravity.example',
+                'api_version': 'v1',
+                'timeout': 1500,
+                'custom_headers': {'x-request-id': 'antigravity'},
+            },
+            context={'secrets': {'api_key': 'tenant-key'}},
+        )
+
+    assert captured['api_key'] == 'tenant-key'
+    assert captured['client_options'] == ClientOptions(
+        base_url='https://antigravity.example',
+        api_version='v1',
+        timeout=1500,
+        custom_headers={'x-request-id': 'antigravity'},
+    )
+    assert create_calls[0]['agent'] == 'antigravity-preview-05-2026'
+    assert 'background' not in create_calls[0]
+    assert response.text == 'hello'
+
+
+@patch('genkit_google_genai.google.genai.client.Client')
+@patch('genkit_google_genai.google._list_genai_models')
+@pytest.mark.asyncio
+async def test_ai_generate_lyria_002_hits_interactions_with_tenant_key(
+    mock_list_models: MagicMock, mock_client: MagicMock
+) -> None:
+    mock_list_models.return_value = GenaiModels()
+    captured: dict[str, Any] = {}
+    patcher, create_calls, _, _ = patch_interactions(
+        'genkit_google_genai.models.interactions_lyria',
+        create_result={'id': 'ly-ai-002', 'status': 'completed', 'steps': []},
+        captured=captured,
+    )
+    ai = Genkit(plugins=[GoogleAI(api_key='plugin-key')])
+    with patcher:
+        await ai.generate(
+            model=GoogleAI.lyria_model('lyria-002'),
+            prompt='a short cinematic sting',
+            config={
+                'base_url': 'https://lyria.example',
+                'api_version': 'v1beta',
+                'timeout': 2000,
+                'custom_headers': {'x-request-id': 'lyria'},
+            },
+            context={'secrets': {'api_key': 'tenant-key'}},
+        )
+
+    assert captured['api_key'] == 'tenant-key'
+    assert captured['client_options'] == ClientOptions(
+        base_url='https://lyria.example',
+        api_version='v1beta',
+        timeout=2000,
+        custom_headers={'x-request-id': 'lyria'},
+    )
+    assert create_calls[0]['model'] == 'lyria-002'

--- a/py/packages/genkit-google-genai/tests/interactions/interactions_models_test.py
+++ b/py/packages/genkit-google-genai/tests/interactions/interactions_models_test.py
@@ -1,0 +1,768 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for Interactions-backed Google AI models."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from genkit_google_genai._interactions.converters import split_system_instruction
+from genkit_google_genai._interactions.options import ClientOptions
+from genkit_google_genai.google import GoogleAI, VertexAI, googleai_name
+from genkit_google_genai.models.antigravity import AntigravityConfig, create_antigravity_action
+from genkit_google_genai.models.deep_research import (
+    DeepResearchConfig,
+    create_deep_research_background_action,
+    deep_research_model,
+    response_format_from_request,
+)
+from genkit_google_genai.models.interactions_lyria import LyriaConfig, create_lyria_action
+from genkit_google_genai.models.interactions_registry import deep_research_model_info
+from google.genai.interactions import Interaction
+
+from genkit import ActionKind, GenkitError, Message, ModelRequest, Part, Role, TextPart
+from genkit.model import Operation
+
+
+def test_split_system_instruction_folds_system_turns() -> None:
+    messages = [
+        Message(role=Role.SYSTEM, content=[Part(TextPart(text='Be helpful'))]),
+        Message(role=Role.USER, content=[Part(TextPart(text='Hi'))]),
+        Message(role=Role.SYSTEM, content=[Part(TextPart(text='Be terse'))]),
+    ]
+    instruction, turns = split_system_instruction(messages)
+    assert instruction == 'Be helpful\n\nBe terse'
+    assert [message.role for message in turns] == [Role.USER]
+
+
+def test_split_system_instruction_without_system_turns() -> None:
+    messages = [Message(role=Role.USER, content=[Part(TextPart(text='Hi'))])]
+    instruction, turns = split_system_instruction(messages)
+    assert instruction is None
+    assert turns == messages
+
+
+def patch_interactions(
+    module: str,
+    *,
+    create_result: dict[str, Any] | None = None,
+    get_result: dict[str, Any] | None = None,
+    cancel_result: dict[str, Any] | None = None,
+    captured: dict[str, Any] | None = None,
+):
+    """Patch raw HTTP Interactions helpers on a model module."""
+    create_calls: list[dict[str, Any]] = []
+    get_calls: list[str] = []
+    cancel_calls: list[str] = []
+
+    async def create(
+        api_key: str,
+        body: dict[str, Any],
+        client_options: ClientOptions | None = None,
+    ) -> Interaction:
+        create_calls.append(body)
+        if captured is not None:
+            captured['create'] = body
+            captured['api_key'] = api_key
+            captured['client_options'] = client_options
+        return Interaction.model_validate(create_result or {'id': 'ix-1', 'status': 'in_progress'})
+
+    async def get(
+        api_key: str,
+        interaction_id: str,
+        client_options: ClientOptions | None = None,
+    ) -> Interaction:
+        get_calls.append(interaction_id)
+        if captured is not None:
+            captured['get'] = interaction_id
+            captured['api_key'] = api_key
+            captured['client_options'] = client_options
+        return Interaction.model_validate(get_result or {'id': interaction_id, 'status': 'completed', 'steps': []})
+
+    async def cancel(
+        api_key: str,
+        interaction_id: str,
+        client_options: ClientOptions | None = None,
+    ) -> Interaction:
+        cancel_calls.append(interaction_id)
+        if captured is not None:
+            captured['cancel'] = interaction_id
+            captured['api_key'] = api_key
+            captured['client_options'] = client_options
+        return Interaction.model_validate(cancel_result or {'id': interaction_id, 'status': 'cancelled'})
+
+    patches: dict[str, Any] = {
+        'create_interaction': AsyncMock(side_effect=create),
+    }
+    # Only deep_research imports get/cancel; patch those when present.
+    if module.endswith('deep_research'):
+        patches['get_interaction'] = AsyncMock(side_effect=get)
+        patches['cancel_interaction'] = AsyncMock(side_effect=cancel)
+
+    return (
+        patch.multiple(module, **patches),
+        create_calls,
+        get_calls,
+        cancel_calls,
+    )
+
+
+@pytest.mark.asyncio
+async def test_deep_research_start_sends_background_request() -> None:
+    captured: dict[str, Any] = {}
+    patcher, create_calls, _, _ = patch_interactions(
+        'genkit_google_genai.models.deep_research',
+        create_result={'id': 'dr-1', 'status': 'in_progress'},
+        captured=captured,
+    )
+    action = create_deep_research_background_action(
+        'deep-research-preview-04-2026',
+        plugin_api_key='plugin-key',
+        client_options=ClientOptions(),
+    )
+    request = ModelRequest(
+        messages=[
+            Message(role=Role.SYSTEM, content=[Part(TextPart(text='sys'))]),
+            Message(role=Role.USER, content=[Part(TextPart(text='research this'))]),
+        ],
+        config={'thinking_summaries': 'auto', 'google_search': True},
+    )
+    with patcher:
+        operation = await action.start(request)
+
+    body = create_calls[0]
+    assert body['background'] is True
+    assert body['agent'] == 'deep-research-preview-04-2026'
+    assert body['agent_config'] == {
+        'type': 'deep-research',
+        'thinking_summaries': 'auto',
+    }
+    assert body['tools'] == [{'type': 'google_search'}]
+    # Deep Research rejects system_instruction; system text lands as a leading input step.
+    assert 'system_instruction' not in body
+    assert body['input'] == [
+        {'type': 'user_input', 'content': [{'type': 'text', 'text': 'sys'}]},
+        {'type': 'user_input', 'content': [{'type': 'text', 'text': 'research this'}]},
+    ]
+    assert operation.id == 'dr-1'
+    assert operation.done is False
+    persisted = (operation.metadata or {}).get('clientOptions') or {}
+    assert 'apiKey' not in persisted
+    assert 'baseUrl' not in persisted
+
+
+@pytest.mark.asyncio
+async def test_deep_research_check_reads_secrets_not_ticket() -> None:
+    captured: dict[str, Any] = {}
+    patcher, _, get_calls, _ = patch_interactions(
+        'genkit_google_genai.models.deep_research',
+        get_result={
+            'id': 'dr-1',
+            'status': 'completed',
+            'steps': [{'type': 'model_output', 'content': [{'type': 'text', 'text': 'done'}]}],
+        },
+        captured=captured,
+    )
+    action = create_deep_research_background_action(
+        'deep-research-preview-04-2026',
+        plugin_api_key='plugin-key',
+        client_options=ClientOptions(),
+    )
+    operation = Operation.model_construct(
+        id='dr-1',
+        metadata={'clientOptions': {'baseUrl': 'https://evil.test', 'apiKey': 'ticket-key'}},
+    )
+    with patcher:
+        updated = await action.check(operation, context={'secrets': {'api_key': 'tenant-key'}})
+
+    assert captured['api_key'] == 'tenant-key'
+    assert captured['client_options'].base_url is None
+    assert get_calls == ['dr-1']
+    assert updated.done is True
+    assert updated.output is not None
+    assert updated.output.message is not None
+    assert updated.output.message.content[0].root.text == 'done'
+    assert isinstance(updated.output, type(updated.output))
+    assert updated.output.message.role == 'model'
+
+
+@pytest.mark.asyncio
+async def test_deep_research_cancel_reads_secrets_not_ticket() -> None:
+    captured: dict[str, Any] = {}
+    patcher, _, _, cancel_calls = patch_interactions(
+        'genkit_google_genai.models.deep_research',
+        cancel_result={'id': 'dr-1', 'status': 'cancelled'},
+        captured=captured,
+    )
+    action = create_deep_research_background_action(
+        'deep-research-preview-04-2026',
+        plugin_api_key='plugin-key',
+        client_options=ClientOptions(),
+    )
+    operation = Operation.model_construct(
+        id='dr-1',
+        metadata={'clientOptions': {'baseUrl': 'https://evil.test', 'apiKey': 'ticket-key'}},
+    )
+    with patcher:
+        updated = await action.cancel(operation, context={'secrets': {'api_key': 'tenant-key'}})
+
+    assert captured['api_key'] == 'tenant-key'
+    assert captured['client_options'].base_url is None
+    assert cancel_calls == ['dr-1']
+    assert updated.done is True
+    assert updated.id == 'dr-1'
+
+
+@pytest.mark.asyncio
+async def test_deep_research_check_falls_back_to_plugin_api_key() -> None:
+    captured: dict[str, Any] = {}
+    patcher, _, _, _ = patch_interactions(
+        'genkit_google_genai.models.deep_research',
+        get_result={'id': 'dr-1', 'status': 'in_progress'},
+        captured=captured,
+    )
+    action = create_deep_research_background_action(
+        'deep-research-preview-04-2026',
+        plugin_api_key='plugin-key',
+        client_options=ClientOptions(),
+    )
+    operation = Operation.model_construct(
+        id='dr-1',
+        metadata={'clientOptions': {'baseUrl': 'https://example.test'}},
+    )
+    with patcher:
+        await action.check(operation)
+
+    assert captured['api_key'] == 'plugin-key'
+
+
+@pytest.mark.asyncio
+async def test_deep_research_passes_previous_interaction_id() -> None:
+    patcher, create_calls, _, _ = patch_interactions(
+        'genkit_google_genai.models.deep_research',
+        create_result={'id': 'dr-2', 'status': 'in_progress'},
+    )
+    action = create_deep_research_background_action(
+        'deep-research-preview-04-2026',
+        plugin_api_key='plugin-key',
+        client_options=ClientOptions(),
+    )
+    request = ModelRequest(
+        messages=[Message(role=Role.USER, content=[Part(TextPart(text='follow up'))])],
+        config={'previous_interaction_id': 'v1_prior'},
+    )
+    with patcher:
+        await action.start(request)
+
+    assert create_calls[0]['previous_interaction_id'] == 'v1_prior'
+
+
+@pytest.mark.asyncio
+async def test_deep_research_rejects_config_api_key() -> None:
+    patcher, create_calls, _, _ = patch_interactions(
+        'genkit_google_genai.models.deep_research',
+        create_result={'id': 'dr-key', 'status': 'in_progress'},
+    )
+    action = create_deep_research_background_action(
+        'deep-research-preview-04-2026',
+        plugin_api_key='plugin-key',
+        client_options=ClientOptions(),
+    )
+    with patcher:
+        with pytest.raises(GenkitError, match='context.secrets') as exc_info:
+            await action.start(
+                ModelRequest(
+                    messages=[Message(role=Role.USER, content=[Part(TextPart(text='q'))])],
+                    config={'api_key': 'request-key'},
+                )
+            )
+    assert exc_info.value.status == 'INVALID_ARGUMENT'
+    assert create_calls == []
+
+
+@pytest.mark.asyncio
+async def test_deep_research_start_uses_context_secrets() -> None:
+    captured: dict[str, Any] = {}
+    patcher, _, _, _ = patch_interactions(
+        'genkit_google_genai.models.deep_research',
+        create_result={'id': 'dr-secret', 'status': 'in_progress'},
+        captured=captured,
+    )
+    action = create_deep_research_background_action(
+        'deep-research-preview-04-2026',
+        plugin_api_key='plugin-key',
+        client_options=ClientOptions(),
+    )
+    request = ModelRequest(messages=[Message(role=Role.USER, content=[Part(TextPart(text='q'))])])
+    with patcher:
+        operation = await action.start_action.run(request, context={'secrets': {'api_key': 'tenant-key'}})
+
+    assert captured['api_key'] == 'tenant-key'
+    persisted = (operation.response.metadata or {}).get('clientOptions') or {}
+    assert 'apiKey' not in persisted
+
+
+@pytest.mark.asyncio
+async def test_antigravity_passes_previous_interaction_id() -> None:
+    patcher, create_calls, _, _ = patch_interactions(
+        'genkit_google_genai.models.antigravity',
+        create_result={
+            'id': 'ag-2',
+            'status': 'completed',
+            'steps': [{'type': 'model_output', 'content': [{'type': 'text', 'text': 'ok'}]}],
+        },
+    )
+    action = create_antigravity_action(
+        'antigravity-preview-05-2026',
+        plugin_api_key='key',
+        client_options=ClientOptions(),
+    )
+    with patcher:
+        await action.run(
+            ModelRequest[AntigravityConfig](
+                messages=[Message(role=Role.USER, content=[Part(TextPart(text='continue'))])],
+                config=AntigravityConfig(previous_interaction_id='v1_prior'),
+            )
+        )
+
+    assert create_calls[0]['previous_interaction_id'] == 'v1_prior'
+
+
+@pytest.mark.asyncio
+async def test_antigravity_rejects_empty_messages() -> None:
+    patcher, create_calls, _, _ = patch_interactions(
+        'genkit_google_genai.models.antigravity',
+        create_result={'id': 'ag-empty', 'status': 'completed', 'steps': []},
+    )
+    action = create_antigravity_action(
+        'antigravity-preview-05-2026',
+        plugin_api_key='key',
+        client_options=ClientOptions(),
+    )
+    with patcher:
+        with pytest.raises(GenkitError, match='Missing input') as exc_info:
+            await action.run(ModelRequest(messages=[]))
+    assert exc_info.value.status == 'INVALID_ARGUMENT'
+    assert create_calls == []
+
+
+@pytest.mark.asyncio
+async def test_deep_research_rejects_empty_messages() -> None:
+    patcher, create_calls, _, _ = patch_interactions(
+        'genkit_google_genai.models.deep_research',
+        create_result={'id': 'dr-empty', 'status': 'in_progress'},
+    )
+    action = create_deep_research_background_action(
+        'deep-research-preview-04-2026',
+        plugin_api_key='plugin-key',
+        client_options=ClientOptions(),
+    )
+    with patcher:
+        with pytest.raises(GenkitError, match='Missing input') as exc_info:
+            await action.start(ModelRequest(messages=[]))
+    assert exc_info.value.status == 'INVALID_ARGUMENT'
+    assert create_calls == []
+
+
+@pytest.mark.asyncio
+async def test_antigravity_generate_folds_system_and_uses_agent() -> None:
+    patcher, create_calls, _, _ = patch_interactions(
+        'genkit_google_genai.models.antigravity',
+        create_result={
+            'id': 'ag-1',
+            'status': 'completed',
+            'steps': [{'type': 'model_output', 'content': [{'type': 'text', 'text': 'hello'}]}],
+        },
+    )
+    action = create_antigravity_action(
+        'antigravity-preview-05-2026',
+        plugin_api_key='key',
+        client_options=ClientOptions(),
+    )
+    request = ModelRequest[AntigravityConfig](
+        messages=[
+            Message(role=Role.SYSTEM, content=[Part(TextPart(text='sys'))]),
+            Message(role=Role.USER, content=[Part(TextPart(text='build'))]),
+        ],
+        config=AntigravityConfig(response_modalities=['text', 'image']),
+    )
+    with patcher:
+        response = await action.run(request)
+
+    body = create_calls[0]
+    assert body['agent'] == 'antigravity-preview-05-2026'
+    assert body['response_modalities'] == ['text', 'image']
+    assert 'background' not in body
+    assert body['environment'] == {'type': 'remote'}
+    # Antigravity rejects system_instruction; system text lands as a leading input step.
+    assert 'system_instruction' not in body
+    assert body['input'] == [
+        {'type': 'user_input', 'content': [{'type': 'text', 'text': 'sys'}]},
+        {'type': 'user_input', 'content': [{'type': 'text', 'text': 'build'}]},
+    ]
+    assert response.response.message is not None
+    assert response.response.message.content[0].root.text == 'hello'
+
+
+def test_bare_model_request_accepts_lyria_config_instance() -> None:
+    """Bare ModelRequest(config=LyriaConfig(...)) should not reject the plugin schema."""
+    request = ModelRequest(
+        messages=[Message(role=Role.USER, content=[Part(TextPart(text='riff'))])],
+        config=LyriaConfig(response_modalities=['audio']),
+    )
+    assert isinstance(request.config, LyriaConfig)
+    assert request.config.response_modalities == ['audio']
+
+
+@pytest.mark.asyncio
+async def test_lyria_defaults_audio_and_text_modalities() -> None:
+    patcher, create_calls, _, _ = patch_interactions(
+        'genkit_google_genai.models.interactions_lyria',
+        create_result={
+            'id': 'ly-1',
+            'status': 'completed',
+            'steps': [
+                {
+                    'type': 'model_output',
+                    'content': [{'type': 'audio', 'data': 'abc', 'mime_type': 'audio/wav'}],
+                }
+            ],
+        },
+    )
+    action = create_lyria_action(
+        'lyria-3-clip-preview',
+        plugin_api_key='key',
+        client_options=ClientOptions(),
+    )
+    request = ModelRequest(
+        messages=[Message(role=Role.USER, content=[Part(TextPart(text='jazz riff'))])],
+    )
+    with patcher:
+        response = await action.run(request)
+
+    body = create_calls[0]
+    assert body['model'] == 'lyria-3-clip-preview'
+    assert body['response_modalities'] == ['audio', 'text']
+    assert response.response.message is not None
+
+
+@pytest.mark.asyncio
+async def test_lyria_passes_through_unknown_config_fields() -> None:
+    patcher, create_calls, _, _ = patch_interactions(
+        'genkit_google_genai.models.interactions_lyria',
+        create_result={
+            'id': 'ly-2',
+            'status': 'completed',
+            'steps': [{'type': 'model_output', 'content': [{'type': 'text', 'text': 'ok'}]}],
+        },
+    )
+    action = create_lyria_action(
+        'lyria-3-clip-preview',
+        plugin_api_key='key',
+        client_options=ClientOptions(),
+    )
+    with patcher:
+        await action.run(
+            ModelRequest(
+                messages=[Message(role=Role.USER, content=[Part(TextPart(text='riff'))])],
+                config={'temperature': 0.4},
+            )
+        )
+
+    body = create_calls[0]
+    assert body['temperature'] == 0.4
+    assert 'api_key' not in body
+    assert 'apiKey' not in body
+
+
+def test_deep_research_model_ref_is_namespaced() -> None:
+    ref = deep_research_model('deep-research-preview-04-2026')
+    assert ref.name == 'googleai/deep-research-preview-04-2026'
+    assert ref.config_schema is not None
+    assert ref.info == deep_research_model_info('deep-research-preview-04-2026')
+
+
+def test_googleai_family_constructors() -> None:
+    dr = GoogleAI.deep_research_model('deep-research-preview-04-2026')
+    assert dr.name == 'googleai/deep-research-preview-04-2026'
+    assert dr.config_schema is DeepResearchConfig
+    assert dr.info == deep_research_model_info('deep-research-preview-04-2026')
+
+    ag = GoogleAI.antigravity_model('antigravity-preview-05-2026')
+    assert ag.name == 'googleai/antigravity-preview-05-2026'
+    assert ag.config_schema is AntigravityConfig
+
+    ly = GoogleAI.lyria_model('lyria-3-clip-preview')
+    assert ly.name == 'googleai/lyria-3-clip-preview'
+    assert ly.config_schema is LyriaConfig
+
+
+@pytest.mark.asyncio
+async def test_deep_research_background_action_sets_action() -> None:
+    """Start stamps Operation.action so check/cancel can find the companions."""
+    patcher, _, _, _ = patch_interactions(
+        'genkit_google_genai.models.deep_research',
+        create_result={'id': 'dr-action-1', 'status': 'in_progress'},
+    )
+    ref = deep_research_model('deep-research-preview-04-2026')
+    bg = create_deep_research_background_action(
+        ref,
+        plugin_api_key='plugin-key',
+        client_options=ClientOptions(),
+    )
+    with patcher:
+        operation = await bg.start(
+            ModelRequest(messages=[Message(role=Role.USER, content=[Part(TextPart(text='q'))])]),
+        )
+
+    assert isinstance(operation, Operation)
+    assert operation.action == f'/background-model/{ref.name}'
+    assert operation.id == 'dr-action-1'
+    model_meta = (bg.start_action.metadata or {}).get('model')
+    assert isinstance(model_meta, dict)
+    supports = model_meta.get('supports')
+    assert isinstance(supports, dict)
+    assert supports.get('longRunning') is True
+
+
+@pytest.mark.asyncio
+async def test_googleai_resolve_model_skips_deep_research_foreground() -> None:
+    mock_client = MagicMock()
+    mock_client.models.list.return_value = iter([])
+
+    with patch('genkit_google_genai.google.genai.client.Client', return_value=mock_client):
+        plugin = GoogleAI(api_key='test-key')
+
+    dr_name = googleai_name('deep-research-preview-04-2026')
+    assert await plugin.resolve(ActionKind.MODEL, dr_name) is None
+    bg = await plugin.resolve(ActionKind.BACKGROUND_MODEL, dr_name)
+    assert bg is not None
+    assert bg.kind == ActionKind.BACKGROUND_MODEL
+
+
+@pytest.mark.asyncio
+async def test_googleai_plugin_registers_interactions_models() -> None:
+    mock_client = MagicMock()
+    mock_client.models.list.return_value = iter([])
+
+    with patch('genkit_google_genai.google.genai.client.Client', return_value=mock_client):
+        plugin = GoogleAI(api_key='test-key')
+        actions = await plugin.init()
+
+    kinds_by_name = {action.name: action.kind for action in actions}
+    dr_name = googleai_name('deep-research-preview-04-2026')
+    ag_name = googleai_name('antigravity-preview-05-2026')
+    ly_name = googleai_name('lyria-3-clip-preview')
+
+    assert kinds_by_name[dr_name] == ActionKind.BACKGROUND_MODEL
+    assert kinds_by_name[f'{dr_name}/check'] == ActionKind.CHECK_OPERATION
+    assert kinds_by_name[f'{dr_name}/cancel'] == ActionKind.CANCEL_OPERATION
+    assert kinds_by_name[ag_name] == ActionKind.MODEL
+    assert kinds_by_name[ly_name] == ActionKind.MODEL
+
+
+@pytest.mark.asyncio
+async def test_googleai_resolve_routes_interactions_models() -> None:
+    mock_client = MagicMock()
+    mock_client.models.list.return_value = iter([])
+
+    with patch('genkit_google_genai.google.genai.client.Client', return_value=mock_client):
+        plugin = GoogleAI(api_key='test-key')
+
+    dr_name = googleai_name('deep-research-pro-preview-12-2025')
+    bg = await plugin.resolve(ActionKind.BACKGROUND_MODEL, dr_name)
+    assert bg is not None
+    assert bg.kind == ActionKind.BACKGROUND_MODEL
+
+    check = await plugin.resolve(ActionKind.CHECK_OPERATION, f'{dr_name}/check')
+    assert check is not None
+
+    cancel = await plugin.resolve(ActionKind.CANCEL_OPERATION, f'{dr_name}/cancel')
+    assert cancel is not None
+
+    ag = await plugin.resolve(ActionKind.MODEL, googleai_name('antigravity-preview-05-2026'))
+    assert ag is not None
+    assert ag.kind == ActionKind.MODEL
+
+    ly = await plugin.resolve(ActionKind.MODEL, googleai_name('lyria-3-pro-preview'))
+    assert ly is not None
+
+    # Legacy Vertex name must not fall through to Gemini capabilities metadata.
+    ly_legacy = await plugin.resolve(ActionKind.MODEL, googleai_name('lyria-002'))
+    assert ly_legacy is not None
+    model_meta = (ly_legacy.metadata or {}).get('model')
+    assert isinstance(model_meta, dict)
+    supports = model_meta.get('supports')
+    assert isinstance(supports, dict)
+    assert supports.get('media') is True
+    assert supports.get('multiturn') is not True
+
+
+@pytest.mark.asyncio
+async def test_googleai_list_actions_includes_interactions_models() -> None:
+    mock_client = MagicMock()
+    mock_client.models.list.return_value = iter([])
+
+    with patch('genkit_google_genai.google.genai.client.Client', return_value=mock_client):
+        plugin = GoogleAI(api_key='test-key')
+        actions = await plugin.list_actions()
+
+    names = {action.name for action in actions}
+    assert googleai_name('deep-research-max-preview-04-2026') in names
+    assert googleai_name('antigravity-preview-05-2026') in names
+    assert googleai_name('lyria-3-pro-preview') in names
+
+
+@pytest.mark.asyncio
+async def test_vertex_keeps_interactions_families_fail_closed() -> None:
+    mock_client = MagicMock()
+    mock_client.models.list.return_value = iter([])
+
+    with patch('genkit_google_genai.google.genai.client.Client', return_value=mock_client):
+        plugin = VertexAI(project='p', location='us-central1')
+
+    assert await plugin.resolve(ActionKind.MODEL, 'vertexai/deep-research-preview-04-2026') is None
+    assert await plugin.resolve(ActionKind.BACKGROUND_MODEL, 'vertexai/deep-research-preview-04-2026') is None
+    assert await plugin.resolve(ActionKind.MODEL, 'vertexai/antigravity-preview-05-2026') is None
+    assert await plugin.resolve(ActionKind.MODEL, 'vertexai/lyria-3-clip-preview') is None
+    assert await plugin.resolve(ActionKind.MODEL, 'vertexai/lyria-002') is None
+
+
+@pytest.mark.asyncio
+async def test_deep_research_file_search_and_mcp_dump_snake_case() -> None:
+    patcher, create_calls, _, _ = patch_interactions(
+        'genkit_google_genai.models.deep_research',
+        create_result={'id': 'dr-tools', 'status': 'in_progress'},
+    )
+    action = create_deep_research_background_action(
+        'deep-research-preview-04-2026',
+        plugin_api_key='plugin-key',
+        client_options=ClientOptions(),
+    )
+    request = ModelRequest(
+        messages=[Message(role=Role.USER, content=[Part(TextPart(text='q'))])],
+        config={
+            'file_search': {'file_search_store_names': ['stores/one']},
+            'mcp_servers': [{'name': 'docs', 'url': 'https://mcp.example', 'allowed_tools': ['search']}],
+        },
+    )
+    with patcher:
+        await action.start(request)
+
+    tools = create_calls[0]['tools']
+    assert {'type': 'file_search', 'file_search_store_names': ['stores/one']} in tools
+    assert {
+        'type': 'mcp_server',
+        'name': 'docs',
+        'url': 'https://mcp.example',
+        'allowed_tools': ['search'],
+    } in tools
+    assert 'fileSearchStoreNames' not in tools[0]
+    assert 'allowedTools' not in tools[1]
+
+
+def test_response_format_from_request_keeps_caller_schema() -> None:
+    schema = {'type': 'object', 'properties': {'title': {'type': 'string'}}}
+    request = ModelRequest(
+        messages=[Message(role=Role.USER, content=[Part(TextPart(text='q'))])],
+        output={'format': 'json', 'schema': schema},
+    )
+    assert response_format_from_request(request) == {
+        'type': 'text',
+        'mime_type': 'application/json',
+        'schema': schema,
+    }
+
+
+def test_deep_research_accepts_uppercase_choice_labels() -> None:
+    config = DeepResearchConfig.model_validate({
+        'thinking_summaries': 'AUTO',
+        'visualization': 'OFF',
+        'response_modalities': ['TEXT', 'IMAGE'],
+    })
+    assert config.thinking_summaries == 'auto'
+    assert config.visualization == 'off'
+    assert config.response_modalities == ['text', 'image']
+
+
+@pytest.mark.asyncio
+async def test_lyria_system_only_is_enough() -> None:
+    """A system prompt is enough to start a clip — no user turn required."""
+    patcher, create_calls, _, _ = patch_interactions(
+        'genkit_google_genai.models.interactions_lyria',
+        create_result={
+            'id': 'ly-sys',
+            'status': 'completed',
+            'steps': [{'type': 'model_output', 'content': [{'type': 'text', 'text': 'ok'}]}],
+        },
+    )
+    action = create_lyria_action(
+        'lyria-3-clip-preview',
+        plugin_api_key='key',
+        client_options=ClientOptions(),
+    )
+    with patcher:
+        await action.run(ModelRequest(messages=[Message(role=Role.SYSTEM, content=[Part(TextPart(text='play jazz'))])]))
+
+    assert create_calls[0]['system_instruction'] == 'play jazz'
+    assert create_calls[0]['input'] == []
+
+
+@pytest.mark.asyncio
+async def test_antigravity_rejects_config_api_key() -> None:
+    patcher, create_calls, _, _ = patch_interactions(
+        'genkit_google_genai.models.antigravity',
+        create_result={'id': 'ag-key', 'status': 'completed', 'steps': []},
+    )
+    action = create_antigravity_action(
+        'antigravity-preview-05-2026',
+        plugin_api_key='key',
+        client_options=ClientOptions(),
+    )
+    with patcher:
+        with pytest.raises(GenkitError, match='context.secrets'):
+            await action.run(
+                ModelRequest(
+                    messages=[Message(role=Role.USER, content=[Part(TextPart(text='hi'))])],
+                    config={'api_key': 'nope'},
+                )
+            )
+    assert create_calls == []
+
+
+@pytest.mark.asyncio
+async def test_lyria_rejects_config_api_key() -> None:
+    patcher, create_calls, _, _ = patch_interactions(
+        'genkit_google_genai.models.interactions_lyria',
+        create_result={'id': 'ly-key', 'status': 'completed', 'steps': []},
+    )
+    action = create_lyria_action(
+        'lyria-3-clip-preview',
+        plugin_api_key='key',
+        client_options=ClientOptions(),
+    )
+    with patcher:
+        with pytest.raises(GenkitError, match='context.secrets'):
+            await action.run(
+                ModelRequest(
+                    messages=[Message(role=Role.USER, content=[Part(TextPart(text='riff'))])],
+                    config={'api_key': 'nope'},
+                )
+            )
+    assert create_calls == []

--- a/py/packages/genkit-google-genai/tests/interactions/interactions_utils_test.py
+++ b/py/packages/genkit-google-genai/tests/interactions/interactions_utils_test.py
@@ -1,0 +1,131 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for Interactions shared helpers."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from genkit_google_genai._interactions.options import ClientOptions
+from genkit_google_genai.models.interactions_utils import (
+    client_options_for_operation,
+    map_genai_error,
+    partition_keys,
+    require_interaction_steps,
+)
+from google.genai.errors import APIError
+
+from genkit import GenkitError
+
+
+def test_map_genai_error_maps_rate_limit_and_retry_after() -> None:
+    response = SimpleNamespace(headers={'retry-after': '1.5'})
+    error = APIError(429, {'error': {'message': 'slow down', 'status': 'RESOURCE_EXHAUSTED'}}, response=response)
+
+    mapped = map_genai_error(error)
+
+    assert isinstance(mapped, GenkitError)
+    assert mapped.status == 'RESOURCE_EXHAUSTED'
+    assert mapped.original_message == 'slow down'
+    assert mapped.response_metadata is not None
+    assert mapped.response_metadata.get('retry_after_ms') == 1500.0
+
+
+def test_map_genai_error_maps_unauthenticated() -> None:
+    error = APIError(401, {'error': {'message': 'bad key'}})
+    mapped = map_genai_error(error)
+    assert mapped.status == 'UNAUTHENTICATED'
+
+
+def test_map_genai_error_maps_gaos_status_code() -> None:
+    """Interactions gaos errors aren't google.genai.errors.APIError but carry status_code."""
+    error = SimpleNamespace(status_code=400, message='Missing input.')
+    mapped = map_genai_error(error)
+    assert mapped.status == 'INVALID_ARGUMENT'
+    assert mapped.original_message == 'Missing input.'
+
+
+def test_map_genai_error_tolerates_non_numeric_code() -> None:
+    """APIError.code comes from response JSON, so it may be a non-numeric string."""
+    error = APIError('boom', {'error': {'message': 'weird proxy error', 'code': 'boom'}})
+    mapped = map_genai_error(error)
+    assert mapped.status == 'UNKNOWN'
+
+
+def test_map_genai_error_maps_gaos_not_found() -> None:
+    error = SimpleNamespace(status_code=404, message="Did you mean 'lyria-3-pro-preview'?")
+    mapped = map_genai_error(error)
+    assert mapped.status == 'NOT_FOUND'
+
+
+def test_partition_keys_is_non_mutating() -> None:
+    payload = {
+        'thinking_summaries': 'auto',
+        'google_search': True,
+        'store': True,
+        'extra': 1,
+    }
+    agent, tools, create, rest = partition_keys(
+        payload,
+        ('thinking_summaries',),
+        ('google_search',),
+        ('store', 'response_modalities'),
+    )
+
+    assert agent == {'thinking_summaries': 'auto'}
+    assert tools == {'google_search': True}
+    assert create == {'store': True}
+    assert rest == {'extra': 1}
+    # Original dump is untouched.
+    assert payload == {
+        'thinking_summaries': 'auto',
+        'google_search': True,
+        'store': True,
+        'extra': 1,
+    }
+
+
+def test_require_interaction_steps_rejects_empty() -> None:
+    with pytest.raises(GenkitError, match='Missing input') as exc_info:
+        require_interaction_steps([])
+    assert exc_info.value.status == 'INVALID_ARGUMENT'
+
+
+def test_require_interaction_steps_passes_through() -> None:
+    steps = [{'type': 'user_input', 'content': [{'type': 'text', 'text': 'hi'}]}]
+    assert require_interaction_steps(steps) is steps
+
+
+def test_client_options_for_operation_drops_key_and_host() -> None:
+    persisted = client_options_for_operation(
+        ClientOptions(
+            api_key='secret',
+            base_url='https://evil.test',
+            api_version='v1beta',
+            timeout=1500,
+            custom_headers={'x-custom': '1'},
+        )
+    )
+    assert persisted.api_key is None
+    assert persisted.base_url is None
+    assert persisted.api_version == 'v1beta'
+    assert persisted.timeout == 1500
+    assert persisted.custom_headers == {'x-custom': '1'}
+    dumped = persisted.to_metadata_dict()
+    assert 'apiKey' not in dumped
+    assert 'baseUrl' not in dumped

--- a/py/packages/genkit-google-genai/tests/interactions/interactions_utils_test.py
+++ b/py/packages/genkit-google-genai/tests/interactions/interactions_utils_test.py
@@ -19,9 +19,7 @@
 from __future__ import annotations
 
 import pytest
-from genkit_google_genai._interactions.options import ClientOptions
 from genkit_google_genai.models.interactions_utils import (
-    client_options_for_operation,
     extract_version,
     partition_keys,
     require_interaction_steps,
@@ -72,23 +70,3 @@ def test_require_interaction_steps_rejects_empty() -> None:
 def test_require_interaction_steps_passes_through() -> None:
     steps = [{'type': 'user_input', 'content': [{'type': 'text', 'text': 'hi'}]}]
     assert require_interaction_steps(steps) is steps
-
-
-def test_client_options_for_operation_drops_key_and_host() -> None:
-    persisted = client_options_for_operation(
-        ClientOptions(
-            api_key='secret',
-            base_url='https://evil.test',
-            api_version='v1beta',
-            timeout=1500,
-            custom_headers={'x-custom': '1'},
-        )
-    )
-    assert persisted.api_key is None
-    assert persisted.base_url is None
-    assert persisted.api_version == 'v1beta'
-    assert persisted.timeout == 1500
-    assert persisted.custom_headers == {'x-custom': '1'}
-    dumped = persisted.to_metadata_dict()
-    assert 'apiKey' not in dumped
-    assert 'baseUrl' not in dumped

--- a/py/packages/genkit-google-genai/tests/interactions/interactions_utils_test.py
+++ b/py/packages/genkit-google-genai/tests/interactions/interactions_utils_test.py
@@ -18,59 +18,22 @@
 
 from __future__ import annotations
 
-from types import SimpleNamespace
-
 import pytest
 from genkit_google_genai._interactions.options import ClientOptions
 from genkit_google_genai.models.interactions_utils import (
     client_options_for_operation,
-    map_genai_error,
+    extract_version,
     partition_keys,
     require_interaction_steps,
 )
-from google.genai.errors import APIError
 
 from genkit import GenkitError
 
 
-def test_map_genai_error_maps_rate_limit_and_retry_after() -> None:
-    response = SimpleNamespace(headers={'retry-after': '1.5'})
-    error = APIError(429, {'error': {'message': 'slow down', 'status': 'RESOURCE_EXHAUSTED'}}, response=response)
-
-    mapped = map_genai_error(error)
-
-    assert isinstance(mapped, GenkitError)
-    assert mapped.status == 'RESOURCE_EXHAUSTED'
-    assert mapped.original_message == 'slow down'
-    assert mapped.response_metadata is not None
-    assert mapped.response_metadata.get('retry_after_ms') == 1500.0
-
-
-def test_map_genai_error_maps_unauthenticated() -> None:
-    error = APIError(401, {'error': {'message': 'bad key'}})
-    mapped = map_genai_error(error)
-    assert mapped.status == 'UNAUTHENTICATED'
-
-
-def test_map_genai_error_maps_gaos_status_code() -> None:
-    """Interactions gaos errors aren't google.genai.errors.APIError but carry status_code."""
-    error = SimpleNamespace(status_code=400, message='Missing input.')
-    mapped = map_genai_error(error)
-    assert mapped.status == 'INVALID_ARGUMENT'
-    assert mapped.original_message == 'Missing input.'
-
-
-def test_map_genai_error_tolerates_non_numeric_code() -> None:
-    """APIError.code comes from response JSON, so it may be a non-numeric string."""
-    error = APIError('boom', {'error': {'message': 'weird proxy error', 'code': 'boom'}})
-    mapped = map_genai_error(error)
-    assert mapped.status == 'UNKNOWN'
-
-
-def test_map_genai_error_maps_gaos_not_found() -> None:
-    error = SimpleNamespace(status_code=404, message="Did you mean 'lyria-3-pro-preview'?")
-    mapped = map_genai_error(error)
-    assert mapped.status == 'NOT_FOUND'
+def test_extract_version_strips_all_pasted_prefixes() -> None:
+    assert extract_version('antigravity-preview-05-2026') == 'antigravity-preview-05-2026'
+    assert extract_version('googleai/antigravity-preview-05-2026') == 'antigravity-preview-05-2026'
+    assert extract_version('models/googleai/antigravity-preview-05-2026') == 'antigravity-preview-05-2026'
 
 
 def test_partition_keys_is_non_mutating() -> None:

--- a/py/packages/genkit-google-genai/tests/interactions/interactions_utils_test.py
+++ b/py/packages/genkit-google-genai/tests/interactions/interactions_utils_test.py
@@ -70,3 +70,64 @@ def test_require_interaction_steps_rejects_empty() -> None:
 def test_require_interaction_steps_passes_through() -> None:
     steps = [{'type': 'user_input', 'content': [{'type': 'text', 'text': 'hi'}]}]
     assert require_interaction_steps(steps) is steps
+
+
+def test_api_key_for_context_prefers_tenant_secret(monkeypatch: pytest.MonkeyPatch) -> None:
+    from genkit_google_genai.models.interactions_utils import api_key_for_context
+
+    monkeypatch.setenv('GEMINI_API_KEY', 'env-key')
+    context = {'secrets': {'api_key': 'tenant-key'}}
+    assert api_key_for_context(context, 'plugin-key') == 'tenant-key'
+
+
+def test_api_key_for_context_falls_back_to_plugin(monkeypatch: pytest.MonkeyPatch) -> None:
+    from genkit_google_genai.models.interactions_utils import api_key_for_context
+
+    monkeypatch.setenv('GEMINI_API_KEY', 'env-key')
+    assert api_key_for_context({}, 'plugin-key') == 'plugin-key'
+
+
+def test_api_key_for_context_falls_back_to_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    from genkit_google_genai.models.interactions_utils import api_key_for_context
+
+    monkeypatch.setenv('GEMINI_API_KEY', 'env-key')
+    assert api_key_for_context({}, None) == 'env-key'
+
+
+def test_api_key_for_context_raises_when_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    from genkit_google_genai.models.interactions_utils import api_key_for_context
+
+    monkeypatch.delenv('GEMINI_API_KEY', raising=False)
+    monkeypatch.delenv('GOOGLE_API_KEY', raising=False)
+    monkeypatch.delenv('GOOGLE_GENAI_API_KEY', raising=False)
+    with pytest.raises(GenkitError) as exc_info:
+        api_key_for_context({}, None)
+    assert exc_info.value.status == 'FAILED_PRECONDITION'
+
+
+def test_client_overrides_from_config_reads_object() -> None:
+    from types import SimpleNamespace
+
+    from genkit_google_genai.models.interactions_utils import client_overrides_from_config
+
+    cfg = SimpleNamespace(base_url='https://custom.api', api_version='v1', timeout=5000.0, custom_headers={'h': 'v'})
+    opts = client_overrides_from_config(cfg)
+    assert opts.base_url == 'https://custom.api'
+    assert opts.api_version == 'v1'
+    assert opts.timeout == 5000.0
+    assert opts.custom_headers == {'h': 'v'}
+
+
+def test_steps_with_folded_system_instruction_prepends_system() -> None:
+    from genkit_google_genai.models.interactions_utils import steps_with_folded_system_instruction
+
+    from genkit import Message, Part, Role, TextPart
+
+    messages = [
+        Message(role=Role.SYSTEM, content=[Part(TextPart(text='Be helpful.'))]),
+        Message(role=Role.USER, content=[Part(TextPart(text='Hello!'))]),
+    ]
+    steps = steps_with_folded_system_instruction(messages)
+    assert len(steps) == 2
+    assert steps[0] == {'type': 'user_input', 'content': [{'type': 'text', 'text': 'Be helpful.'}]}
+    assert steps[1] == {'type': 'user_input', 'content': [{'type': 'text', 'text': 'Hello!'}]}

--- a/py/packages/genkit-google-genai/tests/interactions/interactions_utils_test.py
+++ b/py/packages/genkit-google-genai/tests/interactions/interactions_utils_test.py
@@ -131,3 +131,34 @@ def test_steps_with_folded_system_instruction_prepends_system() -> None:
     assert len(steps) == 2
     assert steps[0] == {'type': 'user_input', 'content': [{'type': 'text', 'text': 'Be helpful.'}]}
     assert steps[1] == {'type': 'user_input', 'content': [{'type': 'text', 'text': 'Hello!'}]}
+
+
+def test_model_name_predicates_support_namespaces() -> None:
+    from genkit_google_genai.models.interactions_registry import (
+        is_antigravity_model_name,
+        is_deep_research_model_name,
+        is_lyria_model_name,
+    )
+
+    # Bare
+    assert is_antigravity_model_name('antigravity-preview-05-2026')
+    assert is_deep_research_model_name('deep-research-pro-preview-12-2025')
+    assert is_lyria_model_name('lyria-3-clip-preview')
+
+    # Namespaced
+    assert is_antigravity_model_name('googleai/antigravity-preview-05-2026')
+    assert is_deep_research_model_name('googleai/deep-research-pro-preview-12-2025')
+    assert is_lyria_model_name('googleai/lyria-3-clip-preview')
+
+    # Full action path
+    assert is_antigravity_model_name('models/googleai/antigravity-preview-05-2026')
+    assert is_deep_research_model_name('models/googleai/deep-research-pro-preview-12-2025')
+    assert is_lyria_model_name('models/googleai/lyria-3-clip-preview')
+
+    # Negative
+    assert not is_antigravity_model_name('gemini-2.5-flash')
+    assert not is_deep_research_model_name('gemini-2.5-flash')
+    assert not is_lyria_model_name('gemini-2.5-flash')
+    assert not is_antigravity_model_name(None)
+    assert not is_deep_research_model_name(None)
+    assert not is_lyria_model_name(None)

--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -148,6 +148,7 @@ fastapi-bugbot       = { workspace = true }
 flask-hello          = { workspace = true }
 gemini-code-execution = { workspace = true }
 gemini-context-caching = { workspace = true }
+google-genai-deep-research = { workspace = true }
 google-genai-media   = { workspace = true }
 middleware           = { workspace = true }
 middleware-coding-agent = { workspace = true }

--- a/py/samples/google-genai-deep-research/README.md
+++ b/py/samples/google-genai-deep-research/README.md
@@ -1,0 +1,28 @@
+# Google Deep Research
+
+Start a background Deep Research job with `generate_operation()`. Poll with
+`check_operation()` from Dev UI — `uv run src/main.py` only starts the job so
+it returns immediately.
+
+```bash
+export GEMINI_API_KEY=your-api-key
+uv sync
+uv run src/main.py
+```
+
+To explore the flow (and poll) in Dev UI:
+
+```bash
+genkit start -- uv run src/main.py
+```
+
+Flow: `deep_research`.
+
+Supported models (set `model` in flow input):
+
+- `googleai/deep-research-preview-04-2026`
+- `googleai/deep-research-max-preview-04-2026`
+- `googleai/deep-research-pro-preview-12-2025`
+
+This sample talks to Google AI Deep Research, not Vertex. A finished report
+can take several minutes; use Dev UI to watch `operation.done`.

--- a/py/samples/google-genai-deep-research/README.md
+++ b/py/samples/google-genai-deep-research/README.md
@@ -1,8 +1,8 @@
 # Google Deep Research
 
-Start a background Deep Research job with `generate_operation()`. Poll with
-`check_operation()` from Dev UI — `uv run src/main.py` only starts the job so
-it returns immediately.
+Start a background Deep Research job with `generate_operation()`, then
+`check_operation()` once. A finished report can take several minutes —
+keep polling from Dev UI.
 
 ```bash
 export GEMINI_API_KEY=your-api-key
@@ -10,7 +10,7 @@ uv sync
 uv run src/main.py
 ```
 
-To explore the flow (and poll) in Dev UI:
+To explore the flow (and keep polling) in Dev UI:
 
 ```bash
 genkit start -- uv run src/main.py
@@ -24,5 +24,6 @@ Supported models (set `model` in flow input):
 - `googleai/deep-research-max-preview-04-2026`
 - `googleai/deep-research-pro-preview-12-2025`
 
-This sample talks to Google AI Deep Research, not Vertex. A finished report
-can take several minutes; use Dev UI to watch `operation.done`.
+This sample talks to Google AI Deep Research, not Vertex. Antigravity and
+Lyria 3 are ordinary `generate` models on the same plugin (`GoogleAI.antigravity_model`,
+`GoogleAI.lyria_model`); they are not in this sample.

--- a/py/samples/google-genai-deep-research/pyproject.toml
+++ b/py/samples/google-genai-deep-research/pyproject.toml
@@ -1,0 +1,16 @@
+[project]
+name = "google-genai-deep-research"
+version = "0.1.0"
+requires-python = ">=3.10"
+dependencies = [
+  "genkit",
+  "genkit-google-genai",
+  "pydantic",
+]
+
+[build-system]
+build-backend = "hatchling.build"
+requires = ["hatchling"]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src"]

--- a/py/samples/google-genai-deep-research/src/main.py
+++ b/py/samples/google-genai-deep-research/src/main.py
@@ -16,8 +16,8 @@
 
 """Google GenAI Deep Research — start a background research job.
 
-`uv run src/main.py` only starts the job so it returns immediately. Poll
-from Dev UI (or call `deep_research` there) — a finished report takes minutes.
+`uv run src/main.py` starts the job and checks once. A finished report
+takes minutes; keep polling from Dev UI (or call `deep_research` there).
 """
 
 from genkit_google_genai import GoogleAI
@@ -43,24 +43,22 @@ class ResearchInput(BaseModel):
 
 @ai.flow(name='deep_research')
 async def deep_research_flow(input: ResearchInput) -> dict[str, str | bool | None]:
-    """Start Deep Research with generate_operation(). Poll from Dev UI."""
+    """Start Deep Research, then check_operation once so callers see the poll call."""
     operation = await ai.generate_operation(
         model=input.model,
         prompt=input.prompt,
     )
+    updated = await ai.check_operation(operation)
     return {
         'model': input.model,
-        'operation_id': operation.id,
-        'done': operation.done,
+        'operation_id': updated.id,
+        'done': updated.done,
     }
 
 
 async def main() -> None:
-    """Start one Deep Research job — does not wait for the report."""
-    try:
-        print(await deep_research_flow(ResearchInput()))  # noqa: T201
-    except Exception as error:
-        print(f'Set GEMINI_API_KEY to a valid value before running this sample directly.\n{error}')  # noqa: T201
+    """Start one Deep Research job and check it once — does not wait for the report."""
+    print(await deep_research_flow(ResearchInput()))  # noqa: T201
 
 
 if __name__ == '__main__':

--- a/py/samples/google-genai-deep-research/src/main.py
+++ b/py/samples/google-genai-deep-research/src/main.py
@@ -1,0 +1,67 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Google GenAI Deep Research — start a background research job.
+
+`uv run src/main.py` only starts the job so it returns immediately. Poll
+from Dev UI (or call `deep_research` there) — a finished report takes minutes.
+"""
+
+from genkit_google_genai import GoogleAI
+from pydantic import BaseModel, Field
+
+from genkit import Genkit
+
+ai = Genkit(plugins=[GoogleAI()])
+
+
+class ResearchInput(BaseModel):
+    """Input for a Deep Research background model."""
+
+    model: str = Field(
+        default='googleai/deep-research-preview-04-2026',
+        description='Deep Research model for the background job',
+    )
+    prompt: str = Field(
+        default='Summarize recent advances in quantum error correction for a technical audience.',
+        description='Research question or topic',
+    )
+
+
+@ai.flow(name='deep_research')
+async def deep_research_flow(input: ResearchInput) -> dict[str, str | bool | None]:
+    """Start Deep Research with generate_operation(). Poll from Dev UI."""
+    operation = await ai.generate_operation(
+        model=input.model,
+        prompt=input.prompt,
+    )
+    return {
+        'model': input.model,
+        'operation_id': operation.id,
+        'done': operation.done,
+    }
+
+
+async def main() -> None:
+    """Start one Deep Research job — does not wait for the report."""
+    try:
+        print(await deep_research_flow(ResearchInput()))  # noqa: T201
+    except Exception as error:
+        print(f'Set GEMINI_API_KEY to a valid value before running this sample directly.\n{error}')  # noqa: T201
+
+
+if __name__ == '__main__':
+    ai.run_main(main())

--- a/py/uv.lock
+++ b/py/uv.lock
@@ -36,6 +36,7 @@ members = [
     "genkit-openai",
     "genkit-vertexai",
     "genkit-workspace",
+    "google-genai-deep-research",
     "google-genai-media",
     "middleware",
     "middleware-coding-agent",
@@ -2412,6 +2413,23 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/60/a7/a45f64f22ab9302b55fcbeb32acb6f313690a7748629b01e451aad1817a3/google_genai-2.21.0.tar.gz", hash = "sha256:0ecc11c6a5b9f5e3cc58e77ae5fead00c6719f8a1b2b654b803f514a9a6b64c0", size = 677301, upload-time = "2026-08-31T21:49:14.508Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/d7/c2419dd5fedd5803ce09810e4e39561a0a13a960b3f48d2581c12e42af3e/google_genai-2.21.0-py3-none-any.whl", hash = "sha256:36b575034be46a03acd603a852e22a6359f2cdd6b26bb1d65d9b7e0cc7ab3648", size = 1080223, upload-time = "2026-08-31T21:49:12.699Z" },
+]
+
+[[package]]
+name = "google-genai-deep-research"
+version = "0.1.0"
+source = { editable = "samples/google-genai-deep-research" }
+dependencies = [
+    { name = "genkit" },
+    { name = "genkit-google-genai" },
+    { name = "pydantic" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "genkit", editable = "packages/genkit" },
+    { name = "genkit-google-genai", editable = "packages/genkit-google-genai" },
+    { name = "pydantic" },
 ]
 
 [[package]]


### PR DESCRIPTION
Google AI callers can run Deep Research as a background operation and generate with Antigravity or Interactions Lyria through the normal Genkit APIs. Tenant credentials come from `context.secrets`, while connection settings can be supplied at the top level of each call's config.

Before, these model families were not routable through the Google AI plugin:
```python
# No Google AI actions were registered for Deep Research,
# Antigravity, or Interactions Lyria.
```

Now callers can use the public generation and operation lifecycle APIs:
```python
from genkit import Genkit
from genkit_google_genai import GoogleAI, LyriaConfig

ai = Genkit(plugins=[GoogleAI()])
tenant = {'secrets': {'api_key': tenant_key}}

operation = await ai.generate_operation(
    model=GoogleAI.deep_research_model('deep-research-preview-04-2026'),
    prompt='Summarize recent advances in quantum error correction.',
    config={
        'base_url': 'https://gateway.example',
        'api_version': 'v1beta',
        'timeout': 30_000,
        'custom_headers': {'x-tenant': 'acme'},
    },
    context=tenant,
)

updated = await ai.check_operation(
    operation,
    config={'base_url': 'https://gateway.example', 'timeout': 30_000},
    context=tenant,
)

antigravity = await ai.generate(
    model=GoogleAI.antigravity_model('antigravity-preview-05-2026'),
    prompt='Plan a three-day itinerary.',
    context=tenant,
)

audio = await ai.generate(
    model=GoogleAI.lyria_model('lyria-002'),
    prompt='A short cinematic sting.',
    config=LyriaConfig(response_modalities=['audio']),
    context=tenant,
)
```

Connection settings are transport-only. Deep Research start consumes `base_url`, `api_version`, `timeout`, and `custom_headers` without sending them in the Interactions request body. Its returned `Operation` carries no client options in metadata. Check and cancel rebuild routing from that current call's config and credentials from that current call's `context.secrets`, so stale or attacker-controlled ticket metadata cannot redirect or authenticate a request.

**Decisions**
- Deep Research is a `BACKGROUND_MODEL`; callers use `generate_operation`, `check_operation`, and `cancel_operation`. Antigravity and Lyria are foreground `MODEL` actions.
- Current-call authority wins. Explicit connection options on each start, check, cancel, or generate call override plugin defaults.
- Operations do not persist `ClientOptions`. Every check and cancel call must provide any per-call routing it needs, and operation metadata is ignored for authentication and routing.
- Tenant API keys live only in `context.secrets.api_key`. Request config API keys remain rejected, and tickets do not carry credentials.
- Top-level connection keys configure the HTTP client but are stripped before the Interactions body is built.
- Unknown `googleai/lyria-*` identifiers, including `lyria-002`, route to Google AI Interactions rather than being minted as Gemini chat models.
- Vertex remains closed for Deep Research, Antigravity, and Interactions Lyria. Existing Vertex predict music support is a separate product surface.
- `from genkit_google_genai import LyriaConfig` is the Interactions schema. Vertex predict configuration remains in its existing module.