### PR TITLE
fix(py/plugins/openai): report finish reason, finish message, and refusals

### DIFF
--- a/py/packages/genkit-openai/src/genkit_openai/models/model.py
+++ b/py/packages/genkit-openai/src/genkit_openai/models/model.py
@@ -27,6 +27,7 @@ from openai.types import CompletionUsage
 from openai.types.completion_usage import CompletionTokensDetails, PromptTokensDetails
 
 from genkit import (
+    FinishReason,
     GenkitError,
     Message,
     ModelRequest,
@@ -146,6 +147,69 @@ def _usage_from_completion(usage: CompletionUsage | None) -> ModelUsage:
         ),
         custom=custom or None,
     )
+
+
+def _failure_message(extras: dict[str, Any] | None) -> str | None:
+    """The message of an error object a provider attached to a choice.
+
+    A gateway whose upstream fails part-way through a generation answers with
+    a 200 — status and headers are already committed — and reports the failure
+    as an ``error`` object on the choice, beside whatever text was produced
+    before it.
+
+    Args:
+        extras: The fields a choice carried that are not in OpenAI's schema.
+
+    Returns:
+        The failure message, or None when the choice carries no error object.
+    """
+    failure = extras.get('error') if extras else None
+    if not isinstance(failure, dict):
+        return None
+    message = failure.get('message')
+    return message if isinstance(message, str) and message else None
+
+
+_FINISH_REASONS: dict[str, FinishReason] = {
+    'content_filter': FinishReason.BLOCKED,
+    'end_turn': FinishReason.STOP,
+    'error': FinishReason.OTHER,
+    'function_call': FinishReason.OTHER,
+    'insufficient_system_resource': FinishReason.OTHER,
+    'length': FinishReason.LENGTH,
+    'model_context_window_exceeded': FinishReason.LENGTH,
+    'network_error': FinishReason.OTHER,
+    'sensitive': FinishReason.BLOCKED,
+    'stop': FinishReason.STOP,
+    'tool_calls': FinishReason.STOP,
+}
+
+
+def _finish_state(
+    reason: str | None, *, refusal: str | None, failure_message: str | None
+) -> tuple[FinishReason, str | None]:
+    """The finish reason and finish message to report for a choice.
+
+    A refusal is the more specific answer and wins over a failure message: the
+    model replied, having declined. A choice that stopped cleanly reports no
+    finish message even when an error-shaped extra rides beside it.
+
+    Args:
+        reason: The ``finish_reason`` the provider sent, or None when it sent
+            none.
+        refusal: The refusal the model replied with, or None.
+        failure_message: The message of an error object on the choice, or None.
+
+    Returns:
+        The mapped finish reason, UNKNOWN when the reason is unrecognized or
+        absent, and the finish message, None when there is none to report.
+    """
+    if refusal:
+        return FinishReason.BLOCKED, refusal
+    finish_reason = _FINISH_REASONS.get(reason or '', FinishReason.UNKNOWN)
+    if finish_reason is FinishReason.STOP:
+        return finish_reason, None
+    return finish_reason, failure_message
 
 
 class OpenAIModel:
@@ -412,9 +476,24 @@ class OpenAIModel:
             finish_reason=str(response.choices[0].finish_reason),
         )
 
+        choice = response.choices[0]
+        message = MessageAdapter(choice.message)
+        finish_reason, finish_message = _finish_state(
+            choice.finish_reason,
+            refusal=message.refusal,
+            failure_message=_failure_message(choice.model_extra),
+        )
+
+        genkit_message = MessageConverter.to_genkit(message)
+        # An empty message is the answer when the model was blocked or cut off; at a clean stop it is unreadable.
+        if not genkit_message.content and finish_reason is FinishReason.STOP:
+            raise ValueError('Unable to determine content part')
+
         result = ModelResponse(
             request=request,
-            message=MessageConverter.to_genkit(MessageAdapter(response.choices[0].message)),
+            message=genkit_message,
+            finish_reason=finish_reason,
+            finish_message=finish_message,
             usage=_usage_from_completion(response.usage),
         )
         return self._clean_json_response(result, request)
@@ -444,6 +523,9 @@ class OpenAIModel:
         accumulated_content: list[Part] = []
         usage: CompletionUsage | None = None
         saw_choice = False
+        raw_finish_reason: str | None = None
+        refusal_fragments: list[str] = []
+        failure_message: str | None = None
         async for chunk in stream:  # type: ignore
             # Usage rides on a final chunk that carries no choices.
             if chunk.usage is not None:
@@ -452,7 +534,18 @@ class OpenAIModel:
                 continue
 
             saw_choice = True
-            delta = chunk.choices[0].delta
+            choice = chunk.choices[0]
+            # The reason rides on the last chunk and is null on the rest.
+            if choice.finish_reason:
+                raw_finish_reason = choice.finish_reason
+            if failure := _failure_message(choice.model_extra):
+                failure_message = failure
+
+            delta = choice.delta
+
+            # A refusal streams in fragments and is reported as the finish message, not content.
+            if delta.refusal:
+                refusal_fragments.append(delta.refusal)
 
             # Text content chunk
             if delta.content:
@@ -510,9 +603,17 @@ class OpenAIModel:
             )
             accumulated_content.extend(message.content)
 
+        finish_reason, finish_message = _finish_state(
+            raw_finish_reason,
+            refusal=''.join(refusal_fragments),
+            failure_message=failure_message,
+        )
+
         result = ModelResponse(
             request=request,
             message=Message(role=Role.MODEL, content=accumulated_content),
+            finish_reason=finish_reason,
+            finish_message=finish_message,
             usage=_usage_from_completion(usage),
         )
         return self._clean_json_response(result, request)

--- a/py/packages/genkit-openai/src/genkit_openai/models/utils.py
+++ b/py/packages/genkit-openai/src/genkit_openai/models/utils.py
@@ -344,6 +344,18 @@ class MessageAdapter:
         except AttributeError:
             return None
 
+    @property
+    def refusal(self) -> str | None:
+        """The 'refusal' attribute of the message if available.
+
+        A model that declines to answer sends the reason it declined here
+        rather than as content.
+
+        Returns:
+            The refusal string or None.
+        """
+        return getattr(self._data, 'refusal', None)
+
 
 ChatCompletionMessageAdapter = DictMessageAdapter | MessageAdapter
 
@@ -461,11 +473,8 @@ class MessageConverter:
             message: A ChatCompletionMessageAdapter instance.
 
         Returns:
-            A Genkit `Message` object.
-
-        Raises:
-            ValueError: If neither content, tool_calls, nor reasoning_content
-                are present in the message.
+            A Genkit `Message` object, with empty content when the message
+            carries no content, tool calls, or reasoning.
         """
         content: list[Part] = []
 
@@ -479,9 +488,6 @@ class MessageConverter:
 
             if message.content:
                 content.append(cls.text_part_to_genkit(message.content))
-
-        if not content:
-            raise ValueError('Unable to determine content part')
 
         role = message.role or Role.MODEL
         return Message(role=cls._genkit_role_map.get(role, role), content=content)

--- a/py/packages/genkit-openai/tests/openai_model_test.py
+++ b/py/packages/genkit-openai/tests/openai_model_test.py
@@ -27,10 +27,11 @@ from genkit_openai.models.model import _usage_from_completion
 from genkit_openai.models.utils import strip_markdown_fences
 from genkit_openai.typing import OpenAIConfig
 from openai.types import CompletionUsage
-from openai.types.chat import ChatCompletionChunk
+from openai.types.chat import ChatCompletion, ChatCompletionChunk
 from pydantic import BaseModel
 
 from genkit import (
+    FinishReason,
     GenkitError,
     Message,
     ModelRequest,
@@ -152,6 +153,7 @@ async def test__generate(sample_request: ModelRequest) -> None:
     mock_message.role = 'model'
     mock_message.tool_calls = None
     mock_message.reasoning_content = None
+    mock_message.refusal = None
 
     mock_response = MagicMock()
     mock_response.choices = [MagicMock(message=mock_message)]
@@ -219,6 +221,7 @@ async def test__generate_stream(sample_request: ModelRequest) -> None:
             delta_mock.role = None
             delta_mock.tool_calls = None
             delta_mock.reasoning_content = None
+            delta_mock.refusal = None
 
             choice_mock = MagicMock()
             choice_mock.delta = delta_mock
@@ -260,16 +263,66 @@ def _assert_usage_payload_reported(usage: Any) -> None:  # noqa: ANN401
     assert usage.custom == {'cost': 0.00042}
 
 
-def _text_chunk(text: str) -> ChatCompletionChunk:
-    """A content chunk with no usage, as the API sends mid-stream."""
-    return ChatCompletionChunk.model_validate({
-        'id': '1',
-        'object': 'chat.completion.chunk',
-        'created': 1,
-        'model': 'gpt-4',
-        'choices': [{'index': 0, 'delta': {'role': 'assistant', 'content': text}, 'finish_reason': None}],
-        'usage': None,
-    })
+def _chunk(
+    *,
+    content: str | None = None,
+    refusal: str | None = None,
+    finish_reason: str | None = None,
+    error: object | None = None,
+) -> ChatCompletionChunk:
+    """A one-choice chunk with no usage, as the API sends mid-stream.
+
+    Built with ``construct``, which is how the SDK reads a response off the
+    wire: a finish reason outside OpenAI's own five and an error object beside
+    the choice both survive it, where validation would reject them.
+    """
+    choice: dict[str, Any] = {
+        'index': 0,
+        'delta': {'role': 'assistant', 'content': content, 'refusal': refusal},
+        'finish_reason': finish_reason,
+    }
+    if error is not None:
+        choice['error'] = error
+    return ChatCompletionChunk.construct(
+        id='1',
+        object='chat.completion.chunk',
+        created=1,
+        model='gpt-4',
+        choices=[choice],
+        usage=None,
+    )
+
+
+def _completion(
+    *,
+    content: str | None = 'Hello, user!',
+    refusal: str | None = None,
+    finish_reason: str | None = 'stop',
+    error: object | None = None,
+) -> ChatCompletion:
+    """A one-choice completion, built the same way as :func:`_chunk`."""
+    choice: dict[str, Any] = {
+        'index': 0,
+        'message': {'role': 'assistant', 'content': content, 'refusal': refusal},
+        'finish_reason': finish_reason,
+    }
+    if error is not None:
+        choice['error'] = error
+    return ChatCompletion.construct(
+        id='1',
+        object='chat.completion',
+        created=1,
+        model='gpt-4',
+        choices=[choice],
+        usage=None,
+    )
+
+
+def _mock_completion(completion: ChatCompletion) -> MagicMock:
+    """A client whose create() answers with one completion."""
+    client = MagicMock()
+    client.chat.completions.create = AsyncMock(return_value=completion)
+    return client
 
 
 def _usage_chunk() -> ChatCompletionChunk:
@@ -330,6 +383,7 @@ async def test__generate_reports_usage(sample_request: ModelRequest) -> None:
     mock_message.role = 'model'
     mock_message.tool_calls = None
     mock_message.reasoning_content = None
+    mock_message.refusal = None
 
     mock_response = MagicMock()
     mock_response.choices = [MagicMock(message=mock_message)]
@@ -355,6 +409,7 @@ async def test__generate_reports_extra_token_counts() -> None:
     mock_message.role = 'model'
     mock_message.tool_calls = None
     mock_message.reasoning_content = None
+    mock_message.refusal = None
 
     mock_response = MagicMock()
     mock_response.choices = [MagicMock(message=mock_message)]
@@ -430,7 +485,7 @@ async def test__generate_stream_requests_usage(sample_request: ModelRequest) -> 
     sample_request.config = config
 
     mock_client = MagicMock()
-    mock_client.chat.completions.create = _mock_stream([_text_chunk('Hello')])
+    mock_client.chat.completions.create = _mock_stream([_chunk(content='Hello')])
 
     model = OpenAIModel(model='gpt-4', client=mock_client)
     await model._generate_stream(sample_request, lambda chunk: None)
@@ -447,7 +502,7 @@ async def test__generate_stream_requests_usage(sample_request: ModelRequest) -> 
 async def test__generate_stream_reports_usage(sample_request: ModelRequest) -> None:
     """The choice-less usage chunk is read, not indexed into."""
     mock_client = MagicMock()
-    mock_client.chat.completions.create = _mock_stream([_text_chunk('Hello'), _usage_chunk()])
+    mock_client.chat.completions.create = _mock_stream([_chunk(content='Hello'), _usage_chunk()])
 
     model = OpenAIModel(model='gpt-4', client=mock_client)
     collected_chunks = []
@@ -501,13 +556,280 @@ async def test__generate_stream_tool_calls_only(sample_request: ModelRequest) ->
 async def test__generate_stream_empty_deltas(sample_request: ModelRequest) -> None:
     """A stream that carries choices but no content succeeds with an empty message."""
     mock_client = MagicMock()
-    mock_client.chat.completions.create = _mock_stream([_text_chunk(''), _text_chunk('')])
+    mock_client.chat.completions.create = _mock_stream([_chunk(content=''), _chunk(content='')])
 
     model = OpenAIModel(model='gpt-4', client=mock_client)
     response = await model._generate_stream(sample_request, lambda _: None)
 
     assert response.message is not None
     assert response.text == ''
+
+
+_FINISH_REASONS: list[tuple[str | None, FinishReason]] = [
+    ('stop', FinishReason.STOP),
+    ('tool_calls', FinishReason.STOP),
+    ('end_turn', FinishReason.STOP),
+    ('length', FinishReason.LENGTH),
+    ('model_context_window_exceeded', FinishReason.LENGTH),
+    ('content_filter', FinishReason.BLOCKED),
+    ('sensitive', FinishReason.BLOCKED),
+    ('error', FinishReason.OTHER),
+    ('function_call', FinishReason.OTHER),
+    ('network_error', FinishReason.OTHER),
+    ('insufficient_system_resource', FinishReason.OTHER),
+    ('a_reason_no_provider_has_sent_yet', FinishReason.UNKNOWN),
+    (None, FinishReason.UNKNOWN),
+]
+
+
+@pytest.mark.parametrize(('reason', 'expected'), _FINISH_REASONS)
+@pytest.mark.asyncio
+async def test__generate_maps_finish_reason(
+    reason: str | None, expected: FinishReason, sample_request: ModelRequest
+) -> None:
+    """Every reason a compatible provider ends a generation with is reported."""
+    model = OpenAIModel(model='gpt-4', client=_mock_completion(_completion(finish_reason=reason)))
+
+    response = await model._generate(sample_request)
+
+    assert response.finish_reason == expected
+    assert response.finish_message is None
+
+
+@pytest.mark.parametrize(('reason', 'expected'), _FINISH_REASONS)
+@pytest.mark.asyncio
+async def test__generate_stream_maps_finish_reason(
+    reason: str | None, expected: FinishReason, sample_request: ModelRequest
+) -> None:
+    """The reason on a stream's last chunk reaches the response."""
+    mock_client = MagicMock()
+    mock_client.chat.completions.create = _mock_stream([_chunk(content='Hello'), _chunk(finish_reason=reason)])
+
+    model = OpenAIModel(model='gpt-4', client=mock_client)
+    response = await model._generate_stream(sample_request, lambda chunk: None)
+
+    assert response.finish_reason == expected
+    assert response.finish_message is None
+
+
+@pytest.mark.parametrize(
+    ('reason', 'expected'),
+    [('content_filter', FinishReason.BLOCKED), ('length', FinishReason.LENGTH)],
+)
+@pytest.mark.asyncio
+async def test__generate_empty_message_keeps_the_finish_reason(
+    reason: str, expected: FinishReason, sample_request: ModelRequest
+) -> None:
+    """A message with no content is the answer when the model was blocked or cut off."""
+    model = OpenAIModel(model='gpt-4', client=_mock_completion(_completion(content=None, finish_reason=reason)))
+
+    response = await model._generate(sample_request)
+
+    assert response.finish_reason == expected
+    assert response.finish_message is None
+    assert response.message is not None
+    assert response.message.content == []
+
+
+@pytest.mark.asyncio
+async def test__generate_refusal_only_is_blocked(sample_request: ModelRequest) -> None:
+    """A message carrying only a refusal is a blocked response, not a failure."""
+    model = OpenAIModel(
+        model='gpt-4',
+        client=_mock_completion(_completion(content=None, refusal='I cannot help with that.')),
+    )
+
+    response = await model._generate(sample_request)
+
+    assert response.finish_reason == FinishReason.BLOCKED
+    assert response.finish_message == 'I cannot help with that.'
+    assert response.message is not None
+    assert response.message.content == []
+
+
+@pytest.mark.asyncio
+async def test__generate_refusal_wins_over_a_clean_stop(sample_request: ModelRequest) -> None:
+    """A refusal beside content blocks the response and keeps the content."""
+    model = OpenAIModel(
+        model='gpt-4',
+        client=_mock_completion(_completion(content='Some of it.', refusal='Not the rest.')),
+    )
+
+    response = await model._generate(sample_request)
+
+    assert response.finish_reason == FinishReason.BLOCKED
+    assert response.finish_message == 'Not the rest.'
+    assert response.message is not None
+    assert response.message.content[0].root.text == 'Some of it.'
+
+
+@pytest.mark.asyncio
+async def test__generate_refusal_wins_over_a_failure_message(sample_request: ModelRequest) -> None:
+    """A refusal beside a gateway's error object is the finish message."""
+    model = OpenAIModel(
+        model='gpt-4',
+        client=_mock_completion(
+            _completion(
+                content=None,
+                refusal='I cannot help with that.',
+                finish_reason='error',
+                error={'message': 'upstream timed out', 'code': 504},
+            )
+        ),
+    )
+
+    response = await model._generate(sample_request)
+
+    assert response.finish_reason == FinishReason.BLOCKED
+    assert response.finish_message == 'I cannot help with that.'
+
+
+@pytest.mark.asyncio
+async def test__generate_reports_the_failure_message_on_a_choice(sample_request: ModelRequest) -> None:
+    """The message of an error object on a failing choice is the finish message."""
+    model = OpenAIModel(
+        model='gpt-4',
+        client=_mock_completion(
+            _completion(
+                content='Partial ',
+                finish_reason='error',
+                error={'message': 'upstream timed out', 'code': 504},
+            )
+        ),
+    )
+
+    response = await model._generate(sample_request)
+
+    assert response.finish_reason == FinishReason.OTHER
+    assert response.finish_message == 'upstream timed out'
+
+
+@pytest.mark.asyncio
+async def test__generate_clean_stop_reports_no_failure_message(sample_request: ModelRequest) -> None:
+    """A choice that stopped cleanly reports no finish message."""
+    model = OpenAIModel(
+        model='gpt-4',
+        client=_mock_completion(_completion(error={'message': 'not this generation'})),
+    )
+
+    response = await model._generate(sample_request)
+
+    assert response.finish_reason == FinishReason.STOP
+    assert response.finish_message is None
+
+
+@pytest.mark.asyncio
+async def test__generate_ignores_an_error_field_that_is_not_an_object(sample_request: ModelRequest) -> None:
+    """An error field that is not an object leaves the finish message unset."""
+    model = OpenAIModel(
+        model='gpt-4',
+        client=_mock_completion(_completion(finish_reason='error', error='upstream timed out')),
+    )
+
+    response = await model._generate(sample_request)
+
+    assert response.finish_reason == FinishReason.OTHER
+    assert response.finish_message is None
+
+
+@pytest.mark.asyncio
+async def test__generate_stream_refusal_is_blocked(sample_request: ModelRequest) -> None:
+    """A streamed refusal blocks the response and is not sent as content."""
+    mock_client = MagicMock()
+    mock_client.chat.completions.create = _mock_stream([
+        _chunk(refusal='I cannot '),
+        _chunk(refusal='help with that.'),
+        _chunk(finish_reason='stop'),
+    ])
+
+    model = OpenAIModel(model='gpt-4', client=mock_client)
+    collected_chunks: list[ModelResponseChunk] = []
+
+    response = await model._generate_stream(sample_request, collected_chunks.append)
+
+    assert response.finish_reason == FinishReason.BLOCKED
+    assert response.finish_message == 'I cannot help with that.'
+    assert collected_chunks == []
+    assert response.message is not None
+    assert response.message.content == []
+
+
+@pytest.mark.asyncio
+async def test__generate_stream_reports_the_failure_message_on_a_choice(sample_request: ModelRequest) -> None:
+    """A stream whose upstream failed reports the message the gateway sent."""
+    mock_client = MagicMock()
+    mock_client.chat.completions.create = _mock_stream([
+        _chunk(content='Partial '),
+        _chunk(finish_reason='error', error={'message': 'upstream timed out', 'code': 504}),
+    ])
+
+    model = OpenAIModel(model='gpt-4', client=mock_client)
+    response = await model._generate_stream(sample_request, lambda chunk: None)
+
+    assert response.finish_reason == FinishReason.OTHER
+    assert response.finish_message == 'upstream timed out'
+    assert response.message is not None
+    assert response.message.content[0].root.text == 'Partial '
+
+
+@pytest.mark.asyncio
+async def test__generate_stream_clean_stop_drops_an_earlier_failure_message(sample_request: ModelRequest) -> None:
+    """An error object on an early chunk is not reported when the stream then stops cleanly."""
+    mock_client = MagicMock()
+    mock_client.chat.completions.create = _mock_stream([
+        _chunk(content='Hello', error={'message': 'not this generation'}),
+        _chunk(finish_reason='stop'),
+    ])
+
+    model = OpenAIModel(model='gpt-4', client=mock_client)
+    response = await model._generate_stream(sample_request, lambda chunk: None)
+
+    assert response.finish_reason == FinishReason.STOP
+    assert response.finish_message is None
+
+
+@pytest.mark.asyncio
+async def test__generate_stream_ignores_an_error_field_that_is_not_an_object(sample_request: ModelRequest) -> None:
+    """A streamed error field that is not an object leaves the finish message unset."""
+    mock_client = MagicMock()
+    mock_client.chat.completions.create = _mock_stream([
+        _chunk(content='Partial '),
+        _chunk(finish_reason='error', error='upstream timed out'),
+    ])
+
+    model = OpenAIModel(model='gpt-4', client=mock_client)
+    response = await model._generate_stream(sample_request, lambda chunk: None)
+
+    assert response.finish_reason == FinishReason.OTHER
+    assert response.finish_message is None
+
+
+@pytest.mark.asyncio
+async def test__generate_stream_refusal_wins_over_a_failure_message(sample_request: ModelRequest) -> None:
+    """A streamed refusal beside a gateway's error object is the finish message."""
+    mock_client = MagicMock()
+    mock_client.chat.completions.create = _mock_stream([
+        _chunk(refusal='I cannot help with that.'),
+        _chunk(finish_reason='error', error={'message': 'upstream timed out', 'code': 504}),
+    ])
+
+    model = OpenAIModel(model='gpt-4', client=mock_client)
+    response = await model._generate_stream(sample_request, lambda chunk: None)
+
+    assert response.finish_reason == FinishReason.BLOCKED
+    assert response.finish_message == 'I cannot help with that.'
+
+
+@pytest.mark.asyncio
+async def test_generate_classifies_an_unreadable_message(sample_request: ModelRequest) -> None:
+    """A message with nothing to read at all is still INTERNAL, so retry runs."""
+    ctx_mock = MagicMock(spec=ActionRunContext)
+    type(ctx_mock).is_streaming = PropertyMock(return_value=False)
+    model = OpenAIModel(model='gpt-4', client=_mock_completion(_completion(content=None)))
+
+    with pytest.raises(GenkitError) as raised:
+        await model.generate(sample_request, ctx_mock)
+    assert raised.value.status == 'INTERNAL'
 
 
 @pytest.mark.parametrize(

--- a/py/packages/genkit-openai/tests/openai_utils_test.py
+++ b/py/packages/genkit-openai/tests/openai_utils_test.py
@@ -511,14 +511,13 @@ class TestMessageConverterReasoningContent:
         assert len(msg.content) == 1
         assert isinstance(msg.content[0].root, TextPart)
 
-    def test_raises_when_no_content_at_all(self) -> None:
-        """Raise ValueError when all content fields are None/empty."""
+    def test_empty_message_has_empty_content(self) -> None:
+        """A message with no content fields converts to a message with no parts."""
         adapter = DictMessageAdapter({
             'content': None,
             'role': 'assistant',
         })
-        with pytest.raises(ValueError, match='Unable to determine content part'):
-            MessageConverter.to_genkit(adapter)
+        assert MessageConverter.to_genkit(adapter).content == []
 
     def test_tool_calls_take_precedence_over_reasoning(self) -> None:
         """Tool calls take precedence; reasoning_content is ignored."""

--- a/py/packages/genkit-openai/tests/tool_calling_test.py
+++ b/py/packages/genkit-openai/tests/tool_calling_test.py
@@ -40,6 +40,7 @@ async def test_generate_with_tool_calls_executes_tools(sample_request: ModelRequ
     first_message.tool_calls = [mock_tool_call]
     first_message.content = None
     first_message.reasoning_content = None
+    first_message.refusal = None
 
     first_response = MagicMock()
     first_response.choices = [MagicMock(finish_reason='tool_calls', message=first_message)]
@@ -51,6 +52,7 @@ async def test_generate_with_tool_calls_executes_tools(sample_request: ModelRequ
     second_message.tool_calls = None
     second_message.content = 'final response'
     second_message.reasoning_content = None
+    second_message.refusal = None
 
     second_response = MagicMock()
     second_response.choices = [MagicMock(finish_reason='stop', message=second_message)]
@@ -118,6 +120,7 @@ async def test_generate_stream_with_tool_calls(sample_request: ModelRequest) -> 
             delta_mock.role = None
             delta_mock.tool_calls = [MockToolCall(id, index, name, args_chunk)]
             delta_mock.reasoning_content = None
+            delta_mock.refusal = None
 
             choice_mock = MagicMock()
             choice_mock.delta = delta_mock


### PR DESCRIPTION
Closes #6230

## Summary

Both chat paths now map the provider's finish reason and set the finish message.

The reason table covers what no OpenAI model sends but the compatible providers do: xAI's end_turn, z.AI's sensitive, model_context_window_exceeded and network_error, DeepSeek's insufficient_system_resource, and a gateway's error. An unrecognized or absent reason is unknown.

The finish message comes from the error object a gateway attaches to a failing choice. A gateway that loses its upstream part way through a generation has already committed a 200, so the failure rides on the choice next to whatever text was produced first, and reading it is the only thing that tells a failed request from a complete answer. A choice that stopped cleanly reports no finish message even when an error-shaped extra rides beside it.

`refusal` is read on both paths. The response is blocked and the refusal is the finish message. A refusal wins over a gateway failure message, since the model did reply, having declined. A refusal-only message converts to an empty-content message instead of raising.

A message with no content at a blocked or truncated stop is the answer and keeps its finish reason; only an empty message at a clean stop is treated as unreadable.