### PR TITLE
feat(py/plugins/openai): add gpt-6-astra to the OpenAI model catalog

### DIFF
--- a/py/packages/genkit-openai/src/genkit_openai/models/model_info.py
+++ b/py/packages/genkit-openai/src/genkit_openai/models/model_info.py
@@ -127,6 +127,7 @@ KnownGpt: TypeAlias = Literal[
     'gpt-5.1',
     'gpt-5.2',
     'gpt-5.2-chat',
+    'gpt-6-astra',
     'gpt-oss-120b',
     'gpt-oss-20b',
 ]
@@ -187,6 +188,18 @@ SUPPORTED_OPENAI_MODELS: dict[KnownGpt, ModelInfo] = {
     'gpt-5.1': ModelInfo(label='OpenAI - gpt-5.1', supports=GPT_5_MODEL_SUPPORTS),
     'gpt-5.2': ModelInfo(label='OpenAI - gpt-5.2', supports=GPT_5_MODEL_SUPPORTS),
     'gpt-5.2-chat': ModelInfo(label='OpenAI - gpt-5.2-chat', supports=GPT_5_MODEL_SUPPORTS),
+    # --- GPT-6 series ---
+    # Chat Completions rejects function tools for this model.
+    'gpt-6-astra': ModelInfo(
+        label='OpenAI - gpt-6-astra',
+        supports=Supports(
+            multiturn=True,
+            media=True,
+            tools=False,
+            system_role=True,
+            output=[SupportedOutputFormat.JSON_MODE, SupportedOutputFormat.TEXT],
+        ),
+    ),
     # --- OSS models (hosted) ---
     'gpt-oss-120b': ModelInfo(label='OpenAI - gpt-oss-120b', supports=GPT_OSS_MODEL_SUPPORTS),
     'gpt-oss-20b': ModelInfo(label='OpenAI - gpt-oss-20b', supports=GPT_OSS_MODEL_SUPPORTS),

--- a/py/packages/genkit-openai/tests/openai_model_test.py
+++ b/py/packages/genkit-openai/tests/openai_model_test.py
@@ -54,6 +54,16 @@ def test_unknown_chat_id_json_mode_uses_json_object() -> None:
     assert model._get_response_format(request) == {'type': 'json_object'}
 
 
+def test_gpt_6_astra_json_mode_uses_json_object() -> None:
+    """A schema-less JSON request to gpt-6-astra sends json_object, as the catalog advertises."""
+    model = OpenAIModel(model='gpt-6-astra', client=MagicMock())
+    request = ModelRequest(
+        messages=[Message(role=Role.USER, content=[Part(root=TextPart(text='Hi'))])],
+        output=OutputConfig(format='json'),
+    )
+    assert model._get_response_format(request) == {'type': 'json_object'}
+
+
 def test_get_messages(sample_request: ModelRequest) -> None:
     """Test _get_messages method.
 

--- a/py/packages/genkit-openai/tests/openai_plugin_test.py
+++ b/py/packages/genkit-openai/tests/openai_plugin_test.py
@@ -24,14 +24,12 @@ from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from genkit_openai.models import OpenAIModel
 from genkit_openai.models.model_info import SUPPORTED_OPENAI_MODELS
 from genkit_openai.openai_plugin import OpenAI, openai_model
 from genkit_openai.typing import SupportedOutputFormat
 from openai.types import Model
 
-from genkit import Message, ModelRequest, Part, Role, Supports, TextPart
-from genkit._core._model import OutputConfig
+from genkit import Supports
 from genkit.plugin_api import ActionKind, ActionMetadata, loop_local_client
 
 
@@ -133,16 +131,6 @@ async def test_unlisted_chat_model_resolves_with_default_supports() -> None:
     assert action.metadata is not None
     model_meta = cast(dict[str, Any], action.metadata['model'])
     assert model_meta['supports'] == {'multiturn': True}
-
-
-def test_gpt_6_astra_json_mode_uses_json_object() -> None:
-    """A schema-less JSON request to gpt-6-astra sends json_object, as the catalog advertises."""
-    model = OpenAIModel(model='gpt-6-astra', client=MagicMock())
-    request = ModelRequest(
-        messages=[Message(role=Role.USER, content=[Part(root=TextPart(text='Hi'))])],
-        output=OutputConfig(format='json'),
-    )
-    assert model._get_response_format(request) == {'type': 'json_object'}
 
 
 @pytest.mark.asyncio

--- a/py/packages/genkit-openai/tests/openai_plugin_test.py
+++ b/py/packages/genkit-openai/tests/openai_plugin_test.py
@@ -24,9 +24,14 @@ from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from genkit_openai.models import OpenAIModel
+from genkit_openai.models.model_info import SUPPORTED_OPENAI_MODELS
 from genkit_openai.openai_plugin import OpenAI, openai_model
+from genkit_openai.typing import SupportedOutputFormat
 from openai.types import Model
 
+from genkit import Message, ModelRequest, Part, Role, Supports, TextPart
+from genkit._core._model import OutputConfig
 from genkit.plugin_api import ActionKind, ActionMetadata, loop_local_client
 
 
@@ -75,6 +80,69 @@ async def test_openai_plugin_resolve_action(kind: ActionKind, name: str) -> None
     assert action is not None
     assert action.name == f'openai/{name}'
     assert action.kind == ActionKind.MODEL
+
+
+GPT_6_ASTRA_SUPPORTS = {
+    'multiturn': True,
+    'media': True,
+    'tools': False,
+    'systemRole': True,
+    'output': [SupportedOutputFormat.JSON_MODE, SupportedOutputFormat.TEXT],
+}
+
+
+def test_gpt_6_astra_catalog_entry() -> None:
+    """gpt-6-astra is a catalog entry with media, system role, and json, but no tools."""
+    info = SUPPORTED_OPENAI_MODELS['gpt-6-astra']
+
+    assert info.label == 'OpenAI - gpt-6-astra'
+    assert info.supports == Supports(
+        multiturn=True,
+        media=True,
+        tools=False,
+        system_role=True,
+        output=[SupportedOutputFormat.JSON_MODE, SupportedOutputFormat.TEXT],
+    )
+
+
+@pytest.mark.asyncio
+async def test_gpt_6_astra_registered_without_tools() -> None:
+    """init() and resolve() both register gpt-6-astra with the catalog supports."""
+    plugin = OpenAI(api_key='test-key')
+
+    init_action = next((a for a in await plugin.init() if a.name == 'openai/gpt-6-astra'), None)
+    resolved = await plugin.resolve(ActionKind.MODEL, OpenAI.gpt_model('gpt-6-astra').name)
+
+    assert init_action is not None
+    assert resolved is not None
+    for action in (init_action, resolved):
+        assert action.metadata is not None
+        model_meta = cast(dict[str, Any], action.metadata['model'])
+        assert model_meta['label'] == 'OpenAI - gpt-6-astra'
+        assert model_meta['supports'] == GPT_6_ASTRA_SUPPORTS
+
+
+@pytest.mark.asyncio
+async def test_unlisted_chat_model_resolves_with_default_supports() -> None:
+    """An id outside the catalog is registered with multiturn only, so tools, media, and json stay hidden."""
+    plugin = OpenAI(api_key='test-key')
+
+    action = await plugin.resolve(ActionKind.MODEL, 'openai/gpt-6-nova')
+
+    assert action is not None
+    assert action.metadata is not None
+    model_meta = cast(dict[str, Any], action.metadata['model'])
+    assert model_meta['supports'] == {'multiturn': True}
+
+
+def test_gpt_6_astra_json_mode_uses_json_object() -> None:
+    """A schema-less JSON request to gpt-6-astra sends json_object, as the catalog advertises."""
+    model = OpenAIModel(model='gpt-6-astra', client=MagicMock())
+    request = ModelRequest(
+        messages=[Message(role=Role.USER, content=[Part(root=TextPart(text='Hi'))])],
+        output=OutputConfig(format='json'),
+    )
+    assert model._get_response_format(request) == {'type': 'json_object'}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
`gpt-6-astra` only reaches the Python OpenAI plugin through dynamic resolution, which registers it with `Supports(multiturn=True)`, so the Dev UI hides media, system role and JSON output. This adds a catalog entry, the Python counterpart of #6303 (JS) and #6304 (Go).

The entry declares `multiturn`, `media`, `system_role` and `json_mode`/`text`, with `tools=False`. The live run in #6303 against `/v1/chat/completions` returned:

```
400 Function tools with reasoning_effort are not supported for gpt-6-astra in /v1/chat/completions. To use function tools, use /v1/responses or set reasoning_effort to 'none'.
```

`none` is itself rejected, so no value lets tools through. Python core does not enforce `supports.tools`, so the flag is advisory. Listing `json_mode` is wire-neutral: unlisted ids already send `json_object` and strict `json_schema`. Both verified live on astra, along with text, streaming, image input, system role and multiturn.

Tests pin the entry, registration via `init()` and `resolve()`, `json_object` selection, and the unlisted default. `pytest` 191 passed; ruff, pyright and ty clean.

Live smoke run from Python. Astra rejects `max_tokens` (`Use 'max_completion_tokens' instead`), which `OpenAIConfig(max_tokens=...)` still sends; pre-existing for every reasoning model, fix pending in a separate change since `model.py` is in flight. Related: #5898.

