### PR TITLE
feat(js/plugins/compat-oai): add gpt-6-astra to the OpenAI model catalog

### DIFF
--- a/js/plugins/compat-oai/src/openai/gpt.ts
+++ b/js/plugins/compat-oai/src/openai/gpt.ts
@@ -275,6 +275,16 @@ const gpt5_5 = openAIModelRef({
   name: 'gpt-5.5',
   info: GPT_5_MODEL_INFO,
 });
+// Chat Completions rejects function tools for this model.
+const gpt6Astra = openAIModelRef({
+  name: 'gpt-6-astra',
+  info: {
+    supports: {
+      ...GPT_5_MODEL_INFO.supports,
+      tools: false,
+    },
+  },
+});
 
 export const SUPPORTED_GPT_MODELS = {
   'gpt-4.5': gpt45,
@@ -312,4 +322,5 @@ export const SUPPORTED_GPT_MODELS = {
   'gpt-5.4-mini': gpt5_4Mini,
   'gpt-5.4-nano': gpt5_4Nano,
   'gpt-5.5': gpt5_5,
+  'gpt-6-astra': gpt6Astra,
 } as const;

--- a/js/plugins/compat-oai/tests/openai_test.ts
+++ b/js/plugins/compat-oai/tests/openai_test.ts
@@ -23,6 +23,7 @@ import {
   defineCompatOpenAIModel,
   toOpenAIRequestBody,
 } from '../src/model';
+import { SUPPORTED_GPT_MODELS } from '../src/openai/gpt';
 
 describe('gptModel', () => {
   afterEach(() => {
@@ -106,6 +107,37 @@ describe('gptModel', () => {
         systemRole: true,
         output: ['text', 'json'],
       },
+    });
+  });
+});
+
+describe('gpt-6-astra', () => {
+  const expectedSupports = {
+    multiturn: true,
+    tools: false,
+    media: true,
+    systemRole: true,
+    output: ['text', 'json'],
+  };
+
+  it('is in the supported GPT model catalog without tool support', () => {
+    const modelRef = SUPPORTED_GPT_MODELS['gpt-6-astra'];
+    expect(modelRef.name).toBe('openai/gpt-6-astra');
+    expect(modelRef.info?.supports).toStrictEqual(expectedSupports);
+  });
+
+  it('defines a model action with the catalog supports', () => {
+    const model = defineCompatOpenAIModel({
+      name: 'openai/gpt-6-astra',
+      client: {} as OpenAI,
+      modelRef: SUPPORTED_GPT_MODELS['gpt-6-astra'],
+    });
+    expect({
+      name: model.__action.name,
+      supports: model.__action.metadata?.model.supports,
+    }).toStrictEqual({
+      name: 'openai/gpt-6-astra',
+      supports: expectedSupports,
     });
   });
 });


### PR DESCRIPTION
`gpt-6-astra` currently falls through the dynamic `gpt-${string}` path, so the registered action and `listActions` carry the default model info, and the Dev UI advertises tool support the model does not have on this endpoint. This adds an explicit `gpt-6-astra` ref to `SUPPORTED_GPT_MODELS`, mirroring how `gpt-5.5` was added. Note that `openAI.model('gpt-6-astra')` still returns generic info; that helper never consults the catalog for any model, so only the registered action and `listActions` change here.

The ref takes `GPT_5_MODEL_INFO` with `tools: false`. A live run against `/v1/chat/completions` with a single function tool returned:

```
400 Function tools with reasoning_effort are not supported for gpt-6-astra in /v1/chat/completions. To use function tools, use /v1/responses or set reasoning_effort to 'none'.
```

The same error came back at `low` and `xhigh`, and `reasoning_effort: 'none'` was itself rejected (`Supported values are: 'low', 'medium', 'high', and 'xhigh'`). So no value lets tools through on this endpoint. The model page lists function calling as supported without an endpoint caveat, so this looks like a Chat Completions restriction that could lift; worth re-checking when the Responses API lands in JS. In JS, core treats `supports.tools` as advisory (a warning, tools still sent), so the entry changes what is advertised, not what is transmitted.

Text, streaming, structured JSON output (`json_schema` without `strict`), image input, system role, multiturn and `maxOutputTokens` all worked live.

Tests in `tests/openai_test.ts` pin the catalog entry and the action metadata produced from it. `pnpm build` and `pnpm test` in `js/plugins/compat-oai` pass (7 suites, 101 tests); prettier is clean.

Caveats: the endpoint accepts `reasoning_effort` `low`, `medium`, `high` and `xhigh` only; `max` and `none` are rejected. `temperature` other than 1 and `top_p` are rejected. The plugin only sends those when a caller sets them. No typed `reasoningEffort` config was added; the existing passthrough covers it. Go counterpart: #6304. The `gpt-5.6-sol/terra/luna` family that Go carries is still missing from the JS catalog; see #5898.
