### PR TITLE
test(py): pin generate message history contract and drop unclosed rounds

### DIFF
--- a/py/packages/genkit/src/genkit/_ai/_generate.py
+++ b/py/packages/genkit/src/genkit/_ai/_generate.py
@@ -1057,6 +1057,9 @@ async def _generate_action_turn(
             response.finish_reason = FinishReason.ABORTED
             response.finish_message = f'Exceeded maximum tool call iterations ({max_iters})'
             log_responded()
+            # This model call opened a tool round we will not run. Only
+            # completed rounds can be reused as conversation history.
+            response.message = None
             return _persist_threaded_conversation(response, turn_options.messages)
 
         raise_if_aborted(ctx.abort_signal)
@@ -1076,6 +1079,7 @@ async def _generate_action_turn(
             response.finish_reason = FinishReason.FAILED
             response.finish_message = f'Tool {missing_tool} not found'
             log_responded()
+            response.message = None
             return _persist_threaded_conversation(response, turn_options.messages)
 
         revised_model_msg, tool_msg = await resolve_tool_requests(

--- a/py/packages/genkit/tests/genkit/ai/generate_test.py
+++ b/py/packages/genkit/tests/genkit/ai/generate_test.py
@@ -35,6 +35,7 @@ from genkit._core._typing import (
     TextPart,
     ToolRequest,
     ToolRequestPart,
+    ToolResponsePart,
 )
 from genkit.middleware import (
     BaseMiddleware,
@@ -2460,13 +2461,85 @@ async def test_generate_returns_on_blocked_finish() -> None:
 
     response = await ai.generate(prompt='hi')
     assert response.finish_reason == FinishReason.BLOCKED
+    assert response.finish_message == 'safety'
     assert response.text == 'nope'
     assert response.output is None
+    assert response.message is not None
+    assert response.message.text == 'nope'
+    assert [message.role for message in response.messages] == [Role.USER, Role.MODEL]
+    assert response.messages[0].text == 'hi'
+    assert response.messages[-1] == response.message
 
 
 @pytest.mark.asyncio
-async def test_generate_returns_error_finish_when_output_does_not_match_schema() -> None:
-    """A leftover string is not a Recipe — generate() returns, .output is None."""
+async def test_generate_blocked_keeps_prior_history_and_truncates_blocked_message() -> None:
+    """A provider can block without returning refusal content."""
+    ai = Genkit(model='programmableModel')
+    pm, _ = define_programmable_model(ai)
+    pm.responses = [
+        ModelResponse(
+            finish_reason=FinishReason.BLOCKED,
+            finish_message='safety',
+        )
+    ]
+
+    response = await ai.generate(prompt='hi')
+
+    assert response.finish_reason == FinishReason.BLOCKED
+    assert response.finish_message == 'safety'
+    assert response.message is None
+    assert [message.role for message in response.messages] == [Role.USER]
+    assert response.messages[0].text == 'hi'
+
+
+@pytest.mark.asyncio
+async def test_generate_aborted_with_content_preserves_terminal_message() -> None:
+    """A model response aborted with partial content retains that model message."""
+    ai = Genkit(model='programmableModel')
+    pm, _ = define_programmable_model(ai)
+    pm.responses = [
+        ModelResponse(
+            finish_reason=FinishReason.ABORTED,
+            finish_message='interrupted by provider',
+            message=Message(role=Role.MODEL, content=[Part(root=TextPart(text='partial text'))]),
+        )
+    ]
+
+    response = await ai.generate(prompt='hi')
+
+    assert response.finish_reason == FinishReason.ABORTED
+    assert response.finish_message == 'interrupted by provider'
+    assert response.text == 'partial text'
+    assert response.message is not None
+    assert response.message.text == 'partial text'
+    assert [message.role for message in response.messages] == [Role.USER, Role.MODEL]
+    assert response.messages[-1] == response.message
+
+
+@pytest.mark.asyncio
+async def test_generate_aborted_without_content_preserves_prior_history() -> None:
+    """A model response aborted with no content preserves prior history and sets message=None."""
+    ai = Genkit(model='programmableModel')
+    pm, _ = define_programmable_model(ai)
+    pm.responses = [
+        ModelResponse(
+            finish_reason=FinishReason.ABORTED,
+            finish_message='interrupted by provider',
+        )
+    ]
+
+    response = await ai.generate(prompt='hi')
+
+    assert response.finish_reason == FinishReason.ABORTED
+    assert response.finish_message == 'interrupted by provider'
+    assert response.message is None
+    assert [message.role for message in response.messages] == [Role.USER]
+    assert response.messages[0].text == 'hi'
+
+
+@pytest.mark.asyncio
+async def test_generate_schema_failure_preserves_history() -> None:
+    """A schema parsing failure preserves the prompt and the raw terminal model reply."""
     ai = Genkit(model='programmableModel')
     pm, _ = define_programmable_model(ai)
 
@@ -2486,6 +2559,256 @@ async def test_generate_returns_error_finish_when_output_does_not_match_schema()
     assert response.output is None
     assert response.finish_message is not None
     assert 'not valid JSON' in response.finish_message
+    assert response.message is not None
+    assert response.message.text == 'not json'
+    assert [message.role for message in response.messages] == [Role.USER, Role.MODEL]
+    assert response.messages[0].text == 'give me a recipe'
+    assert response.messages[-1] == response.message
+
+
+@pytest.mark.asyncio
+async def test_generate_blocked_after_tool_turn_keeps_prior_history() -> None:
+    """A blocked model response without content after a tool turn preserves completed tool rounds."""
+    ai = Genkit(model='programmableModel')
+    pm, _ = define_programmable_model(ai)
+
+    @ai.tool(name='lookup')
+    async def lookup() -> str:
+        return '72F'
+
+    pm.responses = [
+        _model_calls_tool(name='lookup', ref='r1'),
+        ModelResponse(
+            finish_reason=FinishReason.BLOCKED,
+            finish_message='safety',
+        ),
+    ]
+
+    response = await ai.generate(prompt='keep going', tools=['lookup'])
+
+    assert response.finish_reason == FinishReason.BLOCKED
+    assert response.finish_message == 'safety'
+    assert response.message is None
+    assert [message.role for message in response.messages] == [Role.USER, Role.MODEL, Role.TOOL]
+    assert response.messages[1].tool_requests[0].tool_request.ref == 'r1'
+    assert _tool_output(response.messages[2]) == '72F'
+    assert response.messages[-1].role == Role.TOOL
+
+
+@pytest.mark.asyncio
+async def test_generate_blocked_with_content_after_tool_turn_preserves_refusal() -> None:
+    """A blocked model response with refusal content after a tool turn includes the terminal model reply."""
+    ai = Genkit(model='programmableModel')
+    pm, _ = define_programmable_model(ai)
+
+    @ai.tool(name='lookup')
+    async def lookup() -> str:
+        return '72F'
+
+    pm.responses = [
+        _model_calls_tool(name='lookup', ref='r1'),
+        ModelResponse(
+            finish_reason=FinishReason.BLOCKED,
+            finish_message='safety',
+            message=Message(role=Role.MODEL, content=[Part(root=TextPart(text='cannot continue'))]),
+        ),
+    ]
+
+    response = await ai.generate(prompt='keep going', tools=['lookup'])
+
+    assert response.finish_reason == FinishReason.BLOCKED
+    assert response.finish_message == 'safety'
+    assert response.text == 'cannot continue'
+    assert response.message is not None
+    assert response.message.text == 'cannot continue'
+    assert [message.role for message in response.messages] == [Role.USER, Role.MODEL, Role.TOOL, Role.MODEL]
+    assert response.messages[1].tool_requests[0].tool_request.ref == 'r1'
+    assert _tool_output(response.messages[2]) == '72F'
+    assert response.messages[-1] == response.message
+
+
+def _model_calls_tool(*, name: str, ref: str) -> ModelResponse:
+    return ModelResponse(
+        finish_reason=FinishReason.STOP,
+        message=Message(
+            role=Role.MODEL,
+            content=[Part(root=ToolRequestPart(tool_request=ToolRequest(name=name, input={}, ref=ref)))],
+        ),
+    )
+
+
+def _tool_output(message: Message) -> object:
+    part = message.content[0].root
+    assert isinstance(part, ToolResponsePart)
+    assert part.tool_response is not None
+    return part.tool_response.output
+
+
+@pytest.mark.asyncio
+async def test_generate_successful_tool_turn_preserves_full_history() -> None:
+    """A completed tool turn followed by a successful reply contains all 4 messages."""
+    ai = Genkit(model='programmableModel')
+    pm, _ = define_programmable_model(ai)
+
+    @ai.tool(name='lookup')
+    async def lookup() -> str:
+        return '72F'
+
+    pm.responses = [
+        _model_calls_tool(name='lookup', ref='r1'),
+        ModelResponse(
+            finish_reason=FinishReason.STOP,
+            message=Message(role=Role.MODEL, content=[Part(root=TextPart(text='the weather is 72F'))]),
+        ),
+    ]
+
+    response = await ai.generate(prompt='weather?', tools=['lookup'])
+
+    assert response.finish_reason == FinishReason.STOP
+    assert response.text == 'the weather is 72F'
+    assert response.message is not None
+    assert response.message.text == 'the weather is 72F'
+    assert [message.role for message in response.messages] == [Role.USER, Role.MODEL, Role.TOOL, Role.MODEL]
+    assert response.messages[0].text == 'weather?'
+    assert response.messages[1].tool_requests[0].tool_request.name == 'lookup'
+    assert _tool_output(response.messages[2]) == '72F'
+    assert response.messages[-1] == response.message
+
+
+@pytest.mark.asyncio
+async def test_generate_completes_within_max_turns_and_preserves_all_rounds() -> None:
+    """Multi-round tool execution completing within max_turns returns all message rounds."""
+    ai = Genkit(model='programmableModel')
+    pm, _ = define_programmable_model(ai)
+
+    @ai.tool(name='step_one')
+    async def step_one() -> str:
+        return 'done 1'
+
+    @ai.tool(name='step_two')
+    async def step_two() -> str:
+        return 'done 2'
+
+    pm.responses = [
+        _model_calls_tool(name='step_one', ref='r1'),
+        _model_calls_tool(name='step_two', ref='r2'),
+        ModelResponse(
+            finish_reason=FinishReason.STOP,
+            message=Message(role=Role.MODEL, content=[Part(root=TextPart(text='all finished'))]),
+        ),
+    ]
+
+    response = await ai.generate(prompt='run both', tools=['step_one', 'step_two'], max_turns=3)
+
+    assert response.finish_reason == FinishReason.STOP
+    assert response.text == 'all finished'
+    assert response.message is not None
+    assert [message.role for message in response.messages] == [
+        Role.USER,
+        Role.MODEL,
+        Role.TOOL,
+        Role.MODEL,
+        Role.TOOL,
+        Role.MODEL,
+    ]
+    assert response.messages[0].text == 'run both'
+    assert response.messages[1].tool_requests[0].tool_request.name == 'step_one'
+    assert _tool_output(response.messages[2]) == 'done 1'
+    assert response.messages[3].tool_requests[0].tool_request.name == 'step_two'
+    assert _tool_output(response.messages[4]) == 'done 2'
+    assert response.messages[-1] == response.message
+
+
+@pytest.mark.asyncio
+async def test_generate_schema_failure_after_tool_turn_preserves_history() -> None:
+    """Output schema failure after a tool turn preserves completed tool rounds and terminal reply."""
+    ai = Genkit(model='programmableModel')
+    pm, _ = define_programmable_model(ai)
+
+    class Recipe(BaseModel):
+        title: str
+
+    @ai.tool(name='lookup')
+    async def lookup() -> str:
+        return '72F'
+
+    pm.responses = [
+        _model_calls_tool(name='lookup', ref='r1'),
+        ModelResponse(
+            finish_reason=FinishReason.STOP,
+            message=Message(role=Role.MODEL, content=[Part(root=TextPart(text='not json'))]),
+        ),
+    ]
+
+    response = await ai.generate(
+        prompt='give me a recipe',
+        output_schema=Recipe,
+        output_instructions=False,
+        tools=['lookup'],
+    )
+
+    assert response.finish_reason == FinishReason.FAILED
+    assert response.text == 'not json'
+    assert response.output is None
+    assert response.message is not None
+    assert response.message.text == 'not json'
+    assert [message.role for message in response.messages] == [Role.USER, Role.MODEL, Role.TOOL, Role.MODEL]
+    assert response.messages[1].tool_requests[0].tool_request.name == 'lookup'
+    assert _tool_output(response.messages[2]) == '72F'
+    assert response.messages[-1] == response.message
+
+
+@pytest.mark.asyncio
+async def test_max_turns_after_tool_turn_drops_unanswered_request() -> None:
+    """Hitting max tool turns keeps closed rounds and drops the unanswered call."""
+    ai = Genkit(model='programmableModel')
+    pm, _ = define_programmable_model(ai)
+
+    @ai.tool(name='lookup')
+    async def lookup() -> str:
+        return '72F'
+
+    pm.responses = [
+        _model_calls_tool(name='lookup', ref='r1'),
+        _model_calls_tool(name='lookup', ref='r2'),
+    ]
+
+    response = await ai.generate(prompt='keep going', tools=['lookup'], max_turns=1)
+
+    assert response.finish_reason == FinishReason.ABORTED
+    assert response.finish_message is not None
+    assert 'maximum tool call iterations' in response.finish_message
+    assert response.message is None
+    assert [message.role for message in response.messages] == [Role.USER, Role.MODEL, Role.TOOL]
+    assert response.messages[1].tool_requests[0].tool_request.ref == 'r1'
+    assert _tool_output(response.messages[2]) == '72F'
+    assert response.messages[-1].role == Role.TOOL
+
+
+@pytest.mark.asyncio
+async def test_unknown_tool_after_tool_turn_drops_unanswered_request() -> None:
+    """An unknown tool drops the unanswered request and keeps closed rounds."""
+    ai = Genkit(model='programmableModel')
+    pm, _ = define_programmable_model(ai)
+
+    @ai.tool(name='lookup')
+    async def lookup() -> str:
+        return '72F'
+
+    pm.responses = [
+        _model_calls_tool(name='lookup', ref='r1'),
+        _model_calls_tool(name='ghost', ref='r2'),
+    ]
+
+    response = await ai.generate(prompt='keep going', tools=['lookup'])
+
+    assert response.finish_reason == FinishReason.FAILED
+    assert response.finish_message == 'Tool ghost not found'
+    assert response.message is None
+    assert [message.role for message in response.messages] == [Role.USER, Role.MODEL, Role.TOOL]
+    assert response.messages[1].tool_requests[0].tool_request.ref == 'r1'
+    assert _tool_output(response.messages[2]) == '72F'
+    assert response.messages[-1].role == Role.TOOL
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Follow-up tests and contract enforcement for #6100 to pin Python `response.messages` and `response.message` behavior across all terminal generate cases.

### Message History Contract
- **Reusable Completed Rounds**: Every tool request in `response.messages` must have a matching tool response so history can be safely passed into subsequent model calls.
- **Dropping Unfinished Message (`response.message = None`)**:
  - *Tool requested but max turns reached*: The unanswered model tool request is omitted.
  - *Tool requested but not found*: The unanswered model tool request for the missing tool is omitted.
  - *Blocked with no content*: Preserves prior request history in `response.messages` without fabricating an empty model message.
- **Preserving Terminal Model Message**:
  - *Blocked with refusal content*: Preserved in both `response.message` and `response.messages` (`response.messages[-1] == response.message`).
  - *Output schema validation failure*: Preserved in both `response.message` and `response.messages` (`response.messages[-1] == response.message`).

### Tool Round Truncation Example
```python
# Before: the final model tool request had no matching tool response
response.messages # [user, model(tool_request), tool, model(tool_request)]

# After: only completed tool rounds are returned
response.message # None
response.messages # [user, model(tool_request), tool]
```