### PR TITLE
fix(py): drop the unanswered max-turns tool call from generate() history

### DIFF
--- a/py/packages/genkit/src/genkit/_ai/_agents/_runtime.py
+++ b/py/packages/genkit/src/genkit/_ai/_agents/_runtime.py
@@ -1053,13 +1053,14 @@ async def generate_prompt_agent_turn(
         )
         return TurnResult(finish_reason=AgentFinishReason.INTERRUPTED)
 
-    if response.message:
-        await persist_turn_messages(
-            session_runner=session_runner,
-            history=history,
-            response_message=response.message,
-            response=response,
-        )
+    # Max-turns abort has no leftover message (the refused round was
+    # dropped) but request.messages still has the closed tool turns.
+    await persist_turn_messages(
+        session_runner=session_runner,
+        history=history,
+        response_message=response.message,
+        response=response,
+    )
 
     # Return the turn result wrapping the model finish reason
     finish_reason = to_agent_finish_reason(response.finish_reason) if response.finish_reason is not None else None

--- a/py/packages/genkit/src/genkit/_ai/_generate.py
+++ b/py/packages/genkit/src/genkit/_ai/_generate.py
@@ -1057,6 +1057,9 @@ async def _generate_action_turn(
             response.finish_reason = FinishReason.ABORTED
             response.finish_message = f'Exceeded maximum tool call iterations ({max_iters})'
             log_responded()
+            # This model call opened a tool round we will not run. Only
+            # closed rounds are history, so the unanswered request is dropped.
+            response.message = None
             return _persist_threaded_conversation(response, turn_options.messages)
 
         raise_if_aborted(ctx.abort_signal)

--- a/py/packages/genkit/tests/genkit/ai/generate_test.py
+++ b/py/packages/genkit/tests/genkit/ai/generate_test.py
@@ -35,6 +35,7 @@ from genkit._core._typing import (
     TextPart,
     ToolRequest,
     ToolRequestPart,
+    ToolResponsePart,
 )
 from genkit.middleware import (
     BaseMiddleware,
@@ -2486,6 +2487,108 @@ async def test_generate_returns_error_finish_when_output_does_not_match_schema()
     assert response.output is None
     assert response.finish_message is not None
     assert 'not valid JSON' in response.finish_message
+
+
+def _model_calls_tool(*, name: str, ref: str) -> ModelResponse:
+    return ModelResponse(
+        finish_reason=FinishReason.STOP,
+        message=Message(
+            role=Role.MODEL,
+            content=[Part(root=ToolRequestPart(tool_request=ToolRequest(name=name, input={}, ref=ref)))],
+        ),
+    )
+
+
+def _tool_output(message: Message) -> object:
+    part = message.content[0].root
+    assert isinstance(part, ToolResponsePart)
+    assert part.tool_response is not None
+    return part.tool_response.output
+
+
+@pytest.mark.asyncio
+async def test_leftover_after_tool_turn_keeps_intermediate_messages() -> None:
+    """A leftover after a tool turn still has that tool request and reply on .messages."""
+    ai = Genkit(model='programmableModel')
+    pm, _ = define_programmable_model(ai)
+
+    class Recipe(BaseModel):
+        title: str
+
+    @ai.tool(name='lookup')
+    async def lookup() -> str:
+        return '72F'
+
+    pm.responses = [
+        _model_calls_tool(name='lookup', ref='r1'),
+        ModelResponse(
+            finish_reason=FinishReason.STOP,
+            message=Message(role=Role.MODEL, content=[Part(root=TextPart(text='not json'))]),
+        ),
+    ]
+
+    response = await ai.generate(
+        prompt='give me a recipe',
+        output_schema=Recipe,
+        output_instructions=False,
+        tools=['lookup'],
+    )
+    assert response.finish_reason == FinishReason.FAILED
+    assert response.text == 'not json'
+    assert response.output is None
+    assert [m.role for m in response.messages] == [Role.USER, Role.MODEL, Role.TOOL, Role.MODEL]
+    assert response.messages[1].tool_requests[0].tool_request.name == 'lookup'
+    assert _tool_output(response.messages[2]) == '72F'
+    assert response.messages[3].text == 'not json'
+
+
+@pytest.mark.asyncio
+async def test_max_turns_after_tool_turn_keeps_intermediate_messages() -> None:
+    """Hitting max tool turns keeps closed rounds and drops the unanswered leftover call."""
+    ai = Genkit(model='programmableModel')
+    pm, _ = define_programmable_model(ai)
+
+    @ai.tool(name='lookup')
+    async def lookup() -> str:
+        return '72F'
+
+    pm.responses = [
+        _model_calls_tool(name='lookup', ref='r1'),
+        _model_calls_tool(name='lookup', ref='r2'),
+    ]
+
+    response = await ai.generate(prompt='keep going', tools=['lookup'], max_turns=1)
+    assert response.finish_reason == FinishReason.ABORTED
+    assert response.finish_message is not None
+    assert 'maximum tool call iterations' in response.finish_message
+    assert response.message is None
+    assert [m.role for m in response.messages] == [Role.USER, Role.MODEL, Role.TOOL]
+    assert response.messages[1].tool_requests[0].tool_request.name == 'lookup'
+    assert _tool_output(response.messages[2]) == '72F'
+
+
+@pytest.mark.asyncio
+async def test_unknown_tool_after_tool_turn_keeps_intermediate_messages() -> None:
+    """An unknown tool name after a successful turn still keeps the earlier tool request and reply."""
+    ai = Genkit(model='programmableModel')
+    pm, _ = define_programmable_model(ai)
+
+    @ai.tool(name='lookup')
+    async def lookup() -> str:
+        return '72F'
+
+    pm.responses = [
+        _model_calls_tool(name='lookup', ref='r1'),
+        _model_calls_tool(name='ghost', ref='r2'),
+    ]
+
+    response = await ai.generate(prompt='keep going', tools=['lookup'])
+    assert response.finish_reason == FinishReason.FAILED
+    assert response.finish_message == 'Tool ghost not found'
+    assert [m.role for m in response.messages] == [Role.USER, Role.MODEL, Role.TOOL, Role.MODEL]
+    assert response.messages[1].tool_requests[0].tool_request.name == 'lookup'
+    assert _tool_output(response.messages[2]) == '72F'
+    assert response.messages[3].tool_requests[0].tool_request.name == 'ghost'
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
After a leftover, completed tool turns stay on `response.messages`. Hitting `maxTurns` is aborted, not failed: the model call that opened a tool round we refuse to run is not history. Closed rounds stay; `message` is None.

A schema leftover still keeps the leftover text (and the closed tool round before it):

```python
response = await ai.generate(
    prompt='give me a recipe',
    output_schema=Recipe,
    tools=['lookup'],
)
# finish_reason == FAILED
# response.text == 'not json'
# messages: user / lookup / 72F / 'not json'
```

`maxTurns=1` after one closed lookup keeps only that closed round — the unanswered second call is dropped:

```python
response = await ai.generate(prompt='keep going', tools=['lookup'], max_turns=1)
# finish_reason == ABORTED
# response.message is None
# messages: user / lookup / 72F
```

### Decisions

- Match the closed-round rule for max-turns abort. A tool request we will not run is not history, so `generate()` clears `response.message` before returning. Closed rounds stay on `response.messages`.
- Schema leftover and unknown-tool keep their leftover reply. Those paths actually produced a model message the caller can read (`'not json'`, or the unknown `ghost` request), so that message stays on history.
- Agent persist now writes `request.messages` even when `message` is None so a max-turns abort does not lose the closed turns.