### PR TITLE
feat(py)!: trim root genkit public surface to 26 canonical symbols

### DIFF
--- a/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/converters.py
+++ b/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/converters.py
@@ -27,20 +27,8 @@ from typing import Any
 
 from pydantic import ValidationError
 
-from genkit import (
-    FinishReason,
-    Message,
-    ModelRequest,
-    ModelResponse,
-    ModelUsage,
-    Part,
-    ReasoningPart,
-    Role,
-    TextPart,
-    ToolDefinition,
-    ToolRequest,
-    ToolRequestPart,
-)
+from genkit import FinishReason, Message, ModelResponse, ModelUsage, Part, Role, ToolRequest, ToolRequestPart
+from genkit.model import ModelRequest, ReasoningPart, TextPart, ToolDefinition
 from genkit.plugin_api import GenkitError
 from genkit_amazon_bedrock.config import BedrockConfig
 

--- a/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/embedders.py
+++ b/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/embedders.py
@@ -42,8 +42,6 @@ from typing import Any, Literal, NamedTuple, Protocol, TypeVar, cast
 import structlog
 from botocore.exceptions import BotoCoreError, ClientError
 
-from genkit import MediaPart, TextPart
-
 # DocumentData has no public re-export yet; the embedder protocol is built on it.
 from genkit._core._typing import DocumentData
 from genkit.embedder import (
@@ -53,6 +51,7 @@ from genkit.embedder import (
     EmbedRequest,
     EmbedResponse,
 )
+from genkit.model import MediaPart, TextPart
 from genkit.plugin_api import GenkitError
 from genkit_amazon_bedrock.model_info import model_label, strip_inference_profile_prefix
 from genkit_amazon_bedrock.models import _from_botocore_error, _from_client_error

--- a/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/image.py
+++ b/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/image.py
@@ -33,17 +33,8 @@ from typing import Any, Literal, cast
 import structlog
 from botocore.exceptions import BotoCoreError, ClientError
 
-from genkit import (
-    FinishReason,
-    Media,
-    MediaPart,
-    Message,
-    ModelRequest,
-    ModelResponse,
-    Part,
-    Role,
-    TextPart,
-)
+from genkit import FinishReason, Media, Message, ModelResponse, Part, Role
+from genkit.model import MediaPart, ModelRequest, TextPart
 from genkit.plugin_api import ActionRunContext, GenkitError, ModelConfig
 from genkit_amazon_bedrock.embedders import InvokeModelTransport
 from genkit_amazon_bedrock.model_info import strip_inference_profile_prefix

--- a/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/model_info.py
+++ b/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/model_info.py
@@ -27,7 +27,7 @@ release.
 
 from typing import Literal, NamedTuple
 
-from genkit import Constrained, ModelInfo, Stage, Supports
+from genkit.model import Constrained, ModelInfo, Stage, Supports
 
 INFERENCE_PROFILE_PREFIXES = (
     'global.',

--- a/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/models.py
+++ b/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/models.py
@@ -36,7 +36,9 @@ from botocore.exceptions import (
     ReadTimeoutError,
 )
 
-from genkit import ErrorResponseMetadata, ModelRequest, ModelResponse
+from genkit import ModelResponse
+from genkit._core._error import ErrorResponseMetadata
+from genkit.model import ModelRequest
 from genkit.plugin_api import ActionRunContext, GenkitError, StatusName
 from genkit_amazon_bedrock.converters import build_converse_request, to_model_response, usage_log_fields
 from genkit_amazon_bedrock.stream import consume_converse_stream

--- a/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/plugin.py
+++ b/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/plugin.py
@@ -27,12 +27,12 @@ from typing import TYPE_CHECKING, Any, Literal
 
 import structlog
 
-from genkit import Document, ModelRequest, ModelResponse
+from genkit import Document, ModelResponse
 
 # DocumentData has no public re-export yet; the rerank helper is built on it.
 from genkit._core._typing import DocumentData
 from genkit.embedder import EmbedRequest, EmbedResponse, embedder_action_metadata
-from genkit.model import model_action_metadata
+from genkit.model import ModelRequest, model_action_metadata
 from genkit.plugin_api import (
     Action,
     ActionKind,

--- a/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/rerank.py
+++ b/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/rerank.py
@@ -44,10 +44,9 @@ from botocore.exceptions import BotoCoreError, ClientError
 from pydantic import BaseModel, ConfigDict, ValidationError, field_validator
 from pydantic.alias_generators import to_camel
 
-from genkit import DocumentPart
-
 # DocumentData has no public re-export yet; the reranker types are built on it.
 from genkit._core._typing import DocumentData
+from genkit.model import DocumentPart
 from genkit.plugin_api import GenkitError
 from genkit_amazon_bedrock.embedders import InvokeModelTransport, document_text
 from genkit_amazon_bedrock.model_info import strip_inference_profile_prefix

--- a/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/stream.py
+++ b/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/stream.py
@@ -29,19 +29,8 @@ from typing import Any
 
 import structlog
 
-from genkit import (
-    FinishReason,
-    Message,
-    ModelRequest,
-    ModelResponse,
-    ModelResponseChunk,
-    Part,
-    Role,
-    TextPart,
-    ToolDefinition,
-    ToolRequest,
-    ToolRequestPart,
-)
+from genkit import FinishReason, Message, ModelResponse, ModelResponseChunk, Part, Role, ToolRequest, ToolRequestPart
+from genkit.model import ModelRequest, TextPart, ToolDefinition
 from genkit.plugin_api import ActionRunContext, GenkitError
 from genkit_amazon_bedrock.converters import (
     bedrock_reasoning_part,

--- a/py/packages/genkit-amazon-bedrock/tests/converters_test.py
+++ b/py/packages/genkit-amazon-bedrock/tests/converters_test.py
@@ -38,16 +38,8 @@ from genkit_amazon_bedrock.converters import (
     usage_from_response,
 )
 
-from genkit import (
-    FinishReason,
-    Message,
-    ModelRequest,
-    Part,
-    ReasoningPart,
-    Role,
-    TextPart,
-    ToolDefinition,
-)
+from genkit import FinishReason, Message, Part, Role
+from genkit.model import ModelRequest, ReasoningPart, TextPart, ToolDefinition
 from genkit.plugin_api import GenkitError, ModelConfig
 
 PNG_BYTES = b'\x89PNG\r\n\x1a\nfakeimagedata'

--- a/py/packages/genkit-amazon-bedrock/tests/embedders_test.py
+++ b/py/packages/genkit-amazon-bedrock/tests/embedders_test.py
@@ -35,9 +35,10 @@ from genkit_amazon_bedrock.embedders import (
 )
 from genkit_amazon_bedrock.model_info import strip_inference_profile_prefix
 
-from genkit import DocumentPart, Media, MediaPart, TextPart
+from genkit import Media
 from genkit._core._typing import DocumentData
 from genkit.embedder import EmbedRequest
+from genkit.model import DocumentPart, MediaPart, TextPart
 from genkit.plugin_api import GenkitError
 
 TITAN_TEXT = 'amazon.titan-embed-text-v2:0'

--- a/py/packages/genkit-amazon-bedrock/tests/image_test.py
+++ b/py/packages/genkit-amazon-bedrock/tests/image_test.py
@@ -24,17 +24,8 @@ from botocore.exceptions import ClientError, NoCredentialsError
 from genkit_amazon_bedrock.config import BedrockConfig, BedrockImageConfig
 from genkit_amazon_bedrock.image import BedrockImageModel, build_amazon_image_body, is_image_model
 
-from genkit import (
-    FinishReason,
-    Media,
-    MediaPart,
-    Message,
-    ModelRequest,
-    ModelResponse,
-    Part,
-    Role,
-    TextPart,
-)
+from genkit import FinishReason, Media, Message, ModelResponse, Part, Role
+from genkit.model import MediaPart, ModelRequest, TextPart
 from genkit.plugin_api import ActionRunContext, GenkitError, ModelConfig, to_json_schema
 
 TITAN_IMAGE = 'amazon.titan-image-generator-v1'

--- a/py/packages/genkit-amazon-bedrock/tests/live_test.py
+++ b/py/packages/genkit-amazon-bedrock/tests/live_test.py
@@ -41,21 +41,10 @@ from genkit_amazon_bedrock.models import BedrockModel
 from genkit_amazon_bedrock.rerank import BedrockReranker, BedrockRerankOptions, RerankerRequest
 from genkit_amazon_bedrock.transport import BedrockTransport
 
-from genkit import (
-    DocumentPart,
-    FinishReason,
-    Media,
-    MediaPart,
-    Message,
-    ModelRequest,
-    ModelResponse,
-    Part,
-    Role,
-    TextPart,
-    ToolDefinition,
-)
+from genkit import FinishReason, Media, Message, ModelResponse, Part, Role
 from genkit._core._typing import DocumentData
 from genkit.embedder import EmbedRequest
+from genkit.model import DocumentPart, MediaPart, ModelRequest, TextPart, ToolDefinition
 from genkit.plugin_api import ActionRunContext, GenkitError
 
 pytestmark = [

--- a/py/packages/genkit-amazon-bedrock/tests/model_info_test.py
+++ b/py/packages/genkit-amazon-bedrock/tests/model_info_test.py
@@ -24,7 +24,7 @@ from genkit_amazon_bedrock.model_info import (
     strip_inference_profile_prefix,
 )
 
-from genkit import Stage
+from genkit.model import Stage
 
 
 @pytest.mark.parametrize('prefix', INFERENCE_PROFILE_PREFIXES)

--- a/py/packages/genkit-amazon-bedrock/tests/models_test.py
+++ b/py/packages/genkit-amazon-bedrock/tests/models_test.py
@@ -34,7 +34,8 @@ from botocore.exceptions import (
 )
 from genkit_amazon_bedrock.models import BedrockModel
 
-from genkit import FinishReason, Message, ModelRequest, Part, Role, TextPart
+from genkit import FinishReason, Message, Part, Role
+from genkit.model import ModelRequest, TextPart
 from genkit.plugin_api import ActionRunContext, GenkitError
 
 

--- a/py/packages/genkit-amazon-bedrock/tests/plugin_test.py
+++ b/py/packages/genkit-amazon-bedrock/tests/plugin_test.py
@@ -26,8 +26,9 @@ from genkit_amazon_bedrock import Bedrock, BedrockConfig, ModelDefinition, bedro
 from genkit_amazon_bedrock.transport import BedrockTransport
 from pydantic import ValidationError
 
-from genkit import Document, MediaPart, ModelRequest, ModelResponse
+from genkit import Document, ModelResponse
 from genkit.embedder import EmbedRequest
+from genkit.model import MediaPart, ModelRequest
 from genkit.plugin_api import ActionKind, GenkitError
 
 

--- a/py/packages/genkit-amazon-bedrock/tests/request_validation_test.py
+++ b/py/packages/genkit-amazon-bedrock/tests/request_validation_test.py
@@ -34,15 +34,8 @@ from botocore.validate import ParamValidator
 from genkit_amazon_bedrock.config import BedrockConfig
 from genkit_amazon_bedrock.converters import build_converse_request, cache_point_part
 
-from genkit import (
-    Message,
-    ModelRequest,
-    Part,
-    ReasoningPart,
-    Role,
-    TextPart,
-    ToolDefinition,
-)
+from genkit import Message, Part, Role
+from genkit.model import ModelRequest, ReasoningPart, TextPart, ToolDefinition
 
 _SERVICE_MODEL = botocore.session.get_session().get_service_model('bedrock-runtime')
 CONVERSE_INPUT_SHAPES = {

--- a/py/packages/genkit-amazon-bedrock/tests/rerank_test.py
+++ b/py/packages/genkit-amazon-bedrock/tests/rerank_test.py
@@ -34,8 +34,9 @@ from genkit_amazon_bedrock.rerank import (
 )
 from genkit_amazon_bedrock.transport import BedrockTransport
 
-from genkit import Document, DocumentPart, TextPart
+from genkit import Document
 from genkit._core._typing import DocumentData
+from genkit.model import DocumentPart, TextPart
 from genkit.plugin_api import GenkitError
 
 COHERE_RERANK = 'cohere.rerank-v3-5:0'

--- a/py/packages/genkit-amazon-bedrock/tests/stream_test.py
+++ b/py/packages/genkit-amazon-bedrock/tests/stream_test.py
@@ -28,7 +28,8 @@ from genkit_amazon_bedrock.converters import (
 )
 from genkit_amazon_bedrock.stream import consume_converse_stream
 
-from genkit import FinishReason, Message, ModelRequest, Part, Role, TextPart, ToolDefinition
+from genkit import FinishReason, Message, Part, Role
+from genkit.model import ModelRequest, TextPart, ToolDefinition
 from genkit.plugin_api import ActionRunContext, GenkitError
 
 pytestmark = pytest.mark.asyncio

--- a/py/packages/genkit-anthropic/src/genkit_anthropic/model_info.py
+++ b/py/packages/genkit-anthropic/src/genkit_anthropic/model_info.py
@@ -18,11 +18,7 @@
 
 from typing import Literal, TypeAlias, cast
 
-from genkit import (
-    Constrained,
-    ModelInfo,
-    Supports,
-)
+from genkit.model import Constrained, ModelInfo, Supports
 
 # Model definitions
 CLAUDE_SONNET_4 = ModelInfo(

--- a/py/packages/genkit-anthropic/src/genkit_anthropic/models.py
+++ b/py/packages/genkit-anthropic/src/genkit_anthropic/models.py
@@ -32,26 +32,28 @@ from anthropic import APIError, AsyncAnthropic
 from anthropic.types import Message as AnthropicMessage
 
 from genkit import (
-    Constrained,
-    CustomPart,
-    ErrorResponseMetadata,
     FinishReason,
     GenkitError,
-    MediaPart,
     Message,
-    ModelRequest,
     ModelResponse,
     ModelResponseChunk,
     ModelUsage,
     Part,
-    ReasoningPart,
     Role,
-    TextPart,
     ToolRequest,
     ToolRequestPart,
     ToolResponsePart,
 )
-from genkit.model import get_basic_usage_stats
+from genkit._core._error import ErrorResponseMetadata
+from genkit.model import (
+    Constrained,
+    CustomPart,
+    MediaPart,
+    ModelRequest,
+    ReasoningPart,
+    TextPart,
+    get_basic_usage_stats,
+)
 from genkit.plugin_api import (
     ActionRunContext,
     StatusName,

--- a/py/packages/genkit-anthropic/src/genkit_anthropic/plugin.py
+++ b/py/packages/genkit-anthropic/src/genkit_anthropic/plugin.py
@@ -21,8 +21,8 @@ from typing import Any, Literal, cast
 import structlog
 from anthropic import AsyncAnthropic
 
-from genkit import GenkitError, ModelRequest, ModelResponse
-from genkit.model import ModelRef, model_action_metadata, model_ref
+from genkit import GenkitError, ModelResponse
+from genkit.model import ModelRef, ModelRequest, model_action_metadata, model_ref
 from genkit.plugin_api import (
     Action,
     ActionKind,

--- a/py/packages/genkit-anthropic/src/genkit_anthropic/utils.py
+++ b/py/packages/genkit-anthropic/src/genkit_anthropic/utils.py
@@ -29,7 +29,8 @@ from typing import Any
 
 import structlog
 
-from genkit import MediaPart, ModelRequest, ModelUsage, Part, TextPart
+from genkit import ModelUsage, Part
+from genkit.model import MediaPart, ModelRequest, TextPart
 
 logger = structlog.get_logger(__name__)
 

--- a/py/packages/genkit-anthropic/tests/anthropic_error_handling_test.py
+++ b/py/packages/genkit-anthropic/tests/anthropic_error_handling_test.py
@@ -24,7 +24,8 @@ import pytest
 from anthropic import APIConnectionError, APIError, APIStatusError
 from genkit_anthropic.models import AnthropicModel
 
-from genkit import GenkitError, Message, ModelRequest, Part, Role, TextPart
+from genkit import GenkitError, Message, Part, Role
+from genkit.model import ModelRequest, TextPart
 from genkit.plugin_api import StatusName
 
 _ERROR_MESSAGE = 'Anthropic request failed'

--- a/py/packages/genkit-anthropic/tests/anthropic_live_test.py
+++ b/py/packages/genkit-anthropic/tests/anthropic_live_test.py
@@ -32,7 +32,8 @@ import pytest
 from anthropic import BadRequestError
 from genkit_anthropic import Anthropic
 
-from genkit import Genkit, GenkitError, Message, ReasoningPart
+from genkit import Genkit, GenkitError, Message
+from genkit.model import ReasoningPart
 
 pytestmark = [
     pytest.mark.asyncio,

--- a/py/packages/genkit-anthropic/tests/anthropic_models_test.py
+++ b/py/packages/genkit-anthropic/tests/anthropic_models_test.py
@@ -27,26 +27,20 @@ from genkit_anthropic.models import BETA_APIS, AnthropicModel, _to_anthropic_thi
 from genkit_anthropic.utils import maybe_strip_fences, strip_markdown_fences
 from pydantic import ValidationError
 
-from genkit import (
+from genkit import FinishReason, Media, Message, ModelResponseChunk, Part, Role, ToolRequestPart
+from genkit._core._model import OutputConfig
+from genkit.model import (
     Constrained,
     CustomPart,
-    FinishReason,
-    Media,
     MediaPart,
-    Message,
     Metadata,
     ModelInfo,
     ModelRequest,
-    ModelResponseChunk,
-    Part,
     ReasoningPart,
-    Role,
     Supports,
     TextPart,
     ToolDefinition,
-    ToolRequestPart,
 )
-from genkit._core._model import OutputConfig
 from genkit.plugin_api import ModelConfig
 
 

--- a/py/packages/genkit-anthropic/tests/anthropic_plugin_test.py
+++ b/py/packages/genkit-anthropic/tests/anthropic_plugin_test.py
@@ -30,16 +30,9 @@ from genkit_anthropic.model_info import (
     get_model_info,
 )
 
-from genkit import (
-    ActionKind,
-    Constrained,
-    Message,
-    ModelRequest,
-    Part,
-    Role,
-    TextPart,
-    ToolDefinition,
-)
+from genkit import Message, Part, Role
+from genkit.model import Constrained, ModelRequest, TextPart, ToolDefinition
+from genkit.plugin_api import ActionKind
 
 
 def test_anthropic_name() -> None:

--- a/py/packages/genkit-anthropic/tests/anthropic_utils_test.py
+++ b/py/packages/genkit-anthropic/tests/anthropic_utils_test.py
@@ -36,13 +36,8 @@ from genkit_anthropic.utils import (
     to_anthropic_media,
 )
 
-from genkit import (
-    Media,
-    MediaPart,
-    Metadata,
-    ModelUsage,
-    TextPart,
-)
+from genkit import Media, ModelUsage
+from genkit.model import MediaPart, Metadata, TextPart
 
 # ---------------------------------------------------------------------------
 # get_cache_control tests

--- a/py/packages/genkit-fastapi/src/genkit_fastapi/handler.py
+++ b/py/packages/genkit-fastapi/src/genkit_fastapi/handler.py
@@ -27,9 +27,9 @@ from fastapi import APIRouter, Depends, Request, Response
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 
-from genkit import Action, ActionKind, Genkit, GenkitError
+from genkit import Action, Genkit, GenkitError
 from genkit.agent import Agent, SessionSnapshot
-from genkit.plugin_api import ContextProvider, RequestData, get_callable_json
+from genkit.plugin_api import ActionKind, ContextProvider, RequestData, get_callable_json
 
 
 def parse_snapshot_lookup_input(input_val: dict[str, Any] | str | None) -> tuple[str | None, str | None]:

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/google.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/google.py
@@ -60,12 +60,11 @@ from google.genai.client import DebugConfig
 from google.genai.types import HttpOptions, HttpOptionsDict
 
 import genkit_google_genai.constants as const
-from genkit import ModelInfo
 from genkit._core._action import ActionRunContext
 from genkit._core._model import ModelRequest, ModelResponse
 from genkit.embedder import EmbedderRef, embedder_action_metadata
 from genkit.evaluator import EvalFnResponse, EvalRequest
-from genkit.model import BackgroundAction, ModelRef, Operation, model_action_metadata
+from genkit.model import BackgroundAction, ModelInfo, ModelRef, Operation, model_action_metadata
 from genkit.plugin_api import (
     GENKIT_CLIENT_HEADER,
     Action,

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/models/context_caching/utils.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/models/context_caching/utils.py
@@ -22,7 +22,8 @@ import json
 import structlog
 from google.genai import types as genai_types
 
-from genkit import GenkitError, ModelRequest
+from genkit import GenkitError
+from genkit.model import ModelRequest
 from genkit_google_genai.models.context_caching.constants import (
     CONTEXT_CACHE_SUPPORTED_MODELS,
     INVALID_ARGUMENT_MESSAGES,

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/models/embedder.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/models/embedder.py
@@ -28,9 +28,10 @@ else:
 from google import genai
 from google.genai import types as genai_types
 
-from genkit import DocumentPart, Embedding, EmbedRequest, EmbedResponse
+from genkit import Embedding
 from genkit._core._typing import DocumentData, MediaPart, TextPart
-from genkit.embedder import EmbedderOptions, EmbedderSupports
+from genkit.embedder import EmbedderOptions, EmbedderSupports, EmbedRequest, EmbedResponse
+from genkit.model import DocumentPart
 from genkit_google_genai.models._routing import strip_ref_prefixes
 from genkit_google_genai.models.utils import PartConverter
 

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/models/gemini.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/models/gemini.py
@@ -45,22 +45,18 @@ from google.genai import types as genai_types
 from google.genai.errors import APIError
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, WithJsonSchema
 
-from genkit import (
+from genkit import GenkitError, Message, ModelResponse, ModelResponseChunk, ModelUsage, Part, Role
+from genkit.model import (
+    Candidate,
     Constrained,
-    GenkitError,
-    Message,
+    FinishReason,
     ModelInfo,
     ModelRequest,
-    ModelResponse,
-    ModelResponseChunk,
-    ModelUsage,
-    Part,
-    Role,
     Supports,
     TextPart,
     ToolDefinition,
+    get_basic_usage_stats,
 )
-from genkit.model import Candidate, FinishReason, get_basic_usage_stats
 from genkit.plugin_api import (
     ActionRunContext,
     ModelConfig,

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/models/imagen.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/models/imagen.py
@@ -33,19 +33,8 @@ from google.genai import types as genai_types
 from google.genai.errors import APIError
 from pydantic import BaseModel, ConfigDict, ValidationError
 
-from genkit import (
-    GenkitError,
-    Media,
-    MediaPart,
-    Message,
-    ModelInfo,
-    ModelRequest,
-    ModelResponse,
-    Part,
-    Role,
-    Supports,
-    TextPart,
-)
+from genkit import GenkitError, Media, Message, ModelResponse, Part, Role
+from genkit.model import MediaPart, ModelInfo, ModelRequest, Supports, TextPart
 from genkit.plugin_api import ActionRunContext, tracer, wrap_http_error
 from genkit_google_genai.models._sdk_config import (
     attach_leftovers,

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/models/lyria.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/models/lyria.py
@@ -32,7 +32,7 @@ from typing import Any
 
 from pydantic import BaseModel, Field
 
-from genkit import ModelInfo, Supports
+from genkit.model import ModelInfo, Supports
 
 
 class LyriaVersion(StrEnum):

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/models/utils.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/models/utils.py
@@ -53,20 +53,8 @@ from urllib.parse import urlparse
 
 from google import genai
 
-from genkit import (
-    CustomPart,
-    DocumentPart,
-    Media,
-    MediaPart,
-    Metadata,
-    Part,
-    ReasoningPart,
-    TextPart,
-    ToolRequest,
-    ToolRequestPart,
-    ToolResponse,
-    ToolResponsePart,
-)
+from genkit import Media, Part, ToolRequest, ToolRequestPart, ToolResponse, ToolResponsePart
+from genkit.model import CustomPart, DocumentPart, MediaPart, Metadata, ReasoningPart, TextPart
 from genkit.plugin_api import get_cached_client
 
 logger = logging.getLogger(__name__)

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/models/veo.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/models/veo.py
@@ -32,13 +32,8 @@ from google.genai import types as genai_types
 from google.genai.errors import APIError
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
-from genkit import (
-    GenkitError,
-    ModelInfo,
-    ModelRequest,
-    Supports,
-)
-from genkit.model import Error, Operation
+from genkit import GenkitError
+from genkit.model import Error, ModelInfo, ModelRequest, Operation, Supports
 from genkit.plugin_api import ActionRunContext, wrap_http_error
 from genkit_google_genai.models._sdk_config import (
     attach_leftovers,

--- a/py/packages/genkit-google-genai/test/google_plugin_test.py
+++ b/py/packages/genkit-google-genai/test/google_plugin_test.py
@@ -42,17 +42,9 @@ from google import genai
 from google.auth.credentials import Credentials
 from google.genai.types import HttpOptions
 
-from genkit import (
-    ActionKind,
-    Genkit,
-    Message,
-    ModelInfo,
-    ModelRequest,
-    Part,
-    Role,
-    TextPart,
-)
-from genkit.plugin_api import GENKIT_CLIENT_HEADER
+from genkit import Genkit, Message, Part, Role
+from genkit.model import ModelInfo, ModelRequest, TextPart
+from genkit.plugin_api import GENKIT_CLIENT_HEADER, ActionKind
 
 
 async def _get_runtime_client(plugin: GoogleAI | VertexAI) -> object:

--- a/py/packages/genkit-google-genai/test/models/googlegenai_embedder_test.py
+++ b/py/packages/genkit-google-genai/test/models/googlegenai_embedder_test.py
@@ -28,15 +28,9 @@ from genkit_google_genai.models.embedder import (
 from google import genai
 from pytest_mock import MockerFixture
 
-from genkit import (
-    Document,
-    DocumentPart,
-    EmbedRequest,
-    EmbedResponse,
-    Media,
-    MediaPart,
-    TextPart,
-)
+from genkit import Document, Media
+from genkit.embedder import EmbedRequest, EmbedResponse
+from genkit.model import DocumentPart, MediaPart, TextPart
 
 
 @pytest.mark.asyncio

--- a/py/packages/genkit-google-genai/test/models/googlegenai_gemini_test.py
+++ b/py/packages/genkit-google-genai/test/models/googlegenai_gemini_test.py
@@ -49,22 +49,8 @@ from google.genai.errors import APIError
 from pydantic import BaseModel, Field
 from pytest_mock import MockerFixture
 
-from genkit import (
-    ActionRunContext,
-    Constrained,
-    FinishReason,
-    GenkitError,
-    MediaPart,
-    Message,
-    ModelInfo,
-    ModelRequest,
-    ModelResponse,
-    Part,
-    Role,
-    Supports,
-    TextPart,
-    ToolDefinition,
-)
+from genkit import ActionRunContext, FinishReason, GenkitError, Message, ModelResponse, Part, Role
+from genkit.model import Constrained, MediaPart, ModelInfo, ModelRequest, Supports, TextPart, ToolDefinition
 from genkit.plugin_api import to_json_schema
 
 ALL_VERSIONS = list(GoogleAIGeminiVersion) + list(VertexAIGeminiVersion)

--- a/py/packages/genkit-google-genai/test/models/googlegenai_imagen_test.py
+++ b/py/packages/genkit-google-genai/test/models/googlegenai_imagen_test.py
@@ -25,17 +25,8 @@ from genkit_google_genai.models.imagen import ImagenConfigSchema, ImagenModel, I
 from google import genai
 from pytest_mock import MockerFixture
 
-from genkit import (
-    ActionRunContext,
-    GenkitError,
-    MediaPart,
-    Message,
-    ModelRequest,
-    ModelResponse,
-    Part,
-    Role,
-    TextPart,
-)
+from genkit import ActionRunContext, GenkitError, Message, ModelResponse, Part, Role
+from genkit.model import MediaPart, ModelRequest, TextPart
 
 
 @pytest.mark.asyncio

--- a/py/packages/genkit-google-genai/tests/google_genai_plugin_test.py
+++ b/py/packages/genkit-google-genai/tests/google_genai_plugin_test.py
@@ -50,9 +50,9 @@ from genkit_google_genai.models.gemini import (
 from genkit_google_genai.models.imagen import ImagenConfigSchema
 from genkit_google_genai.models.veo import VeoConfigSchema, VeoModel
 
-from genkit import ActionKind, Genkit, GenkitError, Message, ModelRequest, Part, Role, TextPart
-from genkit.model import Operation
-from genkit.plugin_api import Action, to_json_schema
+from genkit import Genkit, GenkitError, Message, Part, Role
+from genkit.model import ModelRequest, Operation, TextPart
+from genkit.plugin_api import Action, ActionKind, to_json_schema
 
 
 def _custom_options(action: Action) -> object:

--- a/py/packages/genkit-google-genai/tests/part_converter_test.py
+++ b/py/packages/genkit-google-genai/tests/part_converter_test.py
@@ -26,7 +26,8 @@ import pytest
 from genkit_google_genai.models.utils import PartConverter
 from google import genai
 
-from genkit import Media, MediaPart, Part, ToolRequest, ToolRequestPart
+from genkit import Media, Part, ToolRequest, ToolRequestPart
+from genkit.model import MediaPart
 
 
 class TestIsGeminiNativeUrl:

--- a/py/packages/genkit-google-genai/tests/veo_test.py
+++ b/py/packages/genkit-google-genai/tests/veo_test.py
@@ -34,8 +34,8 @@ from genkit_google_genai.models.veo import (
 from google.genai import types as genai_types
 from google.genai.errors import APIError
 
-from genkit import ActionRunContext, GenkitError, Message, ModelRequest, Part, Role, TextPart
-from genkit.model import Operation
+from genkit import ActionRunContext, GenkitError, Message, Part, Role
+from genkit.model import ModelRequest, Operation, TextPart
 
 
 def _text_request(*, config: object | None = None) -> ModelRequest:

--- a/py/packages/genkit-google-genai/tests/vertexai_location_test.py
+++ b/py/packages/genkit-google-genai/tests/vertexai_location_test.py
@@ -34,7 +34,8 @@ from google import genai
 from google.genai import types as genai_types
 from google.genai.types import HttpOptions
 
-from genkit import GenkitError, Message, ModelRequest, Part, Role, TextPart
+from genkit import GenkitError, Message, Part, Role
+from genkit.model import ModelRequest, TextPart
 
 US_REP_URL = 'https://aiplatform.us.rep.googleapis.com'
 EU_REP_URL = 'https://aiplatform.eu.rep.googleapis.com'

--- a/py/packages/genkit-middleware/src/genkit_middleware/_filesystem.py
+++ b/py/packages/genkit-middleware/src/genkit_middleware/_filesystem.py
@@ -40,10 +40,9 @@ from typing import Any
 
 from pydantic import BaseModel as PydanticBaseModel
 
-from genkit._ai._tools import Interrupt, define_tool
+from genkit import Interrupt, Message, tool
 from genkit._core._action import Action
-from genkit._core._model import Message, ModelResponse, ModelResponseChunk
-from genkit._core._registry import Registry
+from genkit._core._model import ModelResponse, ModelResponseChunk
 from genkit._core._typing import (
     Media,
     MediaPart,
@@ -271,7 +270,6 @@ class Filesystem(BaseMiddleware[FilesystemConfig]):
 
     def tools(self, ctx: GenerateMiddlewareContext) -> list[Action]:
         """Return filesystem tool actions for this generate() call."""
-        scratch = Registry()
 
         async def list_files(input: _ListFilesInput) -> list[dict[str, Any]]:
             return await asyncio.to_thread(self._list_files, input.dir_path, input.recursive)
@@ -284,14 +282,12 @@ class Filesystem(BaseMiddleware[FilesystemConfig]):
                 input.limit,
             )
 
-        t_list = define_tool(
-            scratch,
+        t_list = tool(
             list_files,
             name=self._tool_name('list_files'),
             description='List files and directories under a path (optional recursive).',
         )
-        t_read = define_tool(
-            scratch,
+        t_read = tool(
             read_file,
             name=self._tool_name('read_file'),
             description='Read a text file, optionally from an offset/limit in lines.',
@@ -310,14 +306,12 @@ class Filesystem(BaseMiddleware[FilesystemConfig]):
                     [e.model_dump() for e in input.edits],
                 )
 
-            t_write = define_tool(
-                scratch,
+            t_write = tool(
                 write_file,
                 name=self._tool_name('write_file'),
                 description='Create or overwrite a text file with the given content.',
             )
-            t_edit = define_tool(
-                scratch,
+            t_edit = tool(
                 edit_file,
                 name=self._tool_name('edit_file'),
                 description='Apply search/replace edits to an existing text file.',

--- a/py/packages/genkit-middleware/src/genkit_middleware/_skills.py
+++ b/py/packages/genkit-middleware/src/genkit_middleware/_skills.py
@@ -26,11 +26,9 @@ from typing import Any
 import yaml
 from pydantic import BaseModel as PydanticBaseModel, Field
 
-from genkit._ai._model import Message
-from genkit._ai._tools import define_tool
+from genkit import Message, tool
 from genkit._core._action import Action
 from genkit._core._model import GenerateActionOptions, ModelResponse
-from genkit._core._registry import Registry
 from genkit._core._typing import Part, Role, TextPart
 from genkit.middleware import BaseMiddleware, GenerateHookParams, GenerateMiddlewareContext
 
@@ -153,8 +151,6 @@ class Skills(BaseMiddleware[SkillsConfig]):
         if not self._scan_skills():
             return []
 
-        scratch = Registry()
-
         async def use_skill(input: _UseSkillInput) -> str:
             skill_name = input.skill_name
             skills = await asyncio.to_thread(self._scan_skills)
@@ -168,7 +164,7 @@ class Skills(BaseMiddleware[SkillsConfig]):
             except Exception as exc:
                 return f'Failed to read skill "{skill_name}": {exc}'
 
-        t = define_tool(scratch, use_skill, name='use_skill')
+        t = tool(use_skill, name='use_skill')
         return [t.action()]
 
     async def wrap_generate(

--- a/py/packages/genkit-middleware/tests/fallback_test.py
+++ b/py/packages/genkit-middleware/tests/fallback_test.py
@@ -21,9 +21,10 @@ from typing import NoReturn
 import pytest
 from genkit_middleware import Fallback
 
-from genkit import ModelRequest, ModelResponse
+from genkit import ModelResponse
 from genkit._core._error import GenkitError
 from genkit.middleware import ModelHookParams
+from genkit.model import ModelRequest
 
 
 def _make_params() -> ModelHookParams:

--- a/py/packages/genkit-middleware/tests/retry_test.py
+++ b/py/packages/genkit-middleware/tests/retry_test.py
@@ -23,9 +23,10 @@ import pytest
 from genkit_middleware import Retry
 from pydantic import ValidationError
 
-from genkit import ModelRequest, ModelResponse
+from genkit import ModelResponse
 from genkit._core._error import GenkitError
 from genkit.middleware import GenerateMiddlewareContext, ModelHookParams
+from genkit.model import ModelRequest
 
 
 def _make_params() -> ModelHookParams:

--- a/py/packages/genkit-ollama/src/genkit_ollama/models.py
+++ b/py/packages/genkit-ollama/src/genkit_ollama/models.py
@@ -95,21 +95,17 @@ from pydantic.alias_generators import to_camel, to_snake
 from genkit import (
     GenkitError,
     Media,
-    MediaPart,
     Message,
-    ModelRequest,
     ModelResponse,
     ModelResponseChunk,
     ModelUsage,
     Part,
-    ReasoningPart,
     Role,
-    TextPart,
     ToolRequest,
     ToolRequestPart,
     ToolResponsePart,
 )
-from genkit.model import get_basic_usage_stats
+from genkit.model import MediaPart, ModelRequest, ReasoningPart, TextPart, get_basic_usage_stats
 from genkit.plugin_api import ActionRunContext, ModelConfig, get_cached_client, wrap_http_error
 from genkit_ollama._errors import wrap_connection_errors
 from genkit_ollama.constants import (

--- a/py/packages/genkit-ollama/src/genkit_ollama/plugin_api.py
+++ b/py/packages/genkit-ollama/src/genkit_ollama/plugin_api.py
@@ -25,7 +25,7 @@ from typing import Any, cast
 import ollama as ollama_api
 import structlog
 
-from genkit import Constrained, ModelInfo, ModelRequest, ModelResponse, Supports
+from genkit import ModelResponse
 from genkit.embedder import (
     EmbedderOptions,
     EmbedderSupports,
@@ -33,7 +33,7 @@ from genkit.embedder import (
     EmbedResponse,
     embedder_action_metadata,
 )
-from genkit.model import model_action_metadata
+from genkit.model import Constrained, ModelInfo, ModelRequest, Supports, model_action_metadata
 from genkit.plugin_api import (
     Action,
     ActionKind,

--- a/py/packages/genkit-ollama/tests/integration_test.py
+++ b/py/packages/genkit-ollama/tests/integration_test.py
@@ -21,7 +21,9 @@ from unittest.mock import Mock
 import ollama as ollama_api
 import pytest
 
-from genkit import ActionKind, Genkit, Message, ModelResponse, Part, Role, TextPart
+from genkit import Genkit, Message, ModelResponse, Part, Role
+from genkit.model import TextPart
+from genkit.plugin_api import ActionKind
 
 
 @pytest.mark.asyncio

--- a/py/packages/genkit-ollama/tests/models/embedders_test.py
+++ b/py/packages/genkit-ollama/tests/models/embedders_test.py
@@ -22,14 +22,9 @@ from unittest.mock import AsyncMock, MagicMock
 import ollama as ollama_api
 from genkit_ollama.embedders import EmbeddingDefinition, OllamaEmbedder
 
-from genkit import (
-    Document,
-    DocumentPart,
-    Embedding,
-    EmbedRequest,
-    EmbedResponse,
-    TextPart,
-)
+from genkit import Document, Embedding
+from genkit.embedder import EmbedRequest, EmbedResponse
+from genkit.model import DocumentPart, TextPart
 
 
 class TestOllamaEmbedderEmbed(unittest.IsolatedAsyncioTestCase):

--- a/py/packages/genkit-ollama/tests/models/ollama_models_test.py
+++ b/py/packages/genkit-ollama/tests/models/ollama_models_test.py
@@ -32,17 +32,14 @@ from genkit import (
     ActionRunContext,
     GenkitError,
     Media,
-    MediaPart,
     Message,
-    ModelRequest,
     ModelResponseChunk,
     ModelUsage,
     Part,
-    ReasoningPart,
     Role,
-    TextPart,
     ToolRequestPart,
 )
+from genkit.model import MediaPart, ModelRequest, ReasoningPart, TextPart
 from genkit.plugin_api import ModelConfig
 
 

--- a/py/packages/genkit-ollama/tests/plugin_api_test.py
+++ b/py/packages/genkit-ollama/tests/plugin_api_test.py
@@ -30,19 +30,10 @@ from genkit_ollama.embedders import EmbeddingDefinition
 from genkit_ollama.models import ModelDefinition, OllamaConfig, OllamaSupports
 from pydantic import BaseModel
 
-from genkit import (
-    ActionKind,
-    Document,
-    EmbedRequest,
-    Media,
-    MediaPart,
-    Message,
-    ModelRequest,
-    Part,
-    Role,
-    TextPart,
-)
-from genkit.plugin_api import to_json_schema
+from genkit import Document, Media, Message, Part, Role
+from genkit.embedder import EmbedRequest
+from genkit.model import MediaPart, ModelRequest, TextPart
+from genkit.plugin_api import ActionKind, to_json_schema
 
 
 class TestOllamaInit(unittest.TestCase):

--- a/py/packages/genkit-openai/src/genkit_openai/models/audio.py
+++ b/py/packages/genkit-openai/src/genkit_openai/models/audio.py
@@ -32,20 +32,8 @@ from openai import APIStatusError, AsyncOpenAI
 from openai._legacy_response import HttpxBinaryResponseContent
 from openai.types.audio import Transcription, Translation
 
-from genkit import (
-    GenkitError,
-    Media,
-    MediaPart,
-    Message,
-    ModelInfo,
-    ModelRequest,
-    ModelResponse,
-    Part,
-    Role,
-    Supports,
-    TextPart,
-)
-from genkit.model import FinishReason
+from genkit import GenkitError, Media, Message, ModelResponse, Part, Role
+from genkit.model import FinishReason, MediaPart, ModelInfo, ModelRequest, Supports, TextPart
 from genkit.plugin_api import ActionRunContext
 from genkit_openai.models.utils import (
     _extract_media,

--- a/py/packages/genkit-openai/src/genkit_openai/models/handler.py
+++ b/py/packages/genkit-openai/src/genkit_openai/models/handler.py
@@ -21,11 +21,8 @@ from typing import cast
 
 from openai import AsyncOpenAI
 
-from genkit import (
-    ModelInfo,
-    ModelRequest,
-    ModelResponse,
-)
+from genkit import ModelResponse
+from genkit.model import ModelInfo, ModelRequest
 from genkit.plugin_api import ActionRunContext
 from genkit_openai.models.model import OpenAIModel
 from genkit_openai.models.model_info import (

--- a/py/packages/genkit-openai/src/genkit_openai/models/image.py
+++ b/py/packages/genkit-openai/src/genkit_openai/models/image.py
@@ -27,18 +27,8 @@ from typing import Any
 from openai import APIStatusError, AsyncOpenAI
 from openai.types.images_response import ImagesResponse
 
-from genkit import (
-    Media,
-    MediaPart,
-    Message,
-    ModelInfo,
-    ModelRequest,
-    ModelResponse,
-    Part,
-    Role,
-    Supports,
-)
-from genkit.model import FinishReason
+from genkit import Media, Message, ModelResponse, Part, Role
+from genkit.model import FinishReason, MediaPart, ModelInfo, ModelRequest, Supports
 from genkit.plugin_api import ActionRunContext
 from genkit_openai.models.utils import _extract_text, extract_config_dict, reraise_openai_error
 

--- a/py/packages/genkit-openai/src/genkit_openai/models/model.py
+++ b/py/packages/genkit-openai/src/genkit_openai/models/model.py
@@ -26,18 +26,8 @@ from openai.lib._pydantic import _ensure_strict_json_schema
 from openai.types import CompletionUsage
 from openai.types.completion_usage import CompletionTokensDetails, PromptTokensDetails
 
-from genkit import (
-    Message,
-    ModelRequest,
-    ModelResponse,
-    ModelResponseChunk,
-    ModelUsage,
-    Part,
-    ReasoningPart,
-    Role,
-    TextPart,
-    ToolDefinition,
-)
+from genkit import Message, ModelResponse, ModelResponseChunk, ModelUsage, Part, Role
+from genkit.model import ModelRequest, ReasoningPart, TextPart, ToolDefinition
 from genkit.plugin_api import ActionRunContext, ModelConfig
 from genkit_openai.models.model_info import SUPPORTED_OPENAI_MODELS, KnownGpt
 from genkit_openai.models.utils import (

--- a/py/packages/genkit-openai/src/genkit_openai/models/model_info.py
+++ b/py/packages/genkit-openai/src/genkit_openai/models/model_info.py
@@ -25,10 +25,7 @@ if sys.version_info < (3, 11):
 else:
     from enum import StrEnum
 
-from genkit import (
-    ModelInfo,
-    Supports,
-)
+from genkit.model import ModelInfo, Supports
 from genkit_openai.typing import SupportedOutputFormat
 
 OPENAI = 'openai'

--- a/py/packages/genkit-openai/src/genkit_openai/models/utils.py
+++ b/py/packages/genkit-openai/src/genkit_openai/models/utils.py
@@ -25,19 +25,8 @@ from typing import Any, NoReturn
 
 from openai import APIStatusError
 
-from genkit import (
-    GenkitError,
-    MediaPart,
-    Message,
-    ModelRequest,
-    Part,
-    ReasoningPart,
-    Role,
-    TextPart,
-    ToolRequest,
-    ToolRequestPart,
-    ToolResponsePart,
-)
+from genkit import GenkitError, Message, Part, Role, ToolRequest, ToolRequestPart, ToolResponsePart
+from genkit.model import MediaPart, ModelRequest, ReasoningPart, TextPart
 from genkit.plugin_api import wrap_http_error
 
 

--- a/py/packages/genkit-openai/src/genkit_openai/openai_plugin.py
+++ b/py/packages/genkit-openai/src/genkit_openai/openai_plugin.py
@@ -23,9 +23,9 @@ from typing import Any, Literal, TypeAlias, cast
 from openai import AsyncOpenAI
 from openai.types import Model
 
-from genkit import Embedding, EmbedRequest, EmbedResponse, GenkitError, ModelInfo, ModelRequest, ModelResponse, Supports
-from genkit.embedder import EmbedderOptions, EmbedderSupports, embedder_action_metadata
-from genkit.model import ModelRef, model_action_metadata, model_ref
+from genkit import Embedding, GenkitError, ModelResponse
+from genkit.embedder import EmbedderOptions, EmbedderSupports, EmbedRequest, EmbedResponse, embedder_action_metadata
+from genkit.model import ModelInfo, ModelRef, ModelRequest, Supports, model_action_metadata, model_ref
 from genkit.plugin_api import (
     Action,
     ActionKind,

--- a/py/packages/genkit-openai/tests/audio_model_test.py
+++ b/py/packages/genkit-openai/tests/audio_model_test.py
@@ -35,16 +35,8 @@ from genkit_openai.models.audio import (
     _to_tts_response,
 )
 
-from genkit import (
-    GenkitError,
-    Media,
-    MediaPart,
-    Message,
-    ModelRequest,
-    Part,
-    Role,
-    TextPart,
-)
+from genkit import GenkitError, Media, Message, Part, Role
+from genkit.model import MediaPart, ModelRequest, TextPart
 
 
 class TestExtractText:

--- a/py/packages/genkit-openai/tests/conftest.py
+++ b/py/packages/genkit-openai/tests/conftest.py
@@ -20,13 +20,8 @@
 import pytest
 from genkit_openai.typing import OpenAIConfig
 
-from genkit import (
-    Message,
-    ModelRequest,
-    Part,
-    Role,
-    TextPart,
-)
+from genkit import Message, Part, Role
+from genkit.model import ModelRequest, TextPart
 
 
 @pytest.fixture

--- a/py/packages/genkit-openai/tests/image_model_test.py
+++ b/py/packages/genkit-openai/tests/image_model_test.py
@@ -29,14 +29,8 @@ from genkit_openai.models.image import (
     _to_image_generate_params,
 )
 
-from genkit import (
-    MediaPart,
-    Message,
-    ModelRequest,
-    Part,
-    Role,
-    TextPart,
-)
+from genkit import Message, Part, Role
+from genkit.model import MediaPart, ModelRequest, TextPart
 
 
 class TestExtractPromptText:

--- a/py/packages/genkit-openai/tests/openai_model_test.py
+++ b/py/packages/genkit-openai/tests/openai_model_test.py
@@ -30,17 +30,9 @@ from openai.types import CompletionUsage
 from openai.types.chat import ChatCompletionChunk
 from pydantic import BaseModel
 
-from genkit import (
-    GenkitError,
-    Message,
-    ModelRequest,
-    ModelResponse,
-    ModelResponseChunk,
-    Part,
-    Role,
-    TextPart,
-)
+from genkit import GenkitError, Message, ModelResponse, ModelResponseChunk, Part, Role
 from genkit._core._model import OutputConfig
+from genkit.model import ModelRequest, TextPart
 from genkit.plugin_api import ActionRunContext, ModelConfig
 
 

--- a/py/packages/genkit-openai/tests/openai_utils_test.py
+++ b/py/packages/genkit-openai/tests/openai_utils_test.py
@@ -36,21 +36,8 @@ from genkit_openai.models.utils import (
 from openai import APIStatusError
 from pydantic import BaseModel
 
-from genkit import (
-    GenkitError,
-    Media,
-    MediaPart,
-    Message,
-    ModelRequest,
-    Part,
-    ReasoningPart,
-    Role,
-    TextPart,
-    ToolRequest,
-    ToolRequestPart,
-    ToolResponse,
-    ToolResponsePart,
-)
+from genkit import GenkitError, Media, Message, Part, Role, ToolRequest, ToolRequestPart, ToolResponse, ToolResponsePart
+from genkit.model import MediaPart, ModelRequest, ReasoningPart, TextPart
 
 
 class TestParseDataUriContentType:

--- a/py/packages/genkit-openai/tests/tool_calling_test.py
+++ b/py/packages/genkit-openai/tests/tool_calling_test.py
@@ -23,7 +23,8 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from genkit_openai.models import OpenAIModel
 
-from genkit import ModelRequest, ModelResponseChunk, TextPart, ToolRequestPart
+from genkit import ModelResponseChunk, ToolRequestPart
+from genkit.model import ModelRequest, TextPart
 
 
 @pytest.mark.asyncio

--- a/py/packages/genkit-vertexai/src/genkit_vertexai/model_garden/anthropic.py
+++ b/py/packages/genkit-vertexai/src/genkit_vertexai/model_garden/anthropic.py
@@ -26,7 +26,8 @@ from genkit_anthropic.models import AnthropicModel
 from pydantic import ConfigDict
 from pydantic.config import JsonDict
 
-from genkit import ModelInfo, ModelRequest, ModelResponse, Supports
+from genkit import ModelResponse
+from genkit.model import ModelInfo, ModelRequest, Supports
 from genkit.plugin_api import ActionRunContext, ModelConfig, loop_local_client
 
 

--- a/py/packages/genkit-vertexai/src/genkit_vertexai/model_garden/model_garden.py
+++ b/py/packages/genkit-vertexai/src/genkit_vertexai/model_garden/model_garden.py
@@ -25,7 +25,7 @@ from collections.abc import Callable
 if typing.TYPE_CHECKING:
     from openai import AsyncOpenAI
 
-    from genkit import ModelRequest, ModelResponse
+    from genkit.model import ModelRequest, ModelResponse
     from genkit.plugin_api import ActionRunContext
 
 from genkit_openai.models import (

--- a/py/packages/genkit/src/genkit/__init__.py
+++ b/py/packages/genkit/src/genkit/__init__.py
@@ -38,11 +38,10 @@ Example:
         ai.run_main(my_flow('Weather in Paris?'))
 """
 
-from genkit._ai._aio import ActionKind, Genkit
+from genkit._ai._aio import Genkit
 from genkit._ai._prompt import (
     ExecutablePrompt,
     ModelStreamResponse,
-    PromptGenerateOptions,
 )
 from genkit._ai._tools import (
     Interrupt,
@@ -53,117 +52,67 @@ from genkit._ai._tools import (
     tool,
 )
 from genkit._core._action import Action, ActionRunContext, StreamResponse
-from genkit._core._error import ErrorResponseMetadata, GenkitError, PublicError
+from genkit._core._error import GenkitError, PublicError
 from genkit._core._model import Document
-from genkit._core._plugin import Plugin
 from genkit._core._typing import (
-    CustomPart,
-    DocumentPart,
     Media,
-    MediaPart,
-    Metadata,
-    MiddlewareRef,
-    MultipartToolResponse,
     Part,
-    ReasoningPart,
     Role,
-    TextPart,
     ToolChoice,
     ToolRequest,
     ToolRequestPart,
     ToolResponse,
     ToolResponsePart,
 )
-
-# Import embedder-related types from the embedder namespace
-from genkit.embedder import (
-    EmbedderOptions,
-    EmbedderRef,
-    Embedding,
-    EmbedRequest,
-    EmbedResponse,
-)
-
-# Import model-related types from the model namespace.
+from genkit.embedder import Embedding
 from genkit.model import (
-    Constrained,
     FinishReason,
     Message,
     ModelConfigDict,
-    ModelInfo,
-    ModelRequest,
     ModelResponse,
     ModelResponseChunk,
     ModelUsage,
-    Stage,
-    Supports,
-    ToolDefinition,
 )
 
 # Flow is an alias for Action (used in samples for flow type hints)
 Flow = Action
 
 __all__ = [
-    # Main class
+    # Main class & flows
     'Genkit',
-    'Flow',
-    # Response types
     'Action',
+    'ActionRunContext',
+    'Flow',
     'StreamResponse',
-    'EmbedRequest',
-    'EmbedResponse',
-    'EmbedderOptions',
-    'EmbedderRef',
-    'ModelConfigDict',
-    'ModelInfo',
+    # Model generation & streaming
+    'ModelResponse',
+    'ModelResponseChunk',
     'ModelStreamResponse',
-    # Errors
-    'ErrorResponseMetadata',
-    'GenkitError',
-    'PublicError',
-    # Tools
-    'Interrupt',
+    'ModelConfigDict',
+    'ModelUsage',
+    'FinishReason',
+    'ToolChoice',
+    # Content & Messaging
+    'Message',
+    'Part',
+    'Role',
+    'Media',
+    'Document',
+    # Tools & HITL
     'Tool',
+    'ToolRunContext',
+    'Interrupt',
+    'ToolRequest',
+    'ToolResponse',
+    'ToolRequestPart',
+    'ToolResponsePart',
     'respond_to_interrupt',
     'restart_tool',
     'tool',
-    # Content types
-    'Constrained',
-    'CustomPart',
+    # Embeddings & Prompts
     'Embedding',
-    'Metadata',
-    'ReasoningPart',
-    'FinishReason',
-    'ModelUsage',
-    'Media',
-    'MediaPart',
-    'Message',
-    'MultipartToolResponse',
-    'Part',
-    'Role',
-    'Stage',
-    'Supports',
-    'TextPart',
-    'ToolChoice',
-    'ToolDefinition',
-    'ToolRequest',
-    'ToolRequestPart',
-    'ToolResponse',
-    'ToolResponsePart',
-    # Domain types
-    'Document',
-    'DocumentPart',
-    # Plugin interface
-    'Plugin',
-    # Middleware references (wire form for use= parameter)
-    'MiddlewareRef',
-    # AI runtime
-    'ActionKind',
-    'ActionRunContext',
     'ExecutablePrompt',
-    'PromptGenerateOptions',
-    'ToolRunContext',
-    'ModelRequest',
-    'ModelResponse',
-    'ModelResponseChunk',
+    # Errors
+    'GenkitError',
+    'PublicError',
 ]

--- a/py/packages/genkit/src/genkit/middleware/__init__.py
+++ b/py/packages/genkit/src/genkit/middleware/__init__.py
@@ -71,6 +71,7 @@ from genkit._core._middleware import (
     ModelHookParams,
     ToolHookParams,
 )
+from genkit._core._model import MiddlewareRef
 from genkit._core._typing import MultipartToolResponse
 
 __all__ = [
@@ -78,6 +79,7 @@ __all__ = [
     'GenerateHookParams',
     'GenerateMiddleware',
     'GenerateMiddlewareContext',
+    'MiddlewareRef',
     'ModelHookParams',
     'MultipartToolResponse',
     'ToolHookParams',

--- a/py/packages/genkit/src/genkit/model/__init__.py
+++ b/py/packages/genkit/src/genkit/model/__init__.py
@@ -35,15 +35,26 @@ from genkit._core._model import (
 from genkit._core._typing import (
     Candidate,
     Constrained,
+    CustomPart,
+    DataPart,
+    DocumentPart,
     Error,
     FinishReason,
+    MediaPart,
+    Metadata,
     ModelInfo,
     Operation,
+    Part,
+    ReasoningPart,
+    Role,
     Stage,
     Supports,
+    TextPart,
     ToolDefinition,
     ToolRequest,
+    ToolRequestPart,
     ToolResponse,
+    ToolResponsePart,
 )
 
 __all__ = [
@@ -60,15 +71,28 @@ __all__ = [
     # Error and operation
     'Error',
     'Operation',
+    # Content & Parts
+    'Message',
+    'Part',
+    'Role',
+    'TextPart',
+    'MediaPart',
+    'DataPart',
+    'CustomPart',
+    'ReasoningPart',
+    'DocumentPart',
     # Tool types
     'ToolRequest',
     'ToolDefinition',
     'ToolResponse',
+    'ToolRequestPart',
+    'ToolResponsePart',
     # Model info
     'ModelInfo',
     'Supports',
     'Constrained',
     'Stage',
+    'Metadata',
     # Factory functions and metadata
     'model_action_metadata',
     'model_ref',
@@ -76,8 +100,6 @@ __all__ = [
     'ModelRef',
     # Config
     'ModelConfigDict',
-    # Message
-    'Message',
     # Usage
     'get_basic_usage_stats',
 ]

--- a/py/packages/genkit/tests/genkit/ai/_tools_test.py
+++ b/py/packages/genkit/tests/genkit/ai/_tools_test.py
@@ -5,7 +5,7 @@
 
 import pytest
 
-from genkit import ActionKind, Genkit
+from genkit import Genkit
 from genkit._ai._tools import (
     Interrupt,
     ToolRunContext,
@@ -19,6 +19,7 @@ from genkit._ai._tools import (
 from genkit._core._error import GenkitError
 from genkit._core._middleware import GenerateMiddlewareContext
 from genkit._core._typing import ToolRequest, ToolRequestPart, ToolResponsePart
+from genkit.plugin_api import ActionKind
 
 
 async def _echo_tool(x: object) -> object:

--- a/py/packages/genkit/tests/genkit/ai/ai_plugin_test.py
+++ b/py/packages/genkit/tests/genkit/ai/ai_plugin_test.py
@@ -22,13 +22,14 @@
 
 import pytest
 
-from genkit import Genkit, Message, ModelResponse, Part, Plugin, Role, TextPart
+from genkit import Genkit, Message, ModelResponse, Part, Role
 from genkit._core._action import Action, ActionRunContext
 from genkit._core._model import ModelRequest
 from genkit._core._registry import ActionKind
 from genkit._core._typing import ActionMetadata, FinishReason
 from genkit.middleware import BaseMiddleware, GenerateMiddleware
-from genkit.plugin_api import new_middleware
+from genkit.model import TextPart
+from genkit.plugin_api import Plugin, new_middleware
 
 
 class AsyncResolveOnlyPlugin(Plugin):

--- a/py/packages/genkit/tests/genkit/ai/background_generate_test.py
+++ b/py/packages/genkit/tests/genkit/ai/background_generate_test.py
@@ -21,7 +21,7 @@ from typing import Any, cast
 
 import pytest
 
-from genkit import ActionKind, Document, Genkit, Message
+from genkit import Document, Genkit, Message
 from genkit._core._action import ActionRunContext
 from genkit._core._error import GenkitError
 from genkit._core._middleware import BaseMiddleware, GenerateHookParams, GenerateMiddlewareContext, ModelHookParams
@@ -38,6 +38,7 @@ from genkit._core._typing import (
     ToolResponse,
     ToolResponsePart,
 )
+from genkit.plugin_api import ActionKind
 
 
 @pytest.fixture

--- a/py/packages/genkit/tests/genkit/ai/generate_test.py
+++ b/py/packages/genkit/tests/genkit/ai/generate_test.py
@@ -14,7 +14,7 @@ import pytest
 import yaml
 from pydantic import BaseModel, TypeAdapter
 
-from genkit import ActionKind, Document, Genkit, Message, MiddlewareRef, ModelResponse, ModelResponseChunk
+from genkit import Document, Genkit, Message, ModelResponse, ModelResponseChunk
 from genkit._ai._generate import ChunkAccumulator, _augment_with_context, generate_action
 from genkit._ai._model import text_from_content, text_from_message
 from genkit._ai._testing import (
@@ -41,11 +41,12 @@ from genkit.middleware import (
     GenerateHookParams,
     GenerateMiddleware,
     GenerateMiddlewareContext,
+    MiddlewareRef,
     ModelHookParams,
     MultipartToolResponse,
     ToolHookParams,
 )
-from genkit.plugin_api import MiddlewarePlugin, new_middleware
+from genkit.plugin_api import ActionKind, MiddlewarePlugin, new_middleware
 
 
 def _to_dict(obj: object) -> object:

--- a/py/packages/genkit/tests/genkit/ai/model_ref_test.py
+++ b/py/packages/genkit/tests/genkit/ai/model_ref_test.py
@@ -207,7 +207,8 @@ def test_model_config_dict_keys_match_generation_common_config() -> None:
 
 def test_public_config_import_contract() -> None:
     """App code gets ModelConfigDict; ModelConfig lives on plugin_api."""
-    from genkit import ModelConfigDict as VeneerModelConfigDict, PromptGenerateOptions
+    from genkit import ModelConfigDict as VeneerModelConfigDict
+    from genkit._ai._prompt import PromptGenerateOptions
     from genkit.plugin_api import ModelConfig as PluginModelConfig
 
     assert VeneerModelConfigDict is ModelConfigDict

--- a/py/packages/genkit/tests/genkit/ai/model_test.py
+++ b/py/packages/genkit/tests/genkit/ai/model_test.py
@@ -10,15 +10,7 @@ import warnings
 import pytest
 from pydantic import BaseModel, ConfigDict, ValidationError
 
-from genkit import (
-    FinishReason,
-    Message,
-    ModelRequest,
-    ModelResponse,
-    ModelResponseChunk,
-    ModelUsage,
-    Role,
-)
+from genkit import FinishReason, Message, ModelResponse, ModelResponseChunk, ModelUsage, Role
 from genkit._ai._model import text_from_content
 from genkit._core._model import OutputConfig
 from genkit._core._schema import InvalidOutputSchemaError, to_json_schema
@@ -33,7 +25,7 @@ from genkit._core._typing import (
     ToolRequest,
     ToolRequestPart,
 )
-from genkit.model import get_basic_usage_stats, model_action_metadata
+from genkit.model import ModelRequest, get_basic_usage_stats, model_action_metadata
 
 
 class PluginConfig(BaseModel):

--- a/py/packages/genkit/tests/genkit/ai/prompt_test.py
+++ b/py/packages/genkit/tests/genkit/ai/prompt_test.py
@@ -26,7 +26,7 @@ from unittest.mock import ANY, MagicMock, patch
 import pytest
 from pydantic import BaseModel, Field
 
-from genkit import Genkit, Message, MiddlewareRef, ModelResponse
+from genkit import Genkit, Message, ModelResponse
 from genkit._ai._model import ModelRequest, text_from_message
 from genkit._ai._prompt import _parse_dotprompt_use, load_prompt_folder, lookup_prompt, prompt, resume_options_to_resume
 from genkit._ai._testing import (
@@ -39,7 +39,7 @@ from genkit._core._action import ActionKind
 from genkit._core._error import GenkitError
 from genkit._core._model import GenerateActionOptions, ModelConfig
 from genkit._core._typing import Part, Role, TextPart, ToolChoice, ToolRequest, ToolRequestPart
-from genkit.middleware import BaseMiddleware, GenerateMiddlewareContext, ModelHookParams
+from genkit.middleware import BaseMiddleware, GenerateMiddlewareContext, MiddlewareRef, ModelHookParams
 from genkit.plugin_api import MiddlewarePlugin, new_middleware
 
 

--- a/py/packages/genkit/tests/genkit/core/action_test.py
+++ b/py/packages/genkit/tests/genkit/core/action_test.py
@@ -11,7 +11,7 @@ from typing import Any, cast
 import pytest
 from pydantic import BaseModel, ConfigDict
 
-from genkit import Message, ModelRequest, Part, TextPart
+from genkit import Message, Part
 from genkit._core._action import (
     Action,
     ActionKind,
@@ -25,6 +25,7 @@ from genkit._core._action import (
 )
 from genkit._core._error import GenkitError
 from genkit._core._model import OutputConfig
+from genkit.model import ModelRequest, TextPart
 
 
 def test_action_enum_behaves_like_str() -> None:

--- a/py/packages/genkit/tests/genkit/core/error_test.py
+++ b/py/packages/genkit/tests/genkit/core/error_test.py
@@ -20,9 +20,9 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from genkit import ErrorResponseMetadata
 from genkit._core import _error as error_mod
 from genkit._core._error import (
+    ErrorResponseMetadata,
     GenkitError,
     PublicError,
     ReflectionError,

--- a/py/packages/genkit/tests/genkit/core/registry_test.py
+++ b/py/packages/genkit/tests/genkit/core/registry_test.py
@@ -11,12 +11,13 @@ functionality, ensuring proper registration and management of Genkit resources.
 
 import pytest
 
-from genkit import Genkit, Plugin
+from genkit import Genkit
 from genkit._core._action import Action, ActionKind, ActionRunContext, create_action_key
 from genkit._core._dap import DapValue, define_dynamic_action_provider
 from genkit._core._model import ModelRequest, ModelResponse
 from genkit._core._registry import Registry
 from genkit._core._typing import ActionMetadata, Operation
+from genkit.plugin_api import Plugin
 
 
 async def _identity(x: object) -> object:

--- a/py/packages/genkit/tests/genkit/core/run_in_new_span_test.py
+++ b/py/packages/genkit/tests/genkit/core/run_in_new_span_test.py
@@ -22,13 +22,14 @@ from opentelemetry.sdk.trace.export import SimpleSpanProcessor, SpanExportResult
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 from pydantic import BaseModel
 
-from genkit import ActionKind, Genkit
+from genkit import Genkit
 from genkit._ai._tools import Interrupt, ToolRunContext
 from genkit._core._action import Action
 from genkit._core._error import GenkitError
 from genkit._core._trace._attrs import metadata_key
 from genkit._core._trace._realtime_processor import RealtimeSpanProcessor
 from genkit._core._tracing import SpanMetadata, _parent_path_context, run_in_new_span, start_attributes
+from genkit.plugin_api import ActionKind
 
 
 @pytest.fixture(autouse=True)

--- a/py/packages/genkit/tests/genkit/testing_test.py
+++ b/py/packages/genkit/tests/genkit/testing_test.py
@@ -57,7 +57,7 @@ Test Coverage
 
 import pytest
 
-from genkit import ActionRunContext, Genkit, Message, ModelRequest, ModelResponse, ModelResponseChunk
+from genkit import ActionRunContext, Genkit, Message, ModelResponse, ModelResponseChunk
 from genkit._ai._testing import (
     EchoModel,
     GablorkenInput,
@@ -75,6 +75,7 @@ from genkit._core._typing import (
     Role,
     TextPart,
 )
+from genkit.model import ModelRequest
 from genkit.plugin_api import ModelConfig
 
 

--- a/py/packages/genkit/tests/genkit/veneer/veneer_test.py
+++ b/py/packages/genkit/tests/genkit/veneer/veneer_test.py
@@ -12,16 +12,7 @@ from typing import Any
 import pytest
 from pydantic import BaseModel, Field
 
-from genkit import (
-    Document,
-    Genkit,
-    Interrupt,
-    Message,
-    MiddlewareRef,
-    ModelResponse,
-    ModelResponseChunk,
-    respond_to_interrupt,
-)
+from genkit import Document, Genkit, Interrupt, Message, ModelResponse, ModelResponseChunk, respond_to_interrupt
 from genkit._ai._formats._types import FormatDef, Formatter, FormatterConfig
 from genkit._ai._model import text_from_message
 from genkit._ai._testing import (
@@ -54,7 +45,7 @@ from genkit._core._typing import (
     ToolResponse,
     ToolResponsePart,
 )
-from genkit.middleware import BaseMiddleware, GenerateMiddlewareContext, ModelHookParams
+from genkit.middleware import BaseMiddleware, GenerateMiddlewareContext, MiddlewareRef, ModelHookParams
 
 # type SetupFixture = tuple[Genkit, EchoModel, ProgrammableModel]
 SetupFixture = tuple[Genkit, EchoModel, ProgrammableModel]

--- a/py/samples/agents/basic/07_artifacts_custom_patch.py
+++ b/py/samples/agents/basic/07_artifacts_custom_patch.py
@@ -32,7 +32,7 @@ from __future__ import annotations
 from genkit_google_genai import GoogleAI
 from pydantic import BaseModel, Field
 
-from genkit import ActionRunContext, FinishReason, Genkit, Message, Part, TextPart
+from genkit import ActionRunContext, FinishReason, Genkit, Message, Part
 from genkit.agent import (
     AgentFinishReason,
     AgentInput,
@@ -44,6 +44,7 @@ from genkit.agent import (
     TurnContext,
     TurnResult,
 )
+from genkit.model import TextPart
 
 ai = Genkit(plugins=[GoogleAI()])
 store = InMemorySessionStore()

--- a/py/samples/agents/basic/08_graceful_failure.py
+++ b/py/samples/agents/basic/08_graceful_failure.py
@@ -28,7 +28,7 @@ from __future__ import annotations
 
 from genkit_google_genai import GoogleAI
 
-from genkit import ActionRunContext, Genkit, GenkitError, Message, Part, TextPart
+from genkit import ActionRunContext, Genkit, GenkitError, Message, Part
 from genkit.agent import (
     AgentError,
     AgentFinishReason,
@@ -39,6 +39,7 @@ from genkit.agent import (
     TurnContext,
     TurnResult,
 )
+from genkit.model import TextPart
 
 ai = Genkit(plugins=[GoogleAI()])
 store = InMemorySessionStore()

--- a/py/samples/agents/basic/14_abort_failure_store_drift.py
+++ b/py/samples/agents/basic/14_abort_failure_store_drift.py
@@ -52,7 +52,7 @@ from __future__ import annotations
 import asyncio
 from typing import Any
 
-from genkit import ActionRunContext, Genkit, GenkitError, Message, Part, TextPart
+from genkit import ActionRunContext, Genkit, GenkitError, Message, Part
 from genkit.agent import (
     AgentChat,
     AgentError,
@@ -65,6 +65,7 @@ from genkit.agent import (
     TurnContext,
     TurnResult,
 )
+from genkit.model import TextPart
 
 ai = Genkit()
 store = InMemorySessionStore()

--- a/py/samples/agents/basic/17_client_transform.py
+++ b/py/samples/agents/basic/17_client_transform.py
@@ -35,7 +35,7 @@ from __future__ import annotations
 
 from genkit_google_genai import GoogleAI
 
-from genkit import ActionRunContext, FinishReason, Genkit, Message, Part, TextPart
+from genkit import ActionRunContext, FinishReason, Genkit, Message, Part
 from genkit.agent import (
     AgentFinishReason,
     AgentInput,
@@ -47,6 +47,7 @@ from genkit.agent import (
     TurnContext,
     TurnResult,
 )
+from genkit.model import TextPart
 
 ai = Genkit(plugins=[GoogleAI()])
 

--- a/py/samples/agents/testapp/workspace_agent.py
+++ b/py/samples/agents/testapp/workspace_agent.py
@@ -31,8 +31,9 @@ from typing import Any
 from _ai import ai
 from pydantic import BaseModel
 
-from genkit import ActionRunContext, Part, TextPart
+from genkit import ActionRunContext, Part
 from genkit.agent import Artifact
+from genkit.model import TextPart
 
 
 class WriteArtifactInput(BaseModel):

--- a/py/samples/gemini-context-caching/src/main.py
+++ b/py/samples/gemini-context-caching/src/main.py
@@ -20,7 +20,8 @@ from pathlib import Path
 
 from genkit_google_genai import GoogleAI
 
-from genkit import Genkit, Message, Role, TextPart
+from genkit import Genkit, Message, Role
+from genkit.model import TextPart
 
 ai = Genkit(plugins=[GoogleAI()], model=GoogleAI.gemini_model('gemini-3-flash-preview'))
 

--- a/py/samples/middleware-coding-agent/src/main.py
+++ b/py/samples/middleware-coding-agent/src/main.py
@@ -21,7 +21,8 @@ from pathlib import Path
 from genkit_google_genai import GoogleAI
 from genkit_middleware import Filesystem, Middleware, Skills, ToolApproval
 
-from genkit import Genkit, Message, Part, Role, TextPart, restart_tool
+from genkit import Genkit, Message, Part, Role, restart_tool
+from genkit.model import TextPart
 
 here = Path(__file__).resolve().parent.parent
 workspace = here / 'workspace'

--- a/py/samples/middleware/src/main.py
+++ b/py/samples/middleware/src/main.py
@@ -22,8 +22,9 @@ from collections.abc import Awaitable, Callable
 from genkit_google_genai import GoogleAI
 from pydantic import BaseModel
 
-from genkit import Genkit, ModelResponse, Part, TextPart
+from genkit import Genkit, ModelResponse, Part
 from genkit.middleware import BaseMiddleware, GenerateMiddlewareContext, ModelHookParams
+from genkit.model import TextPart
 
 ai = Genkit(plugins=[GoogleAI()], model=GoogleAI.gemini_model('gemini-flash-latest'))
 


### PR DESCRIPTION
## Overview

Trims `genkit` top-level namespace exports from 53 symbols down to **26 canonical symbols** intended for day-to-day application development. 

Low-level plugin author primitives, wire types, and internal abstractions are relocated to dedicated submodules (`genkit.model`, `genkit.embedder`, `genkit.plugin_api`, `genkit.middleware`).

In addition, cleans up dynamic tool construction in `genkit-middleware` (`_skills.py`, `_filesystem.py`) to use the top-level `tool(...)` helper directly rather than internal scratch registries.

---

## Developer Experience & Snippet

### Application Developer (Clean, focused root namespace)
```python
import asyncio
from genkit import Genkit, Message, Role, tool
from genkit_google_genai import GoogleAI

# 1. Initialize Genkit instance
ai = Genkit(plugins=[GoogleAI()], model=GoogleAI.gemini_model('gemini-2.5-flash'))

# 2. Define tools and flows with core app primitives
@ai.tool(description='Get stock price')
def get_price(symbol: str) -> float:
    return 150.25

@ai.flow()
async def stock_advisor(ticker: str) -> str:
    res = await ai.generate(
        messages=[Message(role=Role.USER, content=f'Should I buy {ticker}?')],
        tools=[get_price],
    )
    return res.text

# 3. Execute
print(asyncio.run(stock_advisor('GOOG')))
# => Based on current market analysis...
```

### Plugin / Middleware Author (Dedicated namespaces)
```python
# Plugin authors import low-level wire formats & interfaces from dedicated submodules:
from genkit.model import (
    ModelRequest,
    ModelResponse,
    ModelInfo,
    Supports,
    Constrained,
    TextPart,
    MediaPart,
)
from genkit.embedder import EmbedRequest, EmbedResponse, EmbedderRef
from genkit.plugin_api import Plugin, ActionRunContext, get_cached_client
from genkit.middleware import BaseMiddleware, GenerateMiddlewareContext
```

---

## Changes

1. **`genkit/__init__.py.__all__`**:
   - Trims root exports down to 26 canonical symbols:
     - **Main**: `Genkit`, `Action`, `ActionRunContext`, `Flow`, `StreamResponse`
     - **Generation & Streaming**: `ModelResponse`, `ModelResponseChunk`, `ModelStreamResponse`, `ModelConfigDict`, `ModelUsage`, `FinishReason`, `ToolChoice`
     - **Content & Messaging**: `Message`, `Part`, `Role`, `Media`, `Document`
     - **Tools & HITL**: `Tool`, `ToolRunContext`, `Interrupt`, `ToolRequest`, `ToolResponse`, `ToolRequestPart`, `ToolResponsePart`, `respond_to_interrupt`, `restart_tool`, `tool`
     - **Embeddings & Prompts**: `Embedding`, `ExecutablePrompt`
     - **Errors**: `GenkitError`, `PublicError`
2. **Submodule Relocations**:
   - Model wire types & part subtypes relocated to `genkit.model`.
   - Embedder protocol types relocated to `genkit.embedder`.
   - Plugin registration & framework hooks relocated to `genkit.plugin_api`.
   - Middleware protocol types relocated to `genkit.middleware`.
3. **`genkit-middleware` Cleanup**:
   - Replaced scratch registry pattern in `_filesystem.py` and `_skills.py` with standalone `tool(...)` helper.
4. **Internal Imports Updated**:
   - Updated all plugin packages (`genkit-google-genai`, `genkit-anthropic`, `genkit-openai`, `genkit-amazon-bedrock`, `genkit-ollama`, `genkit-vertexai`, `genkit-fastapi`) and test suites to import from their respective submodule namespaces.

---

## Verification

- **pyright**: `uv run pyright packages/*/src` (0 errors)
- **ty**: `uv run ty check packages/` (All checks passed)
- **ruff**: `uv run ruff check --preview . && uv run ruff format .` (All checks passed)
- **pytest**: `uv run pytest` (1173 passed across all packages)
- **schema typing**: `./bin/generate_schema_typing --ci` (All checks passed)