### PR TITLE
fix(py/plugins/google-genai): TTS fallback ModelInfo no longer claims constrained support

### DIFF
--- a/py/packages/genkit-google-genai/src/genkit_google_genai/models/gemini.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/models/gemini.py
@@ -731,8 +731,9 @@ GENERIC_TTS_MODEL = ModelInfo(
         media=False,
         tools=False,
         tool_choice=False,
-        system_role=True,
-        constrained=Constrained.ALL,
+        system_role=False,
+        constrained=Constrained.NONE,
+        output=['media'],
     ),
 )
 

--- a/py/packages/genkit-google-genai/test/models/googlegenai_gemini_test.py
+++ b/py/packages/genkit-google-genai/test/models/googlegenai_gemini_test.py
@@ -65,6 +65,7 @@ from genkit import (
     TextPart,
     ToolDefinition,
 )
+from genkit._core._model import OutputConfig
 from genkit.plugin_api import to_json_schema
 
 ALL_VERSIONS = list(GoogleAIGeminiVersion) + list(VertexAIGeminiVersion)
@@ -546,6 +547,21 @@ async def test_generate_with_system_instructions(mocker: MockerFixture) -> None:
                     tool_choice=False,
                     system_role=True,
                     constrained=Constrained.ALL,
+                    output=['media'],
+                ),
+            ),
+        ),
+        (
+            'gemini-2.5-flash-preview-tts',
+            ModelInfo(
+                label='Google AI - Gemini TTS',
+                supports=Supports(
+                    multiturn=False,
+                    media=False,
+                    tools=False,
+                    tool_choice=False,
+                    system_role=False,
+                    constrained=Constrained.NONE,
                     output=['media'],
                 ),
             ),
@@ -1100,6 +1116,41 @@ async def test_gemini_model__unknown_extra_rides_on_extra_body(
     assert cfg.temperature == 0.5
     assert cfg.http_options is not None
     assert cfg.http_options.extra_body == {'generationConfig': {'fooBar': 1}}
+
+
+def _json_output_request() -> ModelRequest:
+    return ModelRequest(
+        messages=[Message(role=Role.USER, content=[Part(root=TextPart(text='hi'))])],
+        output=OutputConfig(
+            format='json',
+            json_schema={'type': 'object', 'properties': {'name': {'type': 'string'}}},
+            constrained=True,
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_gemini_model__json_output_sets_constrained_config() -> None:
+    """A standard Gemini model receives response_mime_type and response_schema for JSON output."""
+    model = GeminiModel(version='gemini-2.5-flash', client=MagicMock(spec=genai.Client))
+
+    cfg = await model._genkit_to_googleai_cfg(_json_output_request())
+
+    assert cfg is not None
+    assert cfg.response_mime_type == 'application/json'
+    assert cfg.response_schema is not None
+
+
+@pytest.mark.asyncio
+async def test_gemini_model__tts_json_output_skips_constrained_config() -> None:
+    """A TTS model receives neither response_mime_type nor response_schema for JSON output."""
+    model = GeminiModel(version='gemini-2.5-flash-preview-tts', client=MagicMock(spec=genai.Client))
+
+    cfg = await model._genkit_to_googleai_cfg(_json_output_request())
+
+    assert cfg is not None
+    assert cfg.response_mime_type is None
+    assert cfg.response_schema is None
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Closes #6183.

`GENERIC_TTS_MODEL` now declares `constrained=Constrained.NONE`, so the gate in `_genkit_to_googleai_cfg` no longer sets `response_mime_type` or `response_schema` for TTS models. The fallback also sets `system_role=False` and `output=['media']`, matching the Go and JS TTS model info.

Adds a TTS row to `test_google_model_info` and two gate tests: a TTS model gets neither field for JSON output, a standard Gemini model still gets both.