### PR TITLE
feat(js/ai): add `waitForSnapshot`, the blocking counterpart of `getSnapshot`

### DIFF
--- a/js/ai/src/agent-core.ts
+++ b/js/ai/src/agent-core.ts
@@ -84,8 +84,44 @@ export interface AgentAPI<State = unknown> {
     lookup: string | SnapshotLookup
   ): Promise<SessionSnapshot<State> | undefined>;
 
+  /**
+   * Blocks until a snapshot settles (`completed`, `failed`, `aborted`, or
+   * `expired`) and returns it, or `undefined` when no such snapshot exists.
+   * Requires a server store. The blocking counterpart of {@link getSnapshot}:
+   * the waiting happens next to the store, so a caller follows a detached turn
+   * in one call instead of a read per tick. Bound the wait with
+   * `abortSignal` (e.g. `AbortSignal.timeout(ms)`); on abort the promise
+   * rejects with the signal's reason and {@link getSnapshot} then reports where
+   * the snapshot stands.
+   */
+  waitForSnapshot(
+    snapshotId: string,
+    opts?: WaitForSnapshotOptions
+  ): Promise<SessionSnapshot<State> | undefined>;
+
   /** Aborts a running snapshot. Requires a server store. */
   abort(snapshotId: string): Promise<SessionSnapshot['status'] | undefined>;
+}
+
+/**
+ * Options for waiting on a snapshot ({@link AgentAPI.waitForSnapshot},
+ * {@link DetachedTask.wait}).
+ */
+export interface WaitForSnapshotOptions {
+  /**
+   * Ends the wait early. The promise rejects with the signal's reason (an
+   * `AbortError`, or a `TimeoutError` from `AbortSignal.timeout`), and the
+   * snapshot keeps whatever status it has.
+   */
+  abortSignal?: AbortSignal;
+  /**
+   * How often (ms) the wait re-reads the snapshot. In process it is the
+   * cadence at which a wait re-reads a pending snapshot to notice a stale
+   * heartbeat or, on a store without change notifications, a settled row;
+   * over a transport that cannot wait server-side it is the polling interval.
+   * Defaults to the transport's own cadence.
+   */
+  intervalMs?: number;
 }
 
 /**
@@ -228,8 +264,15 @@ export interface DetachedTask<State = unknown> {
   /** Yields status until a terminal state. */
   poll(opts?: { intervalMs?: number }): AsyncIterable<SessionSnapshot<State>>;
 
-  /** Resolves when the task reaches a terminal state. */
-  wait(opts?: { intervalMs?: number }): Promise<SessionSnapshot<State>>;
+  /**
+   * Resolves with the terminal snapshot once the task settles. A task that
+   * failed, aborted, or expired still resolves with its snapshot (inspect
+   * `status` and `error`), so a rejection means the wait itself could not
+   * proceed: the snapshot is gone, or `abortSignal` ended the wait. The wait
+   * runs server-side where the transport supports it and falls back to
+   * polling {@link AgentTransport.getSnapshot} otherwise.
+   */
+  wait(opts?: WaitForSnapshotOptions): Promise<SessionSnapshot<State>>;
 
   /** Aborts the task. */
   abort(): Promise<SessionSnapshot['status'] | undefined>;
@@ -298,6 +341,17 @@ export interface AgentTransport {
     lookup: SnapshotLookup
   ): Promise<SessionSnapshot<any> | undefined>;
 
+  /**
+   * Blocks until a snapshot settles and returns it (`undefined` when it does
+   * not exist). Optional: a transport that cannot wait server-side omits it,
+   * and {@link AgentAPI.waitForSnapshot} / {@link DetachedTask.wait} then poll
+   * {@link getSnapshot} instead.
+   */
+  waitForSnapshot?(
+    snapshotId: string,
+    opts?: WaitForSnapshotOptions
+  ): Promise<SessionSnapshot<any> | undefined>;
+
   /** Aborts a running snapshot. Requires a server store. */
   abort(snapshotId: string): Promise<SessionSnapshot['status'] | undefined>;
 }
@@ -309,8 +363,56 @@ const TERMINAL_STATUSES = new Set([
   'expired',
 ]);
 
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+/**
+ * Sleeps for `ms`, rejecting with the signal's reason if `signal` aborts
+ * first.
+ */
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(signal.reason);
+      return;
+    }
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(signal!.reason);
+    };
+    const timer = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+    signal?.addEventListener('abort', onAbort, { once: true });
+  });
+}
+
+/**
+ * Waits for a snapshot to settle through `transport`: server-side where the
+ * transport supports it, otherwise by polling {@link AgentTransport.getSnapshot}
+ * every `intervalMs` (default 1s). Resolves `undefined` when the snapshot does
+ * not exist, and rejects with the signal's reason when `abortSignal` ends the
+ * wait first.
+ */
+async function waitForSnapshotViaTransport<State>(
+  transport: AgentTransport,
+  snapshotId: string,
+  opts?: WaitForSnapshotOptions
+): Promise<SessionSnapshot<State> | undefined> {
+  if (transport.waitForSnapshot) {
+    return transport.waitForSnapshot(snapshotId, opts) as Promise<
+      SessionSnapshot<State> | undefined
+    >;
+  }
+  const intervalMs = opts?.intervalMs ?? 1000;
+  while (true) {
+    opts?.abortSignal?.throwIfAborted();
+    const snap = (await transport.getSnapshot({ snapshotId })) as
+      | SessionSnapshot<State>
+      | undefined;
+    if (!snap || (snap.status && TERMINAL_STATUSES.has(snap.status))) {
+      return snap;
+    }
+    await sleep(intervalMs, opts?.abortSignal);
+  }
 }
 
 function toAgentInput(input: string | AgentInput): AgentInput {
@@ -582,17 +684,16 @@ class DetachedTaskImpl<State = unknown> implements DetachedTask<State> {
     }
   }
 
-  async wait(opts?: { intervalMs?: number }): Promise<SessionSnapshot<State>> {
-    let last: SessionSnapshot<State> | undefined;
-    for await (const snap of this.poll(opts)) {
-      last = snap;
+  async wait(opts?: WaitForSnapshotOptions): Promise<SessionSnapshot<State>> {
+    const snap = await waitForSnapshotViaTransport<State>(
+      this.transport,
+      this.snapshotId,
+      opts
+    );
+    if (!snap) {
+      throw new Error(`Snapshot ${this.snapshotId} not found.`);
     }
-    if (!last) {
-      throw new Error(
-        `Detached task ${this.snapshotId} did not produce a snapshot.`
-      );
-    }
-    return last;
+    return snap;
   }
 
   abort(): Promise<SessionSnapshot['status'] | undefined> {
@@ -999,8 +1100,8 @@ export class AgentChatImpl<State = unknown> implements AgentChat<State> {
 
 /**
  * Composes the {@link AgentAPI} surface (`chat`/`loadChat`/`getSnapshot`/
- * `abort`) over a {@link AgentTransport}. Shared by the in-process server agent
- * and the HTTP `remoteAgent`.
+ * `waitForSnapshot`/`abort`) over a {@link AgentTransport}. Shared by the
+ * in-process server agent and the HTTP `remoteAgent`.
  */
 export function createAgentAPI<State = unknown>(
   transport: AgentTransport
@@ -1032,6 +1133,13 @@ export function createAgentAPI<State = unknown>(
       return transport.getSnapshot(normalized) as Promise<
         SessionSnapshot<State> | undefined
       >;
+    },
+
+    waitForSnapshot(
+      snapshotId: string,
+      opts?: WaitForSnapshotOptions
+    ): Promise<SessionSnapshot<State> | undefined> {
+      return waitForSnapshotViaTransport<State>(transport, snapshotId, opts);
     },
 
     abort(snapshotId: string): Promise<SessionSnapshot['status'] | undefined> {

--- a/js/ai/src/agent-types.ts
+++ b/js/ai/src/agent-types.ts
@@ -412,7 +412,8 @@ export interface SessionSnapshot<S = unknown> {
 
 /**
  * Schema for the input of an agent's `getSnapshot` companion action. Provide
- * exactly one of `snapshotId` or `sessionId`.
+ * exactly one of `snapshotId` or `sessionId`. The `waitForSnapshot` companion
+ * action takes the same request but requires `snapshotId`.
  */
 export const GetSnapshotRequestSchema = z.object({
   snapshotId: z.string().optional(),

--- a/js/ai/src/agent.ts
+++ b/js/ai/src/agent.ts
@@ -34,6 +34,7 @@ import {
   type AgentAPI,
   type AgentTransport,
   type SnapshotLookup,
+  type WaitForSnapshotOptions,
 } from './agent-core.js';
 
 import { parseSchema, toJsonSchema } from '@genkit-ai/core/schema';
@@ -115,6 +116,30 @@ const DEFAULT_HEARTBEAT_INTERVAL_MS = 30_000;
 const DEFAULT_HEARTBEAT_TIMEOUT_MS = 60_000;
 
 /**
+ * Default cadence (ms) at which a wait re-reads a pending snapshot when the
+ * store cannot push status changes (no `onSnapshotStateChange`), and at which
+ * any wait retries after a transient read failure.
+ */
+const DEFAULT_SNAPSHOT_WAIT_POLL_INTERVAL_MS = 2_000;
+
+/**
+ * Bound (ms) on one store read inside a wait. A wait is long by design and a
+ * read is not, and only the wait can tell the two apart, so this is where a
+ * hung store is caught: without it an unbounded wait would freeze on one
+ * rather than surface the read error. Generous, because it guards against a
+ * hang and not against a slow store.
+ */
+const SNAPSHOT_WAIT_READ_TIMEOUT_MS = 30_000;
+
+/**
+ * Consecutive transient read failures a wait rides out, at its re-read
+ * cadence, before surfacing the error. A wait runs for as long as the work
+ * does, so one store blip must not fail it; dead ends (see
+ * {@link isDeadEndReadError}) surface at once.
+ */
+const SNAPSHOT_WAIT_READ_RETRIES = 3;
+
+/**
  * Returns `true` when a snapshot is a `pending` (detached, in-flight) snapshot
  * whose heartbeat is older than `timeoutMs` - i.e. its background worker is
  * presumed dead. A pending snapshot that has not yet written a first heartbeat
@@ -132,6 +157,199 @@ function isHeartbeatExpired(
     return false;
   }
   return Date.now() - last > timeoutMs;
+}
+
+/**
+ * Returns `true` when a snapshot status is settled: no further transition will
+ * happen on its own. `pending` is the only status that can still change (an
+ * absent status counts as the documented `completed` default), so waiters stop
+ * on `completed`, `failed`, `aborted`, and `expired` alike. An expired
+ * snapshot's stored row is still `pending`, but its worker is presumed dead,
+ * so nothing will finalize it.
+ */
+function isTerminalSnapshotStatus(status: SessionSnapshot['status']): boolean {
+  return status !== 'pending';
+}
+
+/**
+ * Returns `true` when a snapshot read failure inside a wait cannot be helped
+ * by retrying: the request itself is rejected, or the row is gone. Anything
+ * else (a store blip, a read that hit {@link SNAPSHOT_WAIT_READ_TIMEOUT_MS})
+ * is presumed transient.
+ */
+function isDeadEndReadError(e: unknown): boolean {
+  const status = (e as { status?: unknown } | undefined)?.status;
+  return (
+    status === 'NOT_FOUND' ||
+    status === 'INVALID_ARGUMENT' ||
+    status === 'FAILED_PRECONDITION'
+  );
+}
+
+/**
+ * Rejects with `DEADLINE_EXCEEDED` when `promise` has not settled within `ms`.
+ */
+function withReadTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(
+      () =>
+        reject(
+          new GenkitError({
+            status: 'DEADLINE_EXCEEDED',
+            message: `Snapshot read did not complete within ${ms}ms.`,
+          })
+        ),
+      ms
+    );
+    promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (e) => {
+        clearTimeout(timer);
+        reject(e);
+      }
+    );
+  });
+}
+
+/**
+ * Waits until the snapshot `read` resolves settles, returning the terminal
+ * snapshot with the same shaping `read` applies (heartbeat expiry, client
+ * transform), or `undefined` when the snapshot does not exist. A snapshot that
+ * is already terminal returns at once, so the wait costs one read in the
+ * common case.
+ *
+ * Where the store implements `onSnapshotStateChange` the wait is push-driven:
+ * it subscribes before it would re-read, so a settlement racing the
+ * subscription is still delivered. It still re-reads on an interval, because
+ * expiry is not a write: a dead worker leaves the row `pending` and only its
+ * heartbeat goes stale, so no notification can report it. Without a
+ * subscription that same interval is the whole mechanism, so it is much
+ * shorter. A notification only means "re-read now": the row is what the caller
+ * gets back, and a store may notify before the write is visible to a reader.
+ *
+ * A read that fails transiently is retried at the poll cadence, up to
+ * {@link SNAPSHOT_WAIT_READ_RETRIES} consecutive failures; a dead end (the
+ * request is rejected, the row is gone) surfaces at once, including on the
+ * first read. Aborting `abortSignal` ends the wait with the signal's reason.
+ */
+async function waitForSnapshotInStore<S>(
+  store: SessionStore<S>,
+  snapshotId: string,
+  read: () => Promise<SessionSnapshot | undefined>,
+  opts: {
+    abortSignal?: AbortSignal;
+    pollIntervalMs?: number;
+    context?: ActionContext;
+  }
+): Promise<SessionSnapshot | undefined> {
+  const { abortSignal } = opts;
+  abortSignal?.throwIfAborted();
+
+  const subscribable = typeof store.onSnapshotStateChange === 'function';
+  const pollIntervalMs =
+    opts.pollIntervalMs ?? DEFAULT_SNAPSHOT_WAIT_POLL_INTERVAL_MS;
+  // A subscribed wait re-reads only to notice a stale heartbeat. Expiry needs
+  // two missed beats (the timeout is twice the interval), so checking once per
+  // beat cannot miss a stale row by more than one beat.
+  const livenessIntervalMs =
+    opts.pollIntervalMs ?? DEFAULT_HEARTBEAT_INTERVAL_MS;
+
+  // RETRY marks a transient read failure the wait rides out.
+  const RETRY = Symbol('retry');
+  let readFailures = 0;
+  const readOrRetry = async (): Promise<
+    SessionSnapshot | undefined | typeof RETRY
+  > => {
+    try {
+      const snap = await withReadTimeout(read(), SNAPSHOT_WAIT_READ_TIMEOUT_MS);
+      readFailures = 0;
+      return snap;
+    } catch (e) {
+      if (isDeadEndReadError(e) || readFailures >= SNAPSHOT_WAIT_READ_RETRIES) {
+        throw e;
+      }
+      readFailures++;
+      return RETRY;
+    }
+  };
+
+  // Wake-ups: a terminal notification from the store, the re-read tick, or the
+  // abort signal. A notification that lands while a read is in flight is
+  // remembered, so the next pass re-reads without waiting for the tick.
+  let notified = false;
+  let wake: (() => void) | undefined;
+  const wakeUp = () => {
+    notified = true;
+    wake?.();
+  };
+  const onAbort = () => wake?.();
+  abortSignal?.addEventListener('abort', onAbort, { once: true });
+  // Subscribe before the first read, so a settlement that lands between the
+  // two is still delivered: the bundled stores do not replay the current
+  // status on subscribe, and a wait that read a pending row just before the
+  // settling write would otherwise learn of it only on its next tick.
+  let unsubscribe: void | (() => void) = undefined;
+  if (subscribable) {
+    unsubscribe = store.onSnapshotStateChange!(
+      snapshotId,
+      (snap) => {
+        if (isTerminalSnapshotStatus(snap.status)) wakeUp();
+      },
+      { context: opts.context }
+    );
+  }
+  try {
+    // The first read prices the common already-terminal case at exactly one
+    // read. A transient failure falls into the wait below and is retried
+    // there, because a store blip at the moment a wait starts is no more fatal
+    // than one in the middle of it.
+    const first = await readOrRetry();
+    if (first !== RETRY && (!first || isTerminalSnapshotStatus(first.status))) {
+      return first;
+    }
+
+    // The next re-read comes soon after a transient failure, or after a
+    // notification that raced the write's visibility: a subscribed wait's
+    // terminal notification fires once and has been consumed, so the re-read
+    // is the only path left to the settled row and must not be a liveness
+    // beat away.
+    let intervalMs =
+      first === RETRY || !subscribable ? pollIntervalMs : livenessIntervalMs;
+    while (true) {
+      await new Promise<void>((resolve) => {
+        if (notified || abortSignal?.aborted) {
+          resolve();
+          return;
+        }
+        const timer = setTimeout(() => {
+          wake = undefined;
+          resolve();
+        }, intervalMs);
+        wake = () => {
+          clearTimeout(timer);
+          wake = undefined;
+          resolve();
+        };
+      });
+      abortSignal?.throwIfAborted();
+      const wokenByNotification = notified;
+      notified = false;
+      const cur = await readOrRetry();
+      if (cur !== RETRY && (!cur || isTerminalSnapshotStatus(cur.status))) {
+        return cur;
+      }
+      intervalMs =
+        cur === RETRY || wokenByNotification || !subscribable
+          ? pollIntervalMs
+          : livenessIntervalMs;
+    }
+  } finally {
+    abortSignal?.removeEventListener('abort', onAbort);
+    if (typeof unsubscribe === 'function') unsubscribe();
+  }
 }
 
 /**
@@ -674,15 +892,41 @@ export type GetSnapshotDataAction<S = unknown> = Action<
 >;
 
 /**
+ * Input for {@link Agent.waitForSnapshotData}: the snapshot to follow, plus
+ * how to bound the wait. It extends {@link GetSnapshotDataInput} so a caller
+ * switching from a read to a wait keeps its payload, but `snapshotId` is
+ * required: a session's latest snapshot can change under a wait.
+ */
+export interface WaitForSnapshotDataInput extends GetSnapshotDataInput {
+  snapshotId: string;
+  /**
+   * Ends the wait early: the promise rejects with the signal's reason (e.g. a
+   * `TimeoutError` from `AbortSignal.timeout`), and the snapshot keeps
+   * whatever status it has.
+   */
+  abortSignal?: AbortSignal;
+  /**
+   * How often (ms) the wait re-reads the snapshot: to notice a stale heartbeat
+   * on a store that pushes status changes, or as the whole mechanism on one
+   * that does not. Defaults to the heartbeat interval with a subscription and
+   * to 2s without.
+   */
+  pollIntervalMs?: number;
+}
+
+/**
  * Represents a configured, registered Agent.
  *
  * An `Agent` exposes two surfaces:
  *
  * 1. The ergonomic, transport-agnostic {@link AgentAPI} (`chat`, `loadChat`,
- *    `getSnapshot`, `abort`) - the same surface returned by `remoteAgent` on
- *    the client, so server- and client-side code share one interface.
+ *    `getSnapshot`, `waitForSnapshot`, `abort`) - the same surface returned by
+ *    `remoteAgent` on the client, so server- and client-side code share one
+ *    interface.
  * 2. The lower-level {@link BidiAction} surface (`run`, `streamBidi`, …) for
- *    advanced use and for serving over HTTP.
+ *    advanced use and for serving over HTTP, plus the companion actions
+ *    (`getSnapshotDataAction`, `waitForSnapshotAction`, `abortAgentAction`)
+ *    to mount next to it.
  */
 export interface Agent<State = unknown>
   extends BidiAction<
@@ -696,12 +940,32 @@ export interface Agent<State = unknown>
     opts: GetSnapshotDataInput
   ): Promise<SessionSnapshot<State> | undefined>;
 
+  /**
+   * Blocks until the snapshot settles (`completed`, `failed`, `aborted`, or
+   * `expired`) and returns it with the same shaping as
+   * {@link getSnapshotData}, or `undefined` when no such snapshot exists.
+   * Requires a server store. A snapshot that failed, aborted, or expired is
+   * returned like any other, so a rejection means the wait itself could not
+   * proceed: reads failed past the wait's transient-retry budget, or
+   * `abortSignal` ended it.
+   */
+  waitForSnapshotData(
+    opts: WaitForSnapshotDataInput
+  ): Promise<SessionSnapshot<State> | undefined>;
+
   abort(
     snapshotId: string,
     options?: SessionStoreOptions
   ): Promise<SessionSnapshot['status'] | undefined>;
 
   readonly getSnapshotDataAction: GetSnapshotDataAction<State>;
+  /**
+   * The `waitForSnapshot` companion action (`agent-wait`): `getSnapshot`'s
+   * blocking counterpart, taking the same request (with `snapshotId`
+   * required) and returning the snapshot once it settles. Mount it next to
+   * the agent so a remote client follows a detached turn in one request.
+   */
+  readonly waitForSnapshotAction: GetSnapshotDataAction<State>;
   readonly abortAgentAction: Action<
     typeof AgentAbortRequestSchema,
     typeof AgentAbortResponseSchema
@@ -1341,6 +1605,27 @@ export function defineCustomAgent<State = unknown>(
     return toClientSnapshot(effective);
   };
 
+  // Waits through the same shaped read as `resolveSnapshot`, so a settled
+  // snapshot comes back exactly as a `getSnapshotData` read would return it.
+  const runWait = async (
+    opts: WaitForSnapshotDataInput
+  ): Promise<SessionSnapshot | undefined> => {
+    requireStore(config.store, 'waitForSnapshotData', config.name);
+    if (!opts.snapshotId) {
+      throw new GenkitError({
+        status: 'INVALID_ARGUMENT',
+        message: `waitForSnapshotData requires a 'snapshotId' for agent '${config.name}'.`,
+      });
+    }
+    const { abortSignal, pollIntervalMs, ...lookup } = opts;
+    return waitForSnapshotInStore(
+      config.store,
+      opts.snapshotId,
+      () => resolveSnapshot(lookup),
+      { abortSignal, pollIntervalMs, context: lookup.context }
+    );
+  };
+
   const runAbort = (
     snapshotId: string,
     options?: SessionStoreOptions
@@ -1371,6 +1656,43 @@ export function defineCustomAgent<State = unknown>(
     }
   );
 
+  // waitForSnapshot takes getSnapshot's request, so a caller switching from
+  // one to the other keeps its payload, but it requires the snapshot ID: a
+  // session's latest snapshot is whichever one is latest at resolution time,
+  // and waiting on that is a race with the session's next turn. The wait runs
+  // on the request's abort signal, so a client that hangs up ends it.
+  const waitForSnapshotAction = defineAction(
+    registry,
+    {
+      name: config.name,
+      description: `Waits until a snapshot of ${config.name} settles (completed, failed, aborted, or expired) and returns it. Requires a snapshotId.`,
+      actionType: 'agent-wait',
+      inputSchema: GetSnapshotRequestSchema,
+      outputSchema: SessionSnapshotSchema,
+    },
+    async (lookup, { abortSignal }) => {
+      if (!lookup.snapshotId) {
+        throw new GenkitError({
+          status: 'INVALID_ARGUMENT',
+          message: `waitForSnapshot requires a 'snapshotId' for agent '${config.name}'.`,
+        });
+      }
+      const snap = await runWait({
+        ...lookup,
+        snapshotId: lookup.snapshotId,
+        context: getContext(),
+        abortSignal,
+      });
+      if (!snap) {
+        throw new GenkitError({
+          status: 'NOT_FOUND',
+          message: `Snapshot '${lookup.snapshotId}' not found for agent '${config.name}'.`,
+        });
+      }
+      return snap;
+    }
+  );
+
   const abortAgentAction = defineAction(
     registry,
     {
@@ -1388,10 +1710,13 @@ export function defineCustomAgent<State = unknown>(
 
   const composite = Object.assign(primaryAction, {
     getSnapshotData: (opts: GetSnapshotDataInput) => resolveSnapshot(opts),
+    waitForSnapshotData: (opts: WaitForSnapshotDataInput) => runWait(opts),
     abort: (snapshotId: string, options?: SessionStoreOptions) =>
       runAbort(snapshotId, options),
     getSnapshotDataAction:
       getSnapshotDataAction as unknown as GetSnapshotDataAction<State>,
+    waitForSnapshotAction:
+      waitForSnapshotAction as unknown as GetSnapshotDataAction<State>,
     abortAgentAction: abortAgentAction as unknown as Action<
       typeof AgentAbortRequestSchema,
       typeof AgentAbortResponseSchema
@@ -1415,7 +1740,8 @@ export function defineCustomAgent<State = unknown>(
 
   // In-process transport: drives the agent action directly (no HTTP). This lets
   // the server-side agent expose the same ergonomic AgentAPI (`chat`,
-  // `loadChat`, `getSnapshot`, `abort`) as the HTTP `remoteAgent` client.
+  // `loadChat`, `getSnapshot`, `waitForSnapshot`, `abort`) as the HTTP
+  // `remoteAgent` client.
   const transport: AgentTransport = {
     stateManagement: config.store ? 'server' : 'client',
 
@@ -1428,6 +1754,14 @@ export function defineCustomAgent<State = unknown>(
       return composite.getSnapshotData(lookup);
     },
 
+    waitForSnapshot(snapshotId: string, opts?: WaitForSnapshotOptions) {
+      return composite.waitForSnapshotData({
+        snapshotId,
+        abortSignal: opts?.abortSignal,
+        pollIntervalMs: opts?.intervalMs,
+      });
+    },
+
     abort(snapshotId: string) {
       return composite.abort(snapshotId);
     },
@@ -1435,13 +1769,14 @@ export function defineCustomAgent<State = unknown>(
 
   const agentApi = createAgentAPI<State>(transport);
 
-  // Expose the AgentAPI surface on the composite. `abort`/`getSnapshotData`
-  // already exist on the composite (richer signatures); we add `chat`,
-  // `loadChat`, and `getSnapshot`.
+  // Expose the AgentAPI surface on the composite. `abort`/`getSnapshotData`/
+  // `waitForSnapshotData` already exist on the composite (richer signatures);
+  // we add `chat`, `loadChat`, `getSnapshot`, and `waitForSnapshot`.
   Object.assign(composite, {
     chat: agentApi.chat,
     loadChat: agentApi.loadChat,
     getSnapshot: agentApi.getSnapshot,
+    waitForSnapshot: agentApi.waitForSnapshot,
   });
 
   return composite as unknown as Agent<State>;

--- a/js/ai/src/session-stores.ts
+++ b/js/ai/src/session-stores.ts
@@ -184,11 +184,12 @@ export class InMemorySessionStore<S = unknown> implements SessionStore<S> {
     };
 
     this.snapshots.set(id, structuredClone(full));
-    const snapshotListeners = this.listeners.get(id);
-    if (snapshotListeners) {
-      for (const listener of snapshotListeners) {
-        listener(structuredClone(full));
-      }
+    // Dispatch over a copy: a listener that unsubscribes while being notified
+    // (the detach runtime does, on an abort) splices itself out of the live
+    // array, and iterating that array would skip the listener after it.
+    const snapshotListeners = [...(this.listeners.get(id) ?? [])];
+    for (const listener of snapshotListeners) {
+      listener(structuredClone(full));
     }
     return id;
   }

--- a/js/ai/tests/agent_test.ts
+++ b/js/ai/tests/agent_test.ts
@@ -23,13 +23,18 @@ import { describe, it } from 'node:test';
 
 import { GenkitError, z } from '@genkit-ai/core';
 import { TestSpanExporter } from '../../core/tests/utils.js';
-import { AgentError } from '../src/agent-core.js';
+import {
+  AgentError,
+  createAgentAPI,
+  type AgentTransport,
+} from '../src/agent-core.js';
 import {
   AgentStreamChunk,
   SessionRunner,
   defineAgent,
   defineCustomAgent,
   definePromptAgent,
+  type Agent,
 } from '../src/agent.js';
 import { definePrompt } from '../src/prompt.js';
 import { InMemorySessionStore } from '../src/session-stores.js';
@@ -37,6 +42,7 @@ import {
   Session,
   reserveSnapshotId,
   type SessionSnapshot,
+  type SessionStore,
 } from '../src/session.js';
 import { ToolInterruptError, defineTool, interrupt } from '../src/tool.js';
 import {
@@ -2261,6 +2267,349 @@ describe('Agent', () => {
       assert.strictEqual(processedCount, 2);
 
       session.close();
+    });
+  });
+
+  describe('waitForSnapshot', () => {
+    type S = { foo: string };
+
+    /**
+     * Defines a store-backed custom agent whose turn blocks until `release()`
+     * is called (or the invocation is aborted), so a detached invocation stays
+     * pending for exactly as long as a test needs.
+     */
+    function defineGatedAgent(name: string, store: SessionStore<S>) {
+      let release!: () => void;
+      const gate = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      const agent = defineCustomAgent<S>(
+        new Registry(),
+        { name, store },
+        async (sess, { abortSignal }) => {
+          await sess.run(async () => {
+            await Promise.race([
+              gate,
+              new Promise<never>((_, reject) =>
+                abortSignal?.addEventListener(
+                  'abort',
+                  () => reject(new Error('aborted')),
+                  { once: true }
+                )
+              ),
+            ]);
+            sess.addMessages([{ role: 'model', content: [{ text: 'done' }] }]);
+            return { finishReason: 'stop' as const };
+          });
+          return {
+            artifacts: [],
+            message: { role: 'model', content: [{ text: 'done' }] },
+            finishReason: 'stop' as const,
+          };
+        }
+      );
+      return { agent, release };
+    }
+
+    /** Starts a detached invocation and returns its pending snapshot id. */
+    async function detach(agent: Agent<S>): Promise<string> {
+      const session = agent.streamBidi({});
+      session.send({
+        message: { role: 'user', content: [{ text: 'hi' }] },
+        detach: true,
+      });
+      session.close();
+      const output = await session.output;
+      assert.strictEqual(output.finishReason, 'detached');
+      assert.ok(output.snapshotId);
+      return output.snapshotId!;
+    }
+
+    it('returns an already-settled snapshot without waiting', async () => {
+      const store = new InMemorySessionStore<S>();
+      const { agent, release } = defineGatedAgent('waitSettled', store);
+      release();
+      const chat = agent.chat();
+      await chat.send('hi');
+      const snapshotId = chat.snapshotId!;
+
+      const snap = await agent.waitForSnapshotData({ snapshotId });
+      assert.strictEqual(snap?.snapshotId, snapshotId);
+      assert.strictEqual(snap?.status, 'completed');
+    });
+
+    it('follows a pending detached snapshot until it settles', async () => {
+      const store = new InMemorySessionStore<S>();
+      const { agent, release } = defineGatedAgent('waitPending', store);
+      const snapshotId = await detach(agent);
+
+      let settled = false;
+      const waiting = agent.waitForSnapshotData({ snapshotId }).then((snap) => {
+        settled = true;
+        return snap;
+      });
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      assert.strictEqual(settled, false, 'the wait must block while pending');
+      const raw = await store.getSnapshot({ snapshotId });
+      assert.strictEqual(raw?.status, 'pending');
+
+      release();
+      const snap = await waiting;
+      assert.strictEqual(snap?.status, 'completed');
+      const messages = snap?.state?.messages ?? [];
+      assert.strictEqual(
+        messages[messages.length - 1]?.content[0].text,
+        'done'
+      );
+    });
+
+    it('resolves with the aborted snapshot when the task is aborted', async () => {
+      const store = new InMemorySessionStore<S>();
+      const { agent } = defineGatedAgent('waitAborted', store);
+      const snapshotId = await detach(agent);
+
+      const waiting = agent.waitForSnapshotData({ snapshotId });
+      assert.strictEqual(await agent.abort(snapshotId), 'pending');
+      const snap = await waiting;
+      assert.strictEqual(snap?.status, 'aborted');
+    });
+
+    it('polls a store that cannot push status changes', async () => {
+      const base = new InMemorySessionStore<S>();
+      // The same store minus `onSnapshotStateChange`: the wait has to notice
+      // the settled row by re-reading it.
+      const store: SessionStore<S> = {
+        getSnapshot: (opts) => base.getSnapshot(opts),
+        saveSnapshot: (id, mutator, options) =>
+          base.saveSnapshot(id, mutator, options),
+      };
+      const { agent, release } = defineGatedAgent('waitPolling', store);
+      const snapshotId = await detach(agent);
+
+      const waiting = agent.waitForSnapshotData({
+        snapshotId,
+        pollIntervalMs: 5,
+      });
+      release();
+      const snap = await waiting;
+      assert.strictEqual(snap?.status, 'completed');
+    });
+
+    it('reports a pending snapshot whose heartbeat went stale as expired', async () => {
+      const store = new InMemorySessionStore<S>();
+      const { agent } = defineGatedAgent('waitExpired', store);
+      const stale = new Date(Date.now() - 120_000).toISOString();
+      const snapshotId = await store.saveSnapshot(undefined, () => ({
+        createdAt: stale,
+        updatedAt: stale,
+        heartbeatAt: stale,
+        status: 'pending',
+        state: { sessionId: 'sess-expired' },
+      }));
+
+      // Expiry is computed on read, so the wait settles on its first read.
+      const snap = await agent.waitForSnapshotData({ snapshotId: snapshotId! });
+      assert.strictEqual(snap?.status, 'expired');
+    });
+
+    it('notices a heartbeat that goes stale while waiting', async () => {
+      // A row that reads as fresh once and stale afterwards, on a store that
+      // cannot notify: only the liveness re-read can see the worker die.
+      const fresh = new Date().toISOString();
+      const stale = new Date(Date.now() - 120_000).toISOString();
+      let reads = 0;
+      const store: SessionStore<S> = {
+        async getSnapshot({ snapshotId }) {
+          reads++;
+          return {
+            snapshotId: snapshotId!,
+            createdAt: fresh,
+            status: 'pending',
+            heartbeatAt: reads === 1 ? fresh : stale,
+          };
+        },
+        async saveSnapshot() {
+          throw new Error('unused');
+        },
+      };
+      const { agent } = defineGatedAgent('waitGoesStale', store);
+
+      const snap = await agent.waitForSnapshotData({
+        snapshotId: 'row',
+        pollIntervalMs: 5,
+      });
+      assert.strictEqual(snap?.status, 'expired');
+      assert.strictEqual(reads, 2);
+    });
+
+    it('returns undefined for a missing snapshot and NOT_FOUND via the companion action', async () => {
+      const store = new InMemorySessionStore<S>();
+      const { agent } = defineGatedAgent('waitMissing', store);
+
+      assert.strictEqual(
+        await agent.waitForSnapshotData({ snapshotId: 'nope' }),
+        undefined
+      );
+      await assert.rejects(
+        agent.waitForSnapshotAction({ snapshotId: 'nope' }),
+        (e: any) => e.status === 'NOT_FOUND'
+      );
+      // The action takes getSnapshot's request but requires the snapshot id:
+      // a session's latest snapshot can change under a wait.
+      await assert.rejects(
+        agent.waitForSnapshotAction({ sessionId: 'some-session' }),
+        (e: any) => e.status === 'INVALID_ARGUMENT'
+      );
+    });
+
+    it('requires a store', async () => {
+      const agent = defineCustomAgent<S>(
+        new Registry(),
+        { name: 'waitNoStore' },
+        async (sess) => {
+          await sess.run(async () => {});
+          return { artifacts: [] };
+        }
+      );
+      await assert.rejects(
+        agent.waitForSnapshotData({ snapshotId: 'x' }),
+        (e: any) => e.status === 'FAILED_PRECONDITION'
+      );
+    });
+
+    it('ends the wait when the abort signal fires and leaves the snapshot pending', async () => {
+      const store = new InMemorySessionStore<S>();
+      const { agent, release } = defineGatedAgent('waitAbortSignal', store);
+      const snapshotId = await detach(agent);
+
+      await assert.rejects(
+        agent.waitForSnapshotData({
+          snapshotId,
+          abortSignal: AbortSignal.timeout(20),
+        }),
+        (e: any) => e?.name === 'TimeoutError'
+      );
+      const pending = await agent.getSnapshotData({ snapshotId });
+      assert.strictEqual(pending?.status, 'pending');
+
+      release();
+      const settled = await agent.waitForSnapshotData({ snapshotId });
+      assert.strictEqual(settled?.status, 'completed');
+    });
+
+    it('rides out transient read failures and surfaces dead ends at once', async () => {
+      const base = new InMemorySessionStore<S>();
+      let failures: unknown[] = [];
+      const store: SessionStore<S> = {
+        getSnapshot(opts) {
+          const failure = failures.shift();
+          return failure ? Promise.reject(failure) : base.getSnapshot(opts);
+        },
+        saveSnapshot: (id, mutator, options) =>
+          base.saveSnapshot(id, mutator, options),
+        onSnapshotStateChange: (id, callback, options) =>
+          base.onSnapshotStateChange(id, callback, options),
+      };
+      const { agent, release } = defineGatedAgent('waitFlaky', store);
+      release();
+      const chat = agent.chat();
+      await chat.send('hi');
+      const snapshotId = chat.snapshotId!;
+
+      // Two blips, then the settled row.
+      failures = [new Error('blip'), new Error('blip')];
+      const snap = await agent.waitForSnapshotData({
+        snapshotId,
+        pollIntervalMs: 5,
+      });
+      assert.strictEqual(snap?.status, 'completed');
+
+      // A rejected request is a dead end: no retry, the error surfaces as is.
+      failures = [
+        new GenkitError({ status: 'INVALID_ARGUMENT', message: 'bad' }),
+      ];
+      await assert.rejects(
+        agent.waitForSnapshotData({ snapshotId, pollIntervalMs: 5 }),
+        (e: any) => e.status === 'INVALID_ARGUMENT'
+      );
+
+      // Past the retry budget the failure surfaces too.
+      failures = Array.from({ length: 5 }, () => new Error('down'));
+      await assert.rejects(
+        agent.waitForSnapshotData({ snapshotId, pollIntervalMs: 5 }),
+        /down/
+      );
+      assert.strictEqual(failures.length, 1, 'four consecutive failures');
+    });
+
+    it('waits through the chat surface (DetachedTask.wait, AgentAPI.waitForSnapshot)', async () => {
+      const store = new InMemorySessionStore<S>();
+      const { agent, release } = defineGatedAgent('waitChat', store);
+      const chat = agent.chat();
+      const task = await chat.detach('hi');
+
+      const waiting = task.wait();
+      release();
+      assert.strictEqual((await waiting).status, 'completed');
+      const again = await agent.waitForSnapshot(task.snapshotId);
+      assert.strictEqual(again?.status, 'completed');
+    });
+
+    it('falls back to polling when the transport cannot wait server-side', async () => {
+      const statuses: SessionSnapshot['status'][] = [
+        'pending',
+        'pending',
+        'completed',
+      ];
+      let reads = 0;
+      const snapshot = (
+        status: SessionSnapshot['status']
+      ): SessionSnapshot => ({
+        snapshotId: 'x',
+        createdAt: '2026',
+        status,
+      });
+      const transport: AgentTransport = {
+        runTurn() {
+          throw new Error('unused');
+        },
+        async getSnapshot() {
+          reads++;
+          return snapshot(statuses.shift() ?? 'completed');
+        },
+        async abort() {
+          return undefined;
+        },
+      };
+
+      const api = createAgentAPI(transport);
+      const snap = await api.waitForSnapshot('x', { intervalMs: 1 });
+      assert.strictEqual(snap?.status, 'completed');
+      assert.strictEqual(reads, 3);
+
+      // A missing snapshot resolves undefined rather than polling forever.
+      const missing = createAgentAPI({
+        ...transport,
+        async getSnapshot() {
+          return undefined;
+        },
+      });
+      assert.strictEqual(await missing.waitForSnapshot('gone'), undefined);
+
+      // The abort signal ends a polling wait too.
+      const stuck = createAgentAPI({
+        ...transport,
+        async getSnapshot() {
+          return snapshot('pending');
+        },
+      });
+      await assert.rejects(
+        stuck.waitForSnapshot('x', {
+          intervalMs: 1,
+          abortSignal: AbortSignal.timeout(10),
+        }),
+        (e: any) => e?.name === 'TimeoutError'
+      );
     });
   });
 

--- a/js/ai/tests/session-stores_test.ts
+++ b/js/ai/tests/session-stores_test.ts
@@ -91,6 +91,34 @@ describe('InMemorySessionStore', () => {
   });
 });
 
+describe('InMemorySessionStore onSnapshotStateChange', () => {
+  it('notifies every listener even when one unsubscribes mid-dispatch', async () => {
+    const store = new InMemorySessionStore<{ foo: string }>();
+    const seen: string[] = [];
+    // The first listener unsubscribes itself as soon as it is notified, as the
+    // detach runtime does on an abort; the second must still be notified.
+    const unsubscribeFirst = store.onSnapshotStateChange('snap-1', () => {
+      seen.push('first');
+      if (typeof unsubscribeFirst === 'function') unsubscribeFirst();
+    });
+    store.onSnapshotStateChange('snap-1', () => {
+      seen.push('second');
+    });
+
+    await store.saveSnapshot('snap-1', () => ({
+      createdAt: new Date().toISOString(),
+      status: 'aborted',
+    }));
+    assert.deepStrictEqual(seen, ['first', 'second']);
+
+    await store.saveSnapshot('snap-1', () => ({
+      createdAt: new Date().toISOString(),
+      status: 'completed',
+    }));
+    assert.deepStrictEqual(seen, ['first', 'second', 'second']);
+  });
+});
+
 describe('FileSessionStore', () => {
   function tmpDir(): string {
     return fs.mkdtempSync(path.join(os.tmpdir(), 'genkit-file-store-'));

--- a/js/core/src/registry.ts
+++ b/js/core/src/registry.ts
@@ -58,6 +58,7 @@ const ACTION_TYPES = [
   'resource',
   'agent',
   'agent-snapshot',
+  'agent-wait',
   'agent-abort',
 ] as const;
 export type ActionType = (typeof ACTION_TYPES)[number];

--- a/js/genkit/src/beta.ts
+++ b/js/genkit/src/beta.ts
@@ -48,6 +48,7 @@ export {
   type AgentTurn,
   type DetachedTask,
   type RemoteAgentOptions,
+  type WaitForSnapshotOptions,
 } from './client/agent.js';
 
 export type { AgentFinishReason } from './client/types.js';

--- a/js/genkit/src/client/agent.ts
+++ b/js/genkit/src/client/agent.ts
@@ -19,6 +19,7 @@ import {
   type AgentAPI,
   type AgentTransport,
   type SnapshotLookup,
+  type WaitForSnapshotOptions,
 } from '@genkit-ai/ai/agent-core';
 
 import type {
@@ -41,6 +42,7 @@ export {
   type AgentResponse,
   type AgentTurn,
   type DetachedTask,
+  type WaitForSnapshotOptions,
 } from '@genkit-ai/ai/agent-core';
 
 // Re-export the JSON Patch helper so apps can apply a chunk's `customPatch` to
@@ -55,6 +57,12 @@ export interface RemoteAgentOptions {
   url: string;
   /** Optional. Defaults to `${url}/getSnapshot`. */
   getSnapshotUrl?: string;
+  /**
+   * Optional. Defaults to `${url}/waitForSnapshot`. The agent's
+   * `waitForSnapshotAction` must be mounted there for `waitForSnapshot` and
+   * `DetachedTask.wait` to follow a background task in one request.
+   */
+  waitForSnapshotUrl?: string;
   /** Optional. Defaults to `${url}/abort`. */
   abortUrl?: string;
   /** Optional. Static headers, or a function called per request. */
@@ -88,6 +96,8 @@ export function remoteAgent<State = unknown>(
 ): AgentAPI<State> {
   const { url } = options;
   const getSnapshotUrl = options.getSnapshotUrl ?? `${url}/getSnapshot`;
+  const waitForSnapshotUrl =
+    options.waitForSnapshotUrl ?? `${url}/waitForSnapshot`;
   const abortUrl = options.abortUrl ?? `${url}/abort`;
 
   const resolveHeaders = async (): Promise<
@@ -139,6 +149,19 @@ export function remoteAgent<State = unknown>(
         url: getSnapshotUrl,
         input: lookup,
         headers,
+      });
+    },
+
+    // One request for the whole wait: the server blocks next to its store and
+    // answers once the snapshot settles, so a client neither picks a cadence
+    // nor pays a round trip per tick. Aborting the signal drops the request.
+    async waitForSnapshot(snapshotId: string, opts?: WaitForSnapshotOptions) {
+      const headers = await resolveHeaders();
+      return runFlow<SessionSnapshot<State> | undefined>({
+        url: waitForSnapshotUrl,
+        input: { snapshotId },
+        headers,
+        abortSignal: opts?.abortSignal,
       });
     },
 

--- a/js/genkit/tests/agent_client_test.ts
+++ b/js/genkit/tests/agent_client_test.ts
@@ -26,6 +26,7 @@ interface RecordedRequest {
   url: string;
   body: any;
   headers: Record<string, string>;
+  signal?: AbortSignal;
 }
 
 /** Builds a streaming (SSE) Response from a list of chunk objects. */
@@ -57,10 +58,14 @@ function jsonResponse(obj: any): Response {
 /** A scriptable fetch mock. */
 class FetchMock {
   requests: RecordedRequest[] = [];
-  private handlers: Array<(req: RecordedRequest) => Response> = [];
+  private handlers: Array<
+    (req: RecordedRequest) => Response | Promise<Response>
+  > = [];
 
   /** Queues a response for the next matching request. */
-  onNext(handler: (req: RecordedRequest) => Response): void {
+  onNext(
+    handler: (req: RecordedRequest) => Response | Promise<Response>
+  ): void {
     this.handlers.push(handler);
   }
 
@@ -70,6 +75,7 @@ class FetchMock {
         url: String(url),
         body: init?.body ? JSON.parse(init.body) : undefined,
         headers: init?.headers ?? {},
+        signal: init?.signal,
       };
       this.requests.push(req);
       const handler = this.handlers.shift();
@@ -468,19 +474,81 @@ describe('remoteAgent', () => {
     const task = await chat.detach('long job');
     assert.equal(task.snapshotId, 'bg-1');
 
-    // wait() polls /getSnapshot until terminal.
-    mock.onNext(() =>
-      jsonResponse({
+    // wait() is one request to /waitForSnapshot, which answers once the
+    // snapshot settles; the client never polls /getSnapshot.
+    mock.onNext((req) => {
+      assert.equal(req.url, '/api/a/waitForSnapshot');
+      assert.deepEqual(req.body.data, { snapshotId: 'bg-1' });
+      return jsonResponse({
         result: {
           snapshotId: 'bg-1',
           createdAt: '2026',
           state: {},
           status: 'completed',
         },
-      })
-    );
-    const snap = await task.wait({ intervalMs: 1 });
+      });
+    });
+    const snap = await task.wait();
     assert.equal(snap.status, 'completed');
+    assert.equal(mock.requests.length, 2);
+  });
+
+  it('waitForSnapshot posts to the waitForSnapshot endpoint', async () => {
+    mock.onNext((req) => {
+      assert.equal(req.url, '/api/a/waitForSnapshot');
+      assert.deepEqual(req.body.data, { snapshotId: 'snap-1' });
+      return jsonResponse({
+        result: {
+          snapshotId: 'snap-1',
+          createdAt: '2026',
+          state: {},
+          status: 'failed',
+          error: { message: 'boom' },
+        },
+      });
+    });
+    const agent = remoteAgent({ url: '/api/a' });
+    // A settled-but-failed snapshot is a result, not an error.
+    const snap = await agent.waitForSnapshot('snap-1');
+    assert.equal(snap?.status, 'failed');
+    assert.equal(snap?.error?.message, 'boom');
+  });
+
+  it('honors a custom waitForSnapshotUrl and forwards the abort signal', async () => {
+    mock.onNext((req) => {
+      assert.equal(req.url, '/wait-here');
+      return jsonResponse({
+        result: {
+          snapshotId: 'snap-1',
+          createdAt: '2026',
+          state: {},
+          status: 'completed',
+        },
+      });
+    });
+    const agent = remoteAgent({
+      url: '/api/a',
+      waitForSnapshotUrl: '/wait-here',
+    });
+    const snap = await agent.waitForSnapshot('snap-1', {
+      abortSignal: AbortSignal.timeout(5_000),
+    });
+    assert.equal(snap?.status, 'completed');
+  });
+
+  it('rejects a wait whose abort signal fires before the server answers', async () => {
+    mock.onNext(async (req) => {
+      // Behave like fetch: reject with the signal's reason once it aborts.
+      await new Promise((_, reject) =>
+        req.signal?.addEventListener('abort', () => reject(req.signal!.reason))
+      );
+      throw new Error('unreachable');
+    });
+    const agent = remoteAgent({ url: '/api/a' });
+    await assert.rejects(
+      agent.waitForSnapshot('snap-1', { abortSignal: AbortSignal.timeout(10) }),
+      (e: any) => e?.name === 'TimeoutError'
+    );
   });
 
   it('applies static and async headers', async () => {

--- a/js/testapps/agents/src/index.ts
+++ b/js/testapps/agents/src/index.ts
@@ -122,7 +122,9 @@ app.use((_req, res, next) => {
 });
 
 // Register an agent at `/api/<name>`, optionally wiring up its companion
-// `/getSnapshot` and `/abort` sub-actions.
+// `/getSnapshot`, `/waitForSnapshot`, and `/abort` sub-actions. The wait
+// route lets a `remoteAgent` client follow a background task in one request
+// (`task.wait()`) instead of polling `/getSnapshot`.
 function exposeAgent(
   name: string,
   agent: Agent,
@@ -133,6 +135,10 @@ function exposeAgent(
     app.post(
       `/api/${name}/getSnapshot`,
       expressHandler(agent.getSnapshotDataAction)
+    );
+    app.post(
+      `/api/${name}/waitForSnapshot`,
+      expressHandler(agent.waitForSnapshotAction)
     );
   }
   if (opts.abort) {


### PR DESCRIPTION
Adds `waitForSnapshot` to every agent: the base PR of a two-PR train (next: background delegation in the `agents` middleware, #6273), porting the wait half of Go [#6118](https://github.com/genkit-ai/genkit/pull/6118). A companion action (`agent-wait`) takes `getSnapshot`'s request with `snapshotId` required and answers once the snapshot settles, so a client follows a detached turn in one request and a trace carries one span per wait instead of one per tick. Experimental surface throughout, like the rest of the agent API.

## Waiting is one call, not a poll loop

```ts
const task = await reportAgent.chat().detach('Write the report');

const snap = await task.wait();                      // server-side wait, no interval to pick
const snap = await reportAgent.waitForSnapshot(id);  // same, from a recorded ID
const snap = await reportAgent.waitForSnapshotData({ // the richer server-side form
  snapshotId: id,
  abortSignal: AbortSignal.timeout(30_000),
});
```

A snapshot that failed, aborted, or expired is returned like any other; a rejection means the wait itself could not proceed. An `abortSignal` bounds the wait (the JS shape of Go's `context.WithTimeout`): the promise rejects with the signal's reason and `getSnapshot` then reports where the task stands.

Where the store implements `onSnapshotStateChange` the wait is push-driven, and it re-reads on an interval either way, because an expiry is not a write: a dead worker leaves the row pending and only its heartbeat goes stale. The subscription is taken before the first read, since the bundled stores do not replay the current status on subscribe, and a settlement landing between the two would otherwise wait out a whole heartbeat interval. Each in-wait read is bounded, three consecutive transient failures are ridden out, and NOT_FOUND, INVALID_ARGUMENT, and FAILED_PRECONDITION surface at once.

## The transport decides how to wait

`AgentTransport` gains an optional `waitForSnapshot`. `DetachedTask.wait` and `AgentAPI.waitForSnapshot` use it when present and fall back to polling `getSnapshot` when not, so a custom transport keeps working unchanged. The in-process transport waits in the store. `remoteAgent` posts to `${url}/waitForSnapshot` (overridable with `waitForSnapshotUrl`), so a server must mount `agent.waitForSnapshotAction` there for a remote `task.wait()` to succeed. That is the one behavior change: a remote `wait()` used to poll `/getSnapshot` and now needs the wait route, exactly as `abort()` needs `/abort`.

## New exported surface

```ts
// @genkit-ai/core
ActionType: 'agent-wait'

// @genkit-ai/ai (Agent)
agent.waitForSnapshotData(opts: WaitForSnapshotDataInput): Promise<SessionSnapshot<State> | undefined>
agent.waitForSnapshotAction: GetSnapshotDataAction<State>   // action type 'agent-wait'
interface WaitForSnapshotDataInput extends GetSnapshotDataInput { snapshotId: string; abortSignal?; pollIntervalMs? }

// @genkit-ai/ai/agent-core (shared by the server agent and remoteAgent)
AgentAPI.waitForSnapshot(snapshotId, opts?: WaitForSnapshotOptions): Promise<SessionSnapshot<State> | undefined>
DetachedTask.wait(opts?: WaitForSnapshotOptions): Promise<SessionSnapshot<State>>   // was { intervalMs? }
AgentTransport.waitForSnapshot?(snapshotId, opts?): Promise<SessionSnapshot | undefined>
interface WaitForSnapshotOptions { abortSignal?: AbortSignal; intervalMs?: number }

// genkit/beta/client
RemoteAgentOptions.waitForSnapshotUrl?: string   // defaults to `${url}/waitForSnapshot`
```

`AgentAPI` gains a required member, so an application that implements `AgentAPI` by hand rather than through `createAgentAPI` or `remoteAgent` must add it. `intervalMs` keeps its meaning on the polling fallback and becomes the in-process re-read cadence.

## `InMemorySessionStore` skipped a listener on abort

The store dispatched notifications by iterating its live listener array. The detach runtime unsubscribes from inside its own callback when it sees `aborted`, which splices the array under the iterator and skips the listener registered after it, so a wait racing an abort learned of it only on its next tick. Dispatch now runs over a copy.

## What was deliberately deferred

- **No `AgentHandle`.** Go added an untyped caller-side agent surface beside the wait. The JS `Agent` composite already carries `run`, the companion actions, and its metadata, so name-resolved callers such as the next PR's middleware need nothing new.
- **No payload timeout on the wait action.** A bounded wait is an `abortSignal`; a `timeoutSeconds` field is a shared-schema change across all runtimes.
- **The web UI still polls.** `BackgroundAgent.tsx` uses `task.poll()` to render each status change, which is what it is for.
