### PR TITLE
feat(py): support container types and non-BaseModel schemas in output_schema

### DIFF
--- a/py/packages/genkit/src/genkit/_ai/_prompt.py
+++ b/py/packages/genkit/src/genkit/_ai/_prompt.py
@@ -216,14 +216,14 @@ class PromptConfig(BaseModel):
     model: str | ModelRef[BaseModel] | None = None
     config: Mapping[str, Any] | BaseModel | None = None
     description: str | None = None
-    input_schema: type | dict[str, Any] | str | None = None
+    input_schema: Any | None = None
     system: str | list[Part] | None = None
     prompt: str | list[Part] | None = None
     messages: str | list[Message] | None = None
     output_format: str | None = None
     output_content_type: str | None = None
     output_instructions: bool | str | None = None
-    output_schema: type | dict[str, Any] | str | None = None
+    output_schema: Any | None = None
     output_constrained: bool | None = None
     max_turns: int | None = None
     return_tool_requests: bool | None = None
@@ -248,14 +248,14 @@ class ExecutablePrompt(Generic[InputT, OutputT]):
         model: ModelArg | None = None,
         config: Mapping[str, Any] | BaseModel | None = None,
         description: str | None = None,
-        input_schema: type | dict[str, Any] | str | None = None,
+        input_schema: Any | None = None,  # noqa: ANN401
         system: str | list[Part] | None = None,
         prompt: str | list[Part] | None = None,
         messages: str | list[Message] | None = None,
         output_format: str | None = None,
         output_content_type: str | None = None,
         output_instructions: bool | str | None = None,
-        output_schema: type | dict[str, Any] | str | None = None,
+        output_schema: Any | None = None,  # noqa: ANN401
         output_constrained: bool | None = None,
         max_turns: int | None = None,
         return_tool_requests: bool | None = None,
@@ -324,8 +324,8 @@ class ExecutablePrompt(Generic[InputT, OutputT]):
         self._output_format = resolved._output_format
         self._output_content_type = resolved._output_content_type
         self._output_instructions = resolved._output_instructions
-        # Keep original Pydantic type if provided, otherwise use resolved (dict) schema
-        if isinstance(original_output_schema, type) and issubclass(original_output_schema, BaseModel):
+        # Keep original schema type if provided, otherwise use resolved (dict) schema
+        if original_output_schema is not None and not isinstance(original_output_schema, (dict, str)):
             self._output_schema = original_output_schema
         else:
             self._output_schema = resolved._output_schema
@@ -553,19 +553,19 @@ def register_prompt_actions(
 
 def _resolve_output_schema(
     registry: Registry,
-    output_schema: type | dict[str, Any] | str | None,
+    output_schema: Any | None,  # noqa: ANN401
     output: GenerateActionOutputConfig,
 ) -> None:
     """Resolve output schema and populate the output config.
 
     Handles three types of output_schema:
     - str: Schema name - look up JSON schema and type from registry
-    - Pydantic type: Store both JSON schema and type for runtime validation
     - dict: Raw JSON schema - convert directly
+    - type / container / schema: Store both JSON schema and type for runtime validation
 
     Args:
         registry: The registry to use for schema lookups.
-        output_schema: The schema to resolve (string name, Pydantic type, or dict).
+        output_schema: The schema to resolve (string name, type/container, or dict).
         output: The output config to populate with json_schema and schema_type.
     """
     if output_schema is None:
@@ -580,13 +580,13 @@ def _resolve_output_schema(
         schema_type = registry.lookup_schema_type(output_schema)
         if schema_type:
             output.schema_type = schema_type
-    elif isinstance(output_schema, type) and issubclass(output_schema, BaseModel):
-        # Pydantic type - store both JSON schema and type
+    elif isinstance(output_schema, dict):
+        # Raw JSON schema dictionary
+        output.json_schema = to_json_schema(output_schema)
+    else:
+        # Pydantic BaseModel, container (e.g. list[T]), Enum, primitive, etc.
         output.json_schema = to_json_schema(output_schema)
         output.schema_type = output_schema
-    else:
-        # dict (raw JSON schema)
-        output.json_schema = to_json_schema(output_schema)
 
 
 async def _prepare(

--- a/py/packages/genkit/src/genkit/_core/_model.py
+++ b/py/packages/genkit/src/genkit/_core/_model.py
@@ -29,7 +29,7 @@ from functools import cached_property
 from importlib import import_module
 from typing import Any, ClassVar, Generic, cast
 
-from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, ValidationError, field_validator
+from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, TypeAdapter, ValidationError, field_validator
 from pydantic.alias_generators import to_camel
 from typing_extensions import TypedDict, TypeVar
 
@@ -503,7 +503,7 @@ class ModelResponse(GenkitModel, Generic[OutputT]):
     # _message_parser and _schema_type are set by the framework after construction
     # when output format parsing or schema validation is needed.
     _message_parser: Callable[[Message], object] | None = PrivateAttr(None)
-    _schema_type: type[BaseModel] | None = PrivateAttr(None)
+    _schema_type: Any | None = PrivateAttr(None)
     # Wire fields (must be declared for extra='forbid' to accept wire responses)
     message: Message | None = None
     finish_reason: FinishReason | None = None
@@ -574,7 +574,10 @@ class ModelResponse(GenkitModel, Generic[OutputT]):
         if self._schema_type is None:
             return
         try:
-            _ = self._schema_type.model_validate(parsed)
+            if isinstance(self._schema_type, type) and issubclass(self._schema_type, BaseModel):
+                _ = self._schema_type.model_validate(parsed)
+            else:
+                _ = TypeAdapter(self._schema_type).validate_python(parsed)
         except ValidationError:
             self.finish_reason = FinishReason.FAILED
             self.finish_message = 'Model output did not match the requested schema.'
@@ -645,7 +648,9 @@ class ModelResponse(GenkitModel, Generic[OutputT]):
                 return cast(OutputT, None)
         if self._schema_type is not None and parsed is not None:
             try:
-                return cast(OutputT, self._schema_type.model_validate(parsed))
+                if isinstance(self._schema_type, type) and issubclass(self._schema_type, BaseModel):
+                    return cast(OutputT, self._schema_type.model_validate(parsed))
+                return cast(OutputT, TypeAdapter(self._schema_type).validate_python(parsed))
             except ValidationError:
                 return cast(OutputT, None)
         return cast(OutputT, parsed)

--- a/py/packages/genkit/src/genkit/_core/_registry.py
+++ b/py/packages/genkit/src/genkit/_core/_registry.py
@@ -22,10 +22,9 @@ import asyncio
 import threading
 import weakref
 from collections.abc import Awaitable, Callable
-from typing import cast
+from typing import Any, cast
 
 from dotpromptz.dotprompt import Dotprompt
-from pydantic import BaseModel
 from typing_extensions import Never, TypeVar
 
 from genkit._core._action import (
@@ -130,7 +129,7 @@ class Registry:
         self._entries: ActionStore = {}
         self._value_by_kind_and_name: dict[str, dict[str, object]] = {}
         self._schemas_by_name: dict[str, dict[str, object]] = {}
-        self._schema_types_by_name: dict[str, type[BaseModel]] = {}
+        self._schema_types_by_name: dict[str, Any] = {}
         self._lock: threading.RLock = threading.RLock()
 
         # Re-entrancy guard for _trigger_lazy_loading.  Prevents infinite
@@ -684,7 +683,12 @@ class Registry:
                 return resolved
         return await self.resolve_action(kind, name)
 
-    def register_schema(self, name: str, schema: dict[str, object], schema_type: type[BaseModel] | None = None) -> None:
+    def register_schema(
+        self,
+        name: str,
+        schema: dict[str, object],
+        schema_type: Any | None = None,  # noqa: ANN401
+    ) -> None:
         """Registers a schema by name.
 
         Schemas registered with this method can be referenced by name in
@@ -693,7 +697,7 @@ class Registry:
         Args:
             name: The name of the schema.
             schema: The schema data (JSON schema format).
-            schema_type: Optional Pydantic model class for runtime validation.
+            schema_type: Optional Pydantic model class or container type for runtime validation.
 
         Raises:
             ValueError: If a schema with the given name is already registered.
@@ -721,14 +725,14 @@ class Registry:
             return local
         return self._parent.lookup_schema(name) if self._parent is not None else None
 
-    def lookup_schema_type(self, name: str) -> type[BaseModel] | None:
-        """Looks up a schema's Pydantic type by name.
+    def lookup_schema_type(self, name: str) -> Any | None:  # noqa: ANN401
+        """Looks up a schema's type by name.
 
         Args:
             name: The name of the schema to look up.
 
         Returns:
-            The Pydantic model class if found, None otherwise.  Falls back to parent.
+            The schema type if found, None otherwise.  Falls back to parent.
         """
         with self._lock:
             local = self._schema_types_by_name.get(name)

--- a/py/packages/genkit/tests/genkit/ai/output_schema_containers_test.py
+++ b/py/packages/genkit/tests/genkit/ai/output_schema_containers_test.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+#
+# Copyright 2025 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for container types and non-BaseModel schemas in output_schema."""
+
+from enum import Enum
+
+import pytest
+from pydantic import BaseModel
+
+from genkit import Genkit, Message, ModelResponse
+from genkit._ai._testing import ProgrammableModel, define_programmable_model
+from genkit._core._typing import FinishReason, Part, Role, TextPart
+
+
+class MenuItem(BaseModel):
+    name: str
+    price: float
+
+
+class StatusEnum(str, Enum):
+    ACTIVE = 'active'
+    INACTIVE = 'inactive'
+
+
+@pytest.fixture
+def setup_test() -> tuple[Genkit, ProgrammableModel]:
+    """Setup test Genkit instance with programmable model."""
+    ai = Genkit(model='programmableModel')
+    pm, _ = define_programmable_model(ai, name='programmableModel')
+    return (ai, pm)
+
+
+@pytest.mark.asyncio
+async def test_output_schema_list_of_models(
+    setup_test: tuple[Genkit, ProgrammableModel],
+) -> None:
+    """Verify output_schema=list[MenuItem] parses and validates into list of Pydantic models."""
+    ai, pm = setup_test
+
+    pm.responses.append(
+        ModelResponse(
+            finish_reason=FinishReason.STOP,
+            message=Message(
+                role=Role.MODEL,
+                content=[
+                    Part(TextPart(text='[{"name": "Espresso", "price": 3.50}, {"name": "Croissant", "price": 4.25}]'))
+                ],
+            ),
+        )
+    )
+
+    response = await ai.generate(
+        prompt='Give me a menu',
+        output_schema=list[MenuItem],
+    )
+
+    assert response.finish_reason == FinishReason.STOP
+    assert isinstance(response.output, list)
+    assert len(response.output) == 2
+    assert isinstance(response.output[0], MenuItem)
+    assert response.output[0].name == 'Espresso'
+    assert response.output[0].price == 3.50
+    assert isinstance(response.output[1], MenuItem)
+    assert response.output[1].name == 'Croissant'
+    assert response.output[1].price == 4.25
+
+
+@pytest.mark.asyncio
+async def test_output_schema_list_of_primitives(
+    setup_test: tuple[Genkit, ProgrammableModel],
+) -> None:
+    """Verify output_schema=list[str] parses and validates string items."""
+    ai, pm = setup_test
+
+    pm.responses.append(
+        ModelResponse(
+            finish_reason=FinishReason.STOP,
+            message=Message(
+                role=Role.MODEL,
+                content=[Part(TextPart(text='["python", "typescript", "go"]'))],
+            ),
+        )
+    )
+
+    response = await ai.generate(
+        prompt='List languages',
+        output_schema=list[str],
+    )
+
+    assert response.finish_reason == FinishReason.STOP
+    assert response.output == ['python', 'typescript', 'go']
+
+
+@pytest.mark.asyncio
+async def test_output_schema_enum(
+    setup_test: tuple[Genkit, ProgrammableModel],
+) -> None:
+    """Verify output_schema=StatusEnum parses and validates enum value."""
+    ai, pm = setup_test
+
+    pm.responses.append(
+        ModelResponse(
+            finish_reason=FinishReason.STOP,
+            message=Message(
+                role=Role.MODEL,
+                content=[Part(TextPart(text='"active"'))],
+            ),
+        )
+    )
+
+    response = await ai.generate(
+        prompt='Get status',
+        output_schema=StatusEnum,
+    )
+
+    assert response.finish_reason == FinishReason.STOP
+    assert response.output == StatusEnum.ACTIVE
+
+
+@pytest.mark.asyncio
+async def test_output_schema_list_validation_failure(
+    setup_test: tuple[Genkit, ProgrammableModel],
+) -> None:
+    """Verify invalid items in list[MenuItem] mark response as FAILED."""
+    ai, pm = setup_test
+
+    # Price is not a valid float
+    pm.responses.append(
+        ModelResponse(
+            finish_reason=FinishReason.STOP,
+            message=Message(
+                role=Role.MODEL,
+                content=[Part(TextPart(text='[{"name": "Espresso", "price": "not_a_number"}]'))],
+            ),
+        )
+    )
+
+    response = await ai.generate(
+        prompt='Give me a menu',
+        output_schema=list[MenuItem],
+    )
+
+    assert response.finish_reason == FinishReason.FAILED
+    assert response.output is None
+
+
+@pytest.mark.asyncio
+async def test_prompt_with_container_output_schema(
+    setup_test: tuple[Genkit, ProgrammableModel],
+) -> None:
+    """Verify define_prompt works seamlessly with container output_schema."""
+    ai, pm = setup_test
+
+    prompt = ai.define_prompt(
+        name='menuPrompt',
+        prompt='List menu items',
+        output_schema=list[MenuItem],
+    )
+
+    pm.responses.append(
+        ModelResponse(
+            finish_reason=FinishReason.STOP,
+            message=Message(
+                role=Role.MODEL,
+                content=[Part(TextPart(text='[{"name": "Tea", "price": 2.50}]'))],
+            ),
+        )
+    )
+
+    response = await prompt()
+    assert response.finish_reason == FinishReason.STOP
+    assert isinstance(response.output, list)
+    assert len(response.output) == 1
+    assert isinstance(response.output[0], MenuItem)
+    assert response.output[0].name == 'Tea'


### PR DESCRIPTION
Allow passing standard container types (e.g. `list[T]`, `dict[str, T]`), `Enum` types, and primitive types directly as `output_schema` in `ai.generate` and `ai.define_prompt`.

Previously, passing generic aliases like `output_schema=list[MenuItem]` triggered Pydantic validation errors in `PromptConfig` and bypassed runtime model validation because the engine strictly checked for `issubclass(schema, BaseModel)`.

### Developer Experience

```python
from pydantic import BaseModel
from genkit import Genkit
from genkit.plugins.googleai import GoogleAI

# 1. Initialize Genkit with model
ai = Genkit(plugins=[GoogleAI()], model='googleai/gemini-2.5-flash')


class MenuItem(BaseModel):
    name: str
    price: float


# 2. Generate structured list output directly
response = await ai.generate(
    prompt='Suggest 3 popular brunch items with prices.',
    output_schema=list[MenuItem],
)

# 3. Access validated list of models
print(response.output)
# => [MenuItem(name='Eggs Benedict', price=14.5), MenuItem(name='Avocado Toast', price=11.0), MenuItem(name='Pancake Stack', price=12.0)]
```

---

### Decisions

- **Universal Type Validation via `TypeAdapter`**: When `_schema_type` is not a `BaseModel` subclass, `ModelResponse` delegates validation to `TypeAdapter(self._schema_type).validate_python(parsed)`.
- **Flexible Schema Typing in `PromptConfig` & `ExecutablePrompt`**: Relaxed `output_schema` and `input_schema` fields in `PromptConfig` from `type | dict[str, Any] | str | None` to `Any | None` to permit `types.GenericAlias` (such as `list[T]`) without validation errors.
- **Registry Schema Type Support**: Updated `Registry.register_schema` and `lookup_schema_type` to store arbitrary schema types for runtime validation.
- **100% Backward Compatible**: Existing `BaseModel` schemas continue to use `.model_validate()` directly.