### PR TITLE
fix(py/plugins/openai): emit content, reasoning, and tool-call deltas that share a chunk

### DIFF
--- a/py/packages/genkit-openai/src/genkit_openai/models/model.py
+++ b/py/packages/genkit-openai/src/genkit_openai/models/model.py
@@ -516,7 +516,8 @@ class OpenAIModel:
         stream = await self._openai_client.chat.completions.create(**openai_config)
 
         tool_calls: dict[int, Any] = {}
-        accumulated_content: list[Part] = []
+        reasoning_parts: list[Part] = []
+        text_parts: list[Part] = []
         metadata: dict[str, Any] = {}
         usage: CompletionUsage | None = None
         saw_choice = False
@@ -546,18 +547,16 @@ class OpenAIModel:
             if delta.refusal:
                 refusal_fragments.append(delta.refusal)
 
-            # Reasoning content (DeepSeek R1 / reasoner models). Pydantic
-            # models raise AttributeError for unknown fields, so the lookup
-            # goes through MessageAdapter.
+            # Reasoning content (DeepSeek R1 / reasoner models).
             if reasoning_text := MessageAdapter(delta).reasoning_content:
                 reasoning_part = Part(root=ReasoningPart(reasoning=reasoning_text))
-                accumulated_content.append(reasoning_part)
+                reasoning_parts.append(reasoning_part)
                 parts.append(reasoning_part)
 
             # Text content
             if delta.content:
                 text_part = MessageConverter.text_part_to_genkit(delta.content)
-                accumulated_content.append(text_part)
+                text_parts.append(text_part)
                 parts.append(text_part)
 
             # Tool calls (partial function calls)
@@ -585,6 +584,7 @@ class OpenAIModel:
                 details={'usage': _usage_from_completion(usage).model_dump(exclude_none=True)},
             )
 
+        accumulated_content: list[Part] = [*reasoning_parts, *text_parts]
         if tool_calls:
             message = MessageConverter.to_genkit(
                 DictMessageAdapter({'tool_calls': tool_calls.values(), 'role': Role.MODEL})

--- a/py/packages/genkit-openai/src/genkit_openai/models/model.py
+++ b/py/packages/genkit-openai/src/genkit_openai/models/model.py
@@ -540,37 +540,28 @@ class OpenAIModel:
                 failure_message = failure
 
             delta = choice.delta
+            parts: list[Part] = []
 
             # A refusal streams in fragments and is reported as the finish message, not content.
             if delta.refusal:
                 refusal_fragments.append(delta.refusal)
 
-            # Text content chunk
-            if delta.content:
-                message = MessageConverter.to_genkit(MessageAdapter(delta))
-                accumulated_content.extend(message.content)
-                callback(
-                    ModelResponseChunk(
-                        role=Role.MODEL,
-                        content=message.content,
-                    )
-                )
-
-            # Reasoning content chunk (DeepSeek R1 / reasoner models).
-            # Note: Pydantic models raise AttributeError for unknown fields,
-            # so getattr() with a default doesn't work. Use try-except.
-            elif reasoning_text := MessageAdapter(delta).reasoning_content:
+            # Reasoning content (DeepSeek R1 / reasoner models). Pydantic
+            # models raise AttributeError for unknown fields, so the lookup
+            # goes through MessageAdapter.
+            if reasoning_text := MessageAdapter(delta).reasoning_content:
                 reasoning_part = Part(root=ReasoningPart(reasoning=reasoning_text))
                 accumulated_content.append(reasoning_part)
-                callback(
-                    ModelResponseChunk(
-                        role=Role.MODEL,
-                        content=[reasoning_part],
-                    )
-                )
+                parts.append(reasoning_part)
 
-            # Tool call chunk (partial function call)
-            elif delta.tool_calls:
+            # Text content
+            if delta.content:
+                text_part = MessageConverter.text_part_to_genkit(delta.content)
+                accumulated_content.append(text_part)
+                parts.append(text_part)
+
+            # Tool calls (partial function calls)
+            if delta.tool_calls:
                 for tool_call in delta.tool_calls:
                     # Accumulate fragmented tool call arguments
                     if tool_call.index not in tool_calls:
@@ -579,14 +570,15 @@ class OpenAIModel:
                         existing = tool_calls[tool_call.index]
                         if hasattr(existing, 'function') and existing.function and tool_call.function:
                             existing.function.arguments += tool_call.function.arguments
-                content = [
-                    MessageConverter.tool_call_to_genkit(
-                        tool_calls[tool_call.index],
-                        args_segment=tool_call.function.arguments if tool_call.function else None,
+                    parts.append(
+                        MessageConverter.tool_call_to_genkit(
+                            tool_calls[tool_call.index],
+                            args_segment=tool_call.function.arguments if tool_call.function else None,
+                        )
                     )
-                    for tool_call in delta.tool_calls
-                ]
-                callback(ModelResponseChunk(role=Role.MODEL, content=content))
+
+            if parts:
+                callback(ModelResponseChunk(role=Role.MODEL, content=parts))
 
         if not saw_choice:
             raise GenkitError(

--- a/py/packages/genkit-openai/src/genkit_openai/models/model.py
+++ b/py/packages/genkit-openai/src/genkit_openai/models/model.py
@@ -563,18 +563,16 @@ class OpenAIModel:
             # Tool calls (partial function calls)
             if delta.tool_calls:
                 for tool_call in delta.tool_calls:
+                    fragment = (tool_call.function.arguments or '') if tool_call.function else ''
                     # Accumulate fragmented tool call arguments
                     if tool_call.index not in tool_calls:
                         tool_calls[tool_call.index] = tool_call
                     else:
                         existing = tool_calls[tool_call.index]
                         if hasattr(existing, 'function') and existing.function and tool_call.function:
-                            existing.function.arguments += tool_call.function.arguments
+                            existing.function.arguments = (existing.function.arguments or '') + fragment
                     parts.append(
-                        MessageConverter.tool_call_to_genkit(
-                            tool_calls[tool_call.index],
-                            args_segment=tool_call.function.arguments if tool_call.function else None,
-                        )
+                        MessageConverter.tool_call_to_genkit(tool_calls[tool_call.index], args_segment=fragment)
                     )
 
             if parts:

--- a/py/packages/genkit-openai/src/genkit_openai/models/utils.py
+++ b/py/packages/genkit-openai/src/genkit_openai/models/utils.py
@@ -520,9 +520,8 @@ class MessageConverter:
     def to_genkit(cls, message: ChatCompletionMessageAdapter) -> Message:
         """Converts an OpenAI-style message into a Genkit `Message` object.
 
-        Handles tool calls, reasoning content (from DeepSeek R1 / reasoner),
-        and regular text content. Matches the JS canonical implementation
-        in fromOpenAIChoice().
+        Emits a reasoning part, a text part, and one tool request part per
+        tool call, in that order, for whichever of them the message carries.
 
         Args:
             message: A ChatCompletionMessageAdapter instance.
@@ -533,16 +532,15 @@ class MessageConverter:
         """
         content: list[Part] = []
 
-        if message.tool_calls:
-            content = [cls.tool_call_to_genkit(tool_call, args_parser=json.loads) for tool_call in message.tool_calls]
-        else:
-            # Reasoning content comes before regular content (matching JS order).
-            reasoning = message.reasoning_content
-            if reasoning:
-                content.append(Part(root=ReasoningPart(reasoning=reasoning)))
+        reasoning = message.reasoning_content
+        if reasoning:
+            content.append(Part(root=ReasoningPart(reasoning=reasoning)))
 
-            if message.content:
-                content.append(cls.text_part_to_genkit(message.content))
+        if message.content:
+            content.append(cls.text_part_to_genkit(message.content))
+
+        for tool_call in message.tool_calls or []:
+            content.append(cls.tool_call_to_genkit(tool_call, args_parser=json.loads))
 
         role = message.role or Role.MODEL
         return Message(role=cls._genkit_role_map.get(role, role), content=content)

--- a/py/packages/genkit-openai/src/genkit_openai/models/utils.py
+++ b/py/packages/genkit-openai/src/genkit_openai/models/utils.py
@@ -588,7 +588,7 @@ class MessageConverter:
         default_args = str(func_args) if func_args else ''
         args_input: str | dict[str, Any] | None = args_segment if args_segment is not None else default_args
         if args_parser and isinstance(args_input, str):
-            args_input = args_parser(args_input)
+            args_input = args_parser(args_input) if args_input else {}
 
         return Part(
             root=ToolRequestPart(

--- a/py/packages/genkit-openai/tests/openai_model_test.py
+++ b/py/packages/genkit-openai/tests/openai_model_test.py
@@ -1165,6 +1165,45 @@ async def test__generate_parses_a_zero_argument_tool_call(
 
 
 @pytest.mark.asyncio
+async def test__generate_stream_final_message_orders_parts_like_to_genkit(
+    sample_request: ModelRequest, make_chunk: Callable[..., ChatCompletionChunk]
+) -> None:
+    """Whatever order the deltas arrive in, the final message is reasoning, text, then tool calls."""
+    mock_client = MagicMock()
+    mock_client.chat.completions.create = _mock_stream([
+        _delta_chunk(make_chunk, content='Sure,'),
+        _delta_chunk(make_chunk, reasoning_content='Need a tool.'),
+        _delta_chunk(
+            make_chunk,
+            tool_calls=[
+                {'index': 0, 'id': 'call_1', 'type': 'function', 'function': {'name': 'get_weather', 'arguments': '{}'}}
+            ],
+        ),
+        _delta_chunk(make_chunk, content=' one moment.'),
+    ])
+
+    model = OpenAIModel(model='deepseek-reasoner', client=mock_client)
+    collected: list[ModelResponseChunk] = []
+
+    response = await model._generate_stream(sample_request, collected.append)
+
+    assert [[type(root).__name__ for root in _roots(chunk)] for chunk in collected] == [
+        ['TextPart'],
+        ['ReasoningPart'],
+        ['ToolRequestPart'],
+        ['TextPart'],
+    ]
+
+    assert response.message is not None
+    final = [part.root for part in response.message.content]
+    assert [type(root).__name__ for root in final] == ['ReasoningPart', 'TextPart', 'TextPart', 'ToolRequestPart']
+    assert final[0].reasoning == 'Need a tool.'
+    assert [root.text for root in final if isinstance(root, TextPart)] == ['Sure,', ' one moment.']
+    assert isinstance(final[3], ToolRequestPart)
+    assert final[3].tool_request.input == {}
+
+
+@pytest.mark.asyncio
 async def test__generate_stream_skips_a_delta_with_nothing_to_report(
     sample_request: ModelRequest, make_chunk: Callable[..., ChatCompletionChunk]
 ) -> None:

--- a/py/packages/genkit-openai/tests/openai_model_test.py
+++ b/py/packages/genkit-openai/tests/openai_model_test.py
@@ -1070,6 +1070,43 @@ async def test__generate_stream_keeps_text_riding_with_tool_call_arguments(
 
 
 @pytest.mark.asyncio
+async def test__generate_stream_tolerates_a_null_arguments_fragment(
+    sample_request: ModelRequest, make_chunk: Callable[..., ChatCompletionChunk]
+) -> None:
+    """A fragment whose arguments are null adds nothing, and the rest still accumulate."""
+    mock_client = MagicMock()
+    mock_client.chat.completions.create = _mock_stream([
+        _delta_chunk(
+            make_chunk,
+            tool_calls=[
+                {
+                    'index': 0,
+                    'id': 'tool123',
+                    'type': 'function',
+                    'function': {'name': 'tool_fn', 'arguments': '{"a": '},
+                }
+            ],
+        ),
+        _delta_chunk(make_chunk, tool_calls=[{'index': 0, 'function': {'arguments': None}}]),
+        _delta_chunk(make_chunk, tool_calls=[{'index': 0, 'function': {'arguments': '1}'}}]),
+    ])
+
+    model = OpenAIModel(model='gpt-4', client=mock_client)
+    collected: list[ModelResponseChunk] = []
+
+    response = await model._generate_stream(sample_request, collected.append)
+
+    fragments = [root for chunk in collected for root in _roots(chunk) if isinstance(root, ToolRequestPart)]
+    assert [root.tool_request.input for root in fragments] == ['{"a": ', '', '1}']
+    assert all(root.tool_request.name == 'tool_fn' for root in fragments)
+
+    assert response.message is not None
+    requests = [part.root.tool_request for part in response.message.content if isinstance(part.root, ToolRequestPart)]
+    assert len(requests) == 1
+    assert requests[0].input == {'a': 1}
+
+
+@pytest.mark.asyncio
 async def test__generate_stream_skips_a_delta_with_nothing_to_report(
     sample_request: ModelRequest, make_chunk: Callable[..., ChatCompletionChunk]
 ) -> None:

--- a/py/packages/genkit-openai/tests/openai_model_test.py
+++ b/py/packages/genkit-openai/tests/openai_model_test.py
@@ -17,6 +17,7 @@
 
 """Tests for OpenAI compatible model implementation."""
 
+import json
 from collections.abc import AsyncIterator, Callable
 from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, PropertyMock
@@ -38,8 +39,10 @@ from genkit import (
     ModelResponse,
     ModelResponseChunk,
     Part,
+    ReasoningPart,
     Role,
     TextPart,
+    ToolRequestPart,
 )
 from genkit._core._model import OutputConfig
 from genkit._core._typing import GenerationUsage, Operation
@@ -941,6 +944,151 @@ _SAMPLE_SCHEMA: dict[str, object] = {
     },
     'required': ['name', 'level'],
 }
+
+
+def _delta_chunk(make_chunk: Callable[..., ChatCompletionChunk], **delta: Any) -> ChatCompletionChunk:
+    """A chunk whose delta carries exactly the given fields."""
+    return make_chunk(choice={'delta': delta})
+
+
+def _roots(chunk: ModelResponseChunk) -> list[Any]:
+    """The part roots of a streamed chunk."""
+    return [part.root for part in chunk.content]
+
+
+@pytest.mark.asyncio
+async def test__generate_stream_emits_reasoning_text_and_tool_call_from_one_chunk(
+    sample_request: ModelRequest, make_chunk: Callable[..., ChatCompletionChunk]
+) -> None:
+    """A delta carrying all three kinds of content yields all three parts."""
+    mock_client = MagicMock()
+    mock_client.chat.completions.create = _mock_stream([
+        _delta_chunk(
+            make_chunk,
+            content='Checking.',
+            reasoning_content='Need the weather.',
+            tool_calls=[
+                {
+                    'index': 0,
+                    'id': 'call_1',
+                    'type': 'function',
+                    'function': {'name': 'get_weather', 'arguments': '{"city": "NYC"}'},
+                }
+            ],
+        )
+    ])
+
+    model = OpenAIModel(model='deepseek-reasoner', client=mock_client)
+    collected: list[ModelResponseChunk] = []
+
+    response = await model._generate_stream(sample_request, collected.append)
+
+    assert len(collected) == 1
+    streamed = _roots(collected[0])
+    assert len(streamed) == 3
+    assert isinstance(streamed[0], ReasoningPart)
+    assert streamed[0].reasoning == 'Need the weather.'
+    assert isinstance(streamed[1], TextPart)
+    assert streamed[1].text == 'Checking.'
+    assert isinstance(streamed[2], ToolRequestPart)
+    assert streamed[2].tool_request.name == 'get_weather'
+    assert streamed[2].tool_request.ref == 'call_1'
+
+    assert response.message is not None
+    final = [part.root for part in response.message.content]
+    assert len(final) == 3
+    assert isinstance(final[0], ReasoningPart)
+    assert isinstance(final[1], TextPart)
+    assert isinstance(final[2], ToolRequestPart)
+    assert final[2].tool_request.input == {'city': 'NYC'}
+
+
+@pytest.mark.asyncio
+async def test__generate_stream_keeps_reasoning_interleaved_with_content(
+    sample_request: ModelRequest, make_chunk: Callable[..., ChatCompletionChunk]
+) -> None:
+    """Reasoning and text that share a delta both reach the callback and the aggregate."""
+    mock_client = MagicMock()
+    mock_client.chat.completions.create = _mock_stream([
+        _delta_chunk(make_chunk, reasoning_content='Think'),
+        _delta_chunk(make_chunk, reasoning_content=' harder.', content='The'),
+        _delta_chunk(make_chunk, content=' answer.'),
+    ])
+
+    model = OpenAIModel(model='deepseek-reasoner', client=mock_client)
+    collected: list[ModelResponseChunk] = []
+
+    response = await model._generate_stream(sample_request, collected.append)
+
+    assert [[type(root).__name__ for root in _roots(chunk)] for chunk in collected] == [
+        ['ReasoningPart'],
+        ['ReasoningPart', 'TextPart'],
+        ['TextPart'],
+    ]
+    assert response.message is not None
+    final = [part.root for part in response.message.content]
+    assert [root.reasoning for root in final if isinstance(root, ReasoningPart)] == ['Think', ' harder.']
+    assert [root.text for root in final if isinstance(root, TextPart)] == ['The', ' answer.']
+
+
+@pytest.mark.asyncio
+async def test__generate_stream_keeps_text_riding_with_tool_call_arguments(
+    sample_request: ModelRequest, make_chunk: Callable[..., ChatCompletionChunk]
+) -> None:
+    """Text sharing a delta with an argument fragment is emitted and the arguments still accumulate."""
+    mock_client = MagicMock()
+    mock_client.chat.completions.create = _mock_stream([
+        _delta_chunk(
+            make_chunk,
+            tool_calls=[
+                {'index': 0, 'id': 'tool123', 'type': 'function', 'function': {'name': 'tool_fn', 'arguments': ''}}
+            ],
+        ),
+        _delta_chunk(make_chunk, content='Calling', tool_calls=[{'index': 0, 'function': {'arguments': '{"a": '}}]),
+        _delta_chunk(make_chunk, content=' the tool.', tool_calls=[{'index': 0, 'function': {'arguments': '1}'}}]),
+    ])
+
+    model = OpenAIModel(model='gpt-4', client=mock_client)
+    collected: list[ModelResponseChunk] = []
+
+    response = await model._generate_stream(sample_request, collected.append)
+
+    streamed = [root for chunk in collected for root in _roots(chunk)]
+    assert [root.text for root in streamed if isinstance(root, TextPart)] == ['Calling', ' the tool.']
+    fragments = [root for root in streamed if isinstance(root, ToolRequestPart)]
+    assert len(fragments) == 3
+    assert all(root.tool_request.name == 'tool_fn' for root in fragments)
+    assert all(root.tool_request.ref == 'tool123' for root in fragments)
+    assert json.loads(''.join(str(root.tool_request.input) for root in fragments)) == {'a': 1}
+
+    assert response.message is not None
+    final = [part.root for part in response.message.content]
+    assert [root.text for root in final if isinstance(root, TextPart)] == ['Calling', ' the tool.']
+    requests = [root.tool_request for root in final if isinstance(root, ToolRequestPart)]
+    assert len(requests) == 1
+    assert requests[0].input == {'a': 1}
+
+
+@pytest.mark.asyncio
+async def test__generate_stream_skips_a_delta_with_nothing_to_report(
+    sample_request: ModelRequest, make_chunk: Callable[..., ChatCompletionChunk]
+) -> None:
+    """A delta with no content, reasoning or tool calls emits no chunk."""
+    mock_client = MagicMock()
+    mock_client.chat.completions.create = _mock_stream([
+        _delta_chunk(make_chunk, content='Hi'),
+        _delta_chunk(make_chunk),
+    ])
+
+    model = OpenAIModel(model='gpt-4', client=mock_client)
+    collected: list[ModelResponseChunk] = []
+
+    response = await model._generate_stream(sample_request, collected.append)
+
+    assert len(collected) == 1
+    assert collected[0].content[0].root.text == 'Hi'
+    assert response.message is not None
+    assert len(response.message.content) == 1
 
 
 class TestNeedsSchemaInPrompt:

--- a/py/packages/genkit-openai/tests/openai_model_test.py
+++ b/py/packages/genkit-openai/tests/openai_model_test.py
@@ -42,6 +42,7 @@ from genkit import (
     ReasoningPart,
     Role,
     TextPart,
+    ToolRequest,
     ToolRequestPart,
 )
 from genkit._core._model import OutputConfig
@@ -1324,6 +1325,29 @@ class TestCleanJsonResponse:
         cleaned = model._clean_json_response(response, request)
         assert cleaned.message is not None
         assert cleaned.message.content[0].root.text == '{"name": "John", "level": 5}'
+
+    def test_keeps_tool_parts_beside_cleaned_text(self) -> None:
+        """Strips fences from the text part and carries a tool request part through unchanged."""
+        model = OpenAIModel(model='deepseek-chat', client=MagicMock())
+        request = ModelRequest(
+            messages=[Message(role=Role.USER, content=[Part(root=TextPart(text='Hi'))])],
+            output=OutputConfig(format='json'),
+        )
+        tool_part = Part(
+            root=ToolRequestPart(tool_request=ToolRequest(ref='call_1', name='get_weather', input={'city': 'NYC'}))
+        )
+        response = ModelResponse(
+            request=request,
+            message=Message(
+                role=Role.MODEL,
+                content=[Part(root=TextPart(text='```json\n{"city": "NYC"}\n```')), tool_part],
+            ),
+        )
+        cleaned = model._clean_json_response(response, request)
+        assert cleaned.message is not None
+        assert [type(part.root).__name__ for part in cleaned.message.content] == ['TextPart', 'ToolRequestPart']
+        assert cleaned.message.content[0].root.text == '{"city": "NYC"}'
+        assert cleaned.message.content[1] is tool_part
 
     def test_no_op_for_gpt_model(self) -> None:
         """Does not modify responses from non-DeepSeek models."""

--- a/py/packages/genkit-openai/tests/openai_model_test.py
+++ b/py/packages/genkit-openai/tests/openai_model_test.py
@@ -1108,6 +1108,63 @@ async def test__generate_stream_tolerates_a_null_arguments_fragment(
 
 
 @pytest.mark.asyncio
+async def test__generate_stream_parses_a_zero_argument_tool_call(
+    sample_request: ModelRequest, make_chunk: Callable[..., ChatCompletionChunk]
+) -> None:
+    """A tool call whose arguments stay empty ends with an empty input, not a parse error."""
+    mock_client = MagicMock()
+    mock_client.chat.completions.create = _mock_stream([
+        _delta_chunk(
+            make_chunk,
+            tool_calls=[
+                {'index': 0, 'id': 'tool123', 'type': 'function', 'function': {'name': 'ping', 'arguments': ''}}
+            ],
+        ),
+    ])
+
+    model = OpenAIModel(model='gpt-4', client=mock_client)
+    collected: list[ModelResponseChunk] = []
+
+    response = await model._generate_stream(sample_request, collected.append)
+
+    fragments = [root for chunk in collected for root in _roots(chunk) if isinstance(root, ToolRequestPart)]
+    assert [root.tool_request.input for root in fragments] == ['']
+
+    assert response.message is not None
+    requests = [part.root.tool_request for part in response.message.content if isinstance(part.root, ToolRequestPart)]
+    assert len(requests) == 1
+    assert requests[0].name == 'ping'
+    assert requests[0].input == {}
+
+
+@pytest.mark.asyncio
+async def test__generate_parses_a_zero_argument_tool_call(
+    sample_request: ModelRequest, make_completion: Callable[..., ChatCompletion]
+) -> None:
+    """A non-streamed tool call whose arguments are empty ends with an empty input."""
+    completion = make_completion(
+        content=None,
+        choice={
+            'finish_reason': 'tool_calls',
+            'message': {
+                'role': 'assistant',
+                'content': None,
+                'tool_calls': [{'id': 'tool123', 'type': 'function', 'function': {'name': 'ping', 'arguments': ''}}],
+            },
+        },
+    )
+    model = OpenAIModel(model='gpt-4', client=_client(completion))
+
+    response = await model._generate(sample_request)
+
+    assert response.message is not None
+    requests = [part.root.tool_request for part in response.message.content if isinstance(part.root, ToolRequestPart)]
+    assert len(requests) == 1
+    assert requests[0].name == 'ping'
+    assert requests[0].input == {}
+
+
+@pytest.mark.asyncio
 async def test__generate_stream_skips_a_delta_with_nothing_to_report(
     sample_request: ModelRequest, make_chunk: Callable[..., ChatCompletionChunk]
 ) -> None:

--- a/py/packages/genkit-openai/tests/openai_utils_test.py
+++ b/py/packages/genkit-openai/tests/openai_utils_test.py
@@ -522,10 +522,10 @@ class TestMessageConverterReasoningContent:
         })
         assert MessageConverter.to_genkit(adapter).content == []
 
-    def test_tool_calls_take_precedence_over_reasoning(self) -> None:
-        """Tool calls take precedence; reasoning_content is ignored."""
+    def test_reasoning_text_and_tool_calls_are_all_kept(self) -> None:
+        """Keep reasoning, text, and tool call parts together, in that order."""
         adapter = DictMessageAdapter({
-            'content': None,
+            'content': 'Checking the weather.',
             'reasoning_content': 'Some reasoning',
             'tool_calls': [
                 {
@@ -539,10 +539,37 @@ class TestMessageConverterReasoningContent:
             'role': 'assistant',
         })
         msg = MessageConverter.to_genkit(adapter)
-        # Should produce tool request parts, not reasoning.
-        assert len(msg.content) == 1
+        assert len(msg.content) == 3
+        assert isinstance(msg.content[0].root, ReasoningPart)
+        assert msg.content[0].root.reasoning == 'Some reasoning'
+        assert isinstance(msg.content[1].root, TextPart)
+        assert msg.content[1].root.text == 'Checking the weather.'
+        assert isinstance(msg.content[2].root, ToolRequestPart)
+        assert msg.content[2].root.tool_request.ref == 'call_1'
+        assert msg.content[2].root.tool_request.name == 'get_weather'
+        assert msg.content[2].root.tool_request.input == {'location': 'NYC'}
 
-        assert isinstance(msg.content[0].root, ToolRequestPart)
+    def test_text_and_tool_calls_without_reasoning(self) -> None:
+        """Keep text alongside tool calls when there is no reasoning."""
+        adapter = DictMessageAdapter({
+            'content': 'Let me look that up.',
+            'tool_calls': [
+                {
+                    'id': 'call_1',
+                    'function': {
+                        'name': 'get_weather',
+                        'arguments': '{"location": "NYC"}',
+                    },
+                }
+            ],
+            'role': 'assistant',
+        })
+        msg = MessageConverter.to_genkit(adapter)
+        assert len(msg.content) == 2
+        assert isinstance(msg.content[0].root, TextPart)
+        assert msg.content[0].root.text == 'Let me look that up.'
+        assert isinstance(msg.content[1].root, ToolRequestPart)
+        assert msg.content[1].root.tool_request.input == {'location': 'NYC'}
 
     def test_role_defaults_to_model(self) -> None:
         """Default role should be MODEL when not provided."""

--- a/py/packages/genkit-openai/tests/openai_utils_test.py
+++ b/py/packages/genkit-openai/tests/openai_utils_test.py
@@ -571,6 +571,19 @@ class TestMessageConverterReasoningContent:
         assert isinstance(msg.content[1].root, ToolRequestPart)
         assert msg.content[1].root.tool_request.input == {'location': 'NYC'}
 
+    def test_zero_argument_tool_call_has_empty_input(self) -> None:
+        """A tool call whose arguments are an empty string parses to an empty input."""
+        adapter = DictMessageAdapter({
+            'content': None,
+            'tool_calls': [{'id': 'call_1', 'function': {'name': 'ping', 'arguments': ''}}],
+            'role': 'assistant',
+        })
+        msg = MessageConverter.to_genkit(adapter)
+        assert len(msg.content) == 1
+        assert isinstance(msg.content[0].root, ToolRequestPart)
+        assert msg.content[0].root.tool_request.name == 'ping'
+        assert msg.content[0].root.tool_request.input == {}
+
     def test_role_defaults_to_model(self) -> None:
         """Default role should be MODEL when not provided."""
         adapter = DictMessageAdapter({


### PR DESCRIPTION
Closes #6233

## Summary

The streaming loop now reads content, reasoning and tool-call deltas independently and appends them to a single outgoing chunk, in reasoning, text, tool-call order. The chunk is emitted only when it carries something. A tool-call fragment that shares a chunk with text reaches the accumulator, so the aggregate response is complete as well.

`MessageConverter.to_genkit` gets the same treatment on the non-streaming path: reasoning, text, then one part per tool call, rather than tool calls to the exclusion of both.

A text delta converts straight to a text part instead of going through `to_genkit`, which would otherwise return the reasoning and tool-call parts riding on the same delta a second time.