### PR TITLE
feat(go/plugins/compat_oai): add gpt-6-astra to the OpenAI model catalog

### DIFF
--- a/go/plugins/compat_oai/openai/README.md
+++ b/go/plugins/compat_oai/openai/README.md
@@ -36,16 +36,18 @@ of the SDK's request options).
 
 ## Models
 
-The plugin registers a curated catalog spanning the GPT-5 line (`gpt-5.6-sol`,
-`gpt-5.6-terra`, `gpt-5.6-luna`, `gpt-5.5`, `gpt-5.4`, and earlier), the GPT-4
-line, and the o-series reasoning models. The catalog is not a ceiling: any
+The plugin registers a curated catalog spanning `gpt-6-astra`, the GPT-5 line
+(`gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`, `gpt-5.5`, `gpt-5.4`, and
+earlier), the GPT-4 line, and the o-series reasoning models. `gpt-6-astra` is
+registered without tool support: the Chat Completions API rejects function
+tools for it at every `reasoning_effort`. The catalog is not a ceiling: any
 model ID the API serves resolves on demand, and the models the endpoint
 reports are listed dynamically. Use the `Models` field to describe or correct
 any model, most often one released after this plugin:
 
 ```go
 plugin := &oai.OpenAI{Models: map[string]ai.ModelOptions{
-    "gpt-6": {Label: "GPT-6", Supports: &compat_oai.Multimodal},
+    "gpt-7": {Label: "GPT-7", Supports: &compat_oai.Multimodal},
 }}
 ```
 

--- a/go/plugins/compat_oai/openai/openai.go
+++ b/go/plugins/compat_oai/openai/openai.go
@@ -80,6 +80,16 @@ var (
 		ToolChoice: true,
 		Output:     []string{"text", "json"},
 	}
+	// For models whose Chat Completions endpoint rejects function tools.
+	multimodalNoTools = ai.ModelSupports{
+		Multiturn:   true,
+		Tools:       false,
+		SystemRole:  true,
+		Media:       true,
+		ToolChoice:  false,
+		Output:      []string{"text", "json"},
+		Constrained: ai.ConstrainedSupportAll,
+	}
 )
 
 // supportedModels curates capabilities for well-known OpenAI models. It is not
@@ -97,8 +107,14 @@ var (
 // Catalog: https://developers.openai.com/api/docs/models
 // Retirements: https://developers.openai.com/api/docs/deprecations
 var supportedModels = map[string]ai.ModelOptions{
-	// GPT-5.6, the current frontier family. No dated snapshots yet; the
-	// bare gpt-5.6 alias routes to sol and resolves dynamically.
+	"gpt-6-astra": {
+		Label:    "OpenAI GPT-6 Astra",
+		Supports: &multimodalNoTools,
+		Versions: []string{"gpt-6-astra"},
+	},
+
+	// GPT-5.6 family. No dated snapshots yet; the bare gpt-5.6 alias routes
+	// to sol and resolves dynamically.
 	"gpt-5.6-sol": {
 		Label:    "OpenAI GPT-5.6 Sol",
 		Supports: &multimodal,

--- a/go/plugins/compat_oai/openai/openai_test.go
+++ b/go/plugins/compat_oai/openai/openai_test.go
@@ -434,6 +434,9 @@ func TestGPT6AstraCatalogEntry(t *testing.T) {
 		Output:      []string{"text", "json"},
 		Constrained: ai.ConstrainedSupportAll,
 	}
+	if opts.Supports == nil {
+		t.Fatal("gpt-6-astra has no Supports")
+	}
 	if diff := cmp.Diff(want, *opts.Supports); diff != "" {
 		t.Errorf("supports mismatch (-want +got):\n%s", diff)
 	}

--- a/go/plugins/compat_oai/openai/openai_test.go
+++ b/go/plugins/compat_oai/openai/openai_test.go
@@ -18,6 +18,7 @@ package openai
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -27,6 +28,7 @@ import (
 	"github.com/firebase/genkit/go/ai"
 	"github.com/firebase/genkit/go/core/api"
 	"github.com/firebase/genkit/go/genkit"
+	"github.com/google/go-cmp/cmp"
 	openaiGo "github.com/openai/openai-go"
 	"github.com/openai/openai-go/option"
 	"github.com/openai/openai-go/shared"
@@ -404,6 +406,74 @@ func TestSupportedModelCatalog(t *testing.T) {
 		if opts.Dimensions == 0 {
 			t.Errorf("%s declares no dimensions", name)
 		}
+	}
+}
+
+// TestGPT6AstraCatalogEntry pins the one catalog entry that advertises no
+// tools. The Chat Completions endpoint rejects function tools for gpt-6-astra
+// at every reasoning_effort, so claiming them would let generation offer the
+// model tools every request then fails on. Text, media, system role, multiturn
+// and structured output do work there and stay advertised.
+func TestGPT6AstraCatalogEntry(t *testing.T) {
+	opts, ok := supportedModels["gpt-6-astra"]
+	if !ok {
+		t.Fatal("gpt-6-astra is not in the catalog")
+	}
+	if opts.Label != "OpenAI GPT-6 Astra" {
+		t.Errorf("label = %q, want %q", opts.Label, "OpenAI GPT-6 Astra")
+	}
+	if len(opts.Versions) != 1 || opts.Versions[0] != "gpt-6-astra" {
+		t.Errorf("versions = %v, want the bare ID alone", opts.Versions)
+	}
+	want := ai.ModelSupports{
+		Multiturn:   true,
+		Tools:       false,
+		SystemRole:  true,
+		Media:       true,
+		ToolChoice:  false,
+		Output:      []string{"text", "json"},
+		Constrained: ai.ConstrainedSupportAll,
+	}
+	if diff := cmp.Diff(want, *opts.Supports); diff != "" {
+		t.Errorf("supports mismatch (-want +got):\n%s", diff)
+	}
+
+	_, g := initPlugin(t)
+	m := genkit.LookupModel(g, "openai/gpt-6-astra")
+	if m == nil {
+		t.Fatal("gpt-6-astra not registered by Init")
+	}
+	model, ok := m.(*ai.ModelAction).Desc().Metadata["model"].(map[string]any)
+	if !ok {
+		t.Fatalf("model metadata missing")
+	}
+	supports, ok := model["supports"].(map[string]any)
+	if !ok {
+		t.Fatalf("supports metadata missing")
+	}
+	if supports["tools"] == true || supports["toolChoice"] == true {
+		t.Errorf("registered supports = %v, want no tools advertised", supports)
+	}
+	if supports["media"] != true || supports["multiturn"] != true || supports["systemRole"] != true {
+		t.Errorf("registered supports = %v, want media, multiturn and systemRole", supports)
+	}
+}
+
+// TestGPT6AstraRejectsToolsBeforeSend pins that a tool request against
+// gpt-6-astra fails in the framework's support check and never reaches the
+// API, since the Chat Completions endpoint would reject it anyway.
+func TestGPT6AstraRejectsToolsBeforeSend(t *testing.T) {
+	_, g := initPlugin(t)
+	lookup := genkit.DefineTool(g, "lookup", "Looks up a value.",
+		func(ctx *ai.ToolContext, in struct{ Key string }) (string, error) { return in.Key, nil })
+
+	_, err := genkit.Generate(context.Background(), g,
+		ai.WithModelName("openai/gpt-6-astra"),
+		ai.WithTools(lookup),
+		ai.WithPrompt("look up foo"),
+	)
+	if !errors.Is(err, ai.ErrUnsupportedByModel) {
+		t.Fatalf("Generate() error = %v, want ai.ErrUnsupportedByModel", err)
 	}
 }
 


### PR DESCRIPTION
`gpt-6-astra` was only reachable through the dynamic resolution path in the Go OpenAI plugin, which describes it with the generic multimodal defaults. Those claim tool support the model does not have on this endpoint, so the Dev UI and `supports` metadata were wrong for it. This is the Go counterpart of #6303; Python is #6306.

The entry takes a new `multimodalNoTools` supports set: multiturn, media and system role stay on, `Tools` and `ToolChoice` are false. The live run in #6303 against `/v1/chat/completions` with a single function tool returned:

```
400 Function tools with reasoning_effort are not supported for gpt-6-astra in /v1/chat/completions. To use function tools, use /v1/responses or set reasoning_effort to 'none'.
```

The same error came back at `low` and `xhigh`, and `reasoning_effort: 'none'` was itself rejected, so no value lets tools through on this endpoint. The model page lists function calling as supported without an endpoint caveat, so this may lift; the Responses API for Go is open in #5346. Unlike JS, Go core enforces `supports`: a request with tools now fails early with `ErrUnsupportedByModel` rather than reaching OpenAI. The README catalog sentence names the model and the constraint.

`TestGPT6AstraCatalogEntry` pins the label, the single version, the exact `ai.ModelSupports` and that `Init` registers the model without tools advertised. `TestGPT6AstraRejectsToolsBeforeSend` pins the early failure offline through `genkit.Generate` with a tool. The existing `TestSupportedModelCatalog` and `TestConstrainedSupport` table checks cover the entry too. In `go/`: `gofmt -l` clean, `go vet ./plugins/compat_oai/...` clean, `go test -count=1 ./plugins/compat_oai/...` passes all 9 packages.

Caveats: no Go live smoke was run. `Constrained` stays at the catalog default of `All`, verified live from Go: `WithOutputType` sent `json_schema` with `strict: true` and astra returned schema-conformant JSON that parsed. A Go live run also confirmed text, streaming, image input, system role, multiturn, `max_completion_tokens`, and that tools fail early with `ErrUnsupportedByModel`; the existing `TestPluginLive` passes 16/16 with a key. Go passes `reasoning_effort` through verbatim, so `max` and `none` will 400 on this endpoint, and `xhigh` needs a raw string since openai-go only defines low, medium and high constants. The model also rejects `temperature` other than 1 and `top_p`. Related: #5898.

