### PR TITLE
feat(js/middleware/context-compression): Add tool response deduplication

### DIFF
--- a/js/plugins/middleware/README.md
+++ b/js/plugins/middleware/README.md
@@ -252,8 +252,9 @@ Compresses conversation context when it grows too large, reducing token usage an
 **Strategies applied:**
 
 1. **Safety cap**: Hard-truncates any single oversized tool response (`maxToolResponseChars`, default: 400,000 chars).
-2. **Tool response truncation**: Truncates tool responses exceeding a character limit (`toolResponses`), preserving the most recent responses.
-3. **Message count cap**: Drops older non-system messages when exceeding `maxMessages`, optionally inserting a notice.
+2. **Deduplication**: Replaces duplicate tool responses with a short notice (`deduplicateToolResponses`).
+3. **Tool response truncation**: Truncates tool responses exceeding a character limit (`toolResponses`), preserving the most recent responses.
+4. **Message count cap**: Drops older non-system messages when exceeding `maxMessages`, optionally inserting a notice.
 
 ```typescript
 import { genkit } from 'genkit';
@@ -268,6 +269,7 @@ const response = await ai.generate({
   use: [
     contextCompression({
       maxInputTokens: 80000,
+      deduplicateToolResponses: { matchBy: 'name-and-input' },
       toolResponses: { maxChars: 2000, preserveRecent: 2 },
       maxMessages: 20,
     }),

--- a/js/plugins/middleware/examples/context_compression.ts
+++ b/js/plugins/middleware/examples/context_compression.ts
@@ -119,6 +119,7 @@ export const researchAgent = ai.defineAgent({
   use: [
     contextCompression({
       maxInputTokens: 200, // Triggers compression as tool responses accumulate in the generate loop
+      deduplicateToolResponses: { matchBy: 'name-and-input' },
       toolResponses: {
         maxChars: 120, // Truncate verbose tool responses beyond 120 chars
         preserveRecent: 1, // Keep most recent tool response intact

--- a/js/plugins/middleware/src/context-compression.ts
+++ b/js/plugins/middleware/src/context-compression.ts
@@ -55,6 +55,40 @@ export const ToolResponsesOptionsSchema = z.object({
     .describe("Don't truncate the last N tool responses. Default: 2."),
 });
 
+export const DeduplicateToolResponsesOptionsSchema = z.object({
+  /**
+   * How to identify duplicates:
+   * - `'name-and-input'`: Match by tool name and exact arguments (default).
+   * - `'name-only'`: Match by tool name only.
+   */
+  matchBy: z
+    .enum(['name-and-input', 'name-only'])
+    .optional()
+    .describe(
+      'Match by tool name and arguments ("name-and-input") or name only ("name-only"). Default: "name-and-input".'
+    ),
+
+  /**
+   * Number of most recent responses to leave untouched per tool/args group.
+   * Older duplicates are replaced with `notice`.
+   * @default 1
+   */
+  keepRecent: z
+    .number()
+    .optional()
+    .describe(
+      'Number of recent duplicates to keep untouched. Default: 1.'
+    ),
+
+  /**
+   * Replacement text for deduplicated tool responses.
+   */
+  notice: z
+    .string()
+    .optional()
+    .describe('Replacement text for deduplicated tool responses.'),
+});
+
 export const ContextCompressionOptionsSchema = z
   .object({
     /**
@@ -94,6 +128,15 @@ export const ContextCompressionOptionsSchema = z
       .optional()
       .describe(
         'Hard cap on any single tool response size. Default: 400000 chars.'
+      ),
+
+    /**
+     * Deduplicate repeated tool calls with the same arguments.
+     * Replaces older duplicate outputs with a short notice.
+     */
+    deduplicateToolResponses:
+      DeduplicateToolResponsesOptionsSchema.optional().describe(
+        'Deduplicate repeated tool calls with same arguments.'
       ),
 
     /**
@@ -143,6 +186,10 @@ export type ContextCompressionOptions = z.infer<
 
 const DEFAULT_MAX_TOOL_RESPONSE_CHARS = 400_000;
 const DEFAULT_TOOL_RESPONSE_PRESERVE_RECENT = 2;
+const DEFAULT_DEDUP_KEEP_RECENT = 1;
+const DEFAULT_DEDUP_NOTICE =
+  '[Deduplicated: This tool response has been removed to save context. ' +
+  'See the most recent call of this tool for current output.]';
 const DEFAULT_TRUNCATION_NOTICE =
   '[NOTE] Some earlier messages in this conversation have been removed to stay within ' +
   'context limits. The most recent messages are preserved. Pay close attention to the ' +
@@ -218,6 +265,12 @@ export const contextCompression: GenerateMiddleware<
     const maxToolResponseChars =
       config?.maxToolResponseChars ?? DEFAULT_MAX_TOOL_RESPONSE_CHARS;
 
+    const dedupConfig = config?.deduplicateToolResponses;
+    const dedupMatchBy = dedupConfig?.matchBy ?? 'name-and-input';
+    const dedupKeepRecent =
+      dedupConfig?.keepRecent ?? DEFAULT_DEDUP_KEEP_RECENT;
+    const dedupNotice = dedupConfig?.notice ?? DEFAULT_DEDUP_NOTICE;
+
     const toolResponseConfig = config?.toolResponses;
     const toolMaxChars = toolResponseConfig?.maxChars;
     const toolPreserveRecent =
@@ -263,6 +316,98 @@ export const contextCompression: GenerateMiddleware<
       });
 
       return { messages: result, capped: cappedCount };
+    }
+
+    function applyToolResponseDeduplication(messages: MessageData[]): {
+      messages: MessageData[];
+      deduplicated: number;
+    } {
+      if (!dedupConfig) return { messages, deduplicated: 0 };
+
+      // Map tool call IDs to tool request input across model messages
+      const toolInputByRef = new Map<string, unknown>();
+      for (const msg of messages) {
+        if (msg.role === 'model') {
+          for (const part of msg.content) {
+            if (part.toolRequest?.ref) {
+              toolInputByRef.set(part.toolRequest.ref, part.toolRequest.input);
+            }
+          }
+        }
+      }
+
+      const groups = new Map<string, number[]>();
+      for (let i = 0; i < messages.length; i++) {
+        const msg = messages[i];
+        if (msg.role !== 'tool') continue;
+
+        for (const part of msg.content) {
+          if (!part.toolResponse) continue;
+
+          let toolInput = part.toolResponse.ref
+            ? toolInputByRef.get(part.toolResponse.ref)
+            : undefined;
+
+          // If no ref was matched, check if preceding model message had a matching toolRequest with input
+          if (
+            toolInput === undefined &&
+            i > 0 &&
+            messages[i - 1]?.role === 'model'
+          ) {
+            const reqPart = messages[i - 1].content.find(
+              (p) => p.toolRequest?.name === part.toolResponse?.name
+            );
+            if (reqPart?.toolRequest) {
+              toolInput = reqPart.toolRequest.input;
+            }
+          }
+
+          const key =
+            dedupMatchBy === 'name-only'
+              ? part.toolResponse.name
+              : JSON.stringify({
+                  name: part.toolResponse.name,
+                  input: toolInput,
+                });
+          if (!groups.has(key)) groups.set(key, []);
+          groups.get(key)!.push(i);
+        }
+      }
+
+      const indicesToReplace = new Set<number>();
+      for (const indices of groups.values()) {
+        if (indices.length > dedupKeepRecent) {
+          const toRemove = indices.slice(0, indices.length - dedupKeepRecent);
+          for (const idx of toRemove) {
+            indicesToReplace.add(idx);
+          }
+        }
+      }
+
+      if (indicesToReplace.size === 0) {
+        return { messages, deduplicated: 0 };
+      }
+
+      let deduplicatedCount = 0;
+      const result = messages.map((msg, idx) => {
+        if (!indicesToReplace.has(idx)) return msg;
+
+        const newContent = msg.content.map((part): Part => {
+          if (part.toolResponse) {
+            deduplicatedCount++;
+            return {
+              toolResponse: {
+                ...part.toolResponse,
+                output: dedupNotice,
+              },
+            };
+          }
+          return part;
+        });
+        return { ...msg, content: newContent };
+      });
+
+      return { messages: result, deduplicated: deduplicatedCount };
     }
 
     function applyToolResponseTruncation(messages: MessageData[]): {
@@ -413,11 +558,13 @@ export const contextCompression: GenerateMiddleware<
           const {
             messages: compressedMessages,
             toolResponsesSafetyCapped,
+            toolResponsesDeduplicated,
             toolResponsesTruncated,
             truncationNoticeInserted,
           } = await ai.run('contextCompression', rawMessages, async () => {
             let messages = [...rawMessages];
             let capped = 0;
+            let deduplicated = 0;
             let truncated = 0;
             let noticeInserted = false;
 
@@ -428,14 +575,21 @@ export const contextCompression: GenerateMiddleware<
               capped = capResult.capped;
             }
 
-            // 2. Tool response truncation
+            // 2. Tool response deduplication
+            if (dedupConfig) {
+              const dedupResult = applyToolResponseDeduplication(messages);
+              messages = dedupResult.messages;
+              deduplicated = dedupResult.deduplicated;
+            }
+
+            // 3. Tool response truncation
             if (toolMaxChars) {
               const truncResult = applyToolResponseTruncation(messages);
               messages = truncResult.messages;
               truncated = truncResult.truncated;
             }
 
-            // 3. Message truncation
+            // 4. Message truncation
             if (maxMessages && messages.length > maxMessages) {
               const msgResult = applyMessageTruncation(messages);
               messages = msgResult.messages;
@@ -445,6 +599,7 @@ export const contextCompression: GenerateMiddleware<
             return {
               messages,
               toolResponsesSafetyCapped: capped,
+              toolResponsesDeduplicated: deduplicated,
               toolResponsesTruncated: truncated,
               truncationNoticeInserted: noticeInserted,
             };
@@ -453,6 +608,7 @@ export const contextCompression: GenerateMiddleware<
           const compressedCount = compressedMessages.length;
           const wasCompressed =
             toolResponsesSafetyCapped > 0 ||
+            toolResponsesDeduplicated > 0 ||
             toolResponsesTruncated > 0 ||
             compressedCount < originalCount ||
             truncationNoticeInserted;
@@ -465,6 +621,7 @@ export const contextCompression: GenerateMiddleware<
               messagesOriginal: originalCount,
               messagesAfter: compressedCount,
               toolResponsesSafetyCapped,
+              toolResponsesDeduplicated,
               toolResponsesTruncated,
               truncationNoticeInserted,
             };

--- a/js/plugins/middleware/tests/context-compression_test.ts
+++ b/js/plugins/middleware/tests/context-compression_test.ts
@@ -454,4 +454,220 @@ describe('contextCompression middleware', () => {
     assert.strictEqual(resp1.custom.contextCompression.messagesAfter, 2);
     assert.strictEqual(resp2.custom?.contextCompression, undefined);
   });
+
+  it('compresses tool responses with deduplication and truncation', async () => {
+    const ai = genkit({});
+    let turn = 0;
+    const capturedRequests: GenerateRequest[] = [];
+
+    const searchTool = ai.defineTool(
+      {
+        name: 'search',
+        description: 'search tool',
+        inputSchema: z.object({ query: z.string() }),
+        outputSchema: z.string(),
+      },
+      async (input) => `Result for ${input.query}: ${'A'.repeat(500)}`
+    );
+
+    const pm = ai.defineModel({ name: 'loopModel' }, async (req) => {
+      capturedRequests.push(req);
+      turn++;
+      if (turn === 1) {
+        return {
+          message: {
+            role: 'model',
+            content: [
+              { toolRequest: { name: 'search', input: { query: 'test' } } },
+            ],
+          },
+          usage: { inputTokens: 200 },
+        };
+      }
+      if (turn === 2) {
+        return {
+          message: {
+            role: 'model',
+            content: [
+              { toolRequest: { name: 'search', input: { query: 'test' } } },
+            ],
+          },
+          usage: { inputTokens: 500 },
+        };
+      }
+      return {
+        message: { role: 'model', content: [{ text: 'finished' }] },
+        usage: { inputTokens: 100 },
+      };
+    });
+
+    const result = await ai.generate({
+      model: pm,
+      prompt: 'Search multiple times',
+      tools: [searchTool],
+      use: [
+        contextCompression({
+          maxInputTokens: 150,
+          deduplicateToolResponses: { matchBy: 'name-and-input' },
+          toolResponses: { maxChars: 50, preserveRecent: 0 },
+        }),
+      ],
+    });
+
+    assert.strictEqual(result.text, 'finished');
+    assert.strictEqual(capturedRequests.length, 3);
+
+    const turn3Messages = capturedRequests[2].messages;
+    const toolMessages = turn3Messages.filter((m) => m.role === 'tool');
+    assert.ok(toolMessages.length >= 2);
+    const firstToolOutput = toolMessages[0].content[0].toolResponse?.output;
+    assert.match(String(firstToolOutput), /Deduplicated/);
+  });
+
+  it('deduplicates tool responses by correlating tool call IDs (ref) to tool inputs', async () => {
+    const ai = genkit({});
+    let turn = 0;
+    const capturedRequests: GenerateRequest[] = [];
+
+    const searchTool = ai.defineTool(
+      {
+        name: 'search',
+        description: 'search tool',
+        inputSchema: z.object({ query: z.string() }),
+        outputSchema: z.string(),
+      },
+      async (input) => `Result for ${input.query}: ${'A'.repeat(200)}`
+    );
+
+    const pm = ai.defineModel({ name: 'refDedupModel' }, async (req) => {
+      capturedRequests.push(req);
+      turn++;
+      if (turn === 1) {
+        return {
+          message: {
+            role: 'model',
+            content: [
+              {
+                toolRequest: {
+                  name: 'search',
+                  ref: 'call_unique_1',
+                  input: { query: 'same-query' },
+                },
+              },
+            ],
+          },
+          usage: { inputTokens: 200 },
+        };
+      }
+      if (turn === 2) {
+        return {
+          message: {
+            role: 'model',
+            content: [
+              {
+                toolRequest: {
+                  name: 'search',
+                  ref: 'call_unique_2', // Distinct call id, but identical tool input
+                  input: { query: 'same-query' },
+                },
+              },
+            ],
+          },
+          usage: { inputTokens: 500 },
+        };
+      }
+      return {
+        message: { role: 'model', content: [{ text: 'finished' }] },
+        usage: { inputTokens: 100 },
+      };
+    });
+
+    const result = await ai.generate({
+      model: pm,
+      prompt: 'Search multiple times with refs',
+      tools: [searchTool],
+      use: [
+        contextCompression({
+          maxInputTokens: 150,
+          deduplicateToolResponses: { matchBy: 'name-and-input' },
+          toolResponses: { maxChars: 50, preserveRecent: 0 },
+        }),
+      ],
+    });
+
+    assert.strictEqual(result.text, 'finished');
+    assert.strictEqual(capturedRequests.length, 3);
+
+    const turn3Messages = capturedRequests[2].messages;
+    const toolMessages = turn3Messages.filter((m) => m.role === 'tool');
+    assert.ok(toolMessages.length >= 2);
+    const firstToolOutput = toolMessages[0].content[0].toolResponse?.output;
+    assert.match(String(firstToolOutput), /Deduplicated/);
+  });
+
+  it('preserves distinct calls with different arguments when matchBy is name-and-input', async () => {
+    const ai = genkit({});
+    let turn = 0;
+    const capturedRequests: GenerateRequest[] = [];
+
+    const searchTool = ai.defineTool(
+      {
+        name: 'search',
+        description: 'search tool',
+        inputSchema: z.object({ query: z.string() }),
+        outputSchema: z.string(),
+      },
+      async (input) => `Result for ${input.query}: ${'B'.repeat(50)}`
+    );
+
+    const pm = ai.defineModel({ name: 'distinctArgsModel' }, async (req) => {
+      capturedRequests.push(req);
+      turn++;
+      if (turn === 1) {
+        return {
+          message: {
+            role: 'model',
+            content: [
+              { toolRequest: { name: 'search', input: { query: 'first-query' } } },
+            ],
+          },
+          usage: { inputTokens: 200 },
+        };
+      }
+      if (turn === 2) {
+        return {
+          message: {
+            role: 'model',
+            content: [
+              { toolRequest: { name: 'search', input: { query: 'second-query' } } },
+            ],
+          },
+          usage: { inputTokens: 500 },
+        };
+      }
+      return {
+        message: { role: 'model', content: [{ text: 'finished' }] },
+        usage: { inputTokens: 100 },
+      };
+    });
+
+    await ai.generate({
+      model: pm,
+      prompt: 'Search with distinct queries',
+      tools: [searchTool],
+      use: [
+        contextCompression({
+          maxInputTokens: 150,
+          deduplicateToolResponses: { matchBy: 'name-and-input' },
+        }),
+      ],
+    });
+
+    const turn3Messages = capturedRequests[2].messages;
+    const toolMessages = turn3Messages.filter((m) => m.role === 'tool');
+    assert.strictEqual(toolMessages.length, 2);
+    // Neither should be deduplicated because arguments differ
+    assert.strictEqual(String(toolMessages[0].content[0].toolResponse?.output).includes('Deduplicated'), false);
+    assert.strictEqual(String(toolMessages[1].content[0].toolResponse?.output).includes('Deduplicated'), false);
+  });
 });


### PR DESCRIPTION
- `deduplicateToolResponses`: Prunes repeated tool outputs, replacing them with a replacement notice while preserving recent responses.
- Input matching: Supports matching by tool name and exact input arguments (`name-and-input`) or tool name only (`name-only`).

