### PR TITLE
chore(go): retract v1.13.0

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -3,6 +3,7 @@ module github.com/firebase/genkit/go
 go 1.25.0
 
 retract (
+	v1.13.0 // Shipped the A2UI preview at plugins/a2ui; v1.13.1 moves it to plugins/a2ui/exp as the notes describe.
 	v0.1.4 // Retraction only.
 	v0.1.3 // This shold have been a minor release.
 )
@@ -108,7 +109,7 @@ require (
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.6 // indirect
-	github.com/googleapis/gax-go/v2 v2.14.2
+	github.com/googleapis/gax-go/v2 v2.14.2 // indirect
 	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/mailru/easyjson v0.9.0 // indirect
@@ -131,7 +132,7 @@ require (
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/contrib/detectors/gcp v1.35.0
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.61.0 // indirect
-	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0
+	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0 // indirect
 	golang.org/x/crypto v0.49.0 // indirect
 	golang.org/x/net v0.52.0 // indirect
 	golang.org/x/oauth2 v0.30.0


### PR DESCRIPTION
Retracts `v1.13.0` in `go.mod`. The tag was cut before #6275 merged, so that version ships the A2UI preview at `go/plugins/a2ui` while its release notes describe `go/plugins/a2ui/exp`. The tag itself stays: the module proxy cached it minutes after publication, so it cannot move. A retraction takes effect through the `go.mod` of a newer version, so `v1.13.1` is tagged from this commit. From then on `go get github.com/firebase/genkit/go@latest` resolves past `v1.13.0`, `go list -m -versions` hides it, and anyone pinned to it sees the rationale as a warning. Also marks two dependencies `// indirect`, as `go mod tidy` already wanted on `main`.
