### PR TITLE
feat(py/plugins/google-genai): add Gemini 3.8 Flash

### DIFF
--- a/py/packages/genkit-google-genai/src/genkit_google_genai/models/gemini.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/models/gemini.py
@@ -621,6 +621,11 @@ GEMINI_3_7_FLASH = ModelInfo(
     supports=GEMINI_TEXT_SUPPORTS,
 )
 
+GEMINI_3_8_FLASH = ModelInfo(
+    label='Google AI - Gemini 3.8 Flash',
+    supports=GEMINI_TEXT_SUPPORTS,
+)
+
 GEMINI_3_1_PRO_PREVIEW = ModelInfo(
     label='Google AI - Gemini 3.1 Pro Preview',
     supports=Supports(
@@ -788,6 +793,7 @@ class VertexAIGeminiVersion(StrEnum, metaclass=Deprecations):  # pyrefly: ignore
     GEMINI_3_5_FLASH = 'gemini-3.5-flash'
     GEMINI_3_6_FLASH = 'gemini-3.6-flash'
     GEMINI_3_7_FLASH = 'gemini-3.7-flash'
+    GEMINI_3_8_FLASH = 'gemini-3.8-flash'
     GEMINI_3_1_PRO_PREVIEW = 'gemini-3.1-pro-preview'
     GEMINI_3_1_FLASH_LITE = 'gemini-3.1-flash-lite'
     GEMMA_3_12B_IT = 'gemma-3-12b-it'
@@ -806,6 +812,7 @@ class GoogleAIGeminiVersion(StrEnum, metaclass=Deprecations):  # pyrefly: ignore
     GEMINI_3_FLASH_PREVIEW = 'gemini-3-flash-preview'
     GEMINI_3_6_FLASH = 'gemini-3.6-flash'
     GEMINI_3_7_FLASH = 'gemini-3.7-flash'
+    GEMINI_3_8_FLASH = 'gemini-3.8-flash'
     GEMINI_2_5_PRO = 'gemini-2.5-pro'
     GEMINI_2_5_FLASH = 'gemini-2.5-flash'
     GEMINI_2_5_FLASH_LITE = 'gemini-2.5-flash-lite'
@@ -845,6 +852,7 @@ KnownGemini: TypeAlias = Literal[
     'gemini-3.5-flash',
     'gemini-3.6-flash',
     'gemini-3.7-flash',
+    'gemini-3.8-flash',
     'gemini-2.5-flash-preview-04-17',
     'gemini-2.5-pro-exp-03-25',
     'gemini-2.5-pro-preview-03-25',
@@ -892,6 +900,7 @@ _add_model(GEMINI_3_PRO_PREVIEW, ['gemini-3-pro-preview', 'gemini-pro-latest'])
 _add_model(GEMINI_3_5_FLASH, ['gemini-3.5-flash', 'gemini-flash-latest'])
 _add_model(GEMINI_3_6_FLASH, ['gemini-3.6-flash'])
 _add_model(GEMINI_3_7_FLASH, ['gemini-3.7-flash'])
+_add_model(GEMINI_3_8_FLASH, ['gemini-3.8-flash'])
 _add_model(GEMINI_3_1_PRO_PREVIEW, ['gemini-3.1-pro-preview'])
 _add_model(GEMINI_3_1_PRO_PREVIEW_CUSTOMTOOLS, ['gemini-3.1-pro-preview-customtools'])
 _add_model(GEMINI_3_1_FLASH_LITE_PREVIEW, ['gemini-3.1-flash-lite-preview'])

--- a/py/packages/genkit-google-genai/test/models/googlegenai_gemini_test.py
+++ b/py/packages/genkit-google-genai/test/models/googlegenai_gemini_test.py
@@ -593,6 +593,7 @@ def test_gemini_3_1_models_register_real_capabilities(model_name: str) -> None:
         'gemini-3.5-flash',
         'gemini-3.6-flash',
         'gemini-3.7-flash',
+        'gemini-3.8-flash',
     ],
 )
 def test_vertexai_gemini_3_x_text_models_register_real_capabilities(model_name: str) -> None:


### PR DESCRIPTION
Advertise the released Gemini 3.8 Flash model in the Python Google GenAI plugin. Developers can select the numbered model through Google AI or Vertex AI, with typed autocomplete and catalog metadata for its text, multimodal, and tool capabilities.

```python
from genkit import Genkit
from genkit_google_genai import GoogleAI, GoogleAIGeminiVersion

ai = Genkit(
    plugins=[GoogleAI()],
    model=GoogleAI.gemini_model(
        GoogleAIGeminiVersion.GEMINI_3_8_FLASH
    ),
)
# The fully qualified model name is:
# googleai/gemini-3.8-flash
```

Decisions:
- Treat `gemini-3.8-flash` as a GA model because Google has released the numbered model ID.
- Add explicit catalog support and autocomplete for both Google AI and Vertex AI.
- Use the same released text, multimodal, and tool capability profile as the adjacent Flash models.
- Keep `gemini-flash-latest` unchanged because Google's SDK release adds only the numbered `gemini-3.8-flash` ID.