### PR TITLE
fix(py/plugins/openai): handle completions with no choices

### DIFF
--- a/py/packages/genkit-openai/src/genkit_openai/models/model.py
+++ b/py/packages/genkit-openai/src/genkit_openai/models/model.py
@@ -399,14 +399,18 @@ class OpenAIModel:
         openai_config.pop('stream_options', None)
         logger.debug('OpenAI generate request', model=self._model, streaming=False)
         response = await self._openai_client.chat.completions.create(**openai_config)
+        if not response.choices:
+            raise GenkitError(
+                status='INTERNAL',
+                message='No choices in completion.',
+                details={'usage': _usage_from_completion(response.usage).model_dump(exclude_none=True)},
+            )
+
         logger.debug(
             'OpenAI raw API response',
             model=self._model,
-            finish_reason=str(response.choices[0].finish_reason) if response.choices else None,
+            finish_reason=str(response.choices[0].finish_reason),
         )
-
-        if not response.choices:
-            raise GenkitError(status='INTERNAL', message='No choices in completion.')
 
         result = ModelResponse(
             request=request,
@@ -494,7 +498,11 @@ class OpenAIModel:
                 callback(ModelResponseChunk(role=Role.MODEL, content=content))
 
         if not saw_choice:
-            raise GenkitError(status='INTERNAL', message='No choices in completion.')
+            raise GenkitError(
+                status='INTERNAL',
+                message='No choices in completion.',
+                details={'usage': _usage_from_completion(usage).model_dump(exclude_none=True)},
+            )
 
         if tool_calls:
             message = MessageConverter.to_genkit(

--- a/py/packages/genkit-openai/src/genkit_openai/models/model.py
+++ b/py/packages/genkit-openai/src/genkit_openai/models/model.py
@@ -27,6 +27,7 @@ from openai.types import CompletionUsage
 from openai.types.completion_usage import CompletionTokensDetails, PromptTokensDetails
 
 from genkit import (
+    GenkitError,
     Message,
     ModelRequest,
     ModelResponse,
@@ -404,6 +405,9 @@ class OpenAIModel:
             finish_reason=str(response.choices[0].finish_reason) if response.choices else None,
         )
 
+        if not response.choices:
+            raise GenkitError(status='INTERNAL', message='No choices in completion.')
+
         result = ModelResponse(
             request=request,
             message=MessageConverter.to_genkit(MessageAdapter(response.choices[0].message)),
@@ -435,6 +439,7 @@ class OpenAIModel:
         tool_calls: dict[int, Any] = {}
         accumulated_content: list[Part] = []
         usage: CompletionUsage | None = None
+        saw_choice = False
         async for chunk in stream:  # type: ignore
             # Usage rides on a final chunk that carries no choices.
             if chunk.usage is not None:
@@ -442,6 +447,7 @@ class OpenAIModel:
             if not chunk.choices:
                 continue
 
+            saw_choice = True
             delta = chunk.choices[0].delta
 
             # Text content chunk
@@ -486,6 +492,9 @@ class OpenAIModel:
                     for tool_call in delta.tool_calls
                 ]
                 callback(ModelResponseChunk(role=Role.MODEL, content=content))
+
+        if not saw_choice:
+            raise GenkitError(status='INTERNAL', message='No choices in completion.')
 
         if tool_calls:
             message = MessageConverter.to_genkit(

--- a/py/packages/genkit-openai/tests/openai_model_test.py
+++ b/py/packages/genkit-openai/tests/openai_model_test.py
@@ -171,6 +171,24 @@ async def test__generate(sample_request: ModelRequest) -> None:
 
 
 @pytest.mark.asyncio
+async def test__generate_no_choices(sample_request: ModelRequest) -> None:
+    """A completion carrying no choices fails with a status the caller can handle."""
+    mock_response = MagicMock()
+    mock_response.choices = []
+
+    mock_client = MagicMock()
+    mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
+
+    model = OpenAIModel(model='gpt-4', client=mock_client)
+
+    with pytest.raises(GenkitError) as exc_info:
+        await model._generate(sample_request)
+
+    assert exc_info.value.status == 'INTERNAL'
+    assert 'No choices in completion.' in str(exc_info.value)
+
+
+@pytest.mark.asyncio
 async def test__generate_stream(sample_request: ModelRequest) -> None:
     """Test generate_stream method ensures it processes streamed responses correctly."""
     mock_client = MagicMock()
@@ -257,6 +275,34 @@ def _usage_chunk() -> ChatCompletionChunk:
         'model': 'gpt-4',
         'choices': [],
         'usage': _USAGE_PAYLOAD,
+    })
+
+
+def _tool_call_chunk(call_id: str, name: str, args_segment: str) -> ChatCompletionChunk:
+    """A chunk whose single choice carries a tool call delta."""
+    return ChatCompletionChunk.model_validate({
+        'id': '1',
+        'object': 'chat.completion.chunk',
+        'created': 1,
+        'model': 'gpt-4',
+        'choices': [
+            {
+                'index': 0,
+                'delta': {
+                    'role': 'assistant',
+                    'tool_calls': [
+                        {
+                            'index': 0,
+                            'id': call_id,
+                            'type': 'function',
+                            'function': {'name': name, 'arguments': args_segment},
+                        }
+                    ],
+                },
+                'finish_reason': None,
+            }
+        ],
+        'usage': None,
     })
 
 
@@ -407,6 +453,54 @@ async def test__generate_stream_reports_usage(sample_request: ModelRequest) -> N
 
     assert collected_chunks == ['Hello']
     _assert_usage_payload_reported(response.usage)
+
+
+@pytest.mark.asyncio
+async def test__generate_stream_no_choices(sample_request: ModelRequest) -> None:
+    """A stream carrying only the usage chunk fails rather than returning an empty response."""
+    mock_client = MagicMock()
+    mock_client.chat.completions.create = _mock_stream([_usage_chunk()])
+
+    model = OpenAIModel(model='gpt-4', client=mock_client)
+
+    with pytest.raises(GenkitError) as exc_info:
+        await model._generate_stream(sample_request, lambda _: None)
+
+    assert exc_info.value.status == 'INTERNAL'
+    assert 'No choices in completion.' in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test__generate_stream_tool_calls_only(sample_request: ModelRequest) -> None:
+    """A stream carrying only tool calls accumulates no text but still succeeds."""
+    mock_client = MagicMock()
+    mock_client.chat.completions.create = _mock_stream([
+        _tool_call_chunk('tool123', 'tool_fn', '{"a": '),
+        _tool_call_chunk('tool123', 'tool_fn', '1}'),
+        _usage_chunk(),
+    ])
+
+    model = OpenAIModel(model='gpt-4', client=mock_client)
+    response = await model._generate_stream(sample_request, lambda _: None)
+
+    assert response.message is not None
+    assert response.text == ''
+    tool_requests = [p.root.tool_request for p in response.message.content if p.root.tool_request]
+    assert len(tool_requests) == 1
+    assert tool_requests[0].name == 'tool_fn'
+
+
+@pytest.mark.asyncio
+async def test__generate_stream_empty_deltas(sample_request: ModelRequest) -> None:
+    """A stream that carries choices but no content succeeds with an empty message."""
+    mock_client = MagicMock()
+    mock_client.chat.completions.create = _mock_stream([_text_chunk(''), _text_chunk('')])
+
+    model = OpenAIModel(model='gpt-4', client=mock_client)
+    response = await model._generate_stream(sample_request, lambda _: None)
+
+    assert response.message is not None
+    assert response.text == ''
 
 
 @pytest.mark.parametrize(

--- a/py/packages/genkit-openai/tests/openai_model_test.py
+++ b/py/packages/genkit-openai/tests/openai_model_test.py
@@ -175,6 +175,11 @@ async def test__generate_no_choices(sample_request: ModelRequest) -> None:
     """A completion carrying no choices fails with a status the caller can handle."""
     mock_response = MagicMock()
     mock_response.choices = []
+    mock_response.usage = CompletionUsage.model_validate({
+        'prompt_tokens': 10,
+        'completion_tokens': 0,
+        'total_tokens': 10,
+    })
 
     mock_client = MagicMock()
     mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
@@ -186,6 +191,7 @@ async def test__generate_no_choices(sample_request: ModelRequest) -> None:
 
     assert exc_info.value.status == 'INTERNAL'
     assert 'No choices in completion.' in str(exc_info.value)
+    assert exc_info.value.details['usage'] == {'inputTokens': 10, 'outputTokens': 0, 'totalTokens': 10}
 
 
 @pytest.mark.asyncio
@@ -468,6 +474,7 @@ async def test__generate_stream_no_choices(sample_request: ModelRequest) -> None
 
     assert exc_info.value.status == 'INTERNAL'
     assert 'No choices in completion.' in str(exc_info.value)
+    assert exc_info.value.details['usage']['totalTokens'] == 17
 
 
 @pytest.mark.asyncio
@@ -551,6 +558,26 @@ async def test_generate_classifies_bad_config_type() -> None:
     with pytest.raises(GenkitError) as raised:
         await model.generate(request, ctx_mock)
     assert raised.value.status == 'INVALID_ARGUMENT'
+
+
+@pytest.mark.asyncio
+async def test_generate_no_choices_reaches_the_caller(sample_request: ModelRequest) -> None:
+    """generate()'s error handling lets the no-choices error through unchanged."""
+    ctx_mock = MagicMock(spec=ActionRunContext)
+    type(ctx_mock).is_streaming = PropertyMock(return_value=False)
+
+    mock_response = MagicMock()
+    mock_response.choices = []
+    mock_response.usage = None
+
+    mock_client = MagicMock()
+    mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
+
+    model = OpenAIModel(model='gpt-4', client=mock_client)
+
+    with pytest.raises(GenkitError) as raised:
+        await model.generate(sample_request, ctx_mock)
+    assert raised.value.status == 'INTERNAL'
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes #6232

## Summary

A completion with no choices now raises `GenkitError(status='INTERNAL')` from the plugin instead of IndexError. INTERNAL matches Go's `ErrInvalidOutput`.

The streaming path gets the same treatment: a stream in which no chunk carried a choice raises the same error instead of returning an empty message. The check keys off whether a choice was seen, not off accumulated content: a tool-call-only stream and OpenAI's usual empty first and last deltas carry choices but no content, and must still succeed.

## Verification

| case | before | after |
| --- | --- | --- |
| non-streaming, `choices: []` | IndexError | GenkitError, INTERNAL |
| stream where no chunk carries a choice | empty message | GenkitError, INTERNAL |
| tool-call-only stream | ok | ok |
| stream of empty deltas | ok | ok |