### PR TITLE
fix(py/plugins/openai): raw and custom response metadata never set

### DIFF
--- a/py/packages/genkit-openai/src/genkit_openai/models/model.py
+++ b/py/packages/genkit-openai/src/genkit_openai/models/model.py
@@ -46,6 +46,7 @@ from genkit_openai.models.utils import (
     DictMessageAdapter,
     MessageAdapter,
     MessageConverter,
+    extract_response_metadata,
     reraise_openai_error,
     strip_markdown_fences,
 )
@@ -380,6 +381,7 @@ class OpenAIModel:
                 latency_ms=response.latency_ms,
                 usage=response.usage,
                 custom=response.custom,
+                raw=response.raw,
             )
         return response
 
@@ -489,12 +491,15 @@ class OpenAIModel:
         if not genkit_message.content and finish_reason is FinishReason.STOP:
             raise ValueError('Unable to determine content part')
 
+        metadata = extract_response_metadata(response)
         result = ModelResponse(
             request=request,
             message=genkit_message,
             finish_reason=finish_reason,
             finish_message=finish_message,
             usage=_usage_from_completion(response.usage),
+            custom=metadata or None,
+            raw=metadata or None,
         )
         return self._clean_json_response(result, request)
 
@@ -521,12 +526,14 @@ class OpenAIModel:
 
         tool_calls: dict[int, Any] = {}
         accumulated_content: list[Part] = []
+        metadata: dict[str, Any] = {}
         usage: CompletionUsage | None = None
         saw_choice = False
         raw_finish_reason: str | None = None
         refusal_fragments: list[str] = []
         failure_message: str | None = None
         async for chunk in stream:  # type: ignore
+            metadata.update(extract_response_metadata(chunk))
             # Usage rides on a final chunk that carries no choices.
             if chunk.usage is not None:
                 usage = chunk.usage
@@ -615,6 +622,8 @@ class OpenAIModel:
             finish_reason=finish_reason,
             finish_message=finish_message,
             usage=_usage_from_completion(usage),
+            custom=metadata or None,
+            raw=metadata or None,
         )
         return self._clean_json_response(result, request)
 

--- a/py/packages/genkit-openai/src/genkit_openai/models/model.py
+++ b/py/packages/genkit-openai/src/genkit_openai/models/model.py
@@ -373,16 +373,7 @@ class OpenAIModel:
                 cleaned_parts.append(part)
 
         if changed:
-            return ModelResponse(
-                request=request,
-                message=Message(role=response.message.role, content=cleaned_parts),
-                finish_reason=response.finish_reason,
-                finish_message=response.finish_message,
-                latency_ms=response.latency_ms,
-                usage=response.usage,
-                custom=response.custom,
-                raw=response.raw,
-            )
+            return response.model_copy(update={'message': Message(role=response.message.role, content=cleaned_parts)})
         return response
 
     @staticmethod

--- a/py/packages/genkit-openai/src/genkit_openai/models/utils.py
+++ b/py/packages/genkit-openai/src/genkit_openai/models/utils.py
@@ -23,7 +23,8 @@ import re
 from collections.abc import Callable
 from typing import Any, NoReturn
 
-from openai import APIStatusError
+from openai import APIStatusError, BaseModel
+from openai.types.chat import ChatCompletion, ChatCompletionChunk
 
 from genkit import (
     GenkitError,
@@ -200,6 +201,60 @@ def extract_config_dict(request: ModelRequest) -> dict[str, Any]:
     if hasattr(request.config, 'model_dump'):
         return request.config.model_dump(exclude_none=True)
     return {}
+
+
+def _unmodeled_field(source: BaseModel, name: str) -> object:
+    """Read a response field the OpenAI schema does not model.
+
+    The SDK's response models allow extra fields and collect them in
+    ``model_extra``, which is where a provider's non-standard fields land.
+
+    Args:
+        source: A response object from the OpenAI SDK.
+        name: The wire name of the field.
+
+    Returns:
+        The field value, or None when it is absent or arrived as null.
+    """
+    extras = source.model_extra
+    if not isinstance(extras, dict):
+        return None
+    return extras.get(name)
+
+
+def extract_response_metadata(response: ChatCompletion | ChatCompletionChunk) -> dict[str, Any]:
+    """Collect the response metadata that is not part of the generated message.
+
+    Accepts a chat completion or a single streamed chunk of one: both carry
+    the same metadata fields.
+
+    Args:
+        response: A ``ChatCompletion`` or ``ChatCompletionChunk``.
+
+    Returns:
+        A dict of the metadata fields the response actually carries, empty
+        when it carries none.
+    """
+    metadata: dict[str, Any] = {}
+    for key, value in (
+        ('systemFingerprint', response.system_fingerprint),
+        ('model', response.model),
+        ('id', response.id),
+    ):
+        if isinstance(value, str) and value:
+            metadata[key] = value
+
+    # xAI returns live-search sources in an unmodeled citations field.
+    citations = _unmodeled_field(response, 'citations')
+    if citations is not None:
+        metadata['citations'] = citations
+
+    # A gateway reports a mid-generation upstream failure as an error object on the choice.
+    failure = _unmodeled_field(response.choices[0], 'error') if response.choices else None
+    if isinstance(failure, dict):
+        metadata['error'] = failure
+
+    return metadata
 
 
 def _extract_media(request: ModelRequest) -> tuple[str, str]:

--- a/py/packages/genkit-openai/tests/conftest.py
+++ b/py/packages/genkit-openai/tests/conftest.py
@@ -17,8 +17,12 @@
 
 """Test configuration for the OpenAI compatible plugin."""
 
+from collections.abc import Callable
+from typing import Any
+
 import pytest
 from genkit_openai.typing import OpenAIConfig
+from openai.types.chat import ChatCompletion, ChatCompletionChunk
 
 from genkit import (
     Message,
@@ -48,3 +52,48 @@ def sample_request() -> ModelRequest:
             max_tokens=100,
         ),
     )
+
+
+@pytest.fixture
+def make_completion() -> Callable[..., ChatCompletion]:
+    """Build a chat completion the way the SDK builds one off the wire."""
+
+    def factory(*, content: str = 'Hello, user!', choice: dict[str, Any] | None = None, **extra: Any) -> ChatCompletion:
+        payload: dict[str, Any] = {
+            'id': 'chatcmpl-abc',
+            'created': 1700000000,
+            'model': 'gpt-4o-2024-08-06',
+            'object': 'chat.completion',
+            'choices': [
+                {
+                    'index': 0,
+                    'finish_reason': 'stop',
+                    'message': {'role': 'assistant', 'content': content},
+                    **(choice or {}),
+                }
+            ],
+        }
+        payload.update(extra)
+        return ChatCompletion.construct(**payload)
+
+    return factory
+
+
+@pytest.fixture
+def make_chunk() -> Callable[..., ChatCompletionChunk]:
+    """Build a streamed chunk the way the SDK builds one off the wire."""
+
+    def factory(
+        *, content: str | None = None, choice: dict[str, Any] | None = None, **extra: Any
+    ) -> ChatCompletionChunk:
+        payload: dict[str, Any] = {
+            'id': 'chatcmpl-stream',
+            'created': 1700000000,
+            'model': 'grok-4',
+            'object': 'chat.completion.chunk',
+            'choices': [{'index': 0, 'delta': {'content': content}, **(choice or {})}],
+        }
+        payload.update(extra)
+        return ChatCompletionChunk.construct(**payload)
+
+    return factory

--- a/py/packages/genkit-openai/tests/openai_model_test.py
+++ b/py/packages/genkit-openai/tests/openai_model_test.py
@@ -17,7 +17,7 @@
 
 """Tests for OpenAI compatible model implementation."""
 
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, PropertyMock
 
@@ -1204,3 +1204,125 @@ class TestCleanJsonResponse:
         result = model._clean_json_response(response, request)
         # Should return the exact same object (no copy).
         assert result is response
+
+
+async def _stream(chunks: list[ChatCompletionChunk]) -> AsyncIterator[ChatCompletionChunk]:
+    """Yield chunks the way an AsyncStream does."""
+    for chunk in chunks:
+        yield chunk
+
+
+def _client(response: object) -> MagicMock:
+    """A client whose chat completion call answers with response."""
+    client = MagicMock()
+    client.chat.completions.create = AsyncMock(return_value=response)
+    return client
+
+
+class TestResponseMetadata:
+    """Tests for the response metadata both chat paths report."""
+
+    @pytest.mark.asyncio
+    async def test_generate_reports_ids_and_fingerprint(
+        self, sample_request: ModelRequest, make_completion: Callable[..., ChatCompletion]
+    ) -> None:
+        """The fingerprint, model and id reach both custom and raw."""
+        model = OpenAIModel(model='gpt-4o', client=_client(make_completion(system_fingerprint='fp_44709d6fcb')))
+        response = await model._generate(sample_request)
+
+        expected = {
+            'systemFingerprint': 'fp_44709d6fcb',
+            'model': 'gpt-4o-2024-08-06',
+            'id': 'chatcmpl-abc',
+        }
+        assert response.custom == expected
+        assert response.raw == expected
+
+    @pytest.mark.asyncio
+    async def test_generate_reports_citations_without_a_fingerprint(
+        self, sample_request: ModelRequest, make_completion: Callable[..., ChatCompletion]
+    ) -> None:
+        """Citations survive on providers that never send a fingerprint."""
+        citations = ['https://a.example', 'https://b.example']
+        model = OpenAIModel(model='grok-4', client=_client(make_completion(citations=citations)))
+        response = await model._generate(sample_request)
+
+        assert response.raw is not None
+        assert response.raw['citations'] == citations
+        assert response.raw['id'] == 'chatcmpl-abc'
+        assert 'systemFingerprint' not in response.raw
+
+    @pytest.mark.asyncio
+    async def test_generate_reports_the_choice_error_object(
+        self, sample_request: ModelRequest, make_completion: Callable[..., ChatCompletion]
+    ) -> None:
+        """A gateway's error object rides on the metadata whole."""
+        failure = {'message': 'Provider returned error', 'code': 429, 'metadata': {'provider_name': 'xai'}}
+        completion = make_completion(choice={'finish_reason': 'error', 'error': failure})
+        model = OpenAIModel(model='gpt-4o', client=_client(completion))
+        response = await model._generate(sample_request)
+
+        assert response.raw is not None
+        assert response.raw['error'] == failure
+
+    @pytest.mark.asyncio
+    async def test_generate_omits_absent_fields(
+        self, sample_request: ModelRequest, make_completion: Callable[..., ChatCompletion]
+    ) -> None:
+        """A response without the optional fields grows no null-valued keys."""
+        model = OpenAIModel(model='gpt-4o', client=_client(make_completion()))
+        response = await model._generate(sample_request)
+
+        assert response.raw == {'model': 'gpt-4o-2024-08-06', 'id': 'chatcmpl-abc'}
+
+    @pytest.mark.asyncio
+    async def test_generate_stream_reports_chunk_metadata(
+        self, sample_request: ModelRequest, make_chunk: Callable[..., ChatCompletionChunk]
+    ) -> None:
+        """Metadata spread across chunks is collected onto the final response."""
+        chunks = [
+            make_chunk(content='Hello', system_fingerprint='fp_stream'),
+            make_chunk(content=', world!'),
+            make_chunk(
+                citations=['https://x.example'],
+                choice={'finish_reason': 'error', 'error': {'message': 'upstream gave up'}},
+            ),
+        ]
+        model = OpenAIModel(model='grok-4', client=_client(_stream(chunks)))
+
+        collected = []
+
+        def callback(chunk: ModelResponseChunk) -> None:
+            collected.append(chunk.content[0].root.text)
+
+        response = await model._generate_stream(sample_request, callback)
+
+        assert collected == ['Hello', ', world!']
+        assert response.custom == {
+            'systemFingerprint': 'fp_stream',
+            'model': 'grok-4',
+            'id': 'chatcmpl-stream',
+            'citations': ['https://x.example'],
+            'error': {'message': 'upstream gave up'},
+        }
+        assert response.raw == response.custom
+
+    @pytest.mark.asyncio
+    async def test_cleaned_json_response_keeps_metadata(self, make_completion: Callable[..., ChatCompletion]) -> None:
+        """Stripping markdown fences does not drop the metadata."""
+        request = ModelRequest(
+            messages=[Message(role=Role.USER, content=[Part(root=TextPart(text='Generate'))])],
+            output=OutputConfig(format='json'),
+        )
+        completion = make_completion(
+            content='```json\n{"name": "John", "level": 5}\n```',
+            system_fingerprint='fp_deepseek',
+        )
+        model = OpenAIModel(model='deepseek-chat', client=_client(completion))
+        response = await model._generate(request)
+
+        assert response.message is not None
+        assert response.message.content[0].root.text == '{"name": "John", "level": 5}'
+        assert response.raw is not None
+        assert response.raw['systemFingerprint'] == 'fp_deepseek'
+        assert response.custom == response.raw

--- a/py/packages/genkit-openai/tests/openai_model_test.py
+++ b/py/packages/genkit-openai/tests/openai_model_test.py
@@ -42,6 +42,7 @@ from genkit import (
     TextPart,
 )
 from genkit._core._model import OutputConfig
+from genkit._core._typing import GenerationUsage, Operation
 from genkit.plugin_api import ActionRunContext, ModelConfig
 
 
@@ -1204,6 +1205,29 @@ class TestCleanJsonResponse:
         result = model._clean_json_response(response, request)
         # Should return the exact same object (no copy).
         assert result is response
+
+    def test_cleaning_keeps_every_other_field(self) -> None:
+        """Only the message changes; the rest of the response comes through untouched."""
+        model = OpenAIModel(model='deepseek-chat', client=MagicMock())
+        request = ModelRequest(
+            messages=[Message(role=Role.USER, content=[Part(root=TextPart(text='Hi'))])],
+            output=OutputConfig(format='json'),
+        )
+        response = ModelResponse(
+            request=request,
+            message=Message(role=Role.MODEL, content=[Part(root=TextPart(text='```json\n{"a": 1}\n```'))]),
+            finish_reason=FinishReason.LENGTH,
+            finish_message='cut off',
+            latency_ms=12.5,
+            usage=GenerationUsage(input_tokens=3, output_tokens=4),
+            custom={'id': 'chatcmpl-abc'},
+            raw={'id': 'chatcmpl-abc'},
+            operation=Operation(id='op-1', done=True),
+        )
+        cleaned = model._clean_json_response(response, request)
+        assert cleaned.message is not None
+        assert cleaned.message.content[0].root.text == '{"a": 1}'
+        assert cleaned.model_dump(exclude={'message'}) == response.model_dump(exclude={'message'})
 
 
 async def _stream(chunks: list[ChatCompletionChunk]) -> AsyncIterator[ChatCompletionChunk]:

--- a/py/packages/genkit-openai/tests/openai_utils_test.py
+++ b/py/packages/genkit-openai/tests/openai_utils_test.py
@@ -18,6 +18,7 @@
 
 import base64
 import json
+from collections.abc import Callable
 
 import httpx
 import pytest
@@ -30,10 +31,12 @@ from genkit_openai.models.utils import (
     _find_text,
     decode_data_uri_bytes,
     extract_config_dict,
+    extract_response_metadata,
     parse_data_uri_content_type,
     reraise_openai_error,
 )
 from openai import APIStatusError
+from openai.types.chat import ChatCompletion, ChatCompletionChunk
 from pydantic import BaseModel
 
 from genkit import (
@@ -786,3 +789,69 @@ def test_reraise_openai_error_marks_malformed_tool_json_internal() -> None:
         assert raised.value.status == 'INTERNAL'
         return
     raise AssertionError('expected JSONDecodeError')
+
+
+class TestExtractResponseMetadata:
+    """Tests for extract_response_metadata."""
+
+    def test_ids_and_fingerprint(self, make_completion: Callable[..., ChatCompletion]) -> None:
+        """The fingerprint, model and id are collected under camelCase keys."""
+        completion = make_completion(system_fingerprint='fp_44709d6fcb')
+        assert extract_response_metadata(completion) == {
+            'systemFingerprint': 'fp_44709d6fcb',
+            'model': 'gpt-4o-2024-08-06',
+            'id': 'chatcmpl-abc',
+        }
+
+    def test_ids_without_fingerprint(self, make_completion: Callable[..., ChatCompletion]) -> None:
+        """Providers that omit the fingerprint still report their model and id."""
+        assert extract_response_metadata(make_completion()) == {
+            'model': 'gpt-4o-2024-08-06',
+            'id': 'chatcmpl-abc',
+        }
+
+    def test_citations(self, make_completion: Callable[..., ChatCompletion]) -> None:
+        """Citations pass through in the shape the provider returned them."""
+        citations = ['https://a.example', 'https://b.example']
+        metadata = extract_response_metadata(make_completion(citations=citations))
+        assert metadata['citations'] == citations
+
+    def test_null_citations_are_absent(self, make_completion: Callable[..., ChatCompletion]) -> None:
+        """A citations field that arrived as null is treated as absent."""
+        assert 'citations' not in extract_response_metadata(make_completion(citations=None))
+
+    def test_choice_error_object(self, make_completion: Callable[..., ChatCompletion]) -> None:
+        """The error object a failing choice carries is kept whole."""
+        failure = {
+            'message': 'Provider returned error',
+            'code': 429,
+            'metadata': {'provider_name': 'xai'},
+        }
+        metadata = extract_response_metadata(make_completion(choice={'finish_reason': 'error', 'error': failure}))
+        assert metadata['error'] == failure
+
+    def test_non_object_choice_error_is_dropped(self, make_completion: Callable[..., ChatCompletion]) -> None:
+        """An error field that is not an object is not metadata."""
+        metadata = extract_response_metadata(make_completion(choice={'error': 'boom'}))
+        assert 'error' not in metadata
+
+    def test_empty_choices(self, make_completion: Callable[..., ChatCompletion]) -> None:
+        """A response with no choices still reports its top-level metadata."""
+        metadata = extract_response_metadata(make_completion(choices=[], citations=['u']))
+        assert metadata == {'model': 'gpt-4o-2024-08-06', 'id': 'chatcmpl-abc', 'citations': ['u']}
+
+    def test_chunk(self, make_chunk: Callable[..., ChatCompletionChunk]) -> None:
+        """A streamed chunk reports the same metadata a completion does."""
+        chunk = make_chunk(
+            content='hi',
+            system_fingerprint='fp_stream',
+            citations=['https://x.example'],
+            choice={'finish_reason': 'error', 'error': {'message': 'boom'}},
+        )
+        assert extract_response_metadata(chunk) == {
+            'systemFingerprint': 'fp_stream',
+            'model': 'grok-4',
+            'id': 'chatcmpl-stream',
+            'citations': ['https://x.example'],
+            'error': {'message': 'boom'},
+        }

--- a/py/packages/genkit-openai/tests/openai_utils_test.py
+++ b/py/packages/genkit-openai/tests/openai_utils_test.py
@@ -855,3 +855,8 @@ class TestExtractResponseMetadata:
             'citations': ['https://x.example'],
             'error': {'message': 'boom'},
         }
+
+    def test_empty_strings_are_absent(self, make_completion: Callable[..., ChatCompletion]) -> None:
+        """An empty id, model or fingerprint is treated as absent."""
+        completion = make_completion(id='', model='', system_fingerprint='')
+        assert extract_response_metadata(completion) == {}


### PR DESCRIPTION
Closes #6231

## Summary

Both chat paths now collect the response metadata the message does not carry and set it on `custom` and `raw`: `systemFingerprint`, `model`, `id`, the `citations` xAI returns for a live search, and the `error` object a gateway attaches to a failing choice. Absent fields are omitted rather than written as null. The fenced-JSON cleanup copies the response instead of rebuilding it field by field.

`model` and `id` are reported whenever present, not only next to a `system_fingerprint`: DeepSeek, xAI, OpenRouter and Ollama never send one. `raw` holds the same map as `custom` on both paths; the streaming path never materialises a full completion to dump.