### PR TITLE
fix(js/core): redact credential-shaped config keys from span attributes

### DIFF
--- a/js/ai/tests/generate/telemetry-redaction_test.ts
+++ b/js/ai/tests/generate/telemetry-redaction_test.ts
@@ -1,0 +1,111 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { initNodeFeatures } from '@genkit-ai/core/node';
+import { Registry } from '@genkit-ai/core/registry';
+import { enableTelemetry } from '@genkit-ai/core/tracing';
+import { SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base';
+import * as assert from 'assert';
+import { beforeEach, describe, it } from 'node:test';
+import { TestSpanExporter } from '../../../core/tests/utils.js';
+import { defineGenerateAction } from '../../src/generate/action.js';
+import { defineProgrammableModel, type ProgrammableModel } from '../helpers.js';
+
+initNodeFeatures();
+
+const spanExporter = new TestSpanExporter();
+enableTelemetry({
+  spanProcessors: [new SimpleSpanProcessor(spanExporter)],
+});
+
+const SECRET = 'test-api-key-value';
+
+describe('generate telemetry redaction', () => {
+  let registry: Registry;
+  let pm: ProgrammableModel;
+
+  beforeEach(() => {
+    registry = new Registry();
+    defineGenerateAction(registry);
+    pm = defineProgrammableModel(registry);
+    spanExporter.exportedSpans = [];
+  });
+
+  it('never exports config.apiKey in any span attribute', async () => {
+    pm.handleResponse = async () =>
+      ({
+        message: { role: 'model', content: [{ text: 'done' }] },
+        finishReason: 'stop',
+      }) as any;
+
+    const action = await registry.lookupAction('/util/generate');
+    await action({
+      model: 'programmableModel',
+      messages: [{ role: 'user', content: [{ text: 'hello' }] }],
+      config: { apiKey: SECRET, temperature: 0.5 },
+    } as any);
+
+    // The model must still receive the real key.
+    assert.strictEqual(
+      (pm.lastRequest as any)?.config?.apiKey,
+      SECRET,
+      'model should still receive the real apiKey'
+    );
+
+    const offenders: string[] = [];
+    for (const span of spanExporter.exportedSpans) {
+      for (const [attrKey, attrValue] of Object.entries(span.attributes)) {
+        if (typeof attrValue === 'string' && attrValue.includes(SECRET)) {
+          offenders.push(`${span.displayName} -> ${attrKey}`);
+        }
+      }
+    }
+
+    assert.deepStrictEqual(
+      offenders,
+      [],
+      `apiKey leaked into span attributes: ${offenders.join(', ')}`
+    );
+  });
+
+  it('preserves non-sensitive config and the shape of genkit:input', async () => {
+    pm.handleResponse = async () =>
+      ({
+        message: { role: 'model', content: [{ text: 'done' }] },
+        finishReason: 'stop',
+      }) as any;
+
+    const action = await registry.lookupAction('/util/generate');
+    await action({
+      model: 'programmableModel',
+      messages: [{ role: 'user', content: [{ text: 'hello' }] }],
+      config: { apiKey: SECRET, temperature: 0.5 },
+    } as any);
+
+    const modelSpan = spanExporter.exportedSpans.find(
+      (s) => s.displayName === 'programmableModel'
+    );
+    assert.ok(modelSpan, 'model span should be exported');
+
+    const input = JSON.parse(modelSpan.attributes['genkit:input'] as string);
+    assert.strictEqual(input.config.temperature, 0.5);
+    assert.strictEqual(
+      input.config.apiKey,
+      '<redacted>',
+      'apiKey key must be kept with a redacted value, not dropped'
+    );
+  });
+});

--- a/js/core/src/action.ts
+++ b/js/core/src/action.ts
@@ -30,6 +30,7 @@ import {
   SPAN_TYPE_ATTR,
   runInNewSpan,
   setCustomMetadataAttributes,
+  telemetryJsonString,
 } from './tracing.js';
 
 export {
@@ -602,7 +603,7 @@ export function action<
           // otherwise we let upstream context carry through.
           const output = await runWithContext(options?.context, actFn);
 
-          metadata.output = JSON.stringify(output);
+          metadata.output = telemetryJsonString(output);
           return output;
         } catch (err) {
           if (typeof err === 'object') {

--- a/js/core/src/tracing/instrumentation.ts
+++ b/js/core/src/tracing/instrumentation.ts
@@ -224,16 +224,17 @@ function getErrorMessage(e: any): string {
  * secret-bearing fields can appear; matching on the key name rather than an
  * allowlist of known fields covers those too.
  *
- * Matched against the key lowercased with `_`/`-` removed. `token` is
- * intentionally only matched in credential-shaped compounds: a bare `token`
- * substring would also redact the numeric `inputTokens`/`outputTokens`/
- * `totalTokens`/`maxOutputTokens` fields that trace consumers read.
+ * Matched case-insensitively against the raw key, with `_`/`-` separators
+ * handled by the pattern itself. `token` is intentionally only matched in
+ * credential-shaped compounds: a bare `token` substring would also redact the
+ * numeric `inputTokens`/`outputTokens`/`totalTokens`/`maxOutputTokens` fields
+ * that trace consumers read.
  */
 const REDACTED_KEY_PATTERN =
-  /apikey|secret|password|passwd|credential|authorization|(?:access|refresh|session|bearer|auth|id|api)token/;
+  /api[-_]*key|secret|pass[-_]*word|passwd|credential|authorization|(?:access|refresh|session|bearer|auth|id|api)[-_]*token/i;
 
 function isRedactedKey(key: string): boolean {
-  return REDACTED_KEY_PATTERN.test(key.toLowerCase().replace(/[_-]/g, ''));
+  return REDACTED_KEY_PATTERN.test(key);
 }
 
 function redactCredentials(value: unknown): unknown {
@@ -258,14 +259,14 @@ function redactCredentials(value: unknown): unknown {
  *
  * @hidden
  */
-export function telemetryJsonString(value: unknown): string {
+export function telemetryJsonString(value: unknown): string | undefined {
   const raw = JSON.stringify(value);
   // Most span values carry no credentials. Avoid walking the value unless the
   // serialized form mentions one of the redacted key names.
   if (raw === undefined) {
     return raw;
   }
-  if (!REDACTED_KEY_PATTERN.test(raw.toLowerCase().replace(/[_-]/g, ''))) {
+  if (!REDACTED_KEY_PATTERN.test(raw)) {
     return raw;
   }
   return JSON.stringify(redactCredentials(JSON.parse(raw)));
@@ -287,7 +288,10 @@ function metadataToAttributes(metadata: SpanMetadata): Record<string, string> {
       key === 'init' ||
       typeof metadata[key] === 'object'
     ) {
-      out[ATTR_PREFIX + ':' + key] = telemetryJsonString(metadata[key]);
+      const json = telemetryJsonString(metadata[key]);
+      if (json !== undefined) {
+        out[ATTR_PREFIX + ':' + key] = json;
+      }
     } else {
       out[ATTR_PREFIX + ':' + key] = metadata[key];
     }

--- a/js/core/src/tracing/instrumentation.ts
+++ b/js/core/src/tracing/instrumentation.ts
@@ -218,6 +218,59 @@ function getErrorMessage(e: any): string {
   return `${e}`;
 }
 
+/**
+ * Key-name patterns whose values are credentials and must never be exported in
+ * a span attribute. Config schemas are `passthrough`, so arbitrary
+ * secret-bearing fields can appear; matching on the key name rather than an
+ * allowlist of known fields covers those too.
+ *
+ * Matched against the key lowercased with `_`/`-` removed. `token` is
+ * intentionally only matched in credential-shaped compounds: a bare `token`
+ * substring would also redact the numeric `inputTokens`/`outputTokens`/
+ * `totalTokens`/`maxOutputTokens` fields that trace consumers read.
+ */
+const REDACTED_KEY_PATTERN =
+  /apikey|secret|password|passwd|credential|authorization|(?:access|refresh|session|bearer|auth|id|api)token/;
+
+function isRedactedKey(key: string): boolean {
+  return REDACTED_KEY_PATTERN.test(key.toLowerCase().replace(/[_-]/g, ''));
+}
+
+function redactCredentials(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(redactCredentials);
+  }
+  if (value !== null && typeof value === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const [key, item] of Object.entries(value)) {
+      out[key] = isRedactedKey(key) ? '<redacted>' : redactCredentials(item);
+    }
+    return out;
+  }
+  return value;
+}
+
+/**
+ * Serializes a value for a span attribute without exporting credentials that
+ * arbitrary (`passthrough`) config objects may carry. Redacted keys are kept
+ * with a `'<redacted>'` value so the attribute stays valid JSON of the same
+ * shape for existing trace consumers.
+ *
+ * @hidden
+ */
+export function telemetryJsonString(value: unknown): string {
+  const raw = JSON.stringify(value);
+  // Most span values carry no credentials. Avoid walking the value unless the
+  // serialized form mentions one of the redacted key names.
+  if (raw === undefined) {
+    return raw;
+  }
+  if (!REDACTED_KEY_PATTERN.test(raw.toLowerCase().replace(/[_-]/g, ''))) {
+    return raw;
+  }
+  return JSON.stringify(redactCredentials(JSON.parse(raw)));
+}
+
 function metadataToAttributes(metadata: SpanMetadata): Record<string, string> {
   const out = {} as Record<string, string>;
   Object.keys(metadata).forEach((key) => {
@@ -234,7 +287,7 @@ function metadataToAttributes(metadata: SpanMetadata): Record<string, string> {
       key === 'init' ||
       typeof metadata[key] === 'object'
     ) {
-      out[ATTR_PREFIX + ':' + key] = JSON.stringify(metadata[key]);
+      out[ATTR_PREFIX + ':' + key] = telemetryJsonString(metadata[key]);
     } else {
       out[ATTR_PREFIX + ':' + key] = metadata[key];
     }

--- a/js/core/tests/instrumentation_test.ts
+++ b/js/core/tests/instrumentation_test.ts
@@ -1,0 +1,140 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base';
+import * as assert from 'assert';
+import { beforeEach, describe, it } from 'node:test';
+import { z } from 'zod';
+import { action } from '../src/action.js';
+import { initNodeFeatures } from '../src/node.js';
+import { enableTelemetry } from '../src/tracing.js';
+import { TestSpanExporter } from './utils.js';
+
+initNodeFeatures();
+
+const spanExporter = new TestSpanExporter();
+enableTelemetry({
+  spanProcessors: [new SimpleSpanProcessor(spanExporter)],
+});
+
+const CREDENTIAL = 'test-credential-value';
+
+/** Runs an action that echoes its input back, so input and output both carry it. */
+async function runEchoAction(input: unknown) {
+  const act = action(
+    {
+      name: 'echoAction',
+      inputSchema: z.any(),
+      outputSchema: z.any(),
+      actionType: 'custom',
+    },
+    async (input) => input
+  );
+  await act.run(input);
+  const span = spanExporter.exportedSpans.find(
+    (s) => s.displayName === 'echoAction'
+  );
+  assert.ok(span, 'echoAction span should be exported');
+  return span;
+}
+
+describe('span attribute credential redaction', () => {
+  beforeEach(() => {
+    spanExporter.exportedSpans = [];
+  });
+
+  it('redacts credential-shaped keys from genkit:input and genkit:output', async () => {
+    const span = await runEchoAction({
+      config: {
+        apiKey: CREDENTIAL,
+        api_key: CREDENTIAL,
+        accessToken: CREDENTIAL,
+        clientSecret: CREDENTIAL,
+        password: CREDENTIAL,
+        authorization: CREDENTIAL,
+        temperature: 0.5,
+      },
+    });
+
+    for (const attr of ['genkit:input', 'genkit:output']) {
+      const raw = span.attributes[attr] as string;
+      assert.ok(raw, `${attr} should be exported`);
+      assert.ok(
+        !raw.includes(CREDENTIAL),
+        `${attr} should not contain the credential value: ${raw}`
+      );
+      const parsed = JSON.parse(raw);
+      // Keys are preserved with a redacted value, not dropped.
+      for (const key of [
+        'apiKey',
+        'api_key',
+        'accessToken',
+        'clientSecret',
+        'password',
+        'authorization',
+      ]) {
+        assert.strictEqual(
+          parsed.config[key],
+          '<redacted>',
+          `${attr}: ${key} should be '<redacted>'`
+        );
+      }
+      assert.strictEqual(
+        parsed.config.temperature,
+        0.5,
+        `${attr}: non-sensitive config should be preserved`
+      );
+    }
+  });
+
+  it('redacts arbitrary passthrough credential fields nested in arrays', async () => {
+    const span = await runEchoAction({
+      items: [{ sessionToken: CREDENTIAL }, { nested: { secret: CREDENTIAL } }],
+    });
+
+    const raw = span.attributes['genkit:input'] as string;
+    assert.ok(!raw.includes(CREDENTIAL), raw);
+    const parsed = JSON.parse(raw);
+    assert.strictEqual(parsed.items[0].sessionToken, '<redacted>');
+    assert.strictEqual(parsed.items[1].nested.secret, '<redacted>');
+  });
+
+  it('does not redact token-count fields that trace consumers read', async () => {
+    const span = await runEchoAction({
+      config: { maxOutputTokens: 100 },
+      usage: { inputTokens: 7, outputTokens: 11, totalTokens: 18 },
+    });
+
+    const parsed = JSON.parse(span.attributes['genkit:input'] as string);
+    assert.strictEqual(parsed.config.maxOutputTokens, 100);
+    assert.deepStrictEqual(parsed.usage, {
+      inputTokens: 7,
+      outputTokens: 11,
+      totalTokens: 18,
+    });
+  });
+
+  it('leaves values without credential-shaped keys byte-identical', async () => {
+    const input = { messages: [{ role: 'user', content: [{ text: 'hi' }] }] };
+    const span = await runEchoAction(input);
+
+    assert.strictEqual(
+      span.attributes['genkit:input'],
+      JSON.stringify(input),
+      'unaffected inputs must serialize exactly as before'
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Redact credential-shaped config keys (e.g. `apiKey`, `accessToken`, `clientSecret`,
  `refreshToken`, `privateKey`, `password`, `authorization`) from the `genkit:input`,
  `genkit:init`, and `genkit:output` telemetry span attributes.
- Match is by key name pattern, not a fixed schema allowlist, so the redaction also
  applies to arbitrary passthrough config fields and to nested/array structures.
- Redacted keys are kept in place with a `'<redacted>'` placeholder value rather than
  dropped, so span attributes stay valid JSON of the same shape for existing trace
  consumers.
- A bare `token` pattern is deliberately not matched: it would also match the numeric
  `inputTokens`/`outputTokens`/`totalTokens`/`maxOutputTokens` fields that trace
  consumers read. `token` is matched only in credential-shaped compounds, and a
  regression test pins this.
- Add regression tests covering the model action span, the `generate` span, and
  nested/array passthrough fields, using synthetic fixture values only.

ISSUE: none — this was found internally; no issue was filed before this PR.

## Validation

- `pnpm build:core` (builds `core` + `ai`)
- `pnpm -F core test` — 185 passed, 0 failed
- `pnpm -F ai test` — 456 passed, 0 failed, 8 skipped
- `pnpm format:check` equivalent (prettier + copyright header check) on changed files

Google CLA is required for this contribution.
