### PR TITLE
refactor(go/plugins/a2ui): move the plugin to `a2ui/exp` while it is in preview

### DIFF
--- a/go/plugins/a2ui/exp/README.md
+++ b/go/plugins/a2ui/exp/README.md
@@ -5,7 +5,8 @@ is a transport-agnostic, JSON-based streaming UI protocol. An A2UI-enabled agent
 can stream not just prose, but rich, interactive UI **surfaces** that a client
 renders incrementally.
 
-> Status: experimental.
+> Status: in preview. The package lives under `go/plugins/a2ui/exp` and its
+> APIs may change in any minor version release. Samples import it as `a2uix`.
 
 ## Design principle: one representation
 
@@ -28,7 +29,7 @@ import (
 
 	"github.com/firebase/genkit/go/ai"
 	"github.com/firebase/genkit/go/genkit"
-	"github.com/firebase/genkit/go/plugins/a2ui"
+	a2uix "github.com/firebase/genkit/go/plugins/a2ui/exp"
 	"github.com/firebase/genkit/go/plugins/googlegenai"
 )
 
@@ -40,11 +41,11 @@ func main() {
 		ai.WithModel(googlegenai.GoogleAIModel(g, "gemini-flash-latest")),
 		ai.WithSystem("You help users. Render UI when it is clearer than prose."),
 		ai.WithPrompt("show me the weather in Tokyo"),
-		ai.WithUse(&a2ui.Surfaces{}), // defaults to the bundled 'basic' catalog
+		ai.WithUse(&a2uix.Surfaces{}), // defaults to the bundled 'basic' catalog
 	)
 
 	// A2UI envelopes ride as data parts on the response message.
-	envelopes := a2ui.EnvelopesFromParts(resp.Message.Content)
+	envelopes := a2uix.EnvelopesFromParts(resp.Message.Content)
 	_ = envelopes
 }
 ```
@@ -56,7 +57,7 @@ a2ui data parts.
 
 ### Options
 
-`a2ui.Surfaces` fields:
+`a2uix.Surfaces` fields:
 
 | Field          | Default            | Description                                                                                       |
 | -------------- | ------------------ | ------------------------------------------------------------------------------------------------- |
@@ -85,31 +86,31 @@ line up; match on the catalog's `id` value instead.
 
 
 ```go
-catalog, err := a2ui.LoadCatalogFile(g, "./my-catalog.json")
+catalog, err := a2uix.LoadCatalogFile(g, "./my-catalog.json")
 if err != nil { /* ... */ }
 
 resp, _ := genkit.Generate(ctx, g,
 	ai.WithModel(m),
 	ai.WithPrompt("..."),
-	ai.WithUse(&a2ui.Surfaces{CatalogID: catalog.ID}),
+	ai.WithUse(&a2uix.Surfaces{CatalogID: catalog.ID}),
 )
 ```
 
 Or construct and register one in memory:
 
 ```go
-myCatalog := &a2ui.Catalog{
+myCatalog := &a2uix.Catalog{
 	ID: "https://my-app.org/catalogs/custom.json",
-	Components: []a2ui.CatalogComponent{
+	Components: []a2uix.CatalogComponent{
 		{Name: "Banner", Description: "A prominent alert banner.", Props: "title: string (required)."},
 	},
 }
-a2ui.LoadCatalog(g, myCatalog)
-// ... ai.WithUse(&a2ui.Surfaces{CatalogID: myCatalog.ID})
+a2uix.LoadCatalog(g, myCatalog)
+// ... ai.WithUse(&a2uix.Surfaces{CatalogID: myCatalog.ID})
 ```
 
 Register the bundled basic catalog too (so it shows up in the Dev UI) with
-`a2ui.RegisterBasicCatalog(g)`.
+`a2uix.RegisterBasicCatalog(g)`.
 
 The middleware resolves the catalog for each turn in this order: an inline
 `Surfaces.Catalog` (code-defined only), then `Surfaces.CatalogID` looked up from the
@@ -134,17 +135,17 @@ When the user interacts with a surface (e.g. presses a `Button`), the client
 renderer emits an action. Send it back as the next turn: put the action's name
 as the user message text, and attach the full action as an a2ui data part. The
 middleware sanitizes inbound a2ui parts into a short text summary so the model
-can reason about them, and `a2ui.EnvelopesFromParts` reads envelopes back off
+can reason about them, and `a2uix.EnvelopesFromParts` reads envelopes back off
 any message/chunk content.
 
 ## Registering as a plugin (optional)
 
-Passing `&a2ui.Surfaces{}` to `ai.WithUse` is all you need. If you also want the
+Passing `&a2uix.Surfaces{}` to `ai.WithUse` is all you need. If you also want the
 middleware to appear in the Dev UI and be referenceable by name, register the
 plugin during init:
 
 ```go
-g := genkit.Init(ctx, genkit.WithPlugins(&a2ui.A2UI{}, &googlegenai.GoogleAI{}))
+g := genkit.Init(ctx, genkit.WithPlugins(&a2uix.A2UI{}, &googlegenai.GoogleAI{}))
 ```
 
 ## Try it with the web UI
@@ -195,7 +196,7 @@ The A2UI team is standardizing prompt formatting, catalog management, and
 inference inside official SDKs (a2ui-core / a2ui-agent). Those are the eventual
 home for the prompt-rendering, parsing, and validation this plugin does today,
 so treat those internals as thin and replaceable. The stable surface is the
-`a2ui.Surfaces` entrypoint and the spec-defined wire part
+`a2uix.Surfaces` entrypoint and the spec-defined wire part
 (`application/a2ui+json`), both of which are unaffected by an SDK swap.
 
 

--- a/go/plugins/a2ui/exp/a2ui.go
+++ b/go/plugins/a2ui/exp/a2ui.go
@@ -14,7 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-package a2ui
+package exp
 
 import (
 	"cmp"
@@ -52,14 +52,14 @@ const (
 //	resp, err := genkit.Generate(ctx, g,
 //	    ai.WithModel(m),
 //	    ai.WithPrompt("show me the weather in Tokyo"),
-//	    ai.WithUse(&a2ui.Surfaces{}), // defaults to the bundled basic catalog
+//	    ai.WithUse(&a2uix.Surfaces{}), // defaults to the bundled basic catalog
 //	)
 //
 // Middleware ordering: A2UI keeps per-turn streaming state (a stream parser and
 // its minted surface ids) for the model call it wraps. Place any retrying or
 // fallback middleware (which re-invokes the model) OUTSIDE A2UI so each attempt
-// gets a fresh A2UI turn, i.e. WithUse(retry, &a2ui.Surfaces{}) rather than
-// WithUse(&a2ui.Surfaces{}, retry). WithUse(A, B) means A wraps B.
+// gets a fresh A2UI turn, i.e. WithUse(retry, &a2uix.Surfaces{}) rather than
+// WithUse(&a2uix.Surfaces{}, retry). WithUse(A, B) means A wraps B.
 //
 // Every field is per-call configuration; the [A2UI] plugin only registers the
 // middleware by name and carries no settings of its own.
@@ -236,7 +236,7 @@ func (c *Surfaces) New(ctx context.Context) (*ai.Hooks, error) {
 // passed directly to [ai.WithUse]. Register it with
 // [github.com/firebase/genkit/go/genkit.WithPlugins] during Init:
 //
-//	g := genkit.Init(ctx, genkit.WithPlugins(&a2ui.A2UI{}))
+//	g := genkit.Init(ctx, genkit.WithPlugins(&a2uix.A2UI{}))
 //
 // The plugin carries no settings; every option lives on the per-call [Surfaces].
 type A2UI struct{}

--- a/go/plugins/a2ui/exp/a2ui_test.go
+++ b/go/plugins/a2ui/exp/a2ui_test.go
@@ -14,7 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-package a2ui
+package exp
 
 import (
 	"context"

--- a/go/plugins/a2ui/exp/catalog.go
+++ b/go/plugins/a2ui/exp/catalog.go
@@ -14,7 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-package a2ui
+package exp
 
 import (
 	"fmt"

--- a/go/plugins/a2ui/exp/catalog_test.go
+++ b/go/plugins/a2ui/exp/catalog_test.go
@@ -14,7 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-package a2ui
+package exp
 
 import (
 	"context"
@@ -97,7 +97,7 @@ func TestLoadCatalogFile(t *testing.T) {
 		t.Fatal("catalog was not registered in the registry")
 	}
 	if _, ok := v.(*Catalog); !ok {
-		t.Errorf("registered value type = %T, want *a2ui.Catalog", v)
+		t.Errorf("registered value type = %T, want %T", v, (*Catalog)(nil))
 	}
 }
 

--- a/go/plugins/a2ui/exp/loader.go
+++ b/go/plugins/a2ui/exp/loader.go
@@ -14,7 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-package a2ui
+package exp
 
 import (
 	"fmt"
@@ -41,9 +41,9 @@ import (
 //
 // Example:
 //
-//	a2ui.LoadCatalog(g, myCatalog)
+//	a2uix.LoadCatalog(g, myCatalog)
 //	// ... then reference it by id:
-//	ai.WithUse(&a2ui.Surfaces{CatalogID: myCatalog.ID})
+//	ai.WithUse(&a2uix.Surfaces{CatalogID: myCatalog.ID})
 func LoadCatalog(g *genkit.Genkit, catalog *Catalog) error {
 	if catalog == nil {
 		return fmt.Errorf("a2ui: LoadCatalog: catalog is nil")
@@ -127,7 +127,7 @@ func resolveCatalog(g *genkit.Genkit, catalog *Catalog, catalogID string) (*Cata
 			if c, ok := v.(*Catalog); ok {
 				return c, nil
 			}
-			return nil, fmt.Errorf("a2ui: registry value %q is not an *a2ui.Catalog", catalogRegistryKey(id))
+			return nil, fmt.Errorf("a2ui: registry value %q is not an A2UI catalog", catalogRegistryKey(id))
 		}
 	}
 	// Fall back to the bundled basic catalog for the default id (and also when
@@ -136,6 +136,6 @@ func resolveCatalog(g *genkit.Genkit, catalog *Catalog, catalogID string) (*Cata
 		return BasicCatalog(), nil
 	}
 	return nil, fmt.Errorf(
-		"a2ui: no catalog registered under id %q; register one with a2ui.LoadCatalog(g, catalog) or use the default %q catalog",
+		"a2ui: no catalog registered under id %q; register one with LoadCatalog(g, catalog) or use the default %q catalog",
 		id, DefaultCatalogID)
 }

--- a/go/plugins/a2ui/exp/parser.go
+++ b/go/plugins/a2ui/exp/parser.go
@@ -14,7 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-package a2ui
+package exp
 
 import (
 	"encoding/json"

--- a/go/plugins/a2ui/exp/parser_test.go
+++ b/go/plugins/a2ui/exp/parser_test.go
@@ -14,7 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-package a2ui
+package exp
 
 import (
 	"strings"

--- a/go/plugins/a2ui/exp/part.go
+++ b/go/plugins/a2ui/exp/part.go
@@ -14,7 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-package a2ui
+package exp
 
 import "github.com/firebase/genkit/go/ai"
 

--- a/go/plugins/a2ui/exp/part_test.go
+++ b/go/plugins/a2ui/exp/part_test.go
@@ -14,7 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-package a2ui
+package exp
 
 import (
 	"encoding/json"

--- a/go/plugins/a2ui/exp/types.go
+++ b/go/plugins/a2ui/exp/types.go
@@ -14,7 +14,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-// Package a2ui adds A2UI ("Agent to UI") support to Genkit agents.
+// Package exp provides in-preview A2UI ("Agent to UI") support for Genkit
+// agents.
 //
 // A2UI is a transport-agnostic, JSON-based streaming UI protocol
 // (https://a2ui.org/). An A2UI-enabled agent can stream not just prose, but
@@ -27,8 +28,13 @@
 // chunks and the final message), extracts a2ui fenced blocks, validates them
 // against the catalog, and rewrites them into a2ui data parts.
 //
-// This is an experimental package.
-package a2ui
+// Examples here import this package as a2uix
+// ("github.com/firebase/genkit/go/plugins/a2ui/exp"), the alias used across the
+// Genkit docs and samples.
+//
+// APIs in this package are under active development and may change in any
+// minor version release.
+package exp
 
 // A2UIMimeType identifies an A2UI payload. It is stamped onto the
 // metadata.mimeType of the Genkit data part that carries A2UI envelopes,

--- a/go/samples/basic-middleware/a2ui/main.go
+++ b/go/samples/basic-middleware/a2ui/main.go
@@ -16,7 +16,7 @@
 
 // This sample serves an A2UI-enabled agent over HTTP, compatible with the
 // browser frontend in js/testapps/a2ui/web. The whole A2UI integration is the
-// a2ui middleware in the agent's inline prompt (`ai.WithUse(&a2ui.Surfaces{})`):
+// a2ui middleware in the agent's inline prompt (`ai.WithUse(&a2uix.Surfaces{})`):
 // it injects the catalog's capabilities into the system prompt and rewrites the
 // model's a2ui fenced blocks into a2ui data parts that the client renderer
 // consumes.
@@ -58,7 +58,7 @@ import (
 	"github.com/firebase/genkit/go/core/api"
 	"github.com/firebase/genkit/go/genkit"
 	genkitx "github.com/firebase/genkit/go/genkit/exp"
-	"github.com/firebase/genkit/go/plugins/a2ui"
+	a2uix "github.com/firebase/genkit/go/plugins/a2ui/exp"
 	"github.com/firebase/genkit/go/plugins/googlegenai"
 	"github.com/firebase/genkit/go/plugins/middleware"
 	"github.com/firebase/genkit/go/plugins/server"
@@ -84,7 +84,7 @@ func main() {
 	// optional (it surfaces the middleware in the Dev UI); the middleware works
 	// via ai.WithUse regardless.
 	g := genkit.Init(ctx,
-		genkit.WithPlugins(&googlegenai.GoogleAI{}, &a2ui.A2UI{}),
+		genkit.WithPlugins(&googlegenai.GoogleAI{}, &a2uix.A2UI{}),
 		genkit.WithExperimental(),
 	)
 
@@ -92,7 +92,7 @@ func main() {
 	// Dev UI (GET /api/values?type=a2ui-catalog) alongside any custom catalogs.
 	// The middleware falls back to the basic catalog even without this, so it is
 	// optional; it is here to demonstrate registry-backed catalogs.
-	if err := a2ui.RegisterBasicCatalog(g); err != nil {
+	if err := a2uix.RegisterBasicCatalog(g); err != nil {
 		log.Fatalf("registering basic catalog: %v", err)
 	}
 
@@ -114,7 +114,7 @@ func main() {
 		},
 	)
 
-	// The A2UI-enabled agent. The whole integration is a2ui.Surfaces in WithUse.
+	// The A2UI-enabled agent. The whole integration is a2uix.Surfaces in WithUse.
 	// An in-memory session store makes state server-managed, so the browser
 	// only needs to pass a session id (remoteAgent handles that for it).
 	uiAgent := genkitx.DefineAgent(g, "uiAgent",
@@ -130,7 +130,7 @@ condition, humidity). Feel free to add a Button (e.g. "Refresh") when useful.`),
 			// Retry transient model failures (UNAVAILABLE, RESOURCE_EXHAUSTED,
 			// etc.) with exponential backoff before giving up.
 			ai.WithUse(&middleware.Retry{MaxRetries: 5}),
-			ai.WithUse(&a2ui.Surfaces{}), // defaults to the bundled basic catalog
+			ai.WithUse(&a2uix.Surfaces{}), // defaults to the bundled basic catalog
 		},
 		aix.WithSessionStore(localstore.NewInMemorySessionStore[any]()),
 	)


### PR DESCRIPTION
Moves the A2UI plugin to `go/plugins/a2ui/exp` as package `exp`, matching `plugins/middleware/exp` and `plugins/firebase/exp`. A2UI is in preview, and the `exp` package suffix is how that channel is spelled in Go, so the old path was the one preview package not saying so. Callers import it as `a2uix`, following `aix` and `genkitx`.

The plugin name stays `a2ui`: there is no stable a2ui plugin to collide with, so the Dev UI name, the `a2ui-catalog` registry value type, and parity with the JS plugin are unchanged. Nothing else about the middleware changes.