### PR TITLE
feat(js/plugins/middleware): add background sub-agent delegation (`async`)

### DIFF
--- a/js/plugins/middleware/README.md
+++ b/js/plugins/middleware/README.md
@@ -17,21 +17,23 @@ pnpm add @genkit-ai/middleware
 Enables sub-agent delegation. For each configured agent the middleware injects a dedicated delegation tool (e.g. `delegate_to_researcher`) and appends a `<sub-agents>` block to the system prompt listing the available agents and their descriptions. When the model calls a delegation tool, the middleware resolves the target agent from the registry, runs it via its `run()` method, and returns the sub-agent's response as the tool result.
 
 **Key behaviors:**
+
 - Injects **one delegation tool per agent**, named `<toolPrefix>_<agentName>` (default prefix: `delegate_to`).
 - Agent descriptions are auto-discovered from the registry (or can be overridden per-agent) and surfaced in the system prompt.
 - Sub-agent interrupts and failures are returned as tool responses (not thrown), allowing the orchestrator to self-correct. (Interactive, stateful back-and-forth with an interrupted sub-agent is a future feature.)
-
 - Sub-agent artifacts are merged into the parent session and/or returned inline, controlled by `artifactStrategy`.
+- With `async: true`, delegations can run in the background and be collected later (see below).
 
 **Options:**
 
-| Option | Type | Default | Description |
-| --- | --- | --- | --- |
-| `agents` | `(string \| { name, description? })[]` | — (required) | Agents available for delegation. A string is the agent name; the object form lets you override the description. |
-| `toolPrefix` | `string` | `'delegate_to'` | Prefix for generated delegation tool names. Set to `''` to use bare agent names. |
-| `maxDelegations` | `number` | unlimited | Maximum sub-agent delegations allowed per generate call. Prevents runaway delegation loops. |
-| `historyLength` | `number` | `0` | Number of recent conversation messages (user/model only) to forward to sub-agents as context. |
-| `artifactStrategy` | `'inline' \| 'session'` | `'inline'` | `inline`: artifact content is included in the tool result **and** merged into the parent session. `session`: artifacts are merged into the parent session only (the tool result lists names only). Pair `session` with the `artifacts` middleware. |
+| Option             | Type                                   | Default         | Description                                                                                                                                                                                                                                                             |
+| ------------------ | -------------------------------------- | --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `agents`           | `(string \| { name, description? })[]` | — (required)    | Agents available for delegation. A string is the agent name; the object form lets you override the description.                                                                                                                                                         |
+| `toolPrefix`       | `string`                               | `'delegate_to'` | Prefix for generated delegation tool names. Set to `''` to use bare agent names.                                                                                                                                                                                        |
+| `maxDelegations`   | `number`                               | unlimited       | Maximum sub-agent delegations allowed per generate call. Prevents runaway delegation loops.                                                                                                                                                                             |
+| `historyLength`    | `number`                               | `0`             | Number of recent conversation messages (user/model only) to forward to sub-agents as context.                                                                                                                                                                           |
+| `artifactStrategy` | `'inline' \| 'session'`                | `'inline'`      | `inline`: artifact content is included in the tool result **and** merged into the parent session. `session`: artifacts are merged into the parent session only (the tool result lists names only). Pair `session` with the `artifacts` middleware.                      |
+| `async`            | `boolean`                              | `false`         | Enables background delegation: delegation tools accept a `background` flag that returns a task ID immediately, and the `check_background_tasks`, `wait_for_background_tasks`, and `abort_background_tasks` tools are added. Requires sub-agents defined with a `store`. |
 
 ```typescript
 import { genkit } from 'genkit';
@@ -79,22 +81,48 @@ use: [
     ],
     maxDelegations: 5,
     historyLength: 4,
-  })
-]
+  }),
+];
 ```
+
+Set `async: true` to let the orchestrator keep working while a sub-agent runs. Each delegation tool gains a `background` flag that returns a task ID instead of waiting, and three shared tools give the orchestrator one control per thing it can do with a launched task: `check_background_tasks` reads statuses without waiting, `wait_for_background_tasks` blocks until they settle, and `abort_background_tasks` stops the ones whose results are no longer needed. The _sub-agent_ is what needs the session store here: background work is tracked by a snapshot, so a sub-agent without a `store` can only be delegated to synchronously.
+
+```typescript
+import { InMemorySessionStore } from 'genkit/beta';
+
+// The sub-agent needs its own store to be delegated to in the background.
+const researcher = ai.defineAgent({
+  name: 'researcher',
+  model: 'gemini-2.5-flash',
+  description: 'Researches a topic and summarizes well-sourced findings.',
+  system: 'You are a thorough research assistant.',
+  store: new InMemorySessionStore(),
+});
+
+const orchestrator = ai.defineAgent({
+  name: 'orchestrator',
+  model: 'gemini-2.5-flash',
+  system:
+    'Delegate research in the background and post an update while it runs.',
+  use: [agents({ agents: ['researcher'], async: true })],
+});
+```
+
+The orchestrator then launches with `{ "task": "...", "background": true }`, posts an update while the sub-agent runs, and collects the result later. Task IDs (`<agent>:<snapshotId>`) ride in the delegation tool result, so they are recorded in the conversation and a re-instantiated orchestrator can collect them from its history alone. `wait_for_background_tasks` takes an optional `timeoutSeconds`, so a slow task becomes an interim answer instead of a blocked turn, and `waitFor: "first"` turns the join into a race: the tool returns as soon as any listed task settles while the rest keep running. An abort is safe to call on any task: one that had already finished is left alone and reports its result, so the orchestrator never loses an answer by giving up on it.
 
 ### 2. Artifacts Middleware (`artifacts`)
 
 Gives the model tools to interact with session artifacts and injects an `<artifacts>` listing into the system prompt each turn. Useful standalone (e.g. a workspace-builder agent that produces files as artifacts) or combined with the `agents` middleware using `artifactStrategy: 'session'`, so the orchestrator can read artifacts produced by sub-agents.
 
 **Tools provided:**
+
 - `read_artifact` — reads a named artifact from the session and returns its text content.
 - `write_artifact` — creates or updates a named artifact (deduplicated by name). Omitted when `readonly: true`.
 
 **Options:**
 
-| Option | Type | Default | Description |
-| --- | --- | --- | --- |
+| Option     | Type      | Default | Description                                           |
+| ---------- | --------- | ------- | ----------------------------------------------------- |
 | `readonly` | `boolean` | `false` | When true, only the `read_artifact` tool is provided. |
 
 ```typescript
@@ -144,7 +172,6 @@ const response = await ai.generate({
 
 ### 4. Skills Middleware (`skills`)
 
-
 Automatically scans a directory for `SKILL.md` files (and their YAML frontmatter) and injects them into the system prompt. It also provides a `use_skill` tool the model can use to retrieve more specific skills on demand.
 
 ```typescript
@@ -162,7 +189,6 @@ const response = await ai.generate({
 ```
 
 ### 5. Tool Approval Middleware (`toolApproval`)
-
 
 Restricts execution of tools to an approved list. If the model attempts to call an unapproved tool, it throws a `ToolInterruptError` allowing you to prompt the user for manual confirmation before resuming.
 
@@ -183,14 +209,14 @@ const response = await ai.generate({
 
 if (response.finishReason === 'interrupted') {
   const interrupt = response.interrupts[0];
-  
+
   // 2. Ask user for approval, then recreate the tool request with approval
   const approvedPart = restartTool(interrupt, { toolApproved: true });
 
   // 3. Resume execution
   const resumedResponse = await ai.generate({
     messages: response.messages,
-    resume: { restart: [approvedPart] }, 
+    resume: { restart: [approvedPart] },
     use: [
       toolApproval({ approved: [] })
     ]
@@ -199,7 +225,6 @@ if (response.finishReason === 'interrupted') {
 ```
 
 ### 6. Retry Middleware (`retry`)
-
 
 Automatically retries failed model generations on transient error codes (like `RESOURCE_EXHAUSTED`, `UNAVAILABLE`) using exponential backoff with jitter.
 
@@ -223,7 +248,6 @@ const response = await ai.generate({
 ```
 
 ### 7. Fallback Middleware (`fallback`)
-
 
 Automatically switches to a different model if the primary model fails on a specific set of error codes. Useful for falling back to a smaller/faster model when a large model exceeds quota limits.
 

--- a/js/plugins/middleware/README.md
+++ b/js/plugins/middleware/README.md
@@ -20,7 +20,7 @@ Enables sub-agent delegation. For each configured agent the middleware injects a
 
 - Injects **one delegation tool per agent**, named `<toolPrefix>_<agentName>` (default prefix: `delegate_to`).
 - Agent descriptions are auto-discovered from the registry (or can be overridden per-agent) and surfaced in the system prompt.
-- Sub-agent interrupts and failures are returned as tool responses (not thrown), allowing the orchestrator to self-correct. (Interactive, stateful back-and-forth with an interrupted sub-agent is a future feature.)
+- Sub-agent interrupts and failures are returned as tool responses (not thrown), allowing the orchestrator to self-correct. (Interactive, stateful back-and-forth with an interrupted sub-agent is a future feature.) A turn that ends without an answer (`length`, `blocked`, `aborted`) is reported as an error naming the reason and the agent's last message, and a success with no final text says so and names its artifact count.
 - Sub-agent artifacts are merged into the parent session and/or returned inline, controlled by `artifactStrategy`.
 - With `async: true`, delegations can run in the background and be collected later (see below).
 

--- a/js/plugins/middleware/src/agents.ts
+++ b/js/plugins/middleware/src/agents.ts
@@ -300,25 +300,6 @@ function isAbortError(e: unknown): boolean {
 }
 
 /**
- * Forwards the first abort among `sources` to `target`, with its reason.
- */
-function linkSignals(
-  target: AbortController,
-  ...sources: Array<AbortSignal | undefined>
-): void {
-  for (const source of sources) {
-    if (!source) continue;
-    if (source.aborted) {
-      target.abort(source.reason);
-      return;
-    }
-    source.addEventListener('abort', () => target.abort(source.reason), {
-      once: true,
-    });
-  }
-}
-
-/**
  * Returns up to `n` of the most recent user/model messages, each reduced to
  * its non-empty text parts. Tool and tool-request parts are dropped: a model
  * message mid-tool-loop can carry a `toolRequest` part with no matching
@@ -1247,12 +1228,16 @@ export const agents: GenerateMiddleware<typeof AgentsOptionsSchema> =
        * Follows one task to its end and returns its report. A fetch error
        * that reaches this level is a dead end worth reporting, with one
        * exception: `signal` ending the wait (its timeout, or a won race). The
-       * task is still running by definition then, so a follow cut short that
-       * way is reported as pending rather than as a read that did not finish.
-       * That is decided from the failure itself, not from the signal alone: a
-       * handle that never resolved is not the signal's doing and keeps its
-       * error however the wait ended, or the model would be told to keep
-       * re-checking an ID that can never settle.
+       * follow was cut short rather than finished then, so the task is
+       * reported as it stands from one more plain read: the runtime's wait
+       * checks the signal before its first read, and a deadline that beats
+       * the dispatch would otherwise report an already-settled task as
+       * pending. A read that fails there leaves the task pending, since it
+       * was still running the last time anyone saw it. That is decided from
+       * the failure itself, not from the signal alone: a handle that never
+       * resolved is not the signal's doing and keeps its error however the
+       * wait ended, or the model would be told to keep re-checking an ID that
+       * can never settle.
        */
       async function awaitTask(
         taskId: string,
@@ -1263,10 +1248,12 @@ export const agents: GenerateMiddleware<typeof AgentsOptionsSchema> =
           awaitSnapshot,
           signal
         );
-        if (error !== undefined && signal.aborted && isAbortError(error)) {
-          return { ...report, status: 'pending', error: undefined };
+        if (error === undefined || !signal.aborted || !isAbortError(error)) {
+          return report;
         }
-        return report;
+        const current = await reportTask(taskId, readSnapshotOnce);
+        if (current.error === undefined) return current.report;
+        return { ...report, status: 'pending', error: undefined };
       }
 
       /**
@@ -1304,26 +1291,43 @@ export const agents: GenerateMiddleware<typeof AgentsOptionsSchema> =
           return reportTasks(taskIds, readSnapshotOnce);
         }
         const timeoutMs = timeoutSeconds * 1000;
-        const deadline =
-          timeoutMs > 0 && timeoutMs <= MAX_TIMEOUT_MS
-            ? AbortSignal.timeout(timeoutMs)
-            : undefined;
 
         // One signal ends every follow: the deadline, the caller hanging up,
         // or (with waitFor "first") the first settlement, after which the
-        // remaining follows report their tasks as they stand.
+        // remaining follows report their tasks as they stand. The controller
+        // is aborted once the collection is over however it ended, so no
+        // follow outlives the call that started it, and the deadline timer is
+        // cleared rather than left to fire into a finished wait.
         const controller = new AbortController();
-        linkSignals(controller, deadline, toolSignal);
+        const signal = toolSignal
+          ? AbortSignal.any([controller.signal, toolSignal])
+          : controller.signal;
+        const deadline =
+          timeoutMs > 0 && timeoutMs <= MAX_TIMEOUT_MS
+            ? setTimeout(
+                () =>
+                  controller.abort(
+                    new DOMException('wait timed out', 'TimeoutError')
+                  ),
+                timeoutMs
+              )
+            : undefined;
 
-        const reports = await collectReports(taskIds, async (taskId) => {
-          const report = await awaitTask(taskId, controller.signal);
-          if (first && isSettled(report.status)) {
-            controller.abort(
-              new DOMException('first task settled', 'AbortError')
-            );
-          }
-          return report;
-        });
+        let reports: BackgroundTaskReport[];
+        try {
+          reports = await collectReports(taskIds, async (taskId) => {
+            const report = await awaitTask(taskId, signal);
+            if (first && isSettled(report.status)) {
+              controller.abort(
+                new DOMException('first task settled', 'AbortError')
+              );
+            }
+            return report;
+          });
+        } finally {
+          clearTimeout(deadline);
+          controller.abort(new DOMException('wait ended', 'AbortError'));
+        }
 
         // The calling tool ending is cancellation, not a timeout; let it fail
         // the tool call rather than dressing it up as a settled result.

--- a/js/plugins/middleware/src/agents.ts
+++ b/js/plugins/middleware/src/agents.ts
@@ -196,20 +196,12 @@ function carriesResult(reason?: AgentFinishReason): boolean {
 }
 
 /**
- * Whether a snapshot status is settled. `pending` is the only status that can
- * still change on its own; an absent status is the `completed` default.
+ * Whether a snapshot or task-report status can no longer change on its own,
+ * which is the rule the wait tool counts by. `pending` is the only status
+ * that can; an absent status is the `completed` default, and the report-only
+ * `unknown` is settled too (see {@link TASK_STATUS_UNKNOWN}).
  */
-function isTerminalStatus(status: SessionSnapshot['status']): boolean {
-  return status !== 'pending';
-}
-
-/**
- * Whether a task report's status can no longer change on its own, which is
- * the rule the wait tool counts by. Report statuses are the snapshot statuses
- * plus `unknown`, and `unknown` is settled too (see
- * {@link TASK_STATUS_UNKNOWN}).
- */
-function reportSettled(status: string): boolean {
+function isSettled(status: string | undefined): boolean {
   return status !== 'pending';
 }
 
@@ -930,24 +922,12 @@ export const agents: GenerateMiddleware<typeof AgentsOptionsSchema> =
         try {
           out = await runSubAgent(agent, task, { detach: true });
         } catch (e: unknown) {
-          // FAILED_PRECONDITION is how the runtime rejects a detach on an agent
-          // that cannot support it. Only a metadata-less agent reaches this
-          // (one that publishes metadata and cannot detach was refused above),
-          // and only this failure earns its slot back: the retry it points at
-          // is the synchronous launch. Every other failure keeps the slot.
-          if (
-            stateManagement === undefined &&
-            errorStatus(e) === 'FAILED_PRECONDITION'
-          ) {
-            releaseDelegation();
-            return {
-              response:
-                `Error calling agent '${ref.name}': ${errorMessage(e)} If this ` +
-                `agent has no session store, it cannot run in the background. ${withoutBackground}`,
-            };
-          }
-          return {
-            response: `Error calling agent '${ref.name}': ${errorMessage(e)}`,
+          // A thrown rejection (e.g. a schema parse error on `run`) carries
+          // the same status a graceful one does, so it takes the failed shape
+          // and is judged once below.
+          out = {
+            finishReason: 'failed',
+            error: { status: errorStatus(e), message: errorMessage(e) },
           };
         }
 
@@ -969,8 +949,12 @@ export const agents: GenerateMiddleware<typeof AgentsOptionsSchema> =
             };
           }
           case 'failed': {
-            // A graceful rejection carries the same status a thrown one does,
-            // and earns the same refund under the same conditions.
+            // FAILED_PRECONDITION is how the runtime rejects a detach on an
+            // agent that cannot support it. Only a metadata-less agent reaches
+            // this (one that publishes metadata and cannot detach was refused
+            // above), and only this failure earns its slot back: the retry it
+            // points at is the synchronous launch. Every other failure keeps
+            // the slot.
             const msg = subAgentFailureMessage(
               out.finishReason,
               out.error,
@@ -1032,7 +1016,7 @@ export const agents: GenerateMiddleware<typeof AgentsOptionsSchema> =
       // settled needs no abort at all and is answered from the row alone.
       const abortSnapshot: SnapshotFetch = async (agent, snapshotId) => {
         const current = await readSnapshotOnce(agent, snapshotId);
-        if (isTerminalStatus(current.status)) {
+        if (isSettled(current.status)) {
           return current;
         }
         const { result } = await agent.abortAgentAction.run({ snapshotId });
@@ -1166,7 +1150,10 @@ export const agents: GenerateMiddleware<typeof AgentsOptionsSchema> =
             // Fold the settled snapshot exactly as a synchronous delegation
             // folds its output, under the deterministic namespace of the run.
             // The response is what the sub-agent last said, not whatever the
-            // transcript happens to end on.
+            // transcript happens to end on. One caveat: this reads through
+            // the sub-agent's companion action, so a sub-agent with a
+            // `clientTransform.state` has already shaped what is read here,
+            // while the synchronous path sees the output unshaped.
             const folded = foldDelegationOutput(
               ref,
               {
@@ -1210,7 +1197,7 @@ export const agents: GenerateMiddleware<typeof AgentsOptionsSchema> =
         // Expired is the one terminal read that can still change its mind:
         // the worker may be alive and merely slow to beat, so a later read can
         // find it settled properly. Everything else terminal is final.
-        if (isTerminalStatus(snapshotStatus) && snapshotStatus !== 'expired') {
+        if (isSettled(snapshotStatus) && snapshotStatus !== 'expired') {
           shared.settledReports.set(taskId, report);
         }
         return { report };
@@ -1237,11 +1224,17 @@ export const agents: GenerateMiddleware<typeof AgentsOptionsSchema> =
         return taskIds.map((id) => fetched.get(id)!);
       }
 
-      /** One report per task with a single fetch each; no waiting. */
+      /**
+       * One report per task with a single fetch each; no waiting. The body of
+       * the check and abort tools, and the wait tool's don't-wait path.
+       */
       async function reportTasks(
         taskIds: string[],
         fetch: SnapshotFetch
       ): Promise<BackgroundTasksResult> {
+        if (taskIds.length === 0) {
+          return { note: NO_TASK_IDS_NOTE };
+        }
         return {
           tasks: await collectReports(
             taskIds,
@@ -1324,7 +1317,7 @@ export const agents: GenerateMiddleware<typeof AgentsOptionsSchema> =
 
         const reports = await collectReports(taskIds, async (taskId) => {
           const report = await awaitTask(taskId, controller.signal);
-          if (first && reportSettled(report.status)) {
+          if (first && isSettled(report.status)) {
             controller.abort(
               new DOMException('first task settled', 'AbortError')
             );
@@ -1336,7 +1329,7 @@ export const agents: GenerateMiddleware<typeof AgentsOptionsSchema> =
         // the tool call rather than dressing it up as a settled result.
         toolSignal?.throwIfAborted();
 
-        const pending = reports.filter((r) => !reportSettled(r.status)).length;
+        const pending = reports.filter((r) => !isSettled(r.status)).length;
         if (pending === 0) {
           return { tasks: reports };
         }
@@ -1354,92 +1347,67 @@ export const agents: GenerateMiddleware<typeof AgentsOptionsSchema> =
         };
       }
 
-      /** A non-blocking background-task tool: one dispatch per task, then a report of where that left it. */
-      function taskReport(
-        input: z.infer<typeof backgroundTasksInputSchema>,
-        fetch: SnapshotFetch
-      ): Promise<BackgroundTasksResult> {
-        const taskIds = input.taskIds ?? [];
-        if (taskIds.length === 0) {
-          return Promise.resolve({ note: NO_TASK_IDS_NOTE });
-        }
-        return reportTasks(taskIds, fetch);
-      }
-
       // ── Per-agent delegation tools ────────────────────────────────────
 
       const delegationTools = agentRefs.map((ref) => {
         const toolName = makeToolName(prefix, ref.name);
         claimName(toolName, `agent '${ref.name}'`);
-        const staticDescription =
-          ref.description ?? `Delegates a task to the "${ref.name}" sub-agent.`;
-
-        if (async) {
-          return tool(
-            {
-              name: toolName,
-              description: staticDescription,
-              inputSchema: asyncDelegateInputSchema,
-              outputSchema: delegationResultSchema,
-            },
-            (input) =>
-              input.background
-                ? launchDelegation(ref, input.task)
-                : runDelegation(ref, input.task)
-          );
-        }
         return tool(
           {
             name: toolName,
-            description: staticDescription,
-            inputSchema: delegateInputSchema,
+            description:
+              ref.description ??
+              `Delegates a task to the "${ref.name}" sub-agent.`,
+            inputSchema: async ? asyncDelegateInputSchema : delegateInputSchema,
             outputSchema: delegationResultSchema,
           },
-          (input) => runDelegation(ref, input.task)
+          (input: z.infer<typeof asyncDelegateInputSchema>) =>
+            input.background
+              ? launchDelegation(ref, input.task)
+              : runDelegation(ref, input.task)
         );
       });
 
       // ── Shared background-task tools ──────────────────────────────────
 
-      const backgroundTools = async
-        ? (() => {
-            for (const name of Object.values(taskTools)) {
-              claimName(name, 'the background-task tools');
-            }
-            return [
-              tool(
-                {
-                  name: taskTools.check,
-                  description:
-                    'Returns the current status of background sub-agent tasks without waiting, including results for tasks that finished.',
-                  inputSchema: backgroundTasksInputSchema,
-                  outputSchema: backgroundTasksResultSchema,
-                },
-                (input) => taskReport(input, readSnapshotOnce)
-              ),
-              tool(
-                {
-                  name: taskTools.wait,
-                  description:
-                    'Waits until the given background sub-agent tasks finish and returns their results. Set timeoutSeconds to bound the wait; on timeout the current statuses are returned. Set waitFor to "first" to return as soon as any one task settles.',
-                  inputSchema: waitBackgroundTasksInputSchema,
-                  outputSchema: backgroundTasksResultSchema,
-                },
-                (input, ctx) => waitForBackgroundTasks(input, ctx.abortSignal)
-              ),
-              tool(
-                {
-                  name: taskTools.abort,
-                  description:
-                    'Stops background sub-agent tasks whose results are no longer needed, and returns where that left each one. A task that had already finished is unaffected and reports its result.',
-                  inputSchema: backgroundTasksInputSchema,
-                  outputSchema: backgroundTasksResultSchema,
-                },
-                (input) => taskReport(input, abortSnapshot)
-              ),
-            ];
-          })()
-        : [];
+      function defineBackgroundTools() {
+        for (const name of Object.values(taskTools)) {
+          claimName(name, 'the background-task tools');
+        }
+        return [
+          tool(
+            {
+              name: taskTools.check,
+              description:
+                'Returns the current status of background sub-agent tasks without waiting, including results for tasks that finished.',
+              inputSchema: backgroundTasksInputSchema,
+              outputSchema: backgroundTasksResultSchema,
+            },
+            (input) => reportTasks(input.taskIds ?? [], readSnapshotOnce)
+          ),
+          tool(
+            {
+              name: taskTools.wait,
+              description:
+                'Waits until the given background sub-agent tasks finish and returns their results. Set timeoutSeconds to bound the wait; on timeout the current statuses are returned. Set waitFor to "first" to return as soon as any one task settles.',
+              inputSchema: waitBackgroundTasksInputSchema,
+              outputSchema: backgroundTasksResultSchema,
+            },
+            (input, ctx) => waitForBackgroundTasks(input, ctx.abortSignal)
+          ),
+          tool(
+            {
+              name: taskTools.abort,
+              description:
+                'Stops background sub-agent tasks whose results are no longer needed, and returns where that left each one. A task that had already finished is unaffected and reports its result.',
+              inputSchema: backgroundTasksInputSchema,
+              outputSchema: backgroundTasksResultSchema,
+            },
+            (input) => reportTasks(input.taskIds ?? [], abortSnapshot)
+          ),
+        ];
+      }
+      const backgroundTools = async ? defineBackgroundTools() : [];
 
       return {
         tools: [...delegationTools, ...backgroundTools],

--- a/js/plugins/middleware/src/agents.ts
+++ b/js/plugins/middleware/src/agents.ts
@@ -15,14 +15,21 @@
  */
 
 import {
+  GenkitError,
   generateMiddleware,
   z,
-  type Action,
   type GenerateMiddleware,
   type MessageData,
   type Part,
 } from 'genkit';
-import { tool, type AgentOutput, type Artifact } from 'genkit/beta';
+import {
+  tool,
+  type Agent,
+  type AgentFinishReason,
+  type AgentOutput,
+  type Artifact,
+  type SessionSnapshot,
+} from 'genkit/beta';
 
 // ---------------------------------------------------------------------------
 // Schema
@@ -57,7 +64,8 @@ export const AgentsOptionsSchema = z.object({
     .optional()
     .describe(
       'Prefix for generated delegation tool names. Defaults to "delegate_to" ' +
-        '(tools become delegate_to_<agent>). Set to empty string to use bare agent names.'
+        '(tools become delegate_to_<agent>). Set to empty string to use bare agent names. ' +
+        'A non-empty prefix also namespaces the background-task tools added by "async".'
     ),
   maxDelegations: z
     .number()
@@ -86,6 +94,16 @@ export const AgentsOptionsSchema = z.object({
         'The tool result mentions artifact names but not content. Use the ' +
         '"artifacts" middleware to give the model read/write access to session artifacts.'
     ),
+  async: z
+    .boolean()
+    .optional()
+    .describe(
+      'Enables background delegation: delegation tools accept a "background" ' +
+        'flag that starts the sub-agent in the background and returns a taskId ' +
+        'immediately, and the check_background_tasks / wait_for_background_tasks / ' +
+        'abort_background_tasks tools are added. Background delegation requires ' +
+        'server-managed sub-agents (agents defined with a session store).'
+    ),
 });
 
 export type AgentsOptions = z.infer<typeof AgentsOptionsSchema>;
@@ -93,6 +111,29 @@ export type AgentsOptions = z.infer<typeof AgentsOptionsSchema>;
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+/** Names of the shared background-task tools added when `async` is set. */
+const CHECK_BACKGROUND_TASKS_TOOL = 'check_background_tasks';
+const WAIT_FOR_BACKGROUND_TASKS_TOOL = 'wait_for_background_tasks';
+const ABORT_BACKGROUND_TASKS_TOOL = 'abort_background_tasks';
+
+/**
+ * The report status for a task that could not be resolved (malformed ID,
+ * unconfigured agent, missing snapshot, or read error). Settled for waiting
+ * purposes: it only arrives once a read failure was classified unhelpable.
+ */
+const TASK_STATUS_UNKNOWN = 'unknown';
+
+/** Guidance returned when a background-task tool is called without task IDs. */
+const NO_TASK_IDS_NOTE =
+  'No task IDs given. Pass the taskId values returned by background delegations.';
+
+/**
+ * The longest delay a timer can represent. A wait timeout beyond it is
+ * treated as unbounded, the same as 0: `setTimeout` would otherwise fire it
+ * at once, and the wait would return instantly with nothing settled.
+ */
+const MAX_TIMEOUT_MS = 2 ** 31 - 1;
 
 interface NormalizedAgentRef {
   name: string;
@@ -110,12 +151,200 @@ function makeToolName(prefix: string, agentName: string): string {
 }
 
 /**
- * Generates a short, unique invocation ID for a sub-agent call.
+ * Generates a short, unique invocation ID for a synchronous sub-agent call.
  * Format: `{agentName}_{random4}` — e.g. `researcher_k9m2`
  */
 function makeInvocationId(agentName: string): string {
   const random = Math.random().toString(36).slice(2, 6);
   return `${agentName}_${random}`;
+}
+
+/**
+ * The artifact namespace of a background task's run: the agent name and a
+ * prefix of the run's snapshot ID. Deterministic, unlike the synchronous
+ * path's random ID: `addArtifacts` replaces by name, so a re-check of the same
+ * task, in this call or after the orchestrator restarts, overwrites the same
+ * artifact names instead of duplicating them.
+ */
+function snapshotNamespace(agentName: string, snapshotId: string): string {
+  return `${agentName}_${snapshotId.slice(0, 8)}`;
+}
+
+/**
+ * The model-facing handle of a background task (`<agent>:<snapshotId>`).
+ * Self-contained, so it can be parsed back after the orchestrator is
+ * re-instantiated with nothing but its conversation history.
+ */
+function formatTaskId(agentName: string, snapshotId: string): string {
+  return `${agentName}:${snapshotId}`;
+}
+
+/**
+ * Whether a turn that ended for `reason` produced an answer its caller can
+ * use: the agent spoke and stopped. Named for the reasons that do carry a
+ * result, so a reason added later defaults to "no answer"; mistaking an
+ * explanation for an answer hands the orchestrator partial work as though it
+ * were final, while the reverse only asks it to look at the text.
+ */
+function carriesResult(reason?: AgentFinishReason): boolean {
+  return (
+    reason === undefined ||
+    reason === 'stop' ||
+    reason === 'other' ||
+    reason === 'unknown'
+  );
+}
+
+/**
+ * Whether a snapshot status is settled. `pending` is the only status that can
+ * still change on its own; an absent status is the `completed` default.
+ */
+function isTerminalStatus(status: SessionSnapshot['status']): boolean {
+  return status !== 'pending';
+}
+
+/**
+ * Whether a task report's status can no longer change on its own, which is
+ * the rule the wait tool counts by. Report statuses are the snapshot statuses
+ * plus `unknown`, and `unknown` is settled too (see
+ * {@link TASK_STATUS_UNKNOWN}).
+ */
+function reportSettled(status: string): boolean {
+  return status !== 'pending';
+}
+
+/** Joins a message's non-empty text parts with newlines. */
+function messageText(message?: MessageData): string {
+  return (message?.content ?? [])
+    .map((p) => p.text)
+    .filter((t): t is string => typeof t === 'string' && t.length > 0)
+    .join('\n');
+}
+
+/**
+ * The persisted conversation's final model message: what the sub-agent last
+ * said. The transcript's tip is not that for every agent (a custom agent can
+ * end its turn on a tool response, or on input it appended itself), and
+ * reporting either as the answer would put someone else's words in the
+ * sub-agent's mouth.
+ */
+function lastModelMessage(snapshot: SessionSnapshot): MessageData | undefined {
+  const messages = snapshot.state?.messages ?? [];
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (messages[i].role === 'model') return messages[i];
+  }
+  return undefined;
+}
+
+/**
+ * The tool text reported when a sub-agent interrupted for input the
+ * orchestrator can never provide.
+ */
+function interruptedResponse(agentName: string): string {
+  return (
+    `Sub-agent '${agentName}' interrupted for additional input ` +
+    `and could not complete the task. Interactive sub-agent ` +
+    `interrupts are not currently supported; try delegating a ` +
+    `more self-contained task.`
+  );
+}
+
+/**
+ * Explains to the orchestrator why a sub-agent turn produced no answer. It
+ * prefers the structured failure, falls back to whatever the agent managed to
+ * say before it stopped, and names the finish reason when it has neither. A
+ * snapshot the runtime finalizes as completed carries no error even when its
+ * finish reason says the turn failed, so for a background task the agent's
+ * last message is often the only account of what happened.
+ */
+function subAgentFailureMessage(
+  reason: AgentFinishReason | undefined,
+  error: { message?: string } | undefined,
+  last: MessageData | undefined
+): string {
+  if (error?.message) return error.message;
+  if (!reason) return 'Unknown sub-agent failure.';
+  let msg = `the turn ended as '${reason}' without completing the task`;
+  const text = messageText(last);
+  if (text) msg += `; the agent's last message was: ${text}`;
+  return msg + '.';
+}
+
+/**
+ * The tool text reported for a run that settled on a result-carrying reason
+ * without a final model text: a custom agent that returned no message, or a
+ * model whose last message holds only tool requests. It says outright that
+ * the run succeeded and where its result is, so the orchestrator neither
+ * mistakes the silence for a failure nor repeats finished work.
+ */
+function noFinalMessageResponse(artifacts: number): string {
+  switch (artifacts) {
+    case 0:
+      return 'The task completed, but the agent gave no final message and produced no artifacts.';
+    case 1:
+      return 'The task completed, but the agent gave no final message; its result is in the one artifact it produced.';
+    default:
+      return `The task completed, but the agent gave no final message; its result is in the ${artifacts} artifacts it produced.`;
+  }
+}
+
+function errorMessage(e: unknown): string {
+  return e instanceof Error ? e.message : String(e);
+}
+
+/** The canonical status name an error carries, if any (`GenkitError.status`). */
+function errorStatus(e: unknown): string | undefined {
+  const status = (e as { status?: unknown } | undefined)?.status;
+  return typeof status === 'string' ? status : undefined;
+}
+
+/**
+ * Whether an error is how an aborted `AbortSignal` surfaces: the signal's own
+ * reason (an `AbortError`, or a `TimeoutError` from `AbortSignal.timeout`).
+ */
+function isAbortError(e: unknown): boolean {
+  const name = (e as { name?: unknown } | undefined)?.name;
+  return name === 'AbortError' || name === 'TimeoutError';
+}
+
+/**
+ * Forwards the first abort among `sources` to `target`, with its reason.
+ */
+function linkSignals(
+  target: AbortController,
+  ...sources: Array<AbortSignal | undefined>
+): void {
+  for (const source of sources) {
+    if (!source) continue;
+    if (source.aborted) {
+      target.abort(source.reason);
+      return;
+    }
+    source.addEventListener('abort', () => target.abort(source.reason), {
+      once: true,
+    });
+  }
+}
+
+/**
+ * Returns up to `n` of the most recent user/model messages, each reduced to
+ * its non-empty text parts. Tool and tool-request parts are dropped: a model
+ * message mid-tool-loop can carry a `toolRequest` part with no matching
+ * response, which would confuse the sub-agent model.
+ */
+function recentTextHistory(messages: MessageData[], n: number): MessageData[] {
+  if (n <= 0) return [];
+  return messages
+    .filter((m) => m.role === 'user' || m.role === 'model')
+    .slice(-n)
+    .map((m) => ({
+      role: m.role,
+      content: m.content.filter(
+        (p): p is Part & { text: string } =>
+          typeof p.text === 'string' && p.text.length > 0
+      ),
+    }))
+    .filter((m) => m.content.length > 0);
 }
 
 // ---------------------------------------------------------------------------
@@ -151,6 +380,28 @@ function makeInvocationId(agentName: string): string {
  * as a normal tool response (not propagated as a `ToolInterruptError`). There is
  * no stateful sub-agent runtime to resume into, so interactive, back-and-forth
  * interaction with an interrupted sub-agent is a future feature.
+ *
+ * With `async: true`, delegation tools additionally accept a `background`
+ * flag. A background delegation starts the sub-agent through its detach
+ * support (`detach: true`): the sub-agent's runtime persists a pending
+ * snapshot, hands back a task ID immediately, and keeps working in the
+ * background, so the orchestrator can continue calling tools and collect the
+ * result later through the added `check_background_tasks` and
+ * `wait_for_background_tasks` tools, or drop it with `abort_background_tasks`.
+ * The pending snapshot (heartbeated while the worker lives, finalized in place
+ * with the cumulative state when the work settles) is the durable record, and
+ * task IDs are self-contained (`<agent>:<snapshotId>`), so a re-instantiated
+ * orchestrator can pick results up using nothing but the IDs recorded in its
+ * conversation history. Background delegation requires server-managed
+ * sub-agents (defined with a `store`); a launch on any other agent is refused
+ * as tool text that points the model at a synchronous delegation.
+ *
+ * Task handles are not access-scoped: the background-task tools read any
+ * snapshot ID belonging to a configured sub-agent, whether or not this
+ * conversation launched it (mirroring the sub-agent's `getSnapshot` companion
+ * action, which is itself unscoped). In multi-tenant deployments treat
+ * snapshot IDs as capability-like secrets: text that reaches the orchestrator
+ * model can steer these tools at any ID it names.
  *
  * @example
 
@@ -200,23 +451,64 @@ export const agents: GenerateMiddleware<typeof AgentsOptionsSchema> =
       const maxDelegations = config.maxDelegations;
       const historyLength = config.historyLength ?? 0;
       const artifactStrategy = config.artifactStrategy ?? 'inline';
+      const async = config.async ?? false;
+
+      // The shared background-task tools take an explicitly set prefix and
+      // none by default: the default delegate_to prefix is a delegation verb,
+      // not an instance namespace. Two async instances in one generate call
+      // therefore need distinct, explicit prefixes; left at the default they
+      // both emit the bare names and the request is rejected for duplicate
+      // tools.
+      const sharedPrefix = config.toolPrefix ?? '';
+      const taskTools = {
+        check: makeToolName(sharedPrefix, CHECK_BACKGROUND_TASKS_TOOL),
+        wait: makeToolName(sharedPrefix, WAIT_FOR_BACKGROUND_TASKS_TOOL),
+        abort: makeToolName(sharedPrefix, ABORT_BACKGROUND_TASKS_TOOL),
+      };
+
+      // Every generated tool name is validated as it is claimed: a collision
+      // (two agents mapping to one delegation tool name, or a delegation tool
+      // landing on a background-task tool's name) would otherwise surface only
+      // at generate time as a duplicate-tool rejection of the whole request.
+      const claimedNames = new Map<string, string>();
+      function claimName(name: string, owner: string): void {
+        const previous = claimedNames.get(name);
+        if (previous) {
+          throw new GenkitError({
+            status: 'INVALID_ARGUMENT',
+            message:
+              `agents middleware: tool name '${name}' for ${owner} collides ` +
+              `with ${previous}; use a different toolPrefix or agent name.`,
+          });
+        }
+        claimedNames.set(name, owner);
+      }
 
       // Shared mutable state — safe because `instantiate()` is called per
       // `generate()` invocation, giving each call its own closure.
       const shared = {
         delegationCount: 0,
         conversationMessages: [] as MessageData[],
+        // Terminal background-task reports by task ID for the rest of the
+        // generate call: completed, failed, and aborted rows never change, so
+        // a re-check skips the snapshot fetch and artifact re-merge (and cannot
+        // clobber a merged artifact the orchestrator has since edited).
+        // Pending, expired, and unresolvable reports can still change and are
+        // never cached.
+        settledReports: new Map<string, BackgroundTaskReport>(),
       };
 
       // Caches (persist across turns within the same generate cycle).
-      const agentCache = new Map<string, Action>();
+      const agentCache = new Map<string, Agent>();
       const descriptionCache = new Map<string, string>();
 
-      async function resolveAgent(name: string): Promise<Action | undefined> {
+      async function resolveAgent(name: string): Promise<Agent | undefined> {
         const cached = agentCache.get(name);
         if (cached) return cached;
 
-        const action = await ai.registry.lookupAction(`/agent/${name}`);
+        const action = (await ai.registry.lookupAction(`/agent/${name}`)) as
+          | Agent
+          | undefined;
         if (action) {
           agentCache.set(name, action);
         }
@@ -247,7 +539,12 @@ export const agents: GenerateMiddleware<typeof AgentsOptionsSchema> =
         return desc;
       }
 
-      // -- Build the output schema based on artifactStrategy ----------------
+      /** Who owns the agent's session state, from its action metadata. */
+      function stateManagementOf(agent: Agent): string | undefined {
+        return agent.__action?.metadata?.agent?.stateManagement;
+      }
+
+      // -- Schemas ------------------------------------------------------------
 
       const inlineArtifactSchema = z.object({
         name: z.string().optional().describe('Name of the artifact.'),
@@ -261,226 +558,891 @@ export const agents: GenerateMiddleware<typeof AgentsOptionsSchema> =
         name: z.string().optional().describe('Name of the artifact.'),
       });
 
-      const toolOutputSchema = z.object({
-        response: z.string().describe("The sub-agent's text response."),
-        artifacts: z
-          .array(
-            artifactStrategy === 'inline'
-              ? inlineArtifactSchema
-              : sessionArtifactSchema
-          )
+      const artifactsField = z
+        .array(
+          artifactStrategy === 'inline'
+            ? inlineArtifactSchema
+            : sessionArtifactSchema
+        )
+        .optional()
+        .describe(
+          artifactStrategy === 'inline'
+            ? 'Artifacts produced by the sub-agent, including their content.'
+            : 'Names of artifacts produced by the sub-agent. Use read_artifact to access content.'
+        );
+
+      const delegationResultSchema = z.object({
+        response: z
+          .string()
+          .describe(
+            "The sub-agent's text response. For a background delegation it describes the launch instead; the sub-agent's response arrives later via the background-task tools."
+          ),
+        artifacts: artifactsField,
+        taskId: z
+          .string()
           .optional()
           .describe(
-            artifactStrategy === 'inline'
-              ? 'Artifacts produced by the sub-agent, including their content.'
-              : 'Names of artifacts produced by the sub-agent. Use read_artifact to access content.'
+            'Handle of the background task ("<agent>:<snapshotId>") when the delegation was started with background: true. Pass it to the background-task tools.'
+          ),
+        status: z
+          .string()
+          .optional()
+          .describe('"pending" when a background delegation was started.'),
+      });
+      type DelegationResult = z.infer<typeof delegationResultSchema>;
+
+      const delegateInputSchema = z.object({
+        task: z
+          .string()
+          .describe(
+            'A clear, self-contained description of the task to delegate.'
           ),
       });
+
+      // The async variant carries the extra "background" flag, so the two
+      // modes need distinct input schemas (tool schemas are static).
+      const asyncDelegateInputSchema = delegateInputSchema.extend({
+        background: z
+          .boolean()
+          .optional()
+          .describe(
+            `Run the delegation in the background. The tool returns immediately with a taskId; collect the result later with ${taskTools.check} or ${taskTools.wait}.`
+          ),
+      });
+
+      // taskIds is optional so the schema does not mark it required. A model
+      // that calls one of these tools with no arguments is making a
+      // recoverable mistake, answered with guidance; a required field would
+      // instead fail validation, which surfaces as a tool error that fails the
+      // whole generate call rather than a turn the model can correct.
+      const backgroundTasksInputSchema = z.object({
+        taskIds: z
+          .array(z.string())
+          .optional()
+          .describe(
+            'Task IDs returned by background delegations (form "<agent>:<snapshotId>").'
+          ),
+      });
+
+      const waitBackgroundTasksInputSchema = backgroundTasksInputSchema.extend({
+        timeoutSeconds: z
+          .number()
+          .optional()
+          .describe(
+            'Maximum seconds to wait before returning the current statuses. 0 or omitted waits until every task settles; a negative value returns the current statuses immediately. Values too large to represent are treated as unbounded.'
+          ),
+        // A free string rather than an enum: an unknown value is answered
+        // with guidance the model can correct, not a validation failure that
+        // kills the turn.
+        waitFor: z
+          .string()
+          .optional()
+          .describe(
+            '"all" (default) waits until every listed task settles. "first" returns as soon as any one settles; the remaining tasks report their current status and keep running.'
+          ),
+      });
+
+      const backgroundTaskReportSchema = z.object({
+        taskId: z.string().describe('The handle the report describes.'),
+        agent: z
+          .string()
+          .optional()
+          .describe('The sub-agent running the task.'),
+        status: z
+          .string()
+          .describe(
+            'The task\'s lifecycle state: "pending", "completed", "failed", "aborted", "expired" (worker presumed dead), or "unknown" (the ID could not be resolved; see error). "completed" always carries a response.'
+          ),
+        response: z
+          .string()
+          .optional()
+          .describe(
+            "The sub-agent's final text response, for completed tasks."
+          ),
+        artifacts: artifactsField,
+        error: z
+          .string()
+          .optional()
+          .describe(
+            'Why no response is available (failure, abort, expiry, or an unresolvable task ID).'
+          ),
+      });
+      type BackgroundTaskReport = z.infer<typeof backgroundTaskReportSchema>;
+
+      const backgroundTasksResultSchema = z.object({
+        tasks: z.array(backgroundTaskReportSchema).optional(),
+        timedOut: z
+          .boolean()
+          .optional()
+          .describe(
+            'Set when the wait returned because timeoutSeconds elapsed while some tasks were still pending.'
+          ),
+        note: z
+          .string()
+          .optional()
+          .describe(
+            'Usage guidance when the call itself was unusable (e.g. no task IDs given).'
+          ),
+      });
+      type BackgroundTasksResult = z.infer<typeof backgroundTasksResultSchema>;
+
+      // -- Delegation ---------------------------------------------------------
+
+      /**
+       * Namespaces the sub-agent's artifacts by invocation ID, tags them with
+       * their source, and merges them into the active session. No-op when
+       * there is no active session (`ai.currentSession()` throws then).
+       */
+      function mergeArtifacts(
+        source: string,
+        invocationId: string,
+        artifacts: Artifact[]
+      ): void {
+        try {
+          const session = ai.currentSession();
+          session.addArtifacts(
+            artifacts.map((a) => ({
+              ...a,
+              name: `${invocationId}/${a.name}`,
+              metadata: { ...a.metadata, source, invocationId },
+            }))
+          );
+        } catch {
+          // No active session — artifacts can't be merged into a parent
+          // session. With the "inline" strategy the content is still returned
+          // in the tool result.
+        }
+      }
+
+      /**
+       * Builds the tool-result artifact list, including content only under
+       * the inline strategy.
+       */
+      function delegatedArtifacts(
+        invocationId: string,
+        artifacts: Artifact[]
+      ): { name: string; content?: string }[] {
+        return artifacts.map((a) => ({
+          name: `${invocationId}/${a.name}`,
+          ...(artifactStrategy === 'inline' && {
+            content: (a.parts ?? [])
+              .map((p) => p.text ?? '')
+              .filter((t) => t.length > 0)
+              .join('\n'),
+          }),
+        }));
+      }
+
+      /**
+       * Turns a settled sub-agent output into a delegation tool result:
+       * interrupts and failures become explanatory text, and artifacts are
+       * merged into the parent session under `invocationId` and surfaced per
+       * the configured strategy. Shared by the synchronous path and the
+       * background-task reports, so a delegation reports the same answer and
+       * the same artifacts whether it ran in the background or not.
+       */
+      function foldDelegationOutput(
+        ref: NormalizedAgentRef,
+        out: AgentOutput,
+        invocationId: string
+      ): DelegationResult {
+        // The agent runtime resolves gracefully rather than throwing: a failed
+        // turn returns `finishReason: 'failed'` with structured error details,
+        // and an interrupted turn returns `finishReason: 'interrupted'`.
+
+        // Interrupted first: it is one of the reasons that carry no result,
+        // and the one with an explanation of its own worth giving. It is
+        // deliberately NOT propagated to the parent: there is no stateful
+        // sub-agent runtime to resume back into, so the parent could never
+        // satisfy it.
+        if (out.finishReason === 'interrupted') {
+          return { response: interruptedResponse(ref.name) };
+        }
+        if (!carriesResult(out.finishReason)) {
+          // Blocked, truncated, aborted, or failed. The turn's last message is
+          // whatever the agent got out before it stopped, so it explains the
+          // outcome rather than answering the task, and reporting it as the
+          // answer would hand the orchestrator partial work as if it were
+          // final.
+          return {
+            response: `Error calling agent '${ref.name}': ${subAgentFailureMessage(
+              out.finishReason,
+              out.error,
+              out.message
+            )}`,
+          };
+        }
+
+        const subArtifacts = (out.artifacts ?? []).filter((a) => a.name);
+        const response =
+          messageText(out.message) ||
+          noFinalMessageResponse(subArtifacts.length);
+        if (subArtifacts.length === 0) {
+          return { response };
+        }
+        // Merge into the parent session under both strategies.
+        mergeArtifacts(ref.name, invocationId, subArtifacts);
+        return {
+          response,
+          artifacts: delegatedArtifacts(invocationId, subArtifacts),
+        };
+      }
+
+      /**
+       * The prologue every delegation shares, synchronous or background: it
+       * enforces `maxDelegations` and resolves the sub-agent. A refusal is the
+       * tool result to return as is. A resolution failure keeps its slot: the
+       * agent is misconfigured or missing, so every retry fails the same way,
+       * and refunding would mean the cap never bites on exactly the runaway
+       * loop it exists to stop.
+       */
+      async function beginDelegation(
+        ref: NormalizedAgentRef
+      ): Promise<{ agent: Agent } | { refusal: DelegationResult }> {
+        if (
+          maxDelegations !== undefined &&
+          shared.delegationCount >= maxDelegations
+        ) {
+          return {
+            refusal: {
+              response:
+                `Delegation limit reached (${maxDelegations}). ` +
+                `Complete the task using information already gathered.`,
+            },
+          };
+        }
+        shared.delegationCount++;
+
+        const agent = await resolveAgent(ref.name);
+        if (!agent) {
+          return {
+            refusal: {
+              response: `Error: Agent '${ref.name}' not found in registry.`,
+            },
+          };
+        }
+        return { agent };
+      }
+
+      /**
+       * Returns a reserved cap slot to a delegation whose refusal names a retry
+       * that can succeed: a background launch refused because the sub-agent
+       * cannot run in the background, whose refusal tells the model to
+       * delegate synchronously instead. Every other refusal keeps its slot.
+       */
+      function releaseDelegation(): void {
+        shared.delegationCount--;
+      }
+
+      /**
+       * Runs one turn of the sub-agent with the task. History rides as
+       * client-managed init state, which only client-managed agents accept;
+       * `detach` asks the sub-agent runtime to move the work to the background
+       * at once, so the output carries the pending snapshot's ID and
+       * `finishReason: 'detached'` while the sub-agent keeps working.
+       */
+      async function runSubAgent(
+        agent: Agent,
+        task: string,
+        opts: { history?: MessageData[]; detach?: boolean } = {}
+      ): Promise<AgentOutput> {
+        const init = opts.history?.length
+          ? { state: { messages: opts.history } }
+          : {};
+        const { result } = await agent.run(
+          {
+            message: { role: 'user' as const, content: [{ text: task }] },
+            ...(opts.detach && { detach: true }),
+          },
+          { init }
+        );
+        return result;
+      }
+
+      /** The synchronous delegation body. */
+      async function runDelegation(
+        ref: NormalizedAgentRef,
+        task: string
+      ): Promise<DelegationResult> {
+        const begun = await beginDelegation(ref);
+        if ('refusal' in begun) return begun.refusal;
+        const { agent } = begun;
+
+        try {
+          // Prior conversation is seeded via the session state (`init.state`),
+          // which only client-managed agents (no persistent store) accept —
+          // sending `state` to a server-managed agent throws a precondition
+          // error. Server-managed sub-agents can't be seeded with ad-hoc
+          // per-delegation history, so history forwarding is skipped for them
+          // (the task is still delivered).
+          const history =
+            stateManagementOf(agent) !== 'server'
+              ? recentTextHistory(shared.conversationMessages, historyLength)
+              : [];
+          const out = await runSubAgent(agent, task, { history });
+          return foldDelegationOutput(ref, out, makeInvocationId(ref.name));
+        } catch (e: unknown) {
+          // The agent runtime resolves failures and interrupts gracefully (see
+          // foldDelegationOutput), so this only fires for exceptions thrown
+          // outside that handling (e.g. schema parse errors on `run`). Return
+          // them as tool output so the model can recover.
+          return {
+            response: `Error calling agent '${ref.name}': ${errorMessage(e)}`,
+          };
+        }
+      }
+
+      /**
+       * Starts a background delegation through the sub-agent's detach support
+       * and returns the task handle without waiting for the work. Launches
+       * count against `maxDelegations` like synchronous delegations, except
+       * for a launch the sub-agent cannot support at all: that refusal returns
+       * its slot, so the synchronous fallback it hints at is not refused by a
+       * cap the refusal consumed. History is never forwarded: detach requires
+       * a server-managed sub-agent, and server-managed init rejects seeded
+       * state.
+       */
+      async function launchDelegation(
+        ref: NormalizedAgentRef,
+        task: string
+      ): Promise<DelegationResult> {
+        const begun = await beginDelegation(ref);
+        if ('refusal' in begun) return begun.refusal;
+        const { agent } = begun;
+
+        const withoutBackground = `Delegate to it without "background" instead.`;
+        // Pre-flight from the agent's own metadata: the runtime accepts a
+        // detach only on a store-backed agent, so a genkit-defined agent
+        // without one is refused here deterministically, without a wasted
+        // invocation and without the hedged wording below (which remains only
+        // for agents that publish no metadata).
+        const stateManagement = stateManagementOf(agent);
+        if (stateManagement !== undefined && stateManagement !== 'server') {
+          releaseDelegation();
+          return {
+            response:
+              `Error calling agent '${ref.name}': this agent has no session ` +
+              `store, so it cannot run tasks in the background. ${withoutBackground}`,
+          };
+        }
+
+        let out: AgentOutput;
+        try {
+          out = await runSubAgent(agent, task, { detach: true });
+        } catch (e: unknown) {
+          // FAILED_PRECONDITION is how the runtime rejects a detach on an agent
+          // that cannot support it. Only a metadata-less agent reaches this
+          // (one that publishes metadata and cannot detach was refused above),
+          // and only this failure earns its slot back: the retry it points at
+          // is the synchronous launch. Every other failure keeps the slot.
+          if (
+            stateManagement === undefined &&
+            errorStatus(e) === 'FAILED_PRECONDITION'
+          ) {
+            releaseDelegation();
+            return {
+              response:
+                `Error calling agent '${ref.name}': ${errorMessage(e)} If this ` +
+                `agent has no session store, it cannot run in the background. ${withoutBackground}`,
+            };
+          }
+          return {
+            response: `Error calling agent '${ref.name}': ${errorMessage(e)}`,
+          };
+        }
+
+        switch (out.finishReason) {
+          case 'detached': {
+            if (!out.snapshotId) {
+              return {
+                response: `Error calling agent '${ref.name}': the background launch returned no task handle.`,
+              };
+            }
+            const taskId = formatTaskId(ref.name, out.snapshotId);
+            return {
+              taskId,
+              status: 'pending',
+              response:
+                `Background task ${taskId} started for agent '${ref.name}'. ` +
+                `Collect the result with ${taskTools.check} or ${taskTools.wait}, ` +
+                `or stop it with ${taskTools.abort}.`,
+            };
+          }
+          case 'failed': {
+            // A graceful rejection carries the same status a thrown one does,
+            // and earns the same refund under the same conditions.
+            const msg = subAgentFailureMessage(
+              out.finishReason,
+              out.error,
+              out.message
+            );
+            if (
+              stateManagement === undefined &&
+              out.error?.status === 'FAILED_PRECONDITION'
+            ) {
+              releaseDelegation();
+              return {
+                response:
+                  `Error calling agent '${ref.name}': ${msg} If this agent has ` +
+                  `no session store, it cannot run in the background. ${withoutBackground}`,
+              };
+            }
+            return { response: `Error calling agent '${ref.name}': ${msg}` };
+          }
+          default:
+            // The invocation settled before the detach landed; fold it like a
+            // synchronous delegation.
+            return foldDelegationOutput(ref, out, makeInvocationId(ref.name));
+        }
+      }
+
+      // -- Background tasks ---------------------------------------------------
+
+      /**
+       * How a task's snapshot is obtained: read once for the check tool,
+       * waited for by the wait tool, aborted first by the abort tool. All three
+       * dispatch companion actions of the sub-agent, so all three apply the
+       * runtime's read shaping (a pending row whose heartbeat went stale reads
+       * as expired) and throw NOT_FOUND for a missing row. Ending on the row,
+       * rather than on each tool's own idea of an outcome, is what lets one
+       * report path serve every tool.
+       */
+      type SnapshotFetch = (
+        agent: Agent,
+        snapshotId: string,
+        signal?: AbortSignal
+      ) => Promise<SessionSnapshot>;
+
+      const readSnapshotOnce: SnapshotFetch = async (agent, snapshotId) =>
+        (await agent.getSnapshotDataAction.run({ snapshotId })).result;
+
+      const awaitSnapshot: SnapshotFetch = async (agent, snapshotId, signal) =>
+        (
+          await agent.waitForSnapshotAction.run(
+            { snapshotId },
+            { abortSignal: signal }
+          )
+        ).result;
+
+      // The abort reads before it stops anything, because there are rows an
+      // abort must not touch. Expiry is decided on read, not stored: a worker
+      // that stopped heartbeating leaves a row that is still pending in the
+      // store and reads as expired, and aborting it would overwrite the one
+      // signal telling the model the work is gone. A task that already
+      // settled needs no abort at all and is answered from the row alone.
+      const abortSnapshot: SnapshotFetch = async (agent, snapshotId) => {
+        const current = await readSnapshotOnce(agent, snapshotId);
+        if (isTerminalStatus(current.status)) {
+          return current;
+        }
+        const { result } = await agent.abortAgentAction.run({ snapshotId });
+        // The abort action answers with the status the row had before the
+        // attempt: `pending` means the flip landed, so the row just read is
+        // handed back restamped rather than re-read (a re-read could fail on
+        // its own and turn a delivered stop into "unknown"). Anything else
+        // means the task settled between the read and the abort, and a re-read
+        // fetches the answer it now carries.
+        if (result.status === 'pending') {
+          return { ...current, status: 'aborted' };
+        }
+        return readSnapshotOnce(agent, snapshotId);
+      };
+
+      /**
+       * Parses a task handle by matching it against the configured agents,
+       * taking the longest matching name so a configured name containing ':'
+       * cannot have its tasks claimed by a shorter configured prefix of it.
+       * The runtime mints snapshot IDs as UUIDs (never containing ':'), so the
+       * longest configured prefix is always the launching agent; anchoring the
+       * parse on the finite set of configured names also confines the
+       * background-task tools to the agents this middleware was configured
+       * with.
+       */
+      function resolveTaskId(
+        taskId: string
+      ): { ref: NormalizedAgentRef; snapshotId: string } | undefined {
+        let best: NormalizedAgentRef | undefined;
+        let bestLength = 0;
+        for (const ref of agentRefs) {
+          const candidate = `${ref.name}:`;
+          if (
+            taskId.length > candidate.length &&
+            taskId.startsWith(candidate) &&
+            candidate.length > bestLength
+          ) {
+            best = ref;
+            bestLength = candidate.length;
+          }
+        }
+        return best
+          ? { ref: best, snapshotId: taskId.slice(bestLength) }
+          : undefined;
+      }
+
+      /**
+       * Resolves one task handle, obtains its snapshot through `fetch`, and
+       * shapes the result into a report. Completed tasks surface the
+       * sub-agent's final response and artifacts; terminal non-success
+       * statuses surface an explanatory error instead. The raw failure rides
+       * alongside for the wait tool, which classifies it.
+       */
+      async function reportTask(
+        taskId: string,
+        fetch: SnapshotFetch,
+        signal?: AbortSignal
+      ): Promise<{ report: BackgroundTaskReport; error?: unknown }> {
+        const cached = shared.settledReports.get(taskId);
+        if (cached) return { report: cached };
+
+        const resolved = resolveTaskId(taskId);
+        if (!resolved) {
+          const error = `Task ID '${taskId}' does not match any configured agent (expected "<agent>:<snapshotId>").`;
+          return {
+            report: { taskId, status: TASK_STATUS_UNKNOWN, error },
+            error: new Error(error),
+          };
+        }
+        const { ref, snapshotId } = resolved;
+        const report: BackgroundTaskReport = {
+          taskId,
+          agent: ref.name,
+          status: TASK_STATUS_UNKNOWN,
+        };
+
+        // Resolving the agent and reading its snapshot fail for unrelated
+        // reasons, so they are reported separately: an unregistered agent
+        // must not get the missing-snapshot advice, which would tell the model
+        // to delegate again into a delegation tool that fails identically.
+        const agent = await resolveAgent(ref.name);
+        if (!agent) {
+          report.error =
+            `Agent '${ref.name}' is configured on the agents middleware but is ` +
+            `not registered. This task cannot be collected here; report it as ` +
+            `unavailable rather than delegating it again.`;
+          return { report, error: new Error(report.error) };
+        }
+        if (
+          !agent.getSnapshotDataAction ||
+          !agent.waitForSnapshotAction ||
+          !agent.abortAgentAction
+        ) {
+          report.error =
+            `Agent '${ref.name}' does not expose the snapshot companion ` +
+            `actions, so its tasks cannot be collected here; report the task ` +
+            `as unavailable.`;
+          return { report, error: new Error(report.error) };
+        }
+
+        let snapshot: SessionSnapshot;
+        try {
+          snapshot = await fetch(agent, snapshotId, signal);
+        } catch (e: unknown) {
+          // The agent resolved above, so NOT_FOUND here is the snapshot and
+          // nothing else, and re-delegating is genuinely the way to get the
+          // work done. A rejected request is reported as is; anything else is
+          // presumed transient.
+          const status = errorStatus(e);
+          if (status === 'NOT_FOUND') {
+            report.error = `No record of this task exists (${errorMessage(e)}). Delegate the task again if the result is still needed.`;
+          } else if (
+            status === 'FAILED_PRECONDITION' ||
+            status === 'INVALID_ARGUMENT'
+          ) {
+            report.error = errorMessage(e);
+          } else {
+            report.error = `Could not read the task's status: ${errorMessage(e)}. Check again later.`;
+          }
+          return { report, error: e };
+        }
+
+        // An absent status is the runtime's `completed` default.
+        const snapshotStatus = snapshot.status ?? 'completed';
+        report.status = snapshotStatus;
+        switch (snapshotStatus) {
+          case 'pending':
+            // Still running; nothing to report yet.
+            break;
+          case 'completed': {
+            // Fold the settled snapshot exactly as a synchronous delegation
+            // folds its output, under the deterministic namespace of the run.
+            // The response is what the sub-agent last said, not whatever the
+            // transcript happens to end on.
+            const folded = foldDelegationOutput(
+              ref,
+              {
+                finishReason: snapshot.finishReason,
+                message: lastModelMessage(snapshot),
+                artifacts: snapshot.state?.artifacts,
+              },
+              snapshotNamespace(ref.name, snapshotId)
+            );
+            if (carriesResult(snapshot.finishReason)) {
+              report.response = folded.response;
+              if (folded.artifacts) report.artifacts = folded.artifacts;
+            } else {
+              // The row committed, so the stored status is completed, but the
+              // agent declared a reason that carries no answer. Report the
+              // outcome the reader has to act on, not the row's bookkeeping:
+              // a model that sees "completed" moves on and never reads the
+              // error. Which reason it was, and what the agent last said, is
+              // in the folded text.
+              report.status = 'failed';
+              report.error = folded.response;
+            }
+            break;
+          }
+          case 'failed':
+            report.error = subAgentFailureMessage(
+              snapshot.finishReason,
+              snapshot.error,
+              lastModelMessage(snapshot)
+            );
+            break;
+          case 'aborted':
+            report.error = 'The task was aborted before it finished.';
+            break;
+          case 'expired':
+            report.error =
+              'The background worker stopped reporting progress and is presumed dead. Delegate the task again if the result is still needed.';
+            break;
+        }
+
+        // Expired is the one terminal read that can still change its mind:
+        // the worker may be alive and merely slow to beat, so a later read can
+        // find it settled properly. Everything else terminal is final.
+        if (isTerminalStatus(snapshotStatus) && snapshotStatus !== 'expired') {
+          shared.settledReports.set(taskId, report);
+        }
+        return { report };
+      }
+
+      /**
+       * Builds one report per entry of `taskIds`, fetching each distinct ID
+       * once and copying its report to every duplicate (the IDs are
+       * model-authored, so repeats happen). The fetches run concurrently, so
+       * the slowest distinct task sets the wall clock rather than the sum, and
+       * failures stay isolated per task: one bad handle cannot hide the status
+       * of the others.
+       */
+      async function collectReports(
+        taskIds: string[],
+        report: (taskId: string) => Promise<BackgroundTaskReport>
+      ): Promise<BackgroundTaskReport[]> {
+        const distinct = [...new Set(taskIds)];
+        const fetched = new Map(
+          await Promise.all(
+            distinct.map(async (id) => [id, await report(id)] as const)
+          )
+        );
+        return taskIds.map((id) => fetched.get(id)!);
+      }
+
+      /** One report per task with a single fetch each; no waiting. */
+      async function reportTasks(
+        taskIds: string[],
+        fetch: SnapshotFetch
+      ): Promise<BackgroundTasksResult> {
+        return {
+          tasks: await collectReports(
+            taskIds,
+            async (taskId) => (await reportTask(taskId, fetch)).report
+          ),
+        };
+      }
+
+      /**
+       * Follows one task to its end and returns its report. A fetch error
+       * that reaches this level is a dead end worth reporting, with one
+       * exception: `signal` ending the wait (its timeout, or a won race). The
+       * task is still running by definition then, so a follow cut short that
+       * way is reported as pending rather than as a read that did not finish.
+       * That is decided from the failure itself, not from the signal alone: a
+       * handle that never resolved is not the signal's doing and keeps its
+       * error however the wait ended, or the model would be told to keep
+       * re-checking an ID that can never settle.
+       */
+      async function awaitTask(
+        taskId: string,
+        signal: AbortSignal
+      ): Promise<BackgroundTaskReport> {
+        const { report, error } = await reportTask(
+          taskId,
+          awaitSnapshot,
+          signal
+        );
+        if (error !== undefined && signal.aborted && isAbortError(error)) {
+          return { ...report, status: 'pending', error: undefined };
+        }
+        return report;
+      }
+
+      /**
+       * The blocking status tool: follows every task to its end, or returns
+       * the current statuses when the optional timeout elapses. Each task is
+       * followed by the sub-agent's `waitForSnapshot` companion action, so the
+       * waiting happens next to the store that knows when the work finished:
+       * one action dispatch per task for the whole wait, and a settlement is
+       * observed as it happens. The waits run concurrently, so the slowest
+       * task sets the wall clock. A timeout returns the current statuses
+       * rather than an error so the orchestrator can do other work and come
+       * back; the calling tool's own abort signal ending propagates as an
+       * error.
+       */
+      async function waitForBackgroundTasks(
+        input: z.infer<typeof waitBackgroundTasksInputSchema>,
+        toolSignal?: AbortSignal
+      ): Promise<BackgroundTasksResult> {
+        const taskIds = input.taskIds ?? [];
+        if (taskIds.length === 0) {
+          return { note: NO_TASK_IDS_NOTE };
+        }
+        const waitFor = input.waitFor ?? 'all';
+        if (waitFor !== 'all' && waitFor !== 'first') {
+          // A recoverable mistake, answered like an empty ID list.
+          return {
+            note: `Unknown waitFor value '${waitFor}'. Use 'all' (the default) to wait for every task, or 'first' to return when any one settles.`,
+          };
+        }
+        const first = waitFor === 'first';
+
+        // A negative timeout means "don't wait": report the current statuses.
+        const timeoutSeconds = input.timeoutSeconds ?? 0;
+        if (timeoutSeconds < 0) {
+          return reportTasks(taskIds, readSnapshotOnce);
+        }
+        const timeoutMs = timeoutSeconds * 1000;
+        const deadline =
+          timeoutMs > 0 && timeoutMs <= MAX_TIMEOUT_MS
+            ? AbortSignal.timeout(timeoutMs)
+            : undefined;
+
+        // One signal ends every follow: the deadline, the caller hanging up,
+        // or (with waitFor "first") the first settlement, after which the
+        // remaining follows report their tasks as they stand.
+        const controller = new AbortController();
+        linkSignals(controller, deadline, toolSignal);
+
+        const reports = await collectReports(taskIds, async (taskId) => {
+          const report = await awaitTask(taskId, controller.signal);
+          if (first && reportSettled(report.status)) {
+            controller.abort(
+              new DOMException('first task settled', 'AbortError')
+            );
+          }
+          return report;
+        });
+
+        // The calling tool ending is cancellation, not a timeout; let it fail
+        // the tool call rather than dressing it up as a settled result.
+        toolSignal?.throwIfAborted();
+
+        const pending = reports.filter((r) => !reportSettled(r.status)).length;
+        if (pending === 0) {
+          return { tasks: reports };
+        }
+        if (first && pending < reports.length) {
+          // The race was won, not timed out.
+          return {
+            tasks: reports,
+            note: 'Returned on the first settled task; the remaining tasks report their current status and keep running.',
+          };
+        }
+        return {
+          tasks: reports,
+          timedOut: true,
+          note: 'Stopped waiting; the pending tasks are still running. Check them again later.',
+        };
+      }
+
+      /** A non-blocking background-task tool: one dispatch per task, then a report of where that left it. */
+      function taskReport(
+        input: z.infer<typeof backgroundTasksInputSchema>,
+        fetch: SnapshotFetch
+      ): Promise<BackgroundTasksResult> {
+        const taskIds = input.taskIds ?? [];
+        if (taskIds.length === 0) {
+          return Promise.resolve({ note: NO_TASK_IDS_NOTE });
+        }
+        return reportTasks(taskIds, fetch);
+      }
 
       // ── Per-agent delegation tools ────────────────────────────────────
 
       const delegationTools = agentRefs.map((ref) => {
         const toolName = makeToolName(prefix, ref.name);
+        claimName(toolName, `agent '${ref.name}'`);
         const staticDescription =
           ref.description ?? `Delegates a task to the "${ref.name}" sub-agent.`;
 
+        if (async) {
+          return tool(
+            {
+              name: toolName,
+              description: staticDescription,
+              inputSchema: asyncDelegateInputSchema,
+              outputSchema: delegationResultSchema,
+            },
+            (input) =>
+              input.background
+                ? launchDelegation(ref, input.task)
+                : runDelegation(ref, input.task)
+          );
+        }
         return tool(
           {
             name: toolName,
             description: staticDescription,
-            inputSchema: z.object({
-              task: z
-                .string()
-                .describe(
-                  'A clear, self-contained description of the task to delegate.'
-                ),
-            }),
-            outputSchema: toolOutputSchema,
+            inputSchema: delegateInputSchema,
+            outputSchema: delegationResultSchema,
           },
-          async (input) => {
-            // ── Guard rail ──────────────────────────────────────────
-            if (
-              maxDelegations !== undefined &&
-              shared.delegationCount >= maxDelegations
-            ) {
-              return {
-                response:
-                  `Delegation limit reached (${maxDelegations}). ` +
-                  `Complete the task using information already gathered.`,
-              };
-            }
-            shared.delegationCount++;
-
-            const agentAction = await resolveAgent(ref.name);
-            if (!agentAction) {
-              return {
-                response: `Error: Agent '${ref.name}' not found in registry.`,
-              };
-            }
-
-            try {
-              // Optionally include recent conversation history as context.
-              // Only user/model messages are forwarded, and each is reduced to
-              // its text parts. This avoids leaking tool/tool-request parts —
-              // a model message mid-tool-loop can carry dangling `toolRequest`
-              // parts with no matching tool response, which would confuse the
-              // sub-agent model.
-              const historyMsgs: MessageData[] = [];
-              if (historyLength > 0 && shared.conversationMessages.length > 0) {
-                const contextMsgs = shared.conversationMessages
-                  .filter((m) => m.role === 'user' || m.role === 'model')
-                  .slice(-historyLength)
-                  .map((m) => ({
-                    role: m.role,
-                    content: m.content.filter(
-                      (p): p is Part & { text: string } =>
-                        typeof p.text === 'string' && p.text.length > 0
-                    ),
-                  }))
-                  .filter((m) => m.content.length > 0);
-                historyMsgs.push(...contextMsgs);
-              }
-
-              // The agent input accepts a single `message` (the task). Prior
-              // conversation is seeded via the session state (`init.state`),
-              // which only client-managed agents (no persistent store) accept —
-              // sending `state` to a server-managed agent throws a precondition
-              // error. Server-managed sub-agents can't be seeded with ad-hoc
-              // per-delegation history, so history forwarding is skipped for
-              // them (the task is still delivered).
-              const stateManagement =
-                agentAction.__action?.metadata?.agent?.stateManagement;
-              const init =
-                historyMsgs.length > 0 && stateManagement !== 'server'
-                  ? { state: { messages: historyMsgs } }
-                  : {};
-
-              const actionResult = await agentAction.run(
-                {
-                  message: {
-                    role: 'user' as const,
-                    content: [{ text: input.task }],
-                  },
-                },
-                { init }
-              );
-              const agentOutput: AgentOutput = actionResult.result;
-
-              // The agent runtime resolves gracefully rather than throwing:
-              // a failed turn returns `finishReason: 'failed'` with structured
-              // error details, and an interrupted turn returns
-              // `finishReason: 'interrupted'`. Handle both explicitly here (the
-              // `catch` below only fires for exceptions thrown outside the
-              // agent's graceful handling).
-
-              // ── Interrupt: surface as a normal tool response ──────
-              // We deliberately do NOT propagate the interrupt to the parent.
-              // Throwing would interrupt the parent's generate, but there is no
-              // stateful sub-agent runtime to resume back into — the sub-agent's
-              // turn state is already gone — so the parent could never satisfy
-              // the interrupt. Interactive, stateful sub-agent interaction is a
-              // future feature. For now we report it as text the orchestrator
-              // can reason about.
-              if (agentOutput.finishReason === 'interrupted') {
-                return {
-                  response:
-                    `Sub-agent '${ref.name}' interrupted for additional input ` +
-                    `and could not complete the task. Interactive sub-agent ` +
-                    `interrupts are not currently supported; try delegating a ` +
-                    `more self-contained task.`,
-                };
-              }
-
-              // ── Failure: surface the error to the orchestrator ────
-              if (agentOutput.finishReason === 'failed') {
-                const message =
-                  agentOutput.error?.message ?? 'Unknown sub-agent failure.';
-                return {
-                  response: `Error calling agent '${ref.name}': ${message}`,
-                };
-              }
-
-              // Extract text content from the agent's response.
-              const textContent = (agentOutput.message?.content ?? [])
-                .map((p) => p.text)
-                .filter(
-                  (t): t is string => typeof t === 'string' && t.length > 0
-                )
-                .join('\n');
-
-              // ── Artifact handling ─────────────────────────────────
-              const subArtifacts: Artifact[] = (
-                agentOutput.artifacts ?? []
-              ).filter((a) => a.name);
-
-              // Generate a unique invocation ID to namespace artifacts
-              const invocationId = makeInvocationId(ref.name);
-
-              // Merge artifacts into the parent session (both strategies).
-              // `ai.currentSession()` throws when there is no active session,
-              // so guard with try/catch rather than a falsy check.
-              if (subArtifacts.length > 0) {
-                try {
-                  const session = ai.currentSession();
-                  const namespacedArtifacts: Artifact[] = subArtifacts.map(
-                    (a) => ({
-                      ...a,
-                      name: `${invocationId}/${a.name}`,
-                      metadata: {
-                        ...a.metadata,
-                        source: ref.name,
-                        invocationId,
-                      },
-                    })
-                  );
-                  session.addArtifacts(namespacedArtifacts);
-                } catch {
-                  // No active session — artifacts can't be merged into a
-                  // parent session. With the "inline" strategy the content is
-                  // still returned in the tool result below.
-                }
-              }
-
-              // Build tool result based on strategy
-              let artifacts: { name: string; content?: string }[] | undefined;
-              if (subArtifacts.length > 0) {
-                if (artifactStrategy === 'inline') {
-                  // Include full content in tool result
-                  artifacts = subArtifacts.map((a) => ({
-                    name: `${invocationId}/${a.name}`,
-                    content: (a.parts ?? [])
-                      .map((p) => p.text ?? '')
-                      .filter((t) => t.length > 0)
-                      .join('\n'),
-                  }));
-                } else {
-                  // Session strategy: names only
-                  artifacts = subArtifacts.map((a) => ({
-                    name: `${invocationId}/${a.name}`,
-                  }));
-                }
-              }
-
-              return {
-                response: textContent || '(no response)',
-                ...(artifacts?.length ? { artifacts } : {}),
-              };
-            } catch (e: unknown) {
-              // The agent runtime resolves failures and interrupts gracefully
-              // (see above), so this only fires for exceptions thrown outside
-              // that handling (e.g. schema parse errors on `run`). Return them
-              // as tool output so the model can recover.
-              const message = e instanceof Error ? e.message : String(e);
-              return {
-                response: `Error calling agent '${ref.name}': ${message}`,
-              };
-            }
-          }
+          (input) => runDelegation(ref, input.task)
         );
       });
 
+      // ── Shared background-task tools ──────────────────────────────────
+
+      const backgroundTools = async
+        ? (() => {
+            for (const name of Object.values(taskTools)) {
+              claimName(name, 'the background-task tools');
+            }
+            return [
+              tool(
+                {
+                  name: taskTools.check,
+                  description:
+                    'Returns the current status of background sub-agent tasks without waiting, including results for tasks that finished.',
+                  inputSchema: backgroundTasksInputSchema,
+                  outputSchema: backgroundTasksResultSchema,
+                },
+                (input) => taskReport(input, readSnapshotOnce)
+              ),
+              tool(
+                {
+                  name: taskTools.wait,
+                  description:
+                    'Waits until the given background sub-agent tasks finish and returns their results. Set timeoutSeconds to bound the wait; on timeout the current statuses are returned. Set waitFor to "first" to return as soon as any one task settles.',
+                  inputSchema: waitBackgroundTasksInputSchema,
+                  outputSchema: backgroundTasksResultSchema,
+                },
+                (input, ctx) => waitForBackgroundTasks(input, ctx.abortSignal)
+              ),
+              tool(
+                {
+                  name: taskTools.abort,
+                  description:
+                    'Stops background sub-agent tasks whose results are no longer needed, and returns where that left each one. A task that had already finished is unaffected and reports its result.',
+                  inputSchema: backgroundTasksInputSchema,
+                  outputSchema: backgroundTasksResultSchema,
+                },
+                (input) => taskReport(input, abortSnapshot)
+              ),
+            ];
+          })()
+        : [];
+
       return {
-        tools: delegationTools,
+        tools: [...delegationTools, ...backgroundTools],
 
         generate: async (envelope, ctx, next) => {
           const { request } = envelope;
@@ -511,6 +1473,19 @@ export const agents: GenerateMiddleware<typeof AgentsOptionsSchema> =
             .map((a) => `  - ${a.toolName}: ${a.description}`)
             .join('\n');
 
+          const asyncInstructions = async
+            ? `\n` +
+              `Delegations can run in the background: set "background": true ` +
+              `on a delegation tool call to get a taskId back immediately ` +
+              `while the sub-agent keeps working. Continue with other work, ` +
+              `then collect results with ${taskTools.check} (returns current ` +
+              `status without waiting) or ${taskTools.wait} (blocks until the ` +
+              `tasks settle). Use ${taskTools.abort} to stop tasks whose ` +
+              `results are no longer needed. Background tasks keep running ` +
+              `across turns, and task IDs from earlier tool results stay ` +
+              `valid: check them before delegating the same work again.\n`
+            : '';
+
           const agentsInstructions =
             `<sub-agents>\n` +
             `You can delegate tasks to specialized sub-agents using their ` +
@@ -520,6 +1495,7 @@ export const agents: GenerateMiddleware<typeof AgentsOptionsSchema> =
             `When a task is better handled by a specialized agent, delegate ` +
             `it using the appropriate tool. Provide a clear, self-contained ` +
             `task description.\n` +
+            asyncInstructions +
             `</sub-agents>`;
 
           // ── Inject into system message ────────────────────────────

--- a/js/plugins/middleware/src/agents.ts
+++ b/js/plugins/middleware/src/agents.ts
@@ -544,13 +544,19 @@ export const agents: GenerateMiddleware<typeof AgentsOptionsSchema> =
             : 'Names of artifacts produced by the sub-agent. Use read_artifact to access content.'
         );
 
-      const delegationResultSchema = z.object({
+      // The result schema is what the model reads, so a synchronous-only
+      // instance must not advertise task handles or background-task tools it
+      // does not have.
+      const syncDelegationResultSchema = z.object({
+        response: z.string().describe("The sub-agent's text response."),
+        artifacts: artifactsField,
+      });
+      const asyncDelegationResultSchema = syncDelegationResultSchema.extend({
         response: z
           .string()
           .describe(
             "The sub-agent's text response. For a background delegation it describes the launch instead; the sub-agent's response arrives later via the background-task tools."
           ),
-        artifacts: artifactsField,
         taskId: z
           .string()
           .optional()
@@ -562,7 +568,10 @@ export const agents: GenerateMiddleware<typeof AgentsOptionsSchema> =
           .optional()
           .describe('"pending" when a background delegation was started.'),
       });
-      type DelegationResult = z.infer<typeof delegationResultSchema>;
+      const delegationResultSchema = async
+        ? asyncDelegationResultSchema
+        : syncDelegationResultSchema;
+      type DelegationResult = z.infer<typeof asyncDelegationResultSchema>;
 
       const delegateInputSchema = z.object({
         task: z

--- a/js/plugins/middleware/src/agents.ts
+++ b/js/plugins/middleware/src/agents.ts
@@ -517,6 +517,15 @@ export const agents: GenerateMiddleware<typeof AgentsOptionsSchema> =
         return agent.__action?.metadata?.agent?.stateManagement;
       }
 
+      /**
+       * Whether the agent's store can signal a running worker to stop, from
+       * its action metadata; undefined when the agent publishes none.
+       */
+      function abortableOf(agent: Agent): boolean | undefined {
+        const abortable = agent.__action?.metadata?.agent?.abortable;
+        return typeof abortable === 'boolean' ? abortable : undefined;
+      }
+
       // -- Schemas ------------------------------------------------------------
 
       const inlineArtifactSchema = z.object({
@@ -1162,8 +1171,9 @@ export const agents: GenerateMiddleware<typeof AgentsOptionsSchema> =
               // outcome the reader has to act on, not the row's bookkeeping:
               // a model that sees "completed" moves on and never reads the
               // error. Which reason it was, and what the agent last said, is
-              // in the folded text.
-              report.status = 'failed';
+              // in the folded text. An aborted turn keeps its own status.
+              report.status =
+                snapshot.finishReason === 'aborted' ? 'aborted' : 'failed';
               report.error = folded.response;
             }
             break;
@@ -1176,7 +1186,16 @@ export const agents: GenerateMiddleware<typeof AgentsOptionsSchema> =
             );
             break;
           case 'aborted':
-            report.error = 'The task was aborted before it finished.';
+            // The runtime stops a worker through its store's change feed.
+            // Where the store has none, the flip still lands and the run's
+            // result is discarded, but the worker itself is not reached; say
+            // so, or a model that aborted to save cost would assume it did.
+            report.error =
+              abortableOf(agent) === false
+                ? 'The task was marked aborted and its result is discarded, ' +
+                  "but this agent's store cannot signal its worker, so the " +
+                  'work may run to completion.'
+                : 'The task was aborted before it finished.';
             break;
           case 'expired':
             report.error =

--- a/js/plugins/middleware/tests/agents_test.ts
+++ b/js/plugins/middleware/tests/agents_test.ts
@@ -15,8 +15,8 @@
  */
 
 import * as assert from 'assert';
-import { z } from 'genkit';
-import { genkit, Session } from 'genkit/beta';
+import { z, type MessageData } from 'genkit';
+import { InMemorySessionStore, Session, genkit } from 'genkit/beta';
 import { describe, it } from 'node:test';
 import { agents } from '../src/agents.js';
 import { artifacts } from '../src/artifacts.js';
@@ -1099,5 +1099,836 @@ describe('agents middleware', () => {
       result.text.includes('recovered'),
       'Orchestrator should be able to recover after the failure'
     );
+  });
+
+  it("reports every non-answer finish reason as a failure that keeps the agent's last words", async () => {
+    const ai = genkit({});
+    const reasons = ['failed', 'blocked', 'length', 'aborted'] as const;
+    for (const reason of reasons) {
+      // A custom sub-agent that ends its turn on `reason` after saying
+      // something partial, without throwing.
+      ai.defineCustomAgent({ name: `ender_${reason}` }, async (sess) => {
+        await sess.run(async () => {
+          sess.addMessages([
+            {
+              role: 'model',
+              content: [{ text: 'partial notes: found 3 of 5 sources' }],
+            },
+          ]);
+          return { finishReason: reason };
+        });
+        const msgs = sess.getMessages();
+        return { message: msgs[msgs.length - 1], finishReason: reason };
+      });
+    }
+
+    for (const reason of reasons) {
+      let mainTurn = 0;
+      let capturedToolOutput: any;
+      const mainModel = ai.defineModel(
+        { name: `main-reason-${reason}-` + Math.random() },
+        async (req) => {
+          mainTurn++;
+          if (mainTurn === 1) {
+            return {
+              message: {
+                role: 'model' as const,
+                content: [
+                  {
+                    toolRequest: {
+                      name: `delegate_to_ender_${reason}`,
+                      input: { task: 'dig' },
+                    },
+                  },
+                ],
+              },
+            };
+          }
+          const toolMsg = req.messages?.find((m: any) => m.role === 'tool');
+          capturedToolOutput = toolMsg?.content.find((p: any) => p.toolResponse)
+            ?.toolResponse?.output;
+          return {
+            message: { role: 'model' as const, content: [{ text: 'ok' }] },
+          };
+        }
+      );
+      await ai.generate({
+        model: mainModel,
+        prompt: 'go',
+        use: [agents({ agents: [`ender_${reason}`] })],
+      });
+      // Reported as a failure that names the reason and keeps the agent's
+      // last words: they explain the outcome, and losing them leaves the
+      // model with nothing it can act on.
+      assert.match(capturedToolOutput.response, /Error calling agent/);
+      assert.ok(
+        capturedToolOutput.response.includes(`'${reason}'`),
+        `response should name the finish reason: ${capturedToolOutput.response}`
+      );
+      assert.ok(
+        capturedToolOutput.response.includes('found 3 of 5 sources'),
+        `response should keep the last message: ${capturedToolOutput.response}`
+      );
+    }
+  });
+
+  it('says outright when a sub-agent completed without a final message', async () => {
+    const ai = genkit({});
+    // Ends on a model message holding only a tool request, after saving one
+    // artifact: there is no answer text, and the result is in the artifact.
+    ai.defineCustomAgent({ name: 'silent' }, async (sess) => {
+      await sess.run(async () => {
+        sess.addArtifacts([{ name: 'report.md', parts: [{ text: 'body' }] }]);
+        sess.addMessages([
+          {
+            role: 'model',
+            content: [{ toolRequest: { name: 'search', input: { q: 'x' } } }],
+          },
+        ]);
+        return { finishReason: 'stop' };
+      });
+      const msgs = sess.getMessages();
+      return {
+        message: msgs[msgs.length - 1],
+        artifacts: sess.getArtifacts(),
+        finishReason: 'stop',
+      };
+    });
+
+    let mainTurn = 0;
+    let capturedToolOutput: any;
+    const mainModel = ai.defineModel(
+      { name: 'main-silent-' + Math.random() },
+      async (req) => {
+        mainTurn++;
+        if (mainTurn === 1) {
+          return {
+            message: {
+              role: 'model' as const,
+              content: [
+                {
+                  toolRequest: {
+                    name: 'delegate_to_silent',
+                    input: { task: 'go' },
+                  },
+                },
+              ],
+            },
+          };
+        }
+        const toolMsg = req.messages?.find((m: any) => m.role === 'tool');
+        capturedToolOutput = toolMsg?.content.find((p: any) => p.toolResponse)
+          ?.toolResponse?.output;
+        return {
+          message: { role: 'model' as const, content: [{ text: 'ok' }] },
+        };
+      }
+    );
+    await ai.generate({
+      model: mainModel,
+      prompt: 'go',
+      use: [agents({ agents: ['silent'] })],
+    });
+    assert.match(capturedToolOutput.response, /completed/);
+    assert.match(capturedToolOutput.response, /no final message/);
+    assert.match(capturedToolOutput.response, /one artifact/);
+    assert.strictEqual(capturedToolOutput.artifacts.length, 1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Background delegation (`async: true`)
+// ---------------------------------------------------------------------------
+
+const CHECK_TOOL = 'check_background_tasks';
+const WAIT_TOOL = 'wait_for_background_tasks';
+const ABORT_TOOL = 'abort_background_tasks';
+
+/** Outputs of every tool response named `toolName` in `messages`. */
+function toolOutputs(messages: MessageData[] | undefined, toolName: string) {
+  return (messages ?? [])
+    .flatMap((m) => m.content)
+    .filter((p) => p.toolResponse?.name === toolName)
+    .map((p) => p.toolResponse!.output as any);
+}
+
+/** The text of the system message in `messages`, if any. */
+function systemText(messages: MessageData[] | undefined): string {
+  return (messages ?? [])
+    .filter((m) => m.role === 'system')
+    .flatMap((m) => m.content)
+    .map((p) => p.text ?? '')
+    .join('\n');
+}
+
+function toolRequest(name: string, input: unknown) {
+  return {
+    message: {
+      role: 'model' as const,
+      content: [{ toolRequest: { name, input } }],
+    },
+  };
+}
+
+function textResponse(text: string) {
+  return { message: { role: 'model' as const, content: [{ text }] } };
+}
+
+/** A gate a test opens to let a sub-agent turn finish. */
+function makeGate() {
+  let release!: () => void;
+  const opened = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  return { opened, release };
+}
+
+/**
+ * Defines a store-backed custom sub-agent whose single turn waits for `gate`
+ * (or the invocation's abort), then says `text` and saves the given
+ * artifacts. Modeled on the gated agents the Go conformance tests use.
+ */
+function defineGatedResearcher(
+  ai: ReturnType<typeof genkit>,
+  name: string,
+  gate: Promise<void>,
+  opts: {
+    text?: string;
+    artifacts?: { name: string; parts: { text: string }[] }[];
+    finishReason?: 'stop' | 'failed';
+    onAbort?: () => void;
+  } = {}
+) {
+  return ai.defineCustomAgent(
+    { name, store: new InMemorySessionStore() },
+    async (sess, { abortSignal }) => {
+      await sess.run(async () => {
+        await Promise.race([
+          gate,
+          new Promise<never>((_, reject) =>
+            abortSignal?.addEventListener(
+              'abort',
+              () => {
+                opts.onAbort?.();
+                reject(new Error('aborted'));
+              },
+              { once: true }
+            )
+          ),
+        ]);
+        if (opts.artifacts) sess.addArtifacts(opts.artifacts);
+        sess.addMessages([
+          {
+            role: 'model',
+            content: [{ text: opts.text ?? 'research complete' }],
+          },
+        ]);
+        return { finishReason: opts.finishReason ?? 'stop' };
+      });
+      const msgs = sess.getMessages();
+      return {
+        message: msgs[msgs.length - 1],
+        artifacts: sess.getArtifacts(),
+        finishReason: opts.finishReason ?? 'stop',
+      };
+    }
+  );
+}
+
+describe('agents middleware (async)', () => {
+  it('launches, checks, and collects a background delegation in one generate call', async () => {
+    const ai = genkit({});
+    const gate = makeGate();
+    defineGatedResearcher(ai, 'researcher', gate.opened, {
+      artifacts: [
+        { name: 'findings.md', parts: [{ text: 'the findings body' }] },
+      ],
+    });
+
+    // Scripted orchestrator: launch in background, check, release the gate,
+    // wait, then finish. Each step keys off the tool responses so far.
+    let capturedSystem = '';
+    const orchestrator = ai.defineModel(
+      { name: 'orch-async-' + Math.random() },
+      async (req) => {
+        capturedSystem = systemText(req.messages);
+        const launches = toolOutputs(req.messages, 'delegate_to_researcher');
+        const checks = toolOutputs(req.messages, CHECK_TOOL);
+        const waits = toolOutputs(req.messages, WAIT_TOOL);
+        if (launches.length === 0) {
+          return toolRequest('delegate_to_researcher', {
+            task: 'dig into X',
+            background: true,
+          });
+        }
+        if (checks.length === 0) {
+          return toolRequest(CHECK_TOOL, { taskIds: [launches[0].taskId] });
+        }
+        if (waits.length === 0) {
+          gate.release();
+          return toolRequest(WAIT_TOOL, { taskIds: [launches[0].taskId] });
+        }
+        return textResponse('done');
+      }
+    );
+
+    const result = await ai.generate({
+      model: orchestrator,
+      prompt: 'research X',
+      maxTurns: 10,
+      use: [agents({ agents: ['researcher'], async: true })],
+    });
+    assert.strictEqual(result.text, 'done');
+
+    for (const want of ['background', CHECK_TOOL, WAIT_TOOL, ABORT_TOOL]) {
+      assert.ok(
+        capturedSystem.includes(want),
+        `async system prompt should mention ${want}: ${capturedSystem}`
+      );
+    }
+
+    const [launch] = toolOutputs(result.messages, 'delegate_to_researcher');
+    assert.strictEqual(launch.status, 'pending');
+    assert.ok(launch.taskId.startsWith('researcher:'), launch.taskId);
+    assert.match(launch.response, /Background task .* started/);
+
+    const [check] = toolOutputs(result.messages, CHECK_TOOL);
+    assert.strictEqual(check.tasks.length, 1);
+    assert.strictEqual(check.tasks[0].status, 'pending');
+
+    const [wait] = toolOutputs(result.messages, WAIT_TOOL);
+    assert.strictEqual(wait.tasks.length, 1);
+    const task = wait.tasks[0];
+    assert.strictEqual(task.status, 'completed');
+    assert.strictEqual(task.agent, 'researcher');
+    assert.strictEqual(task.response, 'research complete');
+    const snapshotId = launch.taskId.slice('researcher:'.length);
+    assert.strictEqual(
+      task.artifacts[0].name,
+      `researcher_${snapshotId.slice(0, 8)}/findings.md`
+    );
+    assert.ok(task.artifacts[0].content.includes('the findings body'));
+    assert.strictEqual(wait.timedOut, undefined);
+  });
+
+  it('collects a task launched by an earlier generate call from its ID alone', async () => {
+    const ai = genkit({});
+    const subModel = ai.defineModel(
+      { name: 'researcher-bg-' + Math.random() },
+      async () => textResponse('background answer')
+    );
+    ai.defineAgent({
+      name: 'researcher',
+      model: subModel,
+      system: 'You research.',
+      store: new InMemorySessionStore(),
+    });
+
+    // First call: launch in the background and stop without waiting.
+    const launcher = ai.defineModel(
+      { name: 'orch-launch-' + Math.random() },
+      async (req) =>
+        toolOutputs(req.messages, 'delegate_to_researcher').length === 0
+          ? toolRequest('delegate_to_researcher', {
+              task: 'long dig',
+              background: true,
+            })
+          : textResponse('launched')
+    );
+    const first = await ai.generate({
+      model: launcher,
+      prompt: 'go',
+      use: [agents({ agents: ['researcher'], async: true })],
+    });
+    const [launch] = toolOutputs(first.messages, 'delegate_to_researcher');
+    assert.ok(launch.taskId);
+
+    // Second call, fresh middleware instance: wait on the recorded task ID
+    // plus a missing snapshot and an unconfigured agent, which must be
+    // reported in isolation from one another.
+    const waiter = ai.defineModel(
+      { name: 'orch-wait-' + Math.random() },
+      async (req) =>
+        toolOutputs(req.messages, WAIT_TOOL).length === 0
+          ? toolRequest(WAIT_TOOL, {
+              taskIds: [
+                launch.taskId,
+                'researcher:no-such-snapshot',
+                'ghost:whatever',
+              ],
+            })
+          : textResponse('collected')
+    );
+    const second = await ai.generate({
+      model: waiter,
+      prompt: 'collect',
+      use: [agents({ agents: ['researcher'], async: true })],
+    });
+    const [wait] = toolOutputs(second.messages, WAIT_TOOL);
+    assert.strictEqual(wait.tasks.length, 3);
+    assert.strictEqual(wait.tasks[0].status, 'completed');
+    assert.strictEqual(wait.tasks[0].response, 'background answer');
+    assert.strictEqual(wait.tasks[1].status, 'unknown');
+    assert.match(wait.tasks[1].error, /not found/);
+    assert.match(wait.tasks[1].error, /Delegate the task again/);
+    assert.strictEqual(wait.tasks[2].status, 'unknown');
+    assert.match(wait.tasks[2].error, /does not match any configured agent/);
+    assert.strictEqual(wait.timedOut, undefined);
+  });
+
+  it('reports a task that committed without an answer as failed', async () => {
+    const ai = genkit({});
+    const gate = makeGate();
+    // The turn commits (the row is `completed`) but declares `failed`.
+    defineGatedResearcher(ai, 'researcher', gate.opened, {
+      text: 'partial notes',
+      finishReason: 'failed',
+    });
+    const orchestrator = ai.defineModel(
+      { name: 'orch-no-answer-' + Math.random() },
+      async (req) => {
+        const launches = toolOutputs(req.messages, 'delegate_to_researcher');
+        if (launches.length === 0) {
+          return toolRequest('delegate_to_researcher', {
+            task: 'dig',
+            background: true,
+          });
+        }
+        if (toolOutputs(req.messages, WAIT_TOOL).length === 0) {
+          gate.release();
+          return toolRequest(WAIT_TOOL, { taskIds: [launches[0].taskId] });
+        }
+        return textResponse('done');
+      }
+    );
+    const result = await ai.generate({
+      model: orchestrator,
+      prompt: 'go',
+      use: [agents({ agents: ['researcher'], async: true })],
+    });
+    const [wait] = toolOutputs(result.messages, WAIT_TOOL);
+    const task = wait.tasks[0];
+    assert.strictEqual(task.status, 'failed');
+    assert.ok(task.error, 'the report must explain why there is no answer');
+    assert.match(task.error, /partial notes/);
+    assert.strictEqual(task.response, undefined);
+  });
+
+  it('times out a wait, reporting running tasks as pending and keeping unresolvable errors', async () => {
+    const ai = genkit({});
+    const gate = makeGate();
+    // Never released: the task is pending for the whole wait.
+    defineGatedResearcher(ai, 'researcher', gate.opened);
+    const orchestrator = ai.defineModel(
+      { name: 'orch-timeout-' + Math.random() },
+      async (req) => {
+        const launches = toolOutputs(req.messages, 'delegate_to_researcher');
+        if (launches.length === 0) {
+          return toolRequest('delegate_to_researcher', {
+            task: 'dig',
+            background: true,
+          });
+        }
+        if (toolOutputs(req.messages, WAIT_TOOL).length === 0) {
+          return toolRequest(WAIT_TOOL, {
+            taskIds: [launches[0].taskId, 'ghost:whatever'],
+            timeoutSeconds: 0.2,
+          });
+        }
+        return textResponse('done');
+      }
+    );
+    const result = await ai.generate({
+      model: orchestrator,
+      prompt: 'go',
+      use: [agents({ agents: ['researcher'], async: true })],
+    });
+    const [wait] = toolOutputs(result.messages, WAIT_TOOL);
+    assert.strictEqual(wait.timedOut, true);
+    assert.strictEqual(wait.tasks.length, 2);
+    assert.strictEqual(wait.tasks[0].status, 'pending');
+    assert.strictEqual(wait.tasks[0].error, undefined);
+    // Nothing about the deadline makes an unresolvable handle more likely to
+    // settle later; reporting it as pending would send the model back to
+    // re-check it forever.
+    assert.strictEqual(wait.tasks[1].status, 'unknown');
+    assert.match(wait.tasks[1].error, /does not match any configured agent/);
+    gate.release();
+  });
+
+  it('treats a timeout too large for a timer as unbounded', async () => {
+    const ai = genkit({});
+    ai.defineAgent({
+      name: 'researcher',
+      model: ai.defineModel(
+        { name: 'researcher-overflow-' + Math.random() },
+        async () => textResponse('unused')
+      ),
+      system: 'unused',
+      store: new InMemorySessionStore(),
+    });
+    // A missing snapshot settles on the first pass (NOT_FOUND is a dead end),
+    // so the wait returns without waiting out the absurd timeout; a deadline
+    // that overflowed into an immediate timer would instead come back timed
+    // out with a read that never happened.
+    const waiter = ai.defineModel(
+      { name: 'orch-overflow-' + Math.random() },
+      async (req) =>
+        toolOutputs(req.messages, WAIT_TOOL).length === 0
+          ? toolRequest(WAIT_TOOL, {
+              taskIds: ['researcher:no-such-snapshot'],
+              timeoutSeconds: 10_000_000_000,
+            })
+          : textResponse('collected')
+    );
+    const result = await ai.generate({
+      model: waiter,
+      prompt: 'go',
+      use: [agents({ agents: ['researcher'], async: true })],
+    });
+    const [wait] = toolOutputs(result.messages, WAIT_TOOL);
+    assert.strictEqual(wait.timedOut, undefined);
+    assert.strictEqual(wait.tasks[0].status, 'unknown');
+    assert.match(wait.tasks[0].error, /not found/);
+  });
+
+  it('returns on the first settled task with waitFor "first"', async () => {
+    const ai = genkit({});
+    ai.defineAgent({
+      name: 'quick',
+      model: ai.defineModel({ name: 'quick-' + Math.random() }, async () =>
+        textResponse('quick answer')
+      ),
+      system: 'unused',
+      store: new InMemorySessionStore(),
+    });
+    // The slow sub-agent finishes only when released, so the race can only
+    // be won by the quick one.
+    const gate = makeGate();
+    defineGatedResearcher(ai, 'slow', gate.opened);
+
+    const orchestrator = ai.defineModel(
+      { name: 'orch-race-' + Math.random() },
+      async (req) => {
+        const slow = toolOutputs(req.messages, 'delegate_to_slow');
+        const quick = toolOutputs(req.messages, 'delegate_to_quick');
+        if (slow.length === 0) {
+          return toolRequest('delegate_to_slow', {
+            task: 'dig forever',
+            background: true,
+          });
+        }
+        if (quick.length === 0) {
+          return toolRequest('delegate_to_quick', {
+            task: 'answer fast',
+            background: true,
+          });
+        }
+        if (toolOutputs(req.messages, WAIT_TOOL).length === 0) {
+          // The slow task first in the list, so a settled result in slot 1
+          // proves the join raced instead of following input order.
+          return toolRequest(WAIT_TOOL, {
+            taskIds: [slow[0].taskId, quick[0].taskId],
+            waitFor: 'first',
+          });
+        }
+        return textResponse('done');
+      }
+    );
+    const result = await ai.generate({
+      model: orchestrator,
+      prompt: 'go',
+      maxTurns: 10,
+      use: [agents({ agents: ['quick', 'slow'], async: true })],
+    });
+    const [wait] = toolOutputs(result.messages, WAIT_TOOL);
+    assert.strictEqual(wait.timedOut, undefined, 'a won race is not a timeout');
+    assert.strictEqual(wait.tasks[0].status, 'pending');
+    assert.strictEqual(wait.tasks[1].status, 'completed');
+    assert.strictEqual(wait.tasks[1].response, 'quick answer');
+    assert.match(wait.note, /first settled/);
+    gate.release();
+  });
+
+  it('answers an unknown waitFor value with guidance', async () => {
+    const ai = genkit({});
+    ai.defineAgent({
+      name: 'quick',
+      model: ai.defineModel({ name: 'quick2-' + Math.random() }, async () =>
+        textResponse('unused')
+      ),
+      system: 'unused',
+      store: new InMemorySessionStore(),
+    });
+    const orchestrator = ai.defineModel(
+      { name: 'orch-badjoin-' + Math.random() },
+      async (req) =>
+        toolOutputs(req.messages, WAIT_TOOL).length === 0
+          ? toolRequest(WAIT_TOOL, {
+              taskIds: ['quick:whatever'],
+              waitFor: 'any',
+            })
+          : textResponse('done')
+    );
+    const result = await ai.generate({
+      model: orchestrator,
+      prompt: 'go',
+      use: [agents({ agents: ['quick'], async: true })],
+    });
+    const [wait] = toolOutputs(result.messages, WAIT_TOOL);
+    assert.match(wait.note, /'first'/);
+    assert.strictEqual(wait.tasks, undefined);
+  });
+
+  it('aborts a running background task and reports it aborted afterwards', async () => {
+    const ai = genkit({});
+    const gate = makeGate();
+    let stopped = false;
+    // Never released: the abort is the only thing that can end this task.
+    defineGatedResearcher(ai, 'researcher', gate.opened, {
+      onAbort: () => {
+        stopped = true;
+      },
+    });
+    const orchestrator = ai.defineModel(
+      { name: 'orch-abort-' + Math.random() },
+      async (req) => {
+        const launches = toolOutputs(req.messages, 'delegate_to_researcher');
+        if (launches.length === 0) {
+          return toolRequest('delegate_to_researcher', {
+            task: 'dig',
+            background: true,
+          });
+        }
+        if (toolOutputs(req.messages, ABORT_TOOL).length === 0) {
+          return toolRequest(ABORT_TOOL, { taskIds: [launches[0].taskId] });
+        }
+        if (toolOutputs(req.messages, CHECK_TOOL).length === 0) {
+          return toolRequest(CHECK_TOOL, { taskIds: [launches[0].taskId] });
+        }
+        return textResponse('done');
+      }
+    );
+    const result = await ai.generate({
+      model: orchestrator,
+      prompt: 'go',
+      maxTurns: 10,
+      use: [agents({ agents: ['researcher'], async: true })],
+    });
+    const [aborted] = toolOutputs(result.messages, ABORT_TOOL);
+    assert.strictEqual(aborted.tasks[0].status, 'aborted');
+    assert.ok(aborted.tasks[0].error);
+    // The row said aborted; the runtime observes that flip and cancels the
+    // work, which is the half a status write alone would not prove.
+    assert.strictEqual(stopped, true, 'the sub-agent was never cancelled');
+    const [checked] = toolOutputs(result.messages, CHECK_TOOL);
+    assert.strictEqual(checked.tasks[0].status, 'aborted');
+  });
+
+  it('reports the result when aborting a task that had already finished', async () => {
+    const ai = genkit({});
+    const researcher = defineGatedResearcher(
+      ai,
+      'researcher',
+      Promise.resolve(),
+      {
+        artifacts: [
+          { name: 'findings.md', parts: [{ text: 'the findings body' }] },
+        ],
+      }
+    );
+    // Launch and settle the task outside the middleware, so nothing has
+    // cached its report before the abort tool runs.
+    const task = await researcher.chat().detach('dig into X');
+    await task.wait();
+
+    const def = agents.instantiate({
+      config: { agents: ['researcher'], async: true },
+      ai,
+      pluginConfig: undefined,
+    });
+    const abortTool = def.tools!.find((t) => t.__action.name === ABORT_TOOL)!;
+    const out = await abortTool({ taskIds: [`researcher:${task.snapshotId}`] });
+    const report = out.tasks[0];
+    assert.strictEqual(report.status, 'completed');
+    assert.strictEqual(report.response, 'research complete');
+    assert.strictEqual(
+      report.artifacts[0].name,
+      `researcher_${task.snapshotId.slice(0, 8)}/findings.md`
+    );
+    assert.ok(report.artifacts[0].content.includes('the findings body'));
+  });
+
+  it('refuses a background launch on a sub-agent without a store and refunds the slot', async () => {
+    const ai = genkit({});
+    ai.defineAgent({
+      name: 'researcher',
+      model: ai.defineModel(
+        { name: 'researcher-nostore-' + Math.random() },
+        async () => textResponse('synchronous answer')
+      ),
+      system: 'unused',
+    });
+    // Launch in the background (refused), then synchronously: with a cap of
+    // one, the retry only succeeds if the refusal returned its slot.
+    const orchestrator = ai.defineModel(
+      { name: 'orch-nostore-' + Math.random() },
+      async (req) => {
+        const results = toolOutputs(req.messages, 'delegate_to_researcher');
+        if (results.length === 0) {
+          return toolRequest('delegate_to_researcher', {
+            task: 'dig',
+            background: true,
+          });
+        }
+        if (results.length === 1) {
+          return toolRequest('delegate_to_researcher', { task: 'dig' });
+        }
+        return textResponse('done');
+      }
+    );
+    const result = await ai.generate({
+      model: orchestrator,
+      prompt: 'go',
+      use: [agents({ agents: ['researcher'], async: true, maxDelegations: 1 })],
+    });
+    const [refused, retried] = toolOutputs(
+      result.messages,
+      'delegate_to_researcher'
+    );
+    assert.strictEqual(refused.taskId, undefined);
+    assert.match(refused.response, /Error calling agent/);
+    assert.match(refused.response, /no session store/);
+    assert.match(refused.response, /without "background"/);
+    assert.strictEqual(retried.response, 'synchronous answer');
+  });
+
+  it('lets two async instances with distinct prefixes share one generate call', async () => {
+    const ai = genkit({});
+    ai.defineAgent({
+      name: 'researcher',
+      model: ai.defineModel(
+        { name: 'researcher-coexist-' + Math.random() },
+        async () => textResponse('unused')
+      ),
+      system: 'unused',
+      store: new InMemorySessionStore(),
+    });
+    const model = ai.defineModel(
+      { name: 'orch-coexist-' + Math.random() },
+      async () => textResponse('done')
+    );
+    const result = await ai.generate({
+      model,
+      prompt: 'go',
+      use: [
+        agents({ agents: ['researcher'], toolPrefix: 'research', async: true }),
+        agents({ agents: ['researcher'], toolPrefix: 'code', async: true }),
+      ],
+    });
+    assert.strictEqual(result.text, 'done');
+  });
+
+  it('rejects colliding tool names at instantiation', () => {
+    const ai = genkit({});
+    assert.throws(
+      () =>
+        agents.instantiate({
+          config: {
+            agents: ['check_background_tasks'],
+            toolPrefix: '',
+            async: true,
+          },
+          ai,
+          pluginConfig: undefined,
+        }),
+      /collides/
+    );
+  });
+
+  it('parses task IDs against the longest configured agent name', async () => {
+    const ai = genkit({});
+    const def = agents.instantiate({
+      config: { agents: ['a', 'a:b'], async: true },
+      ai,
+      pluginConfig: undefined,
+    });
+    const checkTool = def.tools!.find((t) => t.__action.name === CHECK_TOOL)!;
+    // Neither agent is registered, so each report fails at resolution and
+    // names the agent the handle was parsed to.
+    const out = await checkTool({ taskIds: ['a:b:1234', 'a:5678', 'a:'] });
+    assert.strictEqual(out.tasks[0].agent, 'a:b');
+    assert.strictEqual(out.tasks[1].agent, 'a');
+    assert.match(out.tasks[1].error, /not registered/);
+    assert.strictEqual(out.tasks[2].status, 'unknown');
+    assert.match(out.tasks[2].error, /does not match any configured agent/);
+  });
+
+  it('answers a background-task tool called without task IDs with guidance', async () => {
+    const ai = genkit({});
+    const def = agents.instantiate({
+      config: { agents: ['researcher'], async: true },
+      ai,
+      pluginConfig: undefined,
+    });
+    for (const name of [CHECK_TOOL, WAIT_TOOL, ABORT_TOOL]) {
+      const t = def.tools!.find((t) => t.__action.name === name);
+      assert.ok(t, `tool ${name} should be registered`);
+      // An omitted taskIds must decode: a required field would fail the whole
+      // generate call rather than a turn the model can correct.
+      const out = await t!({});
+      assert.match(out.note, /No task IDs given/);
+    }
+  });
+
+  it('reports what the sub-agent last said, not whatever the transcript ends on', async () => {
+    const ai = genkit({});
+    const gate = makeGate();
+    // The transcript ends on a tool response after the model spoke.
+    ai.defineCustomAgent(
+      { name: 'researcher', store: new InMemorySessionStore() },
+      async (sess) => {
+        await sess.run(async () => {
+          await gate.opened;
+          sess.addMessages([
+            { role: 'model', content: [{ text: 'working on it' }] },
+            {
+              role: 'tool',
+              content: [
+                { toolResponse: { name: 'search', output: 'raw results' } },
+              ],
+            },
+          ]);
+          return { finishReason: 'stop' };
+        });
+        return { artifacts: sess.getArtifacts(), finishReason: 'stop' };
+      }
+    );
+    const orchestrator = ai.defineModel(
+      { name: 'orch-last-model-' + Math.random() },
+      async (req) => {
+        const launches = toolOutputs(req.messages, 'delegate_to_researcher');
+        if (launches.length === 0) {
+          return toolRequest('delegate_to_researcher', {
+            task: 'dig',
+            background: true,
+          });
+        }
+        if (toolOutputs(req.messages, WAIT_TOOL).length === 0) {
+          gate.release();
+          return toolRequest(WAIT_TOOL, { taskIds: [launches[0].taskId] });
+        }
+        return textResponse('done');
+      }
+    );
+    const result = await ai.generate({
+      model: orchestrator,
+      prompt: 'go',
+      use: [agents({ agents: ['researcher'], async: true })],
+    });
+    const [wait] = toolOutputs(result.messages, WAIT_TOOL);
+    assert.strictEqual(wait.tasks[0].status, 'completed');
+    assert.strictEqual(wait.tasks[0].response, 'working on it');
+    assert.strictEqual(wait.tasks[0].error, undefined);
   });
 });

--- a/js/plugins/middleware/tests/agents_test.ts
+++ b/js/plugins/middleware/tests/agents_test.ts
@@ -1514,6 +1514,34 @@ describe('agents middleware (async)', () => {
     assert.strictEqual(task.response, undefined);
   });
 
+  it('reports a settled task on a deadline that beats the follow', async () => {
+    const ai = genkit({});
+    const researcher = defineGatedResearcher(
+      ai,
+      'researcher',
+      Promise.resolve()
+    );
+    const task = await researcher.chat().detach('dig');
+    await task.wait();
+
+    const def = agents.instantiate({
+      config: { agents: ['researcher'], async: true },
+      ai,
+      pluginConfig: undefined,
+    });
+    const waitTool = def.tools!.find((t) => t.__action.name === WAIT_TOOL)!;
+    // Whichever wins, the deadline or the follow's first read, the row is
+    // settled and the report must say so: a timeout returns the current
+    // statuses, not the follow's last look at them.
+    const out = await waitTool({
+      taskIds: [`researcher:${task.snapshotId}`],
+      timeoutSeconds: 0.000001,
+    });
+    assert.strictEqual(out.tasks[0].status, 'completed');
+    assert.strictEqual(out.tasks[0].response, 'research complete');
+    assert.strictEqual(out.timedOut, undefined);
+  });
+
   it('times out a wait, reporting running tasks as pending and keeping unresolvable errors', async () => {
     const ai = genkit({});
     const gate = makeGate();

--- a/js/plugins/middleware/tests/agents_test.ts
+++ b/js/plugins/middleware/tests/agents_test.ts
@@ -1542,6 +1542,42 @@ describe('agents middleware (async)', () => {
     assert.strictEqual(out.timedOut, undefined);
   });
 
+  it('does not advertise task handles on a synchronous instance', async () => {
+    const ai = genkit({});
+    ai.defineAgent({
+      name: 'researcher',
+      model: ai.defineModel(
+        { name: 'researcher-sync-schema-' + Math.random() },
+        async () => textResponse('unused')
+      ),
+      system: 'unused',
+    });
+    let delegateDef: any;
+    const orchestrator = ai.defineModel(
+      { name: 'orch-sync-schema-' + Math.random() },
+      async (req) => {
+        delegateDef = req.tools?.find(
+          (t) => t.name === 'delegate_to_researcher'
+        );
+        return textResponse('done');
+      }
+    );
+    await ai.generate({
+      model: orchestrator,
+      prompt: 'go',
+      use: [agents({ agents: ['researcher'] })],
+    });
+    assert.ok(delegateDef, 'the delegation tool must reach the model');
+    // The schemas are what the model reads: nothing in them may point at
+    // background tasks or the tools that collect them, which this instance
+    // does not have.
+    const inputSchema = JSON.stringify(delegateDef.inputSchema);
+    const outputSchema = JSON.stringify(delegateDef.outputSchema);
+    assert.ok(!inputSchema.includes('background'));
+    assert.ok(!outputSchema.includes('taskId'));
+    assert.ok(!outputSchema.includes('background'));
+  });
+
   it('times out a wait, reporting running tasks as pending and keeping unresolvable errors', async () => {
     const ai = genkit({});
     const gate = makeGate();

--- a/js/plugins/middleware/tests/agents_test.ts
+++ b/js/plugins/middleware/tests/agents_test.ts
@@ -1295,12 +1295,13 @@ function defineGatedResearcher(
   opts: {
     text?: string;
     artifacts?: { name: string; parts: { text: string }[] }[];
-    finishReason?: 'stop' | 'failed';
+    finishReason?: 'stop' | 'failed' | 'aborted';
     onAbort?: () => void;
+    store?: InMemorySessionStore;
   } = {}
 ) {
   return ai.defineCustomAgent(
-    { name, store: new InMemorySessionStore() },
+    { name, store: opts.store ?? new InMemorySessionStore() },
     async (sess, { abortSignal }) => {
       await sess.run(async () => {
         await Promise.race([
@@ -1514,6 +1515,43 @@ describe('agents middleware (async)', () => {
     assert.strictEqual(task.response, undefined);
   });
 
+  it('reports a task that committed as aborted under that status', async () => {
+    const ai = genkit({});
+    const gate = makeGate();
+    // The turn commits (the row is `completed`) but declares `aborted`.
+    defineGatedResearcher(ai, 'researcher', gate.opened, {
+      text: 'stopped early',
+      finishReason: 'aborted',
+    });
+    const orchestrator = ai.defineModel(
+      { name: 'orch-aborted-reason-' + Math.random() },
+      async (req) => {
+        const launches = toolOutputs(req.messages, 'delegate_to_researcher');
+        if (launches.length === 0) {
+          return toolRequest('delegate_to_researcher', {
+            task: 'dig',
+            background: true,
+          });
+        }
+        if (toolOutputs(req.messages, WAIT_TOOL).length === 0) {
+          gate.release();
+          return toolRequest(WAIT_TOOL, { taskIds: [launches[0].taskId] });
+        }
+        return textResponse('done');
+      }
+    );
+    const result = await ai.generate({
+      model: orchestrator,
+      prompt: 'go',
+      use: [agents({ agents: ['researcher'], async: true })],
+    });
+    const [wait] = toolOutputs(result.messages, WAIT_TOOL);
+    const task = wait.tasks[0];
+    assert.strictEqual(task.status, 'aborted');
+    assert.match(task.error, /stopped early/);
+    assert.strictEqual(task.response, undefined);
+  });
+
   it('reports a settled task on a deadline that beats the follow', async () => {
     const ai = genkit({});
     const researcher = defineGatedResearcher(
@@ -1540,6 +1578,30 @@ describe('agents middleware (async)', () => {
     assert.strictEqual(out.tasks[0].status, 'completed');
     assert.strictEqual(out.tasks[0].response, 'research complete');
     assert.strictEqual(out.timedOut, undefined);
+  });
+
+  it('says when an abort cannot reach the worker', async () => {
+    const ai = genkit({});
+    const gate = makeGate();
+    // A store without a change feed: the runtime can flip the row but has no
+    // way to signal the worker, and publishes the agent as not abortable.
+    const store = new InMemorySessionStore();
+    Object.defineProperty(store, 'onSnapshotStateChange', { value: undefined });
+    const researcher = defineGatedResearcher(ai, 'researcher', gate.opened, {
+      store,
+    });
+    const task = await researcher.chat().detach('dig');
+
+    const def = agents.instantiate({
+      config: { agents: ['researcher'], async: true },
+      ai,
+      pluginConfig: undefined,
+    });
+    const abortTool = def.tools!.find((t) => t.__action.name === ABORT_TOOL)!;
+    const out = await abortTool({ taskIds: [`researcher:${task.snapshotId}`] });
+    assert.strictEqual(out.tasks[0].status, 'aborted');
+    assert.match(out.tasks[0].error, /cannot signal its worker/);
+    gate.release();
   });
 
   it('does not advertise task handles on a synchronous instance', async () => {

--- a/js/testapps/agents/src/commander-agent.ts
+++ b/js/testapps/agents/src/commander-agent.ts
@@ -1,0 +1,253 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Incident Commander — demonstrates background delegation (`async: true`)
+ *
+ * The orchestrator sample delegates and waits: its turn is blocked for as long
+ * as the sub-agent runs. This agent cannot afford that. It is an incident
+ * commander, and an incident has two clocks that do not agree. The
+ * investigation takes as long as it takes. The status update is owed now.
+ *
+ * So every investigation starts with `background: true`. The delegation tool
+ * returns a task ID at once and the sub-agent keeps running after the tool
+ * call returns, so the commander posts its first update while the
+ * investigators are still reading logs. It collects the results afterwards
+ * with `wait_for_background_tasks`: first with a short timeout, so a slow
+ * investigation turns into an interim update instead of silence, then without
+ * one.
+ *
+ * The parts worth reading:
+ *
+ *   - `async: true` on the middleware. It adds the `background` flag to every
+ *     delegation tool and the three task tools that go with it: check, wait
+ *     and abort.
+ *   - Both sub-agents have a session store. A background delegation records a
+ *     pending snapshot as the durable task, so a store is what makes an agent
+ *     able to run in the background at all; a store-less agent is refused at
+ *     launch and the commander is told to delegate to it synchronously.
+ *   - The task ID (`<agent>:<snapshotId>`) comes back in the delegation tool
+ *     result, so it lands in the conversation. Nothing else tracks the task,
+ *     which is why a commander rebuilt from its history alone can still
+ *     collect the answer.
+ *   - Neither investigator is told anything about this conversation. History
+ *     is never forwarded to a sub-agent that has a store, so the task text has
+ *     to stand alone and each investigator pulls its own input with tools.
+ *   - `read_status_board` is work the commander can do with the time
+ *     background delegation gives it back. A blocking orchestrator has no such
+ *     time: its turn is inside the sub-agent call.
+ *   - `maxTurns`. Launching, posting, reading the board, waiting, posting and
+ *     waiting again are all tool rounds, so an orchestrator that collects in
+ *     the background needs a higher ceiling than one that blocks on each
+ *     delegation.
+ *
+ * Try it with:
+ *
+ *     checkout-api is throwing 500s and customers can't pay
+ *
+ * Watch the order of the tool calls: two delegations, then post_status, then
+ * the waits, with read_status_board filling the time in between. The task IDs
+ * are visible in the wait tool's input.
+ */
+
+import { agents, retry } from '@genkit-ai/middleware';
+import { z } from 'genkit';
+import { InMemorySessionStore } from 'genkit/beta';
+import { ai, defaultModel } from './genkit.js';
+
+// ---------------------------------------------------------------------------
+// The incident: checkout-api started failing at 14:03. The logs and the
+// deploy history each hold one half of the answer, and neither investigator
+// can reach the other's half.
+// ---------------------------------------------------------------------------
+
+const searchLogs = ai.defineTool(
+  {
+    name: 'searchLogs',
+    description:
+      'Searches the recent logs of a service and returns matching lines with timestamps.',
+    inputSchema: z.object({
+      service: z.string().describe('Service name, e.g. "checkout-api".'),
+      query: z
+        .string()
+        .optional()
+        .describe('Optional substring to filter log lines by.'),
+    }),
+    outputSchema: z.object({ lines: z.array(z.string()) }),
+  },
+  async ({ service, query }) => {
+    // The investigation "takes as long as it takes": long enough for the
+    // commander's first wait to time out and turn into an interim update.
+    await new Promise((resolve) => setTimeout(resolve, 8_000));
+    const lines = [
+      `14:03:12 ${service} ERROR connection refused to payments-db-v2:5432 (x412 in 60s)`,
+      `14:03:12 ${service} ERROR POST /checkout 500 upstream=payments-db-v2 timeout`,
+      `14:02:58 ${service} INFO  config reloaded PAYMENTS_DB_HOST=payments-db-v2`,
+      `13:59:40 ${service} INFO  POST /checkout 200 (p95 210ms)`,
+    ];
+    return {
+      lines: query ? lines.filter((l) => l.includes(query)) : lines,
+    };
+  }
+);
+
+const listDeploys = ai.defineTool(
+  {
+    name: 'listDeploys',
+    description:
+      'Lists the recent deploys and configuration changes of a service, newest first.',
+    inputSchema: z.object({
+      service: z.string().describe('Service name, e.g. "checkout-api".'),
+    }),
+    outputSchema: z.object({ deploys: z.array(z.string()) }),
+  },
+  async ({ service }) => ({
+    deploys: [
+      `14:02 ${service} config change: PAYMENTS_DB_HOST payments-db -> payments-db-v2 (ticket INFRA-881, migration not yet cut over)`,
+      `13:10 ${service} v2.41.0 deployed (cart rounding fix)`,
+      `09:45 ${service} v2.40.3 deployed`,
+    ],
+  })
+);
+
+// ---------------------------------------------------------------------------
+// The investigators. Each has its own session store: that is what lets the
+// commander delegate to it in the background.
+// ---------------------------------------------------------------------------
+
+export const logAnalyst = ai.defineAgent({
+  name: 'logAnalyst',
+  description:
+    "Reads a service's recent logs and reports what they show: the error signature, when it started, and the blast radius.",
+  model: defaultModel,
+  system: `You are an SRE log analyst. Use searchLogs to read the logs of the service you are asked about, then report in a few sentences: the error signature, when it started, what it points at, and how widespread it is. Report only what the logs show.`,
+  tools: [searchLogs],
+  maxTurns: 6,
+  store: new InMemorySessionStore(),
+  use: [retry()],
+});
+
+export const deployHistorian = ai.defineAgent({
+  name: 'deployHistorian',
+  description:
+    'Checks what changed: recent deploys and configuration changes for a service, with timestamps.',
+  model: defaultModel,
+  system: `You are a release engineer. Use listDeploys to look up the recent changes of the service you are asked about, then report in a few sentences which changes landed shortly before the reported time and what each one touched.`,
+  tools: [listDeploys],
+  maxTurns: 6,
+  store: new InMemorySessionStore(),
+  use: [retry()],
+});
+
+// ---------------------------------------------------------------------------
+// The commander's own tools: the status feed it owes updates to, and a board
+// it can read while the investigators work.
+// ---------------------------------------------------------------------------
+
+/** Updates posted during the current incident, newest last. */
+const statusLog: { at: string; update: string }[] = [];
+
+const postStatus = ai.defineTool(
+  {
+    name: 'post_status',
+    description:
+      'Posts an update to the incident status feed. Post as soon as you know anything, and again whenever the picture changes.',
+    inputSchema: z.object({
+      update: z.string().describe('The status update, two sentences at most.'),
+    }),
+    outputSchema: z.object({ posted: z.boolean(), at: z.string() }),
+  },
+  async ({ update }) => {
+    const at = new Date().toISOString();
+    statusLog.push({ at, update });
+    return { posted: true, at };
+  }
+);
+
+const readStatusBoard = ai.defineTool(
+  {
+    name: 'read_status_board',
+    description:
+      'Reads the live status board: the latest signals from monitoring and support. Cheap to call; the board changes often.',
+    inputSchema: z.object({}),
+    outputSchema: z.object({ signals: z.array(z.string()) }),
+  },
+  async () => {
+    const useful = [
+      'Support: 37 tickets in the last 10 minutes, all "payment failed at checkout".',
+      'Monitoring: checkout-api error rate 94%, other services nominal.',
+      'Monitoring: payments-db (old host) healthy, 0 connections in the last minute.',
+    ];
+    const noise = [
+      'Facilities: the 4th floor coffee machine is being descaled.',
+      'Marketing: newsletter open rate up 2% week over week.',
+      'IT: printer queue on floor 2 cleared.',
+    ];
+    const pick = (list: string[]) =>
+      list[Math.floor(Math.random() * list.length)];
+    return { signals: [pick(useful), pick(noise)] };
+  }
+);
+
+// ---------------------------------------------------------------------------
+// The commander. Delegates in the background, posts while it waits.
+// ---------------------------------------------------------------------------
+
+export const commanderAgent = ai.defineAgent({
+  name: 'commanderAgent',
+  model: defaultModel,
+  system: `You are the incident commander for a production incident. You owe the status feed an update now, and a root cause as soon as one is known.
+
+Work like this:
+1. Immediately delegate two investigations IN THE BACKGROUND (set "background": true on each delegation): ask the log analyst what the logs of the affected service show, and ask the deploy historian what changed in that service recently. Each task description must stand alone: the investigators know nothing about this conversation.
+2. Post a first status update with post_status right away, while they work.
+3. Read the status board with read_status_board once or twice; use what is relevant, ignore what is not.
+4. Collect the investigations with wait_for_background_tasks. Use a short timeoutSeconds (about 5) the first time; if some are still pending, post an interim update, then wait again without a timeout.
+5. Post a final update with the root cause and the fix, then answer the user with the same.`,
+  tools: [postStatus, readStatusBoard],
+  maxTurns: 20,
+  use: [
+    agents({
+      agents: ['logAnalyst', 'deployHistorian'],
+      async: true,
+    }),
+    retry(),
+  ],
+});
+
+// ---------------------------------------------------------------------------
+// Test flow — runs one incident and returns the status feed with the answer.
+// ---------------------------------------------------------------------------
+
+export const testCommanderAgent = ai.defineFlow(
+  {
+    name: 'testCommanderAgent',
+    inputSchema: z
+      .string()
+      .default("checkout-api is throwing 500s and customers can't pay"),
+    outputSchema: z.any(),
+  },
+  async (text, { sendChunk }) => {
+    statusLog.length = 0;
+    const chat = commanderAgent.chat();
+    const turn = chat.sendStream(text);
+    for await (const chunk of turn.stream) {
+      sendChunk(chunk.raw);
+    }
+    const res = await turn.response;
+    return { answer: res.text, statusUpdates: [...statusLog] };
+  }
+);

--- a/js/testapps/agents/src/index.ts
+++ b/js/testapps/agents/src/index.ts
@@ -48,6 +48,7 @@ import {
   readWorkspaceFile,
   testCodingAgent,
 } from './coding-agent.js';
+import { commanderAgent, testCommanderAgent } from './commander-agent.js';
 import {
   orchestratorAgent,
   testOrchestratorAgent,
@@ -87,6 +88,8 @@ void [
   orchestratorAgent,
   testOrchestratorAgent,
   testOrchestratorAgentSimple,
+  commanderAgent,
+  testCommanderAgent,
   tripPlannerAgent,
   testTripPlannerAgent,
   codingAgent,
@@ -159,6 +162,7 @@ exposeAgent('backgroundAgent', backgroundAgent, {
 exposeAgent('branchingAgent', branchingAgent, { snapshot: true });
 exposeAgent('taskAgent', taskAgent);
 exposeAgent('orchestratorAgent', orchestratorAgent);
+exposeAgent('commanderAgent', commanderAgent);
 exposeAgent('tripPlannerAgent', tripPlannerAgent, { snapshot: true });
 exposeAgent('codingAgent', codingAgent, { snapshot: true });
 


### PR DESCRIPTION
Second PR of the train, on the `waitForSnapshot` base (#6272). Adds background delegation to the `agents` middleware, porting Go [#6119](https://github.com/genkit-ai/genkit/pull/6119): with `async: true`, every delegation tool takes a `background` flag that launches the sub-agent through its detach support and returns a task ID at once, and three shared tools let the orchestrator check, join, and stop what it launched. `async` is the only new option.

## One control per thing the orchestrator can do with a task

```ts
use: [agents({ agents: ['researcher'], async: true })]
```

```
delegate_to_researcher    {task, background: true}
                          -> {response, taskId: "researcher:<snapshotId>", status: "pending"}
check_background_tasks    {taskIds}
                          -> {tasks: [{taskId, agent, status, response?, artifacts?, error?}]}
wait_for_background_tasks {taskIds, timeoutSeconds?, waitFor?: "all" | "first"}
                          -> the same, plus timedOut
abort_background_tasks    {taskIds}
                          -> the same, each task reported where the stop left it
```

A non-empty `toolPrefix` namespaces the shared tools as it does the delegation tools, so two async instances in one generate call need distinct prefixes; colliding names are rejected at instantiation rather than as a duplicate-tool failure of the whole request. A launch spends a `maxDelegations` slot, and a launch refused because the sub-agent has no store refunds it, so the synchronous retry the refusal points at is not turned away by a cap the refusal consumed. History is never forwarded to a background launch: detach requires a server-managed sub-agent, and server-managed init rejects seeded state.

## The sub-agent's snapshot is the whole record

The middleware keeps no task registry. The task ID rides in the tool result, so the orchestrator's history is the registry, and a re-instantiated orchestrator collects with nothing but the IDs it finds there. Every read goes through the sub-agent's own companion actions (`getSnapshotDataAction`, `waitForSnapshotAction`, `abortAgentAction`), so a stale-heartbeat row reads as `expired` here exactly as it does over HTTP. Reports key on the row: `pending` is status only; `completed` carries the last model message and the artifacts, merged under the deterministic `<agent>_<snapshotId[:8]>` namespace so a re-check after a restart overwrites rather than duplicates; a completed row whose finish reason carries no answer reports as `failed` with the reason in `error`, because a model told `completed` moves on without reading `error`. NOT_FOUND means "delegate again", FAILED_PRECONDITION and INVALID_ARGUMENT are reported verbatim, and any other read error is "check again later". Settled reports are cached for the rest of the generate call.

## Wait follows tasks instead of polling them

The wait tool dispatches each task's `waitForSnapshot` action once, concurrently, so a task is reported the moment it settles and a trace carries one span per task. An elapsed `timeoutSeconds` returns the current statuses with `timedOut`; zero waits until settled, negative reports immediately, and a value past what a timer can hold (2^31-1 ms) is unbounded rather than an instant timeout. `waitFor: "first"` returns as soon as any listed task settles (`unknown` counts, since an unresolvable handle is an answer to act on), and a won race is not a timeout. `waitFor` is a free string, so an unknown value is answered with guidance; a Zod enum would fail tool-input validation and end the generate call. Abort reads first and stops only a live row, because an expired row is still `pending` in the store and aborting it would overwrite the one signal saying the work is gone; it then reports the row through the check path, since the abort action's bare previous status would answer `completed` for a task that had already finished and strand its response.

## Synchronous delegation reads its outcome the same way

The synchronous path now folds through the report's rules, which is what keeps a delegation's answer identical whether it ran in the background or not. Two visible shifts: a turn that ended `length`, `blocked`, or `aborted` used to hand its last message over as the answer and now reads as `Error calling agent ...` naming the reason and keeping that message, and a success with no final text says `The task completed, but the agent gave no final message ...` and names its artifact count where it said `(no response)`.

## What was deliberately deferred

- **No interrupt resume for background tasks.** Same report-as-text policy as synchronous delegation.
- **Task handles are not access-scoped**, mirroring the sub-agent's own unscoped companion actions; the middleware doc tells multi-tenant deployments to treat snapshot IDs as capability-like secrets.
- **No operator cap on the wait.** `timeoutSeconds` is the model's to choose.
- **The pre-flight keys on the store, not on abort support.** JS detaches on any store, so a sub-agent whose store lacks `onSnapshotStateChange` can run in the background; its abort flips the row and the wait polls, as the runtime already does for such stores.
