### PR TITLE
refactor(go/plugins/a2ui): rename `Plugin` to `A2UI` and `Config` to `Surfaces`

### DIFF
--- a/go/plugins/a2ui/README.md
+++ b/go/plugins/a2ui/README.md
@@ -40,7 +40,7 @@ func main() {
 		ai.WithModel(googlegenai.GoogleAIModel(g, "gemini-flash-latest")),
 		ai.WithSystem("You help users. Render UI when it is clearer than prose."),
 		ai.WithPrompt("show me the weather in Tokyo"),
-		ai.WithUse(&a2ui.Config{}), // defaults to the bundled 'basic' catalog
+		ai.WithUse(&a2ui.Surfaces{}), // defaults to the bundled 'basic' catalog
 	)
 
 	// A2UI envelopes ride as data parts on the response message.
@@ -56,7 +56,7 @@ a2ui data parts.
 
 ### Options
 
-`a2ui.Config` fields:
+`a2ui.Surfaces` fields:
 
 | Field          | Default            | Description                                                                                       |
 | -------------- | ------------------ | ------------------------------------------------------------------------------------------------- |
@@ -91,7 +91,7 @@ if err != nil { /* ... */ }
 resp, _ := genkit.Generate(ctx, g,
 	ai.WithModel(m),
 	ai.WithPrompt("..."),
-	ai.WithUse(&a2ui.Config{CatalogID: catalog.ID}),
+	ai.WithUse(&a2ui.Surfaces{CatalogID: catalog.ID}),
 )
 ```
 
@@ -105,14 +105,14 @@ myCatalog := &a2ui.Catalog{
 	},
 }
 a2ui.LoadCatalog(g, myCatalog)
-// ... ai.WithUse(&a2ui.Config{CatalogID: myCatalog.ID})
+// ... ai.WithUse(&a2ui.Surfaces{CatalogID: myCatalog.ID})
 ```
 
 Register the bundled basic catalog too (so it shows up in the Dev UI) with
 `a2ui.RegisterBasicCatalog(g)`.
 
 The middleware resolves the catalog for each turn in this order: an inline
-`Config.Catalog` (code-defined only), then `Config.CatalogID` looked up from the
+`Surfaces.Catalog` (code-defined only), then `Surfaces.CatalogID` looked up from the
 registry, then the bundled basic catalog. Prefer `CatalogID`: unlike an inline
 `Catalog`, it survives JSON/Dev-UI dispatch and appears in tooling.
 
@@ -139,12 +139,12 @@ any message/chunk content.
 
 ## Registering as a plugin (optional)
 
-Passing `&a2ui.Config{}` to `ai.WithUse` is all you need. If you also want the
+Passing `&a2ui.Surfaces{}` to `ai.WithUse` is all you need. If you also want the
 middleware to appear in the Dev UI and be referenceable by name, register the
 plugin during init:
 
 ```go
-g := genkit.Init(ctx, genkit.WithPlugins(&a2ui.Plugin{}, &googlegenai.GoogleAI{}))
+g := genkit.Init(ctx, genkit.WithPlugins(&a2ui.A2UI{}, &googlegenai.GoogleAI{}))
 ```
 
 ## Try it with the web UI
@@ -195,7 +195,7 @@ The A2UI team is standardizing prompt formatting, catalog management, and
 inference inside official SDKs (a2ui-core / a2ui-agent). Those are the eventual
 home for the prompt-rendering, parsing, and validation this plugin does today,
 so treat those internals as thin and replaceable. The stable surface is the
-`a2ui.Config` entrypoint and the spec-defined wire part
+`a2ui.Surfaces` entrypoint and the spec-defined wire part
 (`application/a2ui+json`), both of which are unaffected by an SDK swap.
 
 

--- a/go/plugins/a2ui/a2ui.go
+++ b/go/plugins/a2ui/a2ui.go
@@ -75,12 +75,12 @@ type Surfaces struct {
 	// The middleware resolves it from the registry at call time. Defaults to
 	// [DefaultCatalogID] (the bundled basic catalog) when neither Catalog nor
 	// CatalogID is set.
-	CatalogID string `json:"catalogId,omitempty"`
+	CatalogID string `json:"catalogId,omitempty" jsonschema_description:"Id of a catalog registered with LoadCatalog, resolved from the registry at call time. Defaults to \"basic\", the bundled basic catalog."`
 
 	// Instructions controls where the catalog's capabilities are injected.
 	// InstructionsSystem (default) appends A2UI instructions to the system
 	// prompt; InstructionsNone injects nothing.
-	Instructions string `json:"instructions,omitempty"`
+	Instructions string `json:"instructions,omitempty" jsonschema:"enum=system,enum=none" jsonschema_description:"Where the catalog's capabilities are injected. \"system\" appends A2UI instructions to the system prompt; \"none\" injects nothing. Defaults to \"system\"."`
 
 	// Validate controls validation of emitted envelopes against the catalog.
 	// ValidateWarn (default) logs and drops bad blocks; ValidateStrict returns
@@ -93,15 +93,15 @@ type Surfaces struct {
 	// Markdown, any other prop) pass through untouched. Prop sanitization is the
 	// renderer/catalog's responsibility, and hosts should CSP-restrict remote
 	// sources. See the "Security and the trust boundary" section of the README.
-	Validate ValidateMode `json:"validate,omitempty"`
+	Validate ValidateMode `json:"validate,omitempty" jsonschema:"enum=strict,enum=warn,enum=off" jsonschema_description:"Validation of emitted envelopes against the catalog. \"warn\" logs and drops bad blocks; \"strict\" returns an error; \"off\" skips checking. This checks structure and component names only, never prop values. Defaults to \"warn\"."`
 
 	// SurfaceID sets the surface-id policy. Provide a fixed id to reuse for
 	// every surface; leave empty for a fresh UUID per surface.
-	SurfaceID string `json:"surfaceId,omitempty"`
+	SurfaceID string `json:"surfaceId,omitempty" jsonschema_description:"Fixed id to reuse for every surface. Defaults to a fresh UUID per surface."`
 
 	// Version is the protocol version stamped on emitted envelopes. Defaults to
 	// [DefaultVersion].
-	Version string `json:"version,omitempty"`
+	Version string `json:"version,omitempty" jsonschema_description:"Protocol version stamped on emitted envelopes. Defaults to \"v0.9\"."`
 }
 
 // Name returns the middleware's stable identifier.

--- a/go/plugins/a2ui/a2ui.go
+++ b/go/plugins/a2ui/a2ui.go
@@ -17,6 +17,7 @@
 package a2ui
 
 import (
+	"cmp"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -32,7 +33,7 @@ import (
 // provider is the plugin/middleware namespace.
 const provider = "a2ui"
 
-// Instruction placement options for [Config.Instructions].
+// Instruction placement options for [Surfaces.Instructions].
 const (
 	// InstructionsSystem appends A2UI capabilities to the system prompt
 	// (default).
@@ -42,25 +43,28 @@ const (
 	InstructionsNone = "none"
 )
 
-// Config is the configuration for the A2UI [ai.Middleware]. Add it to a generate
-// call with [github.com/firebase/genkit/go/ai.WithUse].
+// Surfaces is the A2UI [ai.Middleware]: it lets the model stream UI surfaces
+// drawn from a catalog. Add it to a generate call with
+// [github.com/firebase/genkit/go/ai.WithUse].
 //
 // Example:
 //
 //	resp, err := genkit.Generate(ctx, g,
 //	    ai.WithModel(m),
 //	    ai.WithPrompt("show me the weather in Tokyo"),
-//	    ai.WithUse(&a2ui.Config{}), // defaults to the bundled basic catalog
+//	    ai.WithUse(&a2ui.Surfaces{}), // defaults to the bundled basic catalog
 //	)
 //
 // Middleware ordering: A2UI keeps per-turn streaming state (a stream parser and
 // its minted surface ids) for the model call it wraps. Place any retrying or
 // fallback middleware (which re-invokes the model) OUTSIDE A2UI so each attempt
-// gets a fresh A2UI turn, i.e. WithUse(retry, &a2ui.Config{}) rather than
-// WithUse(&a2ui.Config{}, retry). WithUse(A, B) means A wraps B.
-type Config struct {
+// gets a fresh A2UI turn, i.e. WithUse(retry, &a2ui.Surfaces{}) rather than
+// WithUse(&a2ui.Surfaces{}, retry). WithUse(A, B) means A wraps B.
+//
+// Every field is per-call configuration; the [A2UI] plugin only registers the
+// middleware by name and carries no settings of its own.
+type Surfaces struct {
 	// Catalog describes what the agent may render, provided inline. When set it
-
 	// takes precedence over CatalogID. Not serialized, so it is only honored for
 	// code-defined use (not JSON/Dev-UI dispatch); prefer CatalogID with
 	// [LoadCatalog] for a registry-backed catalog that also survives dispatch
@@ -101,35 +105,26 @@ type Config struct {
 }
 
 // Name returns the middleware's stable identifier.
-func (c *Config) Name() string { return provider }
+func (c *Surfaces) Name() string { return provider }
 
 // New produces the per-call [ai.Hooks] bundle that implements the A2UI
 // integration.
-func (c *Config) New(ctx context.Context) (*ai.Hooks, error) {
+func (c *Surfaces) New(ctx context.Context) (*ai.Hooks, error) {
 	explicitCatalog := c.Catalog
 	catalogID := c.CatalogID
-	validate := c.Validate
-	if validate == "" {
-		validate = ValidateWarn
-	}
+	validate := cmp.Or(c.Validate, ValidateWarn)
 	if !validValidateModes[validate] {
 		return nil, fmt.Errorf(
 			"a2ui: invalid Validate %q; want one of %q, %q, %q",
 			validate, ValidateStrict, ValidateWarn, ValidateOff)
 	}
-	version := c.Version
-	if version == "" {
-		version = DefaultVersion
-	}
+	version := cmp.Or(c.Version, DefaultVersion)
 	if !supportedVersions[version] {
 		return nil, fmt.Errorf(
 			"a2ui: unsupported Version %q; want one of %s",
 			version, strings.Join(supportedVersionList(), ", "))
 	}
-	instructions := c.Instructions
-	if instructions == "" {
-		instructions = InstructionsSystem
-	}
+	instructions := cmp.Or(c.Instructions, InstructionsSystem)
 	if instructions != InstructionsSystem && instructions != InstructionsNone {
 		return nil, fmt.Errorf(
 			"a2ui: invalid Instructions %q; want %q or %q",
@@ -235,26 +230,33 @@ func (c *Config) New(ctx context.Context) (*ai.Hooks, error) {
 	return &ai.Hooks{WrapModel: wrapModel}, nil
 }
 
-// Plugin provides A2UI as a Genkit plugin so the middleware appears in the Dev
-// UI and can be referenced by name. Registering the plugin is optional: the
-// middleware works when passed directly to [ai.WithUse]. Register it with
-// [github.com/firebase/genkit/go/genkit.WithPlugins] during Init.
-type Plugin struct{}
+// A2UI provides the [Surfaces] middleware as a Genkit plugin, so it appears in
+// the Dev UI and can be referenced by name (for example from a prompt file's
+// `use:` list). Registering the plugin is optional: the middleware works when
+// passed directly to [ai.WithUse]. Register it with
+// [github.com/firebase/genkit/go/genkit.WithPlugins] during Init:
+//
+//	g := genkit.Init(ctx, genkit.WithPlugins(&a2ui.A2UI{}))
+//
+// The plugin carries no settings; every option lives on the per-call [Surfaces].
+type A2UI struct{}
 
-// Name returns the plugin's unique identifier.
-func (p *Plugin) Name() string { return provider }
+// Name returns the plugin's unique identifier, which is also the registered
+// name of the [Surfaces] middleware.
+func (p *A2UI) Name() string { return provider }
 
-// Init implements the plugin interface. A2UI registers no actions.
-func (p *Plugin) Init(ctx context.Context) []api.Action { return nil }
+// Init implements [api.Plugin]. A2UI registers no actions.
+func (p *A2UI) Init(ctx context.Context) []api.Action { return nil }
 
-// Middlewares exposes the A2UI middleware descriptor to Genkit.
-func (p *Plugin) Middlewares(ctx context.Context) ([]*ai.MiddlewareDesc, error) {
+// Middlewares implements [ai.MiddlewarePlugin], exposing the [Surfaces]
+// middleware descriptor to Genkit.
+func (p *A2UI) Middlewares(ctx context.Context) ([]*ai.MiddlewareDesc, error) {
 	return []*ai.MiddlewareDesc{
 		ai.NewMiddleware(
 			"Adds A2UI (Agent-to-UI) streaming UI support: injects catalog "+
 				"capabilities into the prompt and rewrites emitted UI blocks into "+
 				"a2ui data parts.",
-			&Config{},
+			&Surfaces{},
 		),
 	}, nil
 }

--- a/go/plugins/a2ui/a2ui_test.go
+++ b/go/plugins/a2ui/a2ui_test.go
@@ -53,7 +53,7 @@ func TestMiddlewareInjectsInstructions(t *testing.T) {
 	r := newTestRegistry(t)
 	m, captured := echoModel(t, r, "test/echo", "ok")
 
-	cfg := &Config{}
+	cfg := &Surfaces{}
 	if _, err := ai.Generate(ctx, r, ai.WithModel(m), ai.WithPrompt("hi"), ai.WithUse(cfg)); err != nil {
 		t.Fatal(err)
 	}
@@ -84,7 +84,7 @@ func TestMiddlewareInstructionsNone(t *testing.T) {
 	r := newTestRegistry(t)
 	m, captured := echoModel(t, r, "test/echo-none", "ok")
 
-	cfg := &Config{Instructions: InstructionsNone}
+	cfg := &Surfaces{Instructions: InstructionsNone}
 	if _, err := ai.Generate(ctx, r, ai.WithModel(m), ai.WithPrompt("hi"), ai.WithUse(cfg)); err != nil {
 		t.Fatal(err)
 	}
@@ -106,7 +106,7 @@ func TestMiddlewareRewritesFinalMessage(t *testing.T) {
 		"\n```"
 	m, _ := echoModel(t, r, "test/rewrite", reply)
 
-	cfg := &Config{SurfaceID: "fixed-surface", Validate: ValidateStrict}
+	cfg := &Surfaces{SurfaceID: "fixed-surface", Validate: ValidateStrict}
 	resp, err := ai.Generate(ctx, r, ai.WithModel(m), ai.WithPrompt("card please"), ai.WithUse(cfg))
 	if err != nil {
 		t.Fatal(err)
@@ -167,7 +167,7 @@ func TestMiddlewareRewritesFinalMessageSplitAcrossParts(t *testing.T) {
 	})
 	m.Register(r)
 
-	cfg := &Config{SurfaceID: "fixed-surface", Validate: ValidateStrict}
+	cfg := &Surfaces{SurfaceID: "fixed-surface", Validate: ValidateStrict}
 	resp, err := ai.Generate(ctx, r, ai.WithModel(m), ai.WithPrompt("card please"), ai.WithUse(cfg))
 	if err != nil {
 		t.Fatal(err)
@@ -251,7 +251,7 @@ func TestMiddlewareTransformsStream(t *testing.T) {
 		return nil
 	}
 
-	cfg := &Config{SurfaceID: "fixed", Validate: ValidateStrict}
+	cfg := &Surfaces{SurfaceID: "fixed", Validate: ValidateStrict}
 	resp, err := ai.Generate(ctx, r,
 		ai.WithModel(m),
 		ai.WithPrompt("card please"),
@@ -305,7 +305,7 @@ func TestMiddlewareSanitizesInboundA2UI(t *testing.T) {
 	})
 	userMsg := ai.NewMessage(ai.RoleUser, nil, ai.NewTextPart("submit"), actionPart)
 
-	cfg := &Config{Instructions: InstructionsNone}
+	cfg := &Surfaces{Instructions: InstructionsNone}
 	if _, err := ai.Generate(ctx, r, ai.WithModel(m), ai.WithMessages(userMsg), ai.WithUse(cfg)); err != nil {
 		t.Fatal(err)
 	}
@@ -346,7 +346,7 @@ func TestMiddlewarePreservesTextPartMetadata(t *testing.T) {
 	})
 	m.Register(r)
 
-	cfg := &Config{Instructions: InstructionsNone, Validate: ValidateStrict}
+	cfg := &Surfaces{Instructions: InstructionsNone, Validate: ValidateStrict}
 	resp, err := ai.Generate(ctx, r, ai.WithModel(m), ai.WithPrompt("hi"), ai.WithUse(cfg))
 	if err != nil {
 		t.Fatal(err)
@@ -382,7 +382,7 @@ func TestMiddlewareSkipsParseOnAbnormalFinish(t *testing.T) {
 	})
 	m.Register(r)
 
-	cfg := &Config{Instructions: InstructionsNone, Validate: ValidateStrict}
+	cfg := &Surfaces{Instructions: InstructionsNone, Validate: ValidateStrict}
 	// Generate itself surfaces a blocked finish as an error, but the middleware
 	// must not replace it with an a2ui parse error, and the response state must
 	// survive. Call the model through the middleware directly to observe that.
@@ -424,7 +424,7 @@ func TestMiddlewareReplaysPriorSurfaceAsBlock(t *testing.T) {
 	modelMsg := ai.NewMessage(ai.RoleModel, nil, ai.NewTextPart("Here you go:"), surfacePart)
 	userMsg := ai.NewUserTextMessage("thanks")
 
-	cfg := &Config{Instructions: InstructionsNone}
+	cfg := &Surfaces{Instructions: InstructionsNone}
 	if _, err := ai.Generate(ctx, r, ai.WithModel(m), ai.WithMessages(modelMsg, userMsg), ai.WithUse(cfg)); err != nil {
 		t.Fatal(err)
 	}
@@ -476,7 +476,7 @@ func TestMiddlewareDropsEmptiedMessage(t *testing.T) {
 	modelMsg := ai.NewMessage(ai.RoleModel, nil, emptyPart)
 	userMsg := ai.NewUserTextMessage("hi")
 
-	cfg := &Config{Instructions: InstructionsNone}
+	cfg := &Surfaces{Instructions: InstructionsNone}
 	if _, err := ai.Generate(ctx, r, ai.WithModel(m), ai.WithMessages(modelMsg, userMsg), ai.WithUse(cfg)); err != nil {
 		t.Fatal(err)
 	}
@@ -526,7 +526,7 @@ func TestMiddlewareNewRenderNeverReusesHistoryID(t *testing.T) {
 	modelMsg := ai.NewMessage(ai.RoleModel, nil, priorSurface)
 	userMsg := ai.NewMessage(ai.RoleUser, nil, actionPart)
 
-	cfg := &Config{SurfaceID: "sfc-new"}
+	cfg := &Surfaces{SurfaceID: "sfc-new"}
 	resp, err := ai.Generate(ctx, r, ai.WithModel(m), ai.WithMessages(modelMsg, userMsg), ai.WithUse(cfg))
 	if err != nil {
 		t.Fatal(err)
@@ -592,7 +592,7 @@ func TestMiddlewareGroupsSurfacesSplitsAroundAction(t *testing.T) {
 	})
 	userMsg := ai.NewMessage(ai.RoleUser, nil, part)
 
-	cfg := &Config{Instructions: InstructionsNone}
+	cfg := &Surfaces{Instructions: InstructionsNone}
 	if _, err := ai.Generate(ctx, r, ai.WithModel(m), ai.WithMessages(userMsg), ai.WithUse(cfg)); err != nil {
 		t.Fatal(err)
 	}
@@ -621,20 +621,20 @@ func TestMiddlewareGroupsSurfacesSplitsAroundAction(t *testing.T) {
 	}
 }
 
-func TestConfigRejectsInvalidValidateMode(t *testing.T) {
-	if _, err := (&Config{Validate: "strick"}).New(ctx); err == nil {
+func TestSurfacesRejectsInvalidValidateMode(t *testing.T) {
+	if _, err := (&Surfaces{Validate: "strick"}).New(ctx); err == nil {
 		t.Fatal("expected an error for an invalid Validate mode")
 	}
 }
 
-func TestConfigRejectsUnsupportedVersion(t *testing.T) {
-	if _, err := (&Config{Version: "0.9"}).New(ctx); err == nil {
+func TestSurfacesRejectsUnsupportedVersion(t *testing.T) {
+	if _, err := (&Surfaces{Version: "0.9"}).New(ctx); err == nil {
 		t.Fatal("expected an error for an unsupported Version")
 	}
 }
 
-func TestConfigRejectsInvalidInstructions(t *testing.T) {
-	if _, err := (&Config{Instructions: "prompt"}).New(ctx); err == nil {
+func TestSurfacesRejectsInvalidInstructions(t *testing.T) {
+	if _, err := (&Surfaces{Instructions: "prompt"}).New(ctx); err == nil {
 		t.Fatal("expected an error for invalid Instructions")
 	}
 }

--- a/go/plugins/a2ui/a2ui_test.go
+++ b/go/plugins/a2ui/a2ui_test.go
@@ -18,11 +18,14 @@ package a2ui
 
 import (
 	"context"
+	"maps"
+	"slices"
 	"strings"
 	"testing"
 
 	"github.com/firebase/genkit/go/ai"
 	"github.com/firebase/genkit/go/internal/registry"
+	"github.com/firebase/genkit/go/internal/schematest"
 )
 
 var ctx = context.Background()
@@ -636,5 +639,75 @@ func TestSurfacesRejectsUnsupportedVersion(t *testing.T) {
 func TestSurfacesRejectsInvalidInstructions(t *testing.T) {
 	if _, err := (&Surfaces{Instructions: "prompt"}).New(ctx); err == nil {
 		t.Fatal("expected an error for invalid Instructions")
+	}
+}
+
+// The plugin exists only to register the middleware so it can be resolved by
+// name: from the Dev UI, from another runtime, or from a prompt file's `use:`
+// list. Its descriptor must carry the name the middleware answers to, a
+// description, a fully documented schema, and exactly the serializable
+// options (Catalog is code-only).
+func TestPluginDescribesMiddleware(t *testing.T) {
+	descs, err := (&A2UI{}).Middlewares(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(descs) != 1 {
+		t.Fatalf("got %d middleware descriptors, want 1", len(descs))
+	}
+	d := descs[0]
+	if d.Name != provider || (&A2UI{}).Name() != provider {
+		t.Errorf("descriptor name = %q, plugin name = %q; both must be %q", d.Name, (&A2UI{}).Name(), provider)
+	}
+	if d.Description == "" {
+		t.Error("middleware has no description")
+	}
+	schematest.AssertDescribed(t, d.Name, d.ConfigSchema)
+
+	props, _ := d.ConfigSchema["properties"].(map[string]any)
+	got := slices.Sorted(maps.Keys(props))
+	want := []string{"catalogId", "instructions", "surfaceId", "validate", "version"}
+	if !slices.Equal(got, want) {
+		t.Errorf("config schema properties = %v, want %v", got, want)
+	}
+}
+
+// TestDescriptionsUseTheDedicatedTag guards against the inline
+// `jsonschema:"description=..."` form, which the schema library truncates at
+// the first comma; see [schematest.AssertNoInlineDescriptions].
+func TestDescriptionsUseTheDedicatedTag(t *testing.T) {
+	schematest.AssertNoInlineDescriptions(t, ".")
+}
+
+// Every JSON-dispatched call (Dev UI, another runtime, a prompt file) builds
+// its own config off the registered prototype, so an option one call sets must
+// not leak into the next.
+func TestJSONDispatchDoesNotLeakConfigBetweenCalls(t *testing.T) {
+	r := newTestRegistry(t)
+	m, captured := echoModel(t, r, "test/echo", "ok")
+	descs, err := (&A2UI{}).Middlewares(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	descs[0].Register(r)
+
+	injectedSystem := func(config map[string]any) bool {
+		t.Helper()
+		_, err := ai.GenerateWithRequest(t.Context(), r, &ai.GenerateActionOptions{
+			Model:    m.Name(),
+			Messages: []*ai.Message{ai.NewUserTextMessage("hi")},
+			Use:      []*ai.MiddlewareRef{{Name: provider, Config: config}},
+		}, nil, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return slices.ContainsFunc(*captured, func(msg *ai.Message) bool { return msg.Role == ai.RoleSystem })
+	}
+
+	if injectedSystem(map[string]any{"instructions": InstructionsNone}) {
+		t.Error("instructions=none still injected a system message")
+	}
+	if !injectedSystem(map[string]any{}) {
+		t.Error("default dispatch injected no system message: instructions=none leaked from the previous call")
 	}
 }

--- a/go/plugins/a2ui/catalog.go
+++ b/go/plugins/a2ui/catalog.go
@@ -36,10 +36,11 @@ type CatalogComponent struct {
 	Props string `json:"props"`
 }
 
-// Catalog pins the set of components a surface may render. The middleware uses
-// it to tell the model what it may render (prompt injection) and to validate
-// that emitted envelopes only reference known components. The renderer on the
-// client registers a matching @a2ui/* catalog under the same ID.
+// Catalog pins the set of components a surface may render. The [Surfaces]
+// middleware uses it to tell the model what it may render (prompt injection)
+// and to validate that emitted envelopes only reference known components. The
+// renderer on the client registers a matching @a2ui/* catalog under the same
+// ID.
 type Catalog struct {
 	// ID is a globally-unique catalog id (also used as catalogId on
 	// createSurface).

--- a/go/plugins/a2ui/loader.go
+++ b/go/plugins/a2ui/loader.go
@@ -27,7 +27,7 @@ import (
 
 // LoadCatalog registers an A2UI catalog in the Genkit registry under the key
 // `/a2ui-catalog/<id>` (using the catalog's own ID), so the [ai.Middleware] can
-// resolve it by id via [Config.CatalogID], and tooling such as the Dev UI can
+// resolve it by id via [Surfaces.CatalogID], and tooling such as the Dev UI can
 // enumerate catalogs (GET /api/values?type=a2ui-catalog). This mirrors the JS
 // and Dart plugins, keeping the catalog representation identical across
 // runtimes.
@@ -43,7 +43,7 @@ import (
 //
 //	a2ui.LoadCatalog(g, myCatalog)
 //	// ... then reference it by id:
-//	ai.WithUse(&a2ui.Config{CatalogID: myCatalog.ID})
+//	ai.WithUse(&a2ui.Surfaces{CatalogID: myCatalog.ID})
 func LoadCatalog(g *genkit.Genkit, catalog *Catalog) error {
 	if catalog == nil {
 		return fmt.Errorf("a2ui: LoadCatalog: catalog is nil")

--- a/go/plugins/a2ui/types.go
+++ b/go/plugins/a2ui/types.go
@@ -40,7 +40,7 @@ const A2UIMimeType = "application/a2ui+json"
 const DefaultVersion = "v0.9"
 
 // SupportedVersions is the set of A2UI protocol versions the plugin can stamp on
-// emitted envelopes. [Config.Version] is validated against it so a typo cannot
+// emitted envelopes. [Surfaces.Version] is validated against it so a typo cannot
 // stamp a version the renderer will reject at runtime. Matches the JS plugin's
 // SUPPORTED_VERSIONS.
 var SupportedVersions = []string{"v0.9", "v0.9.1"}
@@ -84,7 +84,7 @@ const BasicCatalogID = "https://a2ui.org/specification/v0_9/catalogs/basic/catal
 // them. Matches the JS plugin's value type.
 const CatalogValueType = "a2ui-catalog"
 
-// DefaultCatalogID is the id used when [Config] specifies neither Catalog nor
+// DefaultCatalogID is the id used when [Surfaces] specifies neither Catalog nor
 // CatalogID. It resolves to the bundled basic catalog.
 const DefaultCatalogID = "basic"
 

--- a/go/samples/basic-middleware/a2ui/main.go
+++ b/go/samples/basic-middleware/a2ui/main.go
@@ -16,7 +16,7 @@
 
 // This sample serves an A2UI-enabled agent over HTTP, compatible with the
 // browser frontend in js/testapps/a2ui/web. The whole A2UI integration is the
-// a2ui middleware in the agent's inline prompt (`ai.WithUse(&a2ui.Config{})`):
+// a2ui middleware in the agent's inline prompt (`ai.WithUse(&a2ui.Surfaces{})`):
 // it injects the catalog's capabilities into the system prompt and rewrites the
 // model's a2ui fenced blocks into a2ui data parts that the client renderer
 // consumes.
@@ -84,7 +84,7 @@ func main() {
 	// optional (it surfaces the middleware in the Dev UI); the middleware works
 	// via ai.WithUse regardless.
 	g := genkit.Init(ctx,
-		genkit.WithPlugins(&googlegenai.GoogleAI{}, &a2ui.Plugin{}),
+		genkit.WithPlugins(&googlegenai.GoogleAI{}, &a2ui.A2UI{}),
 		genkit.WithExperimental(),
 	)
 
@@ -114,7 +114,7 @@ func main() {
 		},
 	)
 
-	// The A2UI-enabled agent. The whole integration is a2ui.Config in WithUse.
+	// The A2UI-enabled agent. The whole integration is a2ui.Surfaces in WithUse.
 	// An in-memory session store makes state server-managed, so the browser
 	// only needs to pass a session id (remoteAgent handles that for it).
 	uiAgent := genkitx.DefineAgent(g, "uiAgent",
@@ -130,7 +130,7 @@ condition, humidity). Feel free to add a Button (e.g. "Refresh") when useful.`),
 			// Retry transient model failures (UNAVAILABLE, RESOURCE_EXHAUSTED,
 			// etc.) with exponential backoff before giving up.
 			ai.WithUse(&middleware.Retry{MaxRetries: 5}),
-			ai.WithUse(&a2ui.Config{}), // defaults to the bundled basic catalog
+			ai.WithUse(&a2ui.Surfaces{}), // defaults to the bundled basic catalog
 		},
 		aix.WithSessionStore(localstore.NewInMemorySessionStore[any]()),
 	)


### PR DESCRIPTION
Names the package's two entry points the way sibling plugins name theirs. `a2ui.A2UI{}` is the plugin, after `googlegenai.GoogleAI{}` and `middleware.Middleware{}`. `a2ui.Surfaces{}` is the per-call middleware, a capability noun like `middleware.Skills{}`, named for what the model gains rather than for the catalog it reads. `Catalog` stays the document type, so `LoadCatalog`, `BasicCatalog`, and the inline `Surfaces.Catalog` field share one name. The old names are removed rather than deprecated, since the package is experimental. The registered middleware name `a2ui` and the JSON field names are unchanged, so prompt-file `use:` entries and Dev UI configs keep working.

```go
// Renamed
a2ui.Config -> a2ui.Surfaces   // ai.WithUse(&a2ui.Surfaces{CatalogID: id})
a2ui.Plugin -> a2ui.A2UI       // genkit.WithPlugins(&a2ui.A2UI{})
```

The middleware's descriptor schema now carries a description per option and enum pickers for `instructions` and `validate`, matching `plugins/middleware`, so the Dev UI stops rendering bare inputs. The plugin gets its first tests: descriptor name and schema, and config isolation across JSON-dispatched calls.
