### PR TITLE
fix(py): omit stream options from non-streaming OpenAI calls

### DIFF
--- a/py/packages/genkit-openai/src/genkit_openai/models/model.py
+++ b/py/packages/genkit-openai/src/genkit_openai/models/model.py
@@ -395,6 +395,7 @@ class OpenAIModel:
             A ModelResponse object containing the generated message.
         """
         openai_config = await self._get_openai_request_config(request=request)
+        openai_config.pop('stream_options', None)
         logger.debug('OpenAI generate request', model=self._model, streaming=False)
         response = await self._openai_client.chat.completions.create(**openai_config)
         logger.debug(

--- a/py/packages/genkit-openai/tests/openai_model_test.py
+++ b/py/packages/genkit-openai/tests/openai_model_test.py
@@ -277,10 +277,11 @@ async def test__generate_reports_usage(sample_request: ModelRequest) -> None:
     mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
 
     model = OpenAIModel(model='gpt-4', client=mock_client)
+    sample_request.config = OpenAIConfig(stream_options={'include_usage': False})
     response = await model._generate(sample_request)
 
     _assert_usage_payload_reported(response.usage)
-    # include_usage is added on the streaming path only.
+    # Streaming-only options must never reach a non-streaming request.
     assert 'stream_options' not in mock_client.chat.completions.create.call_args.kwargs
 
 


### PR DESCRIPTION
## Description

`OpenAIConfig.stream_options` is passed through by `_openai_create_kwargs`, so a caller-provided value currently reaches `chat.completions.create()` even on the non-streaming path. OpenAI documents `stream_options` as valid only when `stream: true`; compatible providers may reject the otherwise valid non-streaming request.

This change removes `stream_options` immediately before the non-streaming API call. The streaming path remains unchanged: it preserves caller-supplied stream options and still forces `include_usage: true` so Genkit can report usage from the final chunk.

The existing non-streaming usage test now supplies `stream_options` and asserts against the actual mocked `create()` kwargs. This keeps the regression at the provider request boundary rather than testing an internal helper.

Fixes #6235.

## Verification

- `uv run pytest packages/genkit-openai/tests -q --no-cov` — 187 passed
- `uv run ruff check` on both changed files
- `uv run ruff format --check` on both changed files
- `uv run pyright packages/genkit-openai/src/genkit_openai/models/model.py` — 0 errors
- Reverting only the implementation while retaining the updated test produces the expected assertion failure because `stream_options` is present in the non-streaming `create()` call

## Checklist

- [x] PR title follows Conventional Commits
- [x] PR description contains context and the bug link
- [x] Unit tested
- [x] No docs/readme change needed; this aligns the provider request with the existing API contract
