### PR TITLE
feat(py): add A2UI Surfaces middleware

### DIFF
--- a/.github/workflows/publish_python.yml
+++ b/.github/workflows/publish_python.yml
@@ -58,6 +58,7 @@ jobs:
           # Publish all core and plugin packages for v0.10.0 release.
           PACKAGES=(
             py/packages/genkit
+            py/packages/genkit-a2ui
             py/packages/genkit-amazon-bedrock
             py/packages/genkit-anthropic
             py/packages/genkit-django

--- a/py/packages/genkit-a2ui/LICENSE
+++ b/py/packages/genkit-a2ui/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2025 Google LLC
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/py/packages/genkit-a2ui/README.md
+++ b/py/packages/genkit-a2ui/README.md
@@ -2,14 +2,14 @@
 
 Experimental [A2UI](https://a2ui.org/) middleware for Genkit Python.
 
-Add `A2ui()` to `use=[...]` on `ai.generate` or `define_agent`. The model may
+Add `Surfaces()` to `use=[...]` on `ai.generate` or `define_agent`. The model may
 emit ` ```a2ui ` fences; the middleware rewrites them into
 `application/a2ui+json` data parts. On the next turn, those parts become text
 again so the model can see prior surfaces and button clicks.
 
 ```python
 from genkit import Genkit
-from genkit_a2ui import A2ui, envelopes_from_parts
+from genkit_a2ui import Surfaces, envelopes_from_parts
 from genkit_google_genai import GoogleAI
 
 ai = Genkit(plugins=[GoogleAI()])
@@ -17,9 +17,34 @@ ai = Genkit(plugins=[GoogleAI()])
 response = await ai.generate(
     model='googleai/gemini-2.5-flash',
     prompt='Show me the weather in Tokyo',
-    use=[A2ui()],
+    use=[Surfaces()],
 )
 envelopes = envelopes_from_parts(response.message.content)
 ```
+
+`Surfaces()` uses the bundled basic catalog. To use your own components, register a
+catalog and pass its id:
+
+```python
+from genkit_a2ui import Surfaces, A2uiCatalog, A2uiCatalogComponent, load_catalog
+
+catalog = A2uiCatalog(
+    id='https://my-app.org/catalogs/custom.json',
+    components=(
+        A2uiCatalogComponent(name='Banner', description='A prominent alert.', props='title: string.'),
+    ),
+)
+load_catalog(ai, catalog)
+
+response = await ai.generate(
+    model='googleai/gemini-2.5-flash',
+    prompt='Show a warning banner',
+    use=[Surfaces(catalog=catalog.id)],
+)
+```
+
+`load_catalog_file(ai, './my-catalog.json')` does the same from disk.
+`register_basic_catalog(ai)` puts the bundled catalog on the registry so the
+Developer UI can list it next to custom ones (`GET /api/values?type=a2ui-catalog`).
 
 > Status: experimental.

--- a/py/packages/genkit-a2ui/README.md
+++ b/py/packages/genkit-a2ui/README.md
@@ -1,0 +1,25 @@
+# genkit-a2ui
+
+Experimental [A2UI](https://a2ui.org/) middleware for Genkit Python.
+
+Add `A2ui()` to `use=[...]` on `ai.generate` or `define_agent`. The model may
+emit ` ```a2ui ` fences; the middleware rewrites them into
+`application/a2ui+json` data parts. On the next turn, those parts become text
+again so the model can see prior surfaces and button clicks.
+
+```python
+from genkit import Genkit
+from genkit_a2ui import A2ui, envelopes_from_parts
+from genkit_google_genai import GoogleAI
+
+ai = Genkit(plugins=[GoogleAI()])
+
+response = await ai.generate(
+    model='googleai/gemini-2.5-flash',
+    prompt='Show me the weather in Tokyo',
+    use=[A2ui()],
+)
+envelopes = envelopes_from_parts(response.message.content)
+```
+
+> Status: experimental.

--- a/py/packages/genkit-a2ui/pyproject.toml
+++ b/py/packages/genkit-a2ui/pyproject.toml
@@ -1,0 +1,81 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+[project]
+authors = [
+  { name = "Google" },
+]
+classifiers = [
+  "Development Status :: 3 - Alpha",
+  "Environment :: Console",
+  "Environment :: Web Environment",
+  "Framework :: AsyncIO",
+  "Framework :: Pydantic",
+  "Framework :: Pydantic :: 2",
+  "Intended Audience :: Developers",
+  "Operating System :: OS Independent",
+  "Programming Language :: Python",
+  "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
+  "Topic :: Scientific/Engineering :: Artificial Intelligence",
+  "Topic :: Software Development :: Libraries",
+  "Typing :: Typed",
+  "License :: OSI Approved :: Apache Software License",
+]
+dependencies = [
+  "genkit>=0.10.0",
+  "pydantic>=2.10.5",
+]
+description = "A2UI (Agent-to-UI) middleware for Genkit."
+keywords = [
+  "genkit",
+  "ai",
+  "llm",
+  "a2ui",
+  "middleware",
+]
+license = "Apache-2.0"
+name = "genkit-a2ui"
+readme = "README.md"
+requires-python = ">=3.10"
+version = "0.11.0"
+
+[project.optional-dependencies]
+dev = [
+  "pytest>=8.3.4",
+  "pytest-asyncio>=0.25.2",
+  "pytest-cov>=6.0.0",
+  "pytest-xdist>=3.6.1",
+]
+
+[project.urls]
+"Bug Tracker"   = "https://github.com/genkit-ai/genkit/issues"
+Changelog       = "https://github.com/genkit-ai/genkit/releases"
+"Documentation" = "https://genkit.dev/docs/get-started/?lang=python"
+"Homepage"      = "https://github.com/genkit-ai/genkit"
+"Repository"    = "https://github.com/genkit-ai/genkit/tree/main/py"
+
+[build-system]
+build-backend = "hatchling.build"
+requires      = ["hatchling"]
+
+[tool.hatch.build.targets.wheel]
+only-include = ["src/genkit_a2ui"]
+sources      = ["src"]

--- a/py/packages/genkit-a2ui/pyproject.toml
+++ b/py/packages/genkit-a2ui/pyproject.toml
@@ -40,7 +40,7 @@ classifiers = [
   "License :: OSI Approved :: Apache Software License",
 ]
 dependencies = [
-  "genkit>=0.10.0",
+  "genkit>=0.9.0",
   "pydantic>=2.10.5",
 ]
 description = "A2UI (Agent-to-UI) middleware for Genkit."

--- a/py/packages/genkit-a2ui/src/genkit_a2ui/__init__.py
+++ b/py/packages/genkit-a2ui/src/genkit_a2ui/__init__.py
@@ -1,0 +1,32 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""A2UI generate middleware for Genkit."""
+
+from ._middleware import A2ui, A2uiConfig
+from ._parser import A2uiParseError
+from ._part import a2ui_part, envelopes_from_parts, is_a2ui_part
+from ._types import A2UI_MIME_TYPE
+
+__all__ = [
+    'A2UI_MIME_TYPE',
+    'A2ui',
+    'A2uiConfig',
+    'A2uiParseError',
+    'a2ui_part',
+    'envelopes_from_parts',
+    'is_a2ui_part',
+]

--- a/py/packages/genkit-a2ui/src/genkit_a2ui/__init__.py
+++ b/py/packages/genkit-a2ui/src/genkit_a2ui/__init__.py
@@ -16,17 +16,26 @@
 
 """A2UI generate middleware for Genkit."""
 
-from ._middleware import A2ui, A2uiConfig
+from ._catalog import A2uiCatalog, A2uiCatalogComponent
+from ._loader import load_catalog, load_catalog_file, register_basic_catalog
+from ._middleware import Surfaces, SurfacesConfig
 from ._parser import A2uiParseError
 from ._part import a2ui_part, envelopes_from_parts, is_a2ui_part
-from ._types import A2UI_MIME_TYPE
+from ._types import A2UI_CATALOG_VALUE_TYPE, A2UI_MIME_TYPE, DEFAULT_CATALOG_ID
 
 __all__ = [
+    'A2UI_CATALOG_VALUE_TYPE',
     'A2UI_MIME_TYPE',
-    'A2ui',
-    'A2uiConfig',
+    'DEFAULT_CATALOG_ID',
+    'A2uiCatalog',
+    'A2uiCatalogComponent',
     'A2uiParseError',
+    'Surfaces',
+    'SurfacesConfig',
     'a2ui_part',
     'envelopes_from_parts',
     'is_a2ui_part',
+    'load_catalog',
+    'load_catalog_file',
+    'register_basic_catalog',
 ]

--- a/py/packages/genkit-a2ui/src/genkit_a2ui/_catalog.py
+++ b/py/packages/genkit-a2ui/src/genkit_a2ui/_catalog.py
@@ -1,0 +1,312 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Bundled basic catalog and the system-prompt instructions it produces."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from ._types import BASIC_CATALOG_ID
+
+BASIC_ICON_NAMES = (
+    'accountCircle',
+    'add',
+    'arrowBack',
+    'arrowForward',
+    'attachFile',
+    'calendarToday',
+    'call',
+    'camera',
+    'check',
+    'close',
+    'delete',
+    'download',
+    'edit',
+    'event',
+    'error',
+    'fastForward',
+    'favorite',
+    'favoriteOff',
+    'folder',
+    'help',
+    'home',
+    'info',
+    'locationOn',
+    'lock',
+    'lockOpen',
+    'mail',
+    'menu',
+    'moreVert',
+    'moreHoriz',
+    'notificationsOff',
+    'notifications',
+    'pause',
+    'payment',
+    'person',
+    'phone',
+    'photo',
+    'play',
+    'print',
+    'refresh',
+    'rewind',
+    'search',
+    'send',
+    'settings',
+    'share',
+    'shoppingCart',
+    'skipNext',
+    'skipPrevious',
+    'star',
+    'starHalf',
+    'starOff',
+    'stop',
+    'upload',
+    'visibility',
+    'visibilityOff',
+    'volumeDown',
+    'volumeMute',
+    'volumeOff',
+    'volumeUp',
+    'warning',
+)
+
+
+@dataclass(frozen=True)
+class A2uiCatalogComponent:
+    name: str
+    description: str
+    props: str
+
+
+@dataclass(frozen=True)
+class A2uiCatalog:
+    id: str
+    components: tuple[A2uiCatalogComponent, ...]
+
+
+BASIC_CATALOG = A2uiCatalog(
+    id=BASIC_CATALOG_ID,
+    components=(
+        A2uiCatalogComponent(
+            name='Text',
+            description=(
+                'Displays a run of text. For headings/titles set the `variant` prop '
+                '(h1..h5) rather than embedding Markdown; the text itself may use '
+                'inline Markdown.'
+            ),
+            props='text: string (required); variant?: one of h1|h2|h3|h4|h5|caption|body.',
+        ),
+        A2uiCatalogComponent(
+            name='Image',
+            description='Displays an image from a URL.',
+            props=(
+                'url: string (required); description?: string; '
+                'fit?: contain|cover|fill|none|scaleDown; '
+                'variant?: icon|avatar|smallFeature|mediumFeature|largeFeature|header.'
+            ),
+        ),
+        A2uiCatalogComponent(
+            name='Icon',
+            description=(
+                'Displays a named material icon. `name` MUST be one of the exact names '
+                'listed below — do NOT invent names (e.g. there is no "cloud", "air", '
+                'or "thermostat"). If none fits, omit the Icon rather than guessing.'
+            ),
+            props=f'name: one of {", ".join(BASIC_ICON_NAMES)} (required, exact).',
+        ),
+        A2uiCatalogComponent(
+            name='Row',
+            description='Lays out children horizontally.',
+            props=(
+                'children: string[] of component ids (required); '
+                'justify?: start|center|end|spaceAround|spaceBetween|spaceEvenly|stretch; '
+                'align?: start|center|end|stretch.'
+            ),
+        ),
+        A2uiCatalogComponent(
+            name='Column',
+            description='Lays out children vertically.',
+            props=(
+                'children: string[] of component ids (required); '
+                'justify?: start|center|end|spaceBetween|spaceAround|spaceEvenly|stretch; '
+                'align?: start|center|end|stretch.'
+            ),
+        ),
+        A2uiCatalogComponent(
+            name='List',
+            description='A list of children.',
+            props=(
+                'children: string[] of component ids (required); '
+                'direction?: vertical|horizontal; listStyle?: ordered|unordered|none.'
+            ),
+        ),
+        A2uiCatalogComponent(
+            name='Card',
+            description='A visually-contained card wrapping a single child.',
+            props='child: string id of a single child component (required; wrap multiple in a Column/Row).',
+        ),
+        A2uiCatalogComponent(
+            name='Divider',
+            description='A horizontal or vertical separator line.',
+            props='axis?: horizontal|vertical.',
+        ),
+        A2uiCatalogComponent(
+            name='Button',
+            description='A clickable button that fires an action back to the agent.',
+            props=(
+                'child: string id of a child (usually a Text) (required); '
+                'variant?: default|primary|borderless; '
+                'action: { event: { name: string, context?: object } } '
+                '(required — the event name is sent back to the agent when clicked).'
+            ),
+        ),
+        A2uiCatalogComponent(
+            name='TextField',
+            description='A single- or multi-line text input.',
+            props=(
+                'label: string (required); value?: string or { path } binding; '
+                'variant?: shortText|longText|number|obscured.'
+            ),
+        ),
+        A2uiCatalogComponent(
+            name='CheckBox',
+            description='A labeled checkbox.',
+            props='label: string (required); value: boolean or { path } binding (required).',
+        ),
+        A2uiCatalogComponent(
+            name='Slider',
+            description='A numeric slider.',
+            props=(
+                'max: number (required); value: number or { path } binding (required); '
+                'label?: string; min?: number; step?: number.'
+            ),
+        ),
+    ),
+)
+
+
+def render_catalog_instructions(catalog: A2uiCatalog) -> str:
+    component_docs = '\n'.join(f'- {c.name}: {c.description} Props: {c.props}' for c in catalog.components)
+    has = {c.name for c in catalog.components}
+    style_section = _render_style_tips(has)
+    example_section = _render_example(catalog, has)
+    inputs = [name for name in ('TextField', 'CheckBox', 'Slider') if name in has]
+    forms_section = ''
+    if inputs:
+        input_list = ', '.join(inputs)
+        forms_section = f"""
+- Forms: input components ({input_list}) do NOT send their values automatically.
+  To capture what the user entered you MUST do BOTH of these:
+  1. Bind each input's `value` to a data-model path, e.g.
+     `{{ "component": "TextField", "label": "Email", "value": {{ "path": "/email" }} }}`.
+     Typing updates the data model at that path.
+  2. On the submit `Button`, echo those same paths in
+     `action.event.context` so their current values are sent back to you, e.g.
+     `"context": {{ "email": {{ "path": "/email" }}, "name": {{ "path": "/name" }} }}`.
+  Without the `{{ path }}` bindings and the button `context`, the action arrives
+  with an empty `context` and the entered values are lost."""
+
+    return f"""# Rendering UI with A2UI
+
+You can render rich, interactive UI (not just text) by emitting an A2UI surface.
+When a result is better *shown* than *told* (weather, lists, forms, comparisons,
+confirmations, anything visual or interactive), render a UI surface.
+
+To render UI, output a single fenced code block tagged `a2ui` containing a JSON
+array of A2UI envelope messages. You may still write normal prose before it.
+
+Rules:
+- The UI is an ADJACENCY LIST: a flat array of components. Build the tree using
+  string `id` references, NOT nested objects. Exactly one component MUST have
+  `id: "root"`.
+- Every component has a `component` (type name) and an `id`. Container
+  components reference their children by id via a `children` array; single-child
+  wrappers reference one `child` id.
+- Values can be literals, or a data-model binding `{{ "path": "/somePath" }}`.
+- Use `createSurface` first (with `catalogId`), then `updateComponents` to add
+  the component list, then optionally `updateDataModel` to set data. You may
+  combine them in one array, in order.
+- Interactive components fire an `action` with an event `name`; that name is
+  sent back to you when the user interacts, so choose meaningful names.{forms_section}
+- When a user interacts with a surface (e.g. presses a button) and you respond
+  with updated UI, RE-RENDER THE WHOLE SURFACE: start again with
+  `createSurface` followed by `updateComponents`. Do not emit a bare
+  `updateDataModel`/`updateComponents` expecting a previous surface to still
+  exist.{style_section}
+
+The catalogId to use is:
+"{catalog.id}"
+
+Available components:
+{component_docs}{example_section}
+
+Do not explain the JSON; just render the block. Use "SURFACE_ID" literally as a
+placeholder for the surface id — the system replaces it with a real id."""
+
+
+def _render_style_tips(has: set[str]) -> str:
+    tips: list[str] = []
+    containers = [c for c in ('Card', 'Column', 'Row') if c in has]
+    if containers:
+        tips.append(
+            f'- Group related content with layout components ({"/".join(containers)}) and give it a clear hierarchy.'
+        )
+    if 'Text' in has:
+        tips.append(
+            '- Give titles a heading `variant` (e.g. h2/h3) and secondary text the '
+            '`caption` variant instead of embedding "#"/"##" heading markers in '
+            'the text.'
+        )
+    accents = [c for c in ('Icon', 'Divider', 'Image') if c in has]
+    if accents:
+        tips.append(f'- Use {"/".join(accents)} to add visual meaning and separate sections where it helps.')
+    if 'Button' in has:
+        tips.append('- Give primary buttons `variant: "primary"`.')
+    if not tips:
+        return ''
+    return '\n\nMake it look good, not bland:\n' + '\n'.join(tips)
+
+
+def _render_example(catalog: A2uiCatalog, has: set[str]) -> str:
+    if {'Card', 'Column', 'Text'} <= has:
+        return f"""
+
+Example (a small weather card):
+```a2ui
+[
+  {{ "createSurface": {{ "surfaceId": "SURFACE_ID", "catalogId": "{catalog.id}" }} }},
+  {{ "updateComponents": {{ "surfaceId": "SURFACE_ID", "components": [
+    {{ "id": "root", "component": "Card", "child": "body" }},
+    {{ "id": "body", "component": "Column", "children": ["title", "temp"] }},
+    {{ "id": "title", "component": "Text", "text": "Weather in Tokyo", "variant": "h3" }},
+    {{ "id": "temp", "component": "Text", "text": {{ "path": "/temp" }} }}
+  ] }} }},
+  {{ "updateDataModel": {{ "surfaceId": "SURFACE_ID", "path": "/temp", "value": "18°C" }} }}
+]
+```"""
+    root = catalog.components[0].name if catalog.components else 'Text'
+    return f"""
+
+Example (a minimal surface):
+```a2ui
+[
+  {{ "createSurface": {{ "surfaceId": "SURFACE_ID", "catalogId": "{catalog.id}" }} }},
+  {{ "updateComponents": {{ "surfaceId": "SURFACE_ID", "components": [
+    {{ "id": "root", "component": "{root}" }}
+  ] }} }}
+]
+```"""

--- a/py/packages/genkit-a2ui/src/genkit_a2ui/_catalog.py
+++ b/py/packages/genkit-a2ui/src/genkit_a2ui/_catalog.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from string import Template
+from typing import Any, cast
 
 from ._types import BASIC_CATALOG_ID
 
@@ -97,6 +98,37 @@ class A2uiCatalogComponent:
 class A2uiCatalog:
     id: str
     components: tuple[A2uiCatalogComponent, ...]
+
+    def as_value(self) -> dict[str, object]:
+        return {
+            'id': self.id,
+            'components': [{'name': c.name, 'description': c.description, 'props': c.props} for c in self.components],
+        }
+
+    @staticmethod
+    def from_value(value: object) -> A2uiCatalog | None:
+        if isinstance(value, A2uiCatalog):
+            return value
+        if not isinstance(value, dict):
+            return None
+        payload = cast(dict[str, Any], value)
+        catalog_id = payload.get('id')
+        raw = payload.get('components')
+        if not isinstance(catalog_id, str) or not catalog_id or not isinstance(raw, list):
+            return None
+        components: list[A2uiCatalogComponent] = []
+        for item in raw:
+            row = cast(dict[str, Any], item) if isinstance(item, dict) else None
+            if row is None or not isinstance(row.get('name'), str):
+                return None
+            components.append(
+                A2uiCatalogComponent(
+                    name=row['name'],
+                    description=row['description'] if isinstance(row.get('description'), str) else '',
+                    props=row['props'] if isinstance(row.get('props'), str) else '',
+                )
+            )
+        return A2uiCatalog(id=catalog_id, components=tuple(components))
 
 
 BASIC_CATALOG = A2uiCatalog(

--- a/py/packages/genkit-a2ui/src/genkit_a2ui/_catalog.py
+++ b/py/packages/genkit-a2ui/src/genkit_a2ui/_catalog.py
@@ -19,6 +19,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from string import Template
 
 from ._types import BASIC_CATALOG_ID
 
@@ -199,28 +200,47 @@ BASIC_CATALOG = A2uiCatalog(
 )
 
 
-def render_catalog_instructions(catalog: A2uiCatalog) -> str:
-    component_docs = '\n'.join(f'- {c.name}: {c.description} Props: {c.props}' for c in catalog.components)
-    has = {c.name for c in catalog.components}
-    style_section = _render_style_tips(has)
-    example_section = _render_example(catalog, has)
-    inputs = [name for name in ('TextField', 'CheckBox', 'Slider') if name in has]
-    forms_section = ''
-    if inputs:
-        input_list = ', '.join(inputs)
-        forms_section = f"""
-- Forms: input components ({input_list}) do NOT send their values automatically.
+FORMS_SECTION = Template("""
+- Forms: input components ($input_list) do NOT send their values automatically.
   To capture what the user entered you MUST do BOTH of these:
   1. Bind each input's `value` to a data-model path, e.g.
-     `{{ "component": "TextField", "label": "Email", "value": {{ "path": "/email" }} }}`.
+     `{ "component": "TextField", "label": "Email", "value": { "path": "/email" } }`.
      Typing updates the data model at that path.
   2. On the submit `Button`, echo those same paths in
      `action.event.context` so their current values are sent back to you, e.g.
-     `"context": {{ "email": {{ "path": "/email" }}, "name": {{ "path": "/name" }} }}`.
-  Without the `{{ path }}` bindings and the button `context`, the action arrives
-  with an empty `context` and the entered values are lost."""
+     `"context": { "email": { "path": "/email" }, "name": { "path": "/name" } }`.
+  Without the `{ path }` bindings and the button `context`, the action arrives
+  with an empty `context` and the entered values are lost.""")
 
-    return f"""# Rendering UI with A2UI
+WEATHER_EXAMPLE = Template("""
+
+Example (a small weather card):
+```a2ui
+[
+  { "createSurface": { "surfaceId": "SURFACE_ID", "catalogId": "$catalog_id" } },
+  { "updateComponents": { "surfaceId": "SURFACE_ID", "components": [
+    { "id": "root", "component": "Card", "child": "body" },
+    { "id": "body", "component": "Column", "children": ["title", "temp"] },
+    { "id": "title", "component": "Text", "text": "Weather in Tokyo", "variant": "h3" },
+    { "id": "temp", "component": "Text", "text": { "path": "/temp" } }
+  ] } },
+  { "updateDataModel": { "surfaceId": "SURFACE_ID", "path": "/temp", "value": "18°C" } }
+]
+```""")
+
+MINIMAL_EXAMPLE = Template("""
+
+Example (a minimal surface):
+```a2ui
+[
+  { "createSurface": { "surfaceId": "SURFACE_ID", "catalogId": "$catalog_id" } },
+  { "updateComponents": { "surfaceId": "SURFACE_ID", "components": [
+    { "id": "root", "component": "$root" }
+  ] } }
+]
+```""")
+
+INSTRUCTIONS = Template("""# Rendering UI with A2UI
 
 You can render rich, interactive UI (not just text) by emitting an A2UI surface.
 When a result is better *shown* than *told* (weather, lists, forms, comparisons,
@@ -236,29 +256,42 @@ Rules:
 - Every component has a `component` (type name) and an `id`. Container
   components reference their children by id via a `children` array; single-child
   wrappers reference one `child` id.
-- Values can be literals, or a data-model binding `{{ "path": "/somePath" }}`.
+- Values can be literals, or a data-model binding `{ "path": "/somePath" }`.
 - Use `createSurface` first (with `catalogId`), then `updateComponents` to add
   the component list, then optionally `updateDataModel` to set data. You may
   combine them in one array, in order.
 - Interactive components fire an `action` with an event `name`; that name is
-  sent back to you when the user interacts, so choose meaningful names.{forms_section}
+  sent back to you when the user interacts, so choose meaningful names.$forms_section
 - When a user interacts with a surface (e.g. presses a button) and you respond
   with updated UI, RE-RENDER THE WHOLE SURFACE: start again with
   `createSurface` followed by `updateComponents`. Do not emit a bare
   `updateDataModel`/`updateComponents` expecting a previous surface to still
-  exist.{style_section}
+  exist.$style_section
 
 The catalogId to use is:
-"{catalog.id}"
+"$catalog_id"
 
 Available components:
-{component_docs}{example_section}
+$component_docs$example_section
 
 Do not explain the JSON; just render the block. Use "SURFACE_ID" literally as a
-placeholder for the surface id — the system replaces it with a real id."""
+placeholder for the surface id — the system replaces it with a real id.""")
 
 
-def _render_style_tips(has: set[str]) -> str:
+def render_catalog_instructions(catalog: A2uiCatalog) -> str:
+    has = {c.name for c in catalog.components}
+    inputs = [name for name in ('TextField', 'CheckBox', 'Slider') if name in has]
+    forms_section = FORMS_SECTION.substitute(input_list=', '.join(inputs)) if inputs else ''
+    return INSTRUCTIONS.substitute(
+        forms_section=forms_section,
+        style_section=render_style_tips(has=has),
+        catalog_id=catalog.id,
+        component_docs='\n'.join(f'- {c.name}: {c.description} Props: {c.props}' for c in catalog.components),
+        example_section=render_example(catalog=catalog, has=has),
+    )
+
+
+def render_style_tips(*, has: set[str]) -> str:
     tips: list[str] = []
     containers = [c for c in ('Card', 'Column', 'Row') if c in has]
     if containers:
@@ -281,32 +314,8 @@ def _render_style_tips(has: set[str]) -> str:
     return '\n\nMake it look good, not bland:\n' + '\n'.join(tips)
 
 
-def _render_example(catalog: A2uiCatalog, has: set[str]) -> str:
+def render_example(*, catalog: A2uiCatalog, has: set[str]) -> str:
     if {'Card', 'Column', 'Text'} <= has:
-        return f"""
-
-Example (a small weather card):
-```a2ui
-[
-  {{ "createSurface": {{ "surfaceId": "SURFACE_ID", "catalogId": "{catalog.id}" }} }},
-  {{ "updateComponents": {{ "surfaceId": "SURFACE_ID", "components": [
-    {{ "id": "root", "component": "Card", "child": "body" }},
-    {{ "id": "body", "component": "Column", "children": ["title", "temp"] }},
-    {{ "id": "title", "component": "Text", "text": "Weather in Tokyo", "variant": "h3" }},
-    {{ "id": "temp", "component": "Text", "text": {{ "path": "/temp" }} }}
-  ] }} }},
-  {{ "updateDataModel": {{ "surfaceId": "SURFACE_ID", "path": "/temp", "value": "18°C" }} }}
-]
-```"""
+        return WEATHER_EXAMPLE.substitute(catalog_id=catalog.id)
     root = catalog.components[0].name if catalog.components else 'Text'
-    return f"""
-
-Example (a minimal surface):
-```a2ui
-[
-  {{ "createSurface": {{ "surfaceId": "SURFACE_ID", "catalogId": "{catalog.id}" }} }},
-  {{ "updateComponents": {{ "surfaceId": "SURFACE_ID", "components": [
-    {{ "id": "root", "component": "{root}" }}
-  ] }} }}
-]
-```"""
+    return MINIMAL_EXAMPLE.substitute(catalog_id=catalog.id, root=root)

--- a/py/packages/genkit-a2ui/src/genkit_a2ui/_loader.py
+++ b/py/packages/genkit-a2ui/src/genkit_a2ui/_loader.py
@@ -1,0 +1,82 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Register A2UI catalogs so generate and the Developer UI can find them."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from genkit._core._logger import get_logger
+from genkit._core._protocols import GenkitLike, RegistryLike
+
+from ._catalog import BASIC_CATALOG, A2uiCatalog
+from ._types import A2UI_CATALOG_VALUE_TYPE, BASIC_CATALOG_ID, DEFAULT_CATALOG_ID
+
+logger = get_logger(__name__)
+
+
+def load_catalog(ai: GenkitLike, catalog: A2uiCatalog) -> A2uiCatalog:
+    if not catalog.id:
+        raise ValueError('a2ui: load_catalog: catalog has no id')
+    existing = ai.registry.lookup_value(A2UI_CATALOG_VALUE_TYPE, catalog.id)
+    if existing is not None:
+        current = A2uiCatalog.from_value(existing)
+        if current is not None and current != catalog:
+            logger.warning(
+                'a2ui: load_catalog: a different catalog is already registered under this id; keeping the existing one'
+            )
+        return current or catalog
+    ai.registry.register_value(A2UI_CATALOG_VALUE_TYPE, catalog.id, catalog.as_value())
+    return catalog
+
+
+def load_catalog_file(ai: GenkitLike, path: str) -> A2uiCatalog:
+    return load_catalog(ai, read_catalog_file(path=path))
+
+
+def register_basic_catalog(ai: GenkitLike) -> A2uiCatalog:
+    return load_catalog(ai, BASIC_CATALOG)
+
+
+def read_catalog_file(*, path: str) -> A2uiCatalog:
+    try:
+        raw = json.loads(Path(path).read_text(encoding='utf-8'))
+    except OSError as exc:
+        raise ValueError(f'a2ui: failed to read catalog file {path!r}: {exc}') from exc
+    except json.JSONDecodeError as exc:
+        raise ValueError(f'a2ui: catalog file {path!r} is not valid JSON: {exc}') from exc
+    catalog = A2uiCatalog.from_value(raw)
+    if catalog is None:
+        raise ValueError(f'a2ui: catalog file {path!r} must have an "id" and a "components" array')
+    return catalog
+
+
+def resolve_catalog(*, registry: RegistryLike, catalog: str | None) -> A2uiCatalog:
+    lookup = catalog or DEFAULT_CATALOG_ID
+    found = registry.lookup_value(A2UI_CATALOG_VALUE_TYPE, lookup)
+    if found is not None:
+        resolved = A2uiCatalog.from_value(found)
+        if resolved is None:
+            raise ValueError(f'a2ui: registry value {lookup!r} is not a catalog')
+        return resolved
+    if lookup in {DEFAULT_CATALOG_ID, BASIC_CATALOG_ID}:
+        return BASIC_CATALOG
+    raise ValueError(
+        f'a2ui: no catalog registered under id {lookup!r}; '
+        f'register one with load_catalog(ai, catalog) or use the default {DEFAULT_CATALOG_ID!r} catalog'
+    )

--- a/py/packages/genkit-a2ui/src/genkit_a2ui/_loader.py
+++ b/py/packages/genkit-a2ui/src/genkit_a2ui/_loader.py
@@ -36,11 +36,13 @@ def load_catalog(ai: GenkitLike, catalog: A2uiCatalog) -> A2uiCatalog:
     existing = ai.registry.lookup_value(A2UI_CATALOG_VALUE_TYPE, catalog.id)
     if existing is not None:
         current = A2uiCatalog.from_value(existing)
-        if current is not None and current != catalog:
+        if current is None:
+            raise ValueError(f'a2ui: load_catalog: registry value {catalog.id!r} is not a catalog')
+        if current != catalog:
             logger.warning(
                 'a2ui: load_catalog: a different catalog is already registered under this id; keeping the existing one'
             )
-        return current or catalog
+        return current
     ai.registry.register_value(A2UI_CATALOG_VALUE_TYPE, catalog.id, catalog.as_value())
     return catalog
 
@@ -56,13 +58,16 @@ def register_basic_catalog(ai: GenkitLike) -> A2uiCatalog:
 def read_catalog_file(*, path: str) -> A2uiCatalog:
     try:
         raw = json.loads(Path(path).read_text(encoding='utf-8'))
-    except OSError as exc:
+    except (OSError, UnicodeDecodeError) as exc:
         raise ValueError(f'a2ui: failed to read catalog file {path!r}: {exc}') from exc
     except json.JSONDecodeError as exc:
         raise ValueError(f'a2ui: catalog file {path!r} is not valid JSON: {exc}') from exc
     catalog = A2uiCatalog.from_value(raw)
     if catalog is None:
-        raise ValueError(f'a2ui: catalog file {path!r} must have an "id" and a "components" array')
+        raise ValueError(
+            f'a2ui: catalog file {path!r} is not a catalog '
+            '(need an id, a components array, and a name on every component)'
+        )
     return catalog
 
 

--- a/py/packages/genkit-a2ui/src/genkit_a2ui/_middleware.py
+++ b/py/packages/genkit-a2ui/src/genkit_a2ui/_middleware.py
@@ -85,41 +85,25 @@ class A2ui(BaseMiddleware[A2uiConfig]):
         if self.config.instructions != 'none':
             params.request = inject_instructions(request=params.request, catalog=catalog)
 
-        original_on_chunk = ctx.on_chunk
-        parse_error: A2uiParseError | None = None
-        if original_on_chunk is not None:
-
-            def handler(chunk: ModelResponseChunk) -> None:
-                nonlocal parse_error
-                if parse_error is not None:
-                    return
-                try:
-                    transformed = transform_chunk(chunk=chunk, parser=parser)
-                except A2uiParseError as exc:
-                    # Raising here would wrap this as a model INTERNAL error.
-                    # Hold it until the model call finishes so the caller still
-                    # sees A2uiParseError.
-                    parse_error = exc
-                    return
-                if transformed is not None:
-                    original_on_chunk(transformed)
-
+        handler: ChunkHandler | None = None
+        if ctx.on_chunk is not None:
+            handler = ChunkHandler(parser=parser, emit=ctx.on_chunk)
             ctx.replace_on_chunk(handler)
         try:
             response = await next_fn(params, ctx)
         finally:
-            if original_on_chunk is not None:
-                ctx.replace_on_chunk(original_on_chunk)
+            if handler is not None:
+                ctx.replace_on_chunk(handler.emit)
 
         if response.finish_reason in ABNORMAL_FINISH_REASONS:
             return response
-        if parse_error is not None:
-            raise parse_error
+        if handler is not None and handler.parse_error is not None:
+            raise handler.parse_error
 
-        if original_on_chunk is not None:
+        if handler is not None:
             tail = parts_from_segments(segments=parser.flush())
             if tail:
-                original_on_chunk(ModelResponseChunk(role=Role.MODEL, content=tail))
+                handler.emit(ModelResponseChunk(role=Role.MODEL, content=tail))
 
         replay.reset()
         return transform_response(
@@ -129,6 +113,26 @@ class A2ui(BaseMiddleware[A2uiConfig]):
             version=version,
             surface_id=replay.replay_next,
         )
+
+
+class ChunkHandler:
+    """Rewrites stream chunks. Stashes a parse error so it is not wrapped as INTERNAL."""
+
+    def __init__(self, *, parser: StreamParser, emit: Callable[[ModelResponseChunk], None]) -> None:
+        self.parser = parser
+        self.emit = emit
+        self.parse_error: A2uiParseError | None = None
+
+    def __call__(self, chunk: ModelResponseChunk) -> None:
+        if self.parse_error is not None:
+            return
+        try:
+            transformed = transform_chunk(chunk=chunk, parser=self.parser)
+        except A2uiParseError as exc:
+            self.parse_error = exc
+            return
+        if transformed is not None:
+            self.emit(transformed)
 
 
 def surface_id_factory(*, policy: str | None) -> Callable[[], str]:

--- a/py/packages/genkit-a2ui/src/genkit_a2ui/_middleware.py
+++ b/py/packages/genkit-a2ui/src/genkit_a2ui/_middleware.py
@@ -14,7 +14,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""A2ui generate middleware."""
+"""Surfaces generate middleware."""
 
 from __future__ import annotations
 
@@ -29,7 +29,8 @@ from genkit._core._model import Message, ModelRequest, ModelResponse, ModelRespo
 from genkit._core._typing import FinishReason, Part, Role, TextPart
 from genkit.middleware import BaseMiddleware, GenerateMiddlewareContext, ModelHookParams
 
-from ._catalog import BASIC_CATALOG, A2uiCatalog, render_catalog_instructions
+from ._catalog import A2uiCatalog, render_catalog_instructions
+from ._loader import resolve_catalog
 from ._parser import A2uiParseError, Segment, StreamParser
 from ._part import a2ui_part, envelopes_from_parts, has_a2ui_mime
 from ._types import DEFAULT_VERSION, SURFACE_KEYS, Envelope, SupportedVersion, ValidateMode
@@ -42,19 +43,21 @@ ABNORMAL_FINISH_REASONS = frozenset({
 })
 
 
-class A2uiConfig(BaseModel):
-    """Options for :class:`A2ui`."""
+class SurfacesConfig(BaseModel):
+    """Options for :class:`Surfaces`."""
 
     model_config = ConfigDict(extra='forbid', populate_by_name=True)
 
     instructions: Literal['system', 'none'] = 'system'
     validation: ValidateMode = Field(default='warn', alias='validate')
     surface_id: str | None = Field(default=None, alias='surfaceId')
+    # Registry id from load_catalog. The Developer UI lists those same ids.
+    catalog: str | None = None
     # A typo here would stamp envelopes the renderer cannot paint.
     version: SupportedVersion = DEFAULT_VERSION
 
 
-class A2ui(BaseMiddleware[A2uiConfig]):
+class Surfaces(BaseMiddleware[SurfacesConfig]):
     """Rewrites A2UI fenced model output into data parts.
 
     On the next turn, inbound A2UI parts become text so the model can see
@@ -68,7 +71,7 @@ class A2ui(BaseMiddleware[A2uiConfig]):
         ctx: GenerateMiddlewareContext,
         next_fn: Callable[[ModelHookParams, GenerateMiddlewareContext], Awaitable[ModelResponse]],
     ) -> ModelResponse:
-        catalog = BASIC_CATALOG
+        catalog = resolve_catalog(registry=ctx.ai.registry, catalog=self.config.catalog)
         version = self.config.version or DEFAULT_VERSION
         validate = self.config.validation
         # Chunks are rewritten as fences close. The finished message is parsed

--- a/py/packages/genkit-a2ui/src/genkit_a2ui/_middleware.py
+++ b/py/packages/genkit-a2ui/src/genkit_a2ui/_middleware.py
@@ -30,7 +30,7 @@ from genkit._core._typing import FinishReason, Part, Role, TextPart
 from genkit.middleware import BaseMiddleware, GenerateMiddlewareContext, ModelHookParams
 
 from ._catalog import BASIC_CATALOG, A2uiCatalog, render_catalog_instructions
-from ._parser import A2uiParseError, Segment, StreamParser, new_stream_parser
+from ._parser import A2uiParseError, Segment, StreamParser
 from ._part import a2ui_part, envelopes_from_parts, has_a2ui_mime
 from ._types import DEFAULT_VERSION, SURFACE_KEYS, Envelope, SupportedVersion, ValidateMode
 
@@ -71,8 +71,10 @@ class A2ui(BaseMiddleware[A2uiConfig]):
         catalog = BASIC_CATALOG
         version = self.config.version or DEFAULT_VERSION
         validate = self.config.validation
+        # Chunks are rewritten as fences close. The finished message is parsed
+        # again so response.message matches; SurfaceIdReplay replays the same ids.
         replay = SurfaceIdReplay(mint=surface_id_factory(policy=self.config.surface_id))
-        parser = new_stream_parser(
+        parser = StreamParser(
             catalog=catalog,
             validate=validate,
             version=version,
@@ -169,18 +171,11 @@ def part_text(*, part: Part) -> str | None:
 def parts_from_segments(*, segments: list[Segment]) -> list[Part]:
     out: list[Part] = []
     for seg in segments:
-        if seg.is_envelope:
+        if seg.envelopes:
             out.append(a2ui_part(seg.envelopes))
         elif seg.prose:
             out.append(Part(TextPart(text=seg.prose)))
     return out
-
-
-def parts_for_text_part(*, src: Part, segments: list[Segment]) -> list[Part]:
-    src_text = part_text(part=src) or ''
-    if len(segments) == 1 and not segments[0].is_envelope and segments[0].prose == src_text:
-        return [src]
-    return parts_from_segments(segments=segments)
 
 
 def rewrite_parts(*, parts: list[Part], parser: StreamParser, flush_nontext: bool) -> list[Part]:
@@ -188,7 +183,12 @@ def rewrite_parts(*, parts: list[Part], parser: StreamParser, flush_nontext: boo
     for part in parts:
         text = part_text(part=part)
         if text:
-            out.extend(parts_for_text_part(src=part, segments=parser.push(text=text)))
+            segments = parser.push(text=text)
+            # Keep the original part when the parser did not split or rewrite it.
+            if len(segments) == 1 and not segments[0].envelopes and segments[0].prose == text:
+                out.append(part)
+            else:
+                out.extend(parts_from_segments(segments=segments))
             continue
         if flush_nontext:
             out.extend(parts_from_segments(segments=parser.flush()))
@@ -220,7 +220,7 @@ def transform_response(
         message = Message(response.candidates[0].message)
     if message is None:
         return response
-    parser = new_stream_parser(
+    parser = StreamParser(
         catalog=catalog,
         validate=validate,
         version=version,

--- a/py/packages/genkit-a2ui/src/genkit_a2ui/_middleware.py
+++ b/py/packages/genkit-a2ui/src/genkit_a2ui/_middleware.py
@@ -217,7 +217,7 @@ def transform_response(
 ) -> ModelResponse:
     message = response.message
     if message is None and response.candidates:
-        message = Message(response.candidates[0].message)
+        message = response.candidates[0].message
     if message is None:
         return response
     parser = StreamParser(
@@ -272,8 +272,9 @@ def sanitize_inbound(*, request: ModelRequest) -> ModelRequest:
             messages.append(message)
             continue
         changed = True
-        if content:
-            messages.append(message.model_copy(update={'content': content}))
+        if not content:
+            content.append(Part(TextPart(text='[UI]')))
+        messages.append(message.model_copy(update={'content': content}))
     if not changed:
         return request
     return request.model_copy(update={'messages': messages})

--- a/py/packages/genkit-a2ui/src/genkit_a2ui/_middleware.py
+++ b/py/packages/genkit-a2ui/src/genkit_a2ui/_middleware.py
@@ -1,0 +1,308 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""A2ui generate middleware."""
+
+from __future__ import annotations
+
+import json
+import uuid
+from collections.abc import Awaitable, Callable
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from genkit._core._model import Message, ModelRequest, ModelResponse, ModelResponseChunk
+from genkit._core._typing import FinishReason, Part, Role, TextPart
+from genkit.middleware import BaseMiddleware, GenerateMiddlewareContext, ModelHookParams
+
+from ._catalog import BASIC_CATALOG, A2uiCatalog, render_catalog_instructions
+from ._parser import A2uiParseError, Segment, StreamParser, new_stream_parser
+from ._part import a2ui_part, envelopes_from_parts, has_a2ui_mime
+from ._types import DEFAULT_VERSION, SURFACE_KEYS, Envelope, SupportedVersion, ValidateMode
+
+ABNORMAL_FINISH_REASONS = frozenset({
+    FinishReason.BLOCKED,
+    FinishReason.ABORTED,
+    FinishReason.INTERRUPTED,
+    FinishReason.OTHER,
+})
+
+
+class A2uiConfig(BaseModel):
+    """Options for :class:`A2ui`."""
+
+    model_config = ConfigDict(extra='forbid', populate_by_name=True)
+
+    instructions: Literal['system', 'none'] = 'system'
+    validation: ValidateMode = Field(default='warn', alias='validate')
+    surface_id: str | None = Field(default=None, alias='surfaceId')
+    # A typo here would stamp envelopes the renderer cannot paint.
+    version: SupportedVersion = DEFAULT_VERSION
+
+
+class A2ui(BaseMiddleware[A2uiConfig]):
+    """Rewrites A2UI fenced model output into data parts.
+
+    On the next turn, inbound A2UI parts become text so the model can see
+    prior surfaces and button clicks. A stopped turn (blocked / cancelled /
+    aborted / other) is left alone — the stop is the result, not a salvaged card.
+    """
+
+    async def wrap_model(
+        self,
+        params: ModelHookParams,
+        ctx: GenerateMiddlewareContext,
+        next_fn: Callable[[ModelHookParams, GenerateMiddlewareContext], Awaitable[ModelResponse]],
+    ) -> ModelResponse:
+        catalog = BASIC_CATALOG
+        version = self.config.version or DEFAULT_VERSION
+        validate = self.config.validation
+        replay = SurfaceIdReplay(mint=surface_id_factory(policy=self.config.surface_id))
+        parser = new_stream_parser(
+            catalog=catalog,
+            validate=validate,
+            version=version,
+            surface_id=replay.next,
+        )
+
+        params.request = sanitize_inbound(request=params.request)
+        if self.config.instructions != 'none':
+            params.request = inject_instructions(request=params.request, catalog=catalog)
+
+        original_on_chunk = ctx.on_chunk
+        parse_error: A2uiParseError | None = None
+        if original_on_chunk is not None:
+
+            def handler(chunk: ModelResponseChunk) -> None:
+                nonlocal parse_error
+                if parse_error is not None:
+                    return
+                try:
+                    transformed = transform_chunk(chunk=chunk, parser=parser)
+                except A2uiParseError as exc:
+                    # Raising here would wrap this as a model INTERNAL error.
+                    # Hold it until the model call finishes so the caller still
+                    # sees A2uiParseError.
+                    parse_error = exc
+                    return
+                if transformed is not None:
+                    original_on_chunk(transformed)
+
+            ctx.replace_on_chunk(handler)
+        try:
+            response = await next_fn(params, ctx)
+        finally:
+            if original_on_chunk is not None:
+                ctx.replace_on_chunk(original_on_chunk)
+
+        if response.finish_reason in ABNORMAL_FINISH_REASONS:
+            return response
+        if parse_error is not None:
+            raise parse_error
+
+        if original_on_chunk is not None:
+            tail = parts_from_segments(segments=parser.flush())
+            if tail:
+                original_on_chunk(ModelResponseChunk(role=Role.MODEL, content=tail))
+
+        replay.reset()
+        return transform_response(
+            response=response,
+            catalog=catalog,
+            validate=validate,
+            version=version,
+            surface_id=replay.replay_next,
+        )
+
+
+def surface_id_factory(*, policy: str | None) -> Callable[[], str]:
+    if policy:
+        return lambda: policy
+    return lambda: str(uuid.uuid4())
+
+
+class SurfaceIdReplay:
+    """Mints surface ids on the stream, then replays the same ids on the final parse."""
+
+    def __init__(self, *, mint: Callable[[], str]) -> None:
+        self.mint = mint
+        self.recorded: list[str] = []
+        self.cursor = 0
+
+    def next(self) -> str:
+        value = self.mint()
+        self.recorded.append(value)
+        return value
+
+    def reset(self) -> None:
+        self.cursor = 0
+
+    def replay_next(self) -> str:
+        if self.cursor < len(self.recorded):
+            value = self.recorded[self.cursor]
+            self.cursor += 1
+            return value
+        return self.next()
+
+
+def part_text(*, part: Part) -> str | None:
+    root = part.root
+    if isinstance(root, TextPart) and root.text:
+        return root.text
+    return None
+
+
+def parts_from_segments(*, segments: list[Segment]) -> list[Part]:
+    out: list[Part] = []
+    for seg in segments:
+        if seg.is_envelope:
+            out.append(a2ui_part(seg.envelopes))
+        elif seg.prose:
+            out.append(Part(TextPart(text=seg.prose)))
+    return out
+
+
+def parts_for_text_part(*, src: Part, segments: list[Segment]) -> list[Part]:
+    src_text = part_text(part=src) or ''
+    if len(segments) == 1 and not segments[0].is_envelope and segments[0].prose == src_text:
+        return [src]
+    return parts_from_segments(segments=segments)
+
+
+def rewrite_parts(*, parts: list[Part], parser: StreamParser, flush_nontext: bool) -> list[Part]:
+    out: list[Part] = []
+    for part in parts:
+        text = part_text(part=part)
+        if text:
+            out.extend(parts_for_text_part(src=part, segments=parser.push(text=text)))
+            continue
+        if flush_nontext:
+            out.extend(parts_from_segments(segments=parser.flush()))
+        out.append(part)
+    if flush_nontext:
+        out.extend(parts_from_segments(segments=parser.flush()))
+    return out
+
+
+def transform_chunk(*, chunk: ModelResponseChunk, parser: StreamParser) -> ModelResponseChunk | None:
+    if not chunk.content:
+        return chunk
+    new_content = rewrite_parts(parts=chunk.content, parser=parser, flush_nontext=False)
+    if not new_content:
+        return None
+    return chunk.model_copy(update={'content': new_content})
+
+
+def transform_response(
+    *,
+    response: ModelResponse,
+    catalog: A2uiCatalog,
+    validate: ValidateMode,
+    version: str,
+    surface_id: Callable[[], str],
+) -> ModelResponse:
+    message = response.message
+    if message is None and response.candidates:
+        message = Message(response.candidates[0].message)
+    if message is None:
+        return response
+    parser = new_stream_parser(
+        catalog=catalog,
+        validate=validate,
+        version=version,
+        surface_id=surface_id,
+    )
+    new_content = rewrite_parts(parts=message.content, parser=parser, flush_nontext=True)
+    new_message = message.model_copy(update={'content': new_content})
+    # Providers that also expose candidates[0] would otherwise leave the fence
+    # there after the top-level message is rewritten.
+    update: dict[str, object] = {'message': new_message}
+    if response.candidates:
+        update['candidates'] = [
+            candidate.model_copy(update={'message': new_message}) if i == 0 else candidate
+            for i, candidate in enumerate(response.candidates)
+        ]
+    return response.model_copy(update=update)
+
+
+def inject_instructions(*, request: ModelRequest, catalog: A2uiCatalog) -> ModelRequest:
+    text = render_catalog_instructions(catalog)
+    messages = list(request.messages)
+    for i, message in enumerate(messages):
+        if message.role != Role.SYSTEM:
+            continue
+        extra = Part(TextPart(text='\n\n' + text))
+        messages[i] = message.model_copy(update={'content': [*message.content, extra]})
+        return request.model_copy(update={'messages': messages})
+    system = Message(role=Role.SYSTEM, content=[Part(TextPart(text=text))])
+    return request.model_copy(update={'messages': [system, *messages]})
+
+
+def sanitize_inbound(*, request: ModelRequest) -> ModelRequest:
+    changed = False
+    messages: list[Message] = []
+    for message in request.messages:
+        rewritten = False
+        content: list[Part] = []
+        for part in message.content:
+            # The mime type is what the renderer and the next generate treat as
+            # a card, even when the part has no envelopes yet.
+            if not has_a2ui_mime(part=part):
+                content.append(part)
+                continue
+            rewritten = True
+            text = summarize_envelopes(envelopes=envelopes_from_parts([part]))
+            if text:
+                content.append(Part(TextPart(text=text)))
+        if not rewritten:
+            messages.append(message)
+            continue
+        changed = True
+        if content:
+            messages.append(message.model_copy(update={'content': content}))
+    if not changed:
+        return request
+    return request.model_copy(update={'messages': messages})
+
+
+def summarize_envelopes(*, envelopes: list[Envelope]) -> str:
+    out: list[str] = []
+    pending: list[Envelope] = []
+
+    def flush_surface() -> None:
+        if not pending:
+            return
+        out.append('```a2ui\n' + json.dumps(pending, separators=(',', ':')) + '\n```')
+        pending.clear()
+
+    for env in envelopes:
+        if not env:
+            continue
+        action = env.get('action')
+        if isinstance(action, dict):
+            flush_surface()
+            name = action.get('name', '')
+            surface_id = action.get('surfaceId', '')
+            ctx = ''
+            context = action.get('context')
+            if isinstance(context, dict) and context:
+                ctx = ' context=' + json.dumps(context, separators=(',', ':'))
+            out.append(f'[UI action "{name}" on surface {surface_id}{ctx}]')
+        elif any(env.get(key) for key in SURFACE_KEYS):
+            pending.append(env)
+    flush_surface()
+    return '\n'.join(out)

--- a/py/packages/genkit-a2ui/src/genkit_a2ui/_middleware.py
+++ b/py/packages/genkit-a2ui/src/genkit_a2ui/_middleware.py
@@ -39,7 +39,9 @@ ABNORMAL_FINISH_REASONS = frozenset({
     FinishReason.BLOCKED,
     FinishReason.ABORTED,
     FinishReason.INTERRUPTED,
+    FinishReason.FAILED,
     FinishReason.OTHER,
+    FinishReason.UNKNOWN,
 })
 
 
@@ -61,8 +63,9 @@ class Surfaces(BaseMiddleware[SurfacesConfig]):
     """Rewrites A2UI fenced model output into data parts.
 
     On the next turn, inbound A2UI parts become text so the model can see
-    prior surfaces and button clicks. A stopped turn (blocked / cancelled /
-    aborted / other) is left alone — the stop is the result, not a salvaged card.
+    prior surfaces and button clicks. A stopped turn (blocked / interrupted /
+    aborted / failed / unknown / other) is left alone — the stop is the result,
+    not a salvaged card.
     """
 
     async def wrap_model(
@@ -169,8 +172,10 @@ class SurfaceIdReplay:
 
 
 def part_text(*, part: Part) -> str | None:
+    # Empty text is still a text part. Treating it as missing would flush an
+    # open fence and drop the card.
     root = part.root
-    if isinstance(root, TextPart) and root.text:
+    if isinstance(root, TextPart):
         return root.text
     return None
 
@@ -189,7 +194,7 @@ def rewrite_parts(*, parts: list[Part], parser: StreamParser, flush_nontext: boo
     out: list[Part] = []
     for part in parts:
         text = part_text(part=part)
-        if text:
+        if text is not None:
             segments = parser.push(text=text)
             # Keep the original part when the parser did not split or rewrite it.
             if len(segments) == 1 and not segments[0].envelopes and segments[0].prose == text:

--- a/py/packages/genkit-a2ui/src/genkit_a2ui/_parser.py
+++ b/py/packages/genkit-a2ui/src/genkit_a2ui/_parser.py
@@ -49,10 +49,11 @@ class Segment:
 
 @dataclass
 class ClosedBlock:
-    """A finished fence, or `need_more` if the closing ``` has not arrived."""
+    """A finished fence, raw prose to keep, or `need_more` if the closing ``` has not arrived."""
 
     need_more: bool = False
     envelopes: list[Envelope] | None = None
+    prose: str = ''
 
 
 class A2uiParseError(ValueError):
@@ -114,6 +115,8 @@ class StreamParser:
             if taken.envelopes:
                 flush_prose()
                 segments.append(Segment(envelopes=taken.envelopes))
+            elif taken.prose:
+                prose_buf += taken.prose
         flush_prose()
         return segments
 
@@ -148,11 +151,12 @@ class StreamParser:
                 if nl + 1 > self.block_scan:
                     self.block_scan = nl + 1
                 return ClosedBlock(need_more=True)
-            batch = self.finalize_block(raw=self.buffer)
+            raw = self.buffer
+            result = self.finalize_block(raw=raw)
             self.buffer = ''
             self.in_block = False
             self.block_scan = 0
-            return ClosedBlock(envelopes=batch)
+            return closed_block(result=result, closed=False)
 
         match_start = self.block_scan + match.start()
         match_end = self.block_scan + match.end()
@@ -160,7 +164,7 @@ class StreamParser:
         self.buffer = LEADING_NEWLINE_RE.sub('', self.buffer[match_end:], count=1)
         self.in_block = False
         self.block_scan = 0
-        return ClosedBlock(envelopes=self.finalize_block(raw=block_text))
+        return closed_block(result=self.finalize_block(raw=block_text), closed=True)
 
     def reject(self, *, message: str) -> None:
         full = f'A2UI: {message}'
@@ -170,7 +174,7 @@ class StreamParser:
             raise A2uiParseError(full)
         logger.warning('%s (dropping block/envelope)', full)
 
-    def finalize_block(self, *, raw: str) -> list[Envelope] | None:
+    def finalize_block(self, *, raw: str) -> list[Envelope] | str | None:
         surface_id = self.current_surface_id or self.surface_id()
         self.current_surface_id = ''
 
@@ -181,7 +185,10 @@ class StreamParser:
             parsed: object = json.loads(text)
         except json.JSONDecodeError as exc:
             self.reject(message=f'failed to parse envelope block as JSON: {exc}')
-            return None
+            if self.validate == 'strict':
+                return None
+            # warn / off: the caller still has the model text, even if it is not a card.
+            return raw
 
         raw_envelopes = parsed if isinstance(parsed, list) else [parsed]
         out: list[Envelope] = []
@@ -217,6 +224,8 @@ class StreamParser:
         return [create, *out]
 
     def require_root(self, *, envelopes: list[Envelope]) -> list[Envelope] | None:
+        if self.validate == 'off':
+            return envelopes
         msg = validate_root(envelopes=envelopes)
         if msg:
             self.reject(message=msg)
@@ -262,6 +271,17 @@ class StreamParser:
             if name not in self.known_components:
                 return f'component {name!r} is not in catalog {self.catalog.id!r}.'
         return ''
+
+
+def closed_block(*, result: list[Envelope] | str | None, closed: bool) -> ClosedBlock:
+    if isinstance(result, list):
+        return ClosedBlock(envelopes=result)
+    if isinstance(result, str):
+        fence = f'```a2ui\n{result}'
+        if closed:
+            fence += '\n```'
+        return ClosedBlock(prose=fence)
+    return ClosedBlock()
 
 
 def fill_placeholder_id(*, body: dict[str, object], surface_id: str) -> None:

--- a/py/packages/genkit-a2ui/src/genkit_a2ui/_parser.py
+++ b/py/packages/genkit-a2ui/src/genkit_a2ui/_parser.py
@@ -1,0 +1,319 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Incremental extractor for ```a2ui fenced blocks."""
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import cast
+
+from genkit._core._logger import get_logger
+
+from ._catalog import A2uiCatalog
+from ._types import DEFAULT_VERSION, SURFACE_ID_PLACEHOLDER, SURFACE_KEYS, Envelope, ValidateMode
+
+logger = get_logger(__name__)
+
+OPEN_FENCE_RE = re.compile(r'(?i)```a2ui[ \t]*\r?\n')
+PARTIAL_OPEN_FENCE_RE = re.compile(r'(?i)(?:`|``|```(?:a(?:2(?:u(?:i[ \t]*\r?)?)?)?)?)$')
+CLOSE_FENCE_RE = re.compile(r'^[ \t]*```', re.MULTILINE)
+LEADING_NEWLINE_RE = re.compile(r'^[ \t]*\r?\n')
+
+
+def as_object_dict(*, value: object) -> dict[str, object] | None:
+    if not isinstance(value, dict):
+        return None
+    return cast(dict[str, object], value)
+
+
+@dataclass
+class Segment:
+    prose: str = ''
+    envelopes: list[Envelope] = field(default_factory=list)
+    is_envelope: bool = False
+
+
+@dataclass
+class ParserOptions:
+    catalog: A2uiCatalog | None
+    validate: ValidateMode
+    version: str
+    surface_id: Callable[[], str]
+
+
+@dataclass
+class ClosedBlock:
+    waiting: bool = False
+    envelopes: list[Envelope] | None = None
+
+
+class A2uiParseError(ValueError):
+    """Raised in strict mode when a fence is malformed or names an unknown component."""
+
+
+class StreamParser:
+    def __init__(self, *, opts: ParserOptions) -> None:
+        self.opts = opts
+        self.buffer = ''
+        self.in_block = False
+        self.current_surface_id = ''
+        self.block_scan = 0
+        self.known_components = {c.name for c in opts.catalog.components} if opts.catalog is not None else set()
+
+    def push(self, *, text: str) -> list[Segment]:
+        self.buffer += text
+        return self.drain(final=False)
+
+    def flush(self) -> list[Segment]:
+        return self.drain(final=True)
+
+    def drain(self, *, final: bool) -> list[Segment]:
+        segments: list[Segment] = []
+        prose_buf = ''
+
+        def flush_prose() -> None:
+            nonlocal prose_buf
+            if prose_buf:
+                segments.append(Segment(prose=prose_buf))
+                prose_buf = ''
+
+        while True:
+            if not self.in_block:
+                prefix = self.take_open_fence()
+                if prefix is None:
+                    if final:
+                        prose_buf += self.buffer
+                        self.buffer = ''
+                    else:
+                        prose_buf += self.take_safe_prose()
+                    break
+                prose_buf += prefix
+                continue
+
+            taken = self.take_closed_block(final=final)
+            if taken.waiting:
+                break
+            if taken.envelopes:
+                flush_prose()
+                segments.append(Segment(envelopes=taken.envelopes, is_envelope=True))
+        flush_prose()
+        return segments
+
+    def take_open_fence(self) -> str | None:
+        match = OPEN_FENCE_RE.search(self.buffer)
+        if match is None:
+            return None
+        prefix = self.buffer[: match.start()]
+        self.buffer = self.buffer[match.end() :]
+        self.in_block = True
+        self.block_scan = 0
+        self.current_surface_id = self.opts.surface_id()
+        return prefix
+
+    def take_safe_prose(self) -> str:
+        keep = 0
+        partial = PARTIAL_OPEN_FENCE_RE.search(self.buffer)
+        if partial is not None:
+            keep = len(self.buffer) - partial.start()
+        safe_len = len(self.buffer) - keep
+        if safe_len <= 0:
+            return ''
+        taken = self.buffer[:safe_len]
+        self.buffer = self.buffer[safe_len:]
+        return taken
+
+    def take_closed_block(self, *, final: bool) -> ClosedBlock:
+        match = CLOSE_FENCE_RE.search(self.buffer[self.block_scan :])
+        if match is None:
+            if not final:
+                nl = self.buffer.rfind('\n')
+                if nl + 1 > self.block_scan:
+                    self.block_scan = nl + 1
+                return ClosedBlock(waiting=True)
+            batch = self.finalize_block(raw=self.buffer)
+            self.buffer = ''
+            self.in_block = False
+            self.block_scan = 0
+            return ClosedBlock(envelopes=batch)
+
+        match_start = self.block_scan + match.start()
+        match_end = self.block_scan + match.end()
+        block_text = self.buffer[:match_start]
+        self.buffer = LEADING_NEWLINE_RE.sub('', self.buffer[match_end:], count=1)
+        self.in_block = False
+        self.block_scan = 0
+        return ClosedBlock(envelopes=self.finalize_block(raw=block_text))
+
+    def reject(self, *, message: str) -> None:
+        full = f'A2UI: {message}'
+        if self.opts.validate == 'off':
+            return
+        if self.opts.validate == 'strict':
+            raise A2uiParseError(full)
+        logger.warning('%s (dropping block/envelope)', full)
+
+    def finalize_block(self, *, raw: str) -> list[Envelope] | None:
+        surface_id = self.current_surface_id or self.opts.surface_id()
+        self.current_surface_id = ''
+
+        text = raw.strip()
+        if not text:
+            return None
+        try:
+            parsed: object = json.loads(text)
+        except json.JSONDecodeError as exc:
+            self.reject(message=f'failed to parse envelope block as JSON: {exc}')
+            return None
+
+        raw_envelopes = parsed if isinstance(parsed, list) else [parsed]
+        out: list[Envelope] = []
+        for env in raw_envelopes:
+            normalized = self.normalize_envelope(env=env, surface_id=surface_id)
+            if normalized is not None:
+                out.append(normalized)
+        if not out:
+            return None
+
+        has_create = any('createSurface' in e for e in out)
+        if has_create:
+            for e in out:
+                force_surface_id(envelope=e, surface_id=surface_id)
+            msg = validate_root(envelopes=out)
+            if msg:
+                self.reject(message=msg)
+                return None
+            return out
+
+        target_id = surface_id
+        for e in out:
+            found = envelope_surface_id(envelope=e)
+            if found:
+                target_id = found
+                break
+        if target_id != surface_id:
+            return out
+
+        msg = validate_root(envelopes=out)
+        if msg:
+            self.reject(message=msg)
+            return None
+        catalog_id = self.opts.catalog.id if self.opts.catalog is not None else ''
+        create: Envelope = {
+            'version': self.opts.version,
+            'createSurface': {'surfaceId': surface_id, 'catalogId': catalog_id},
+        }
+        return [create, *out]
+
+    def normalize_envelope(self, *, env: object, surface_id: str) -> Envelope | None:
+        payload = as_object_dict(value=env)
+        if payload is None:
+            self.reject(message='envelope must be an object.')
+            return None
+        raw_version = payload.get('version')
+        version = raw_version if isinstance(raw_version, str) and raw_version else self.opts.version
+
+        for key in SURFACE_KEYS:
+            body = as_object_dict(value=payload.get(key))
+            if body is None:
+                continue
+            fill_placeholder_id(body=body, surface_id=surface_id)
+            if key == 'updateComponents' and self.opts.validate != 'off':
+                err = self.validate_components(components=body.get('components'))
+                if err:
+                    self.reject(message=err)
+                    return None
+            out = dict(payload)
+            out['version'] = version
+            return out
+
+        keys = ', '.join(str(k) for k in payload)
+        self.reject(message=f'unknown envelope type (keys: {keys}).')
+        return None
+
+    def validate_components(self, *, components: object) -> str:
+        if self.opts.catalog is None:
+            return ''
+        if not isinstance(components, list):
+            return 'updateComponents.components must be an array.'
+        for item in components:
+            component = as_object_dict(value=item)
+            name = component.get('component') if component is not None else None
+            if not isinstance(name, str):
+                return 'every component needs a "component" type name.'
+            if name not in self.known_components:
+                return f'component {name!r} is not in catalog {self.opts.catalog.id!r}.'
+        return ''
+
+
+def fill_placeholder_id(*, body: dict[str, object], surface_id: str) -> None:
+    sid = body.get('surfaceId')
+    if not isinstance(sid, str) or sid == '' or sid == SURFACE_ID_PLACEHOLDER:
+        body['surfaceId'] = surface_id
+
+
+def force_surface_id(*, envelope: Envelope, surface_id: str) -> None:
+    for key in SURFACE_KEYS:
+        payload = envelope.get(key)
+        if isinstance(payload, dict):
+            payload['surfaceId'] = surface_id
+            return
+
+
+def envelope_surface_id(*, envelope: Envelope) -> str:
+    for key in SURFACE_KEYS:
+        payload = envelope.get(key)
+        if isinstance(payload, dict) and isinstance(payload.get('surfaceId'), str) and payload['surfaceId']:
+            return payload['surfaceId']
+    return ''
+
+
+def validate_root(*, envelopes: list[Envelope]) -> str:
+    saw_list = False
+    for e in envelopes:
+        uc = e.get('updateComponents')
+        if not isinstance(uc, dict):
+            continue
+        arr = uc.get('components')
+        if not isinstance(arr, list):
+            continue
+        saw_list = True
+        for item in arr:
+            if isinstance(item, dict) and item.get('id') == 'root':
+                return ''
+    if not saw_list:
+        return ''
+    return 'component list must contain a component id "root".'
+
+
+def new_stream_parser(
+    *,
+    catalog: A2uiCatalog | None,
+    validate: ValidateMode,
+    version: str,
+    surface_id: Callable[[], str],
+) -> StreamParser:
+    return StreamParser(
+        opts=ParserOptions(
+            catalog=catalog,
+            validate=validate or 'warn',
+            version=version or DEFAULT_VERSION,
+            surface_id=surface_id,
+        )
+    )

--- a/py/packages/genkit-a2ui/src/genkit_a2ui/_parser.py
+++ b/py/packages/genkit-a2ui/src/genkit_a2ui/_parser.py
@@ -22,7 +22,7 @@ import json
 import re
 from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import cast
+from typing import Any, cast
 
 from genkit._core._logger import get_logger
 
@@ -32,35 +32,26 @@ from ._types import DEFAULT_VERSION, SURFACE_ID_PLACEHOLDER, SURFACE_KEYS, Envel
 logger = get_logger(__name__)
 
 OPEN_FENCE_RE = re.compile(r'(?i)```a2ui[ \t]*\r?\n')
+# Hold back a trailing `, ``, or incomplete ```a2ui so a fence split across
+# chunks is not leaked as prose.
 PARTIAL_OPEN_FENCE_RE = re.compile(r'(?i)(?:`|``|```(?:a(?:2(?:u(?:i[ \t]*\r?)?)?)?)?)$')
 CLOSE_FENCE_RE = re.compile(r'^[ \t]*```', re.MULTILINE)
 LEADING_NEWLINE_RE = re.compile(r'^[ \t]*\r?\n')
 
 
-def as_object_dict(*, value: object) -> dict[str, object] | None:
-    if not isinstance(value, dict):
-        return None
-    return cast(dict[str, object], value)
-
-
 @dataclass
 class Segment:
+    """Prose, or a finished A2UI block (`envelopes` set)."""
+
     prose: str = ''
     envelopes: list[Envelope] = field(default_factory=list)
-    is_envelope: bool = False
-
-
-@dataclass
-class ParserOptions:
-    catalog: A2uiCatalog | None
-    validate: ValidateMode
-    version: str
-    surface_id: Callable[[], str]
 
 
 @dataclass
 class ClosedBlock:
-    waiting: bool = False
+    """A finished fence, or `need_more` if the closing ``` has not arrived."""
+
+    need_more: bool = False
     envelopes: list[Envelope] | None = None
 
 
@@ -69,13 +60,23 @@ class A2uiParseError(ValueError):
 
 
 class StreamParser:
-    def __init__(self, *, opts: ParserOptions) -> None:
-        self.opts = opts
+    def __init__(
+        self,
+        *,
+        catalog: A2uiCatalog | None,
+        validate: ValidateMode,
+        version: str,
+        surface_id: Callable[[], str],
+    ) -> None:
+        self.catalog = catalog
+        self.validate = validate or 'warn'
+        self.version = version or DEFAULT_VERSION
+        self.surface_id = surface_id
         self.buffer = ''
         self.in_block = False
         self.current_surface_id = ''
         self.block_scan = 0
-        self.known_components = {c.name for c in opts.catalog.components} if opts.catalog is not None else set()
+        self.known_components = {c.name for c in catalog.components} if catalog is not None else set()
 
     def push(self, *, text: str) -> list[Segment]:
         self.buffer += text
@@ -108,11 +109,11 @@ class StreamParser:
                 continue
 
             taken = self.take_closed_block(final=final)
-            if taken.waiting:
+            if taken.need_more:
                 break
             if taken.envelopes:
                 flush_prose()
-                segments.append(Segment(envelopes=taken.envelopes, is_envelope=True))
+                segments.append(Segment(envelopes=taken.envelopes))
         flush_prose()
         return segments
 
@@ -124,7 +125,7 @@ class StreamParser:
         self.buffer = self.buffer[match.end() :]
         self.in_block = True
         self.block_scan = 0
-        self.current_surface_id = self.opts.surface_id()
+        self.current_surface_id = self.surface_id()
         return prefix
 
     def take_safe_prose(self) -> str:
@@ -146,7 +147,7 @@ class StreamParser:
                 nl = self.buffer.rfind('\n')
                 if nl + 1 > self.block_scan:
                     self.block_scan = nl + 1
-                return ClosedBlock(waiting=True)
+                return ClosedBlock(need_more=True)
             batch = self.finalize_block(raw=self.buffer)
             self.buffer = ''
             self.in_block = False
@@ -163,14 +164,14 @@ class StreamParser:
 
     def reject(self, *, message: str) -> None:
         full = f'A2UI: {message}'
-        if self.opts.validate == 'off':
+        if self.validate == 'off':
             return
-        if self.opts.validate == 'strict':
+        if self.validate == 'strict':
             raise A2uiParseError(full)
         logger.warning('%s (dropping block/envelope)', full)
 
     def finalize_block(self, *, raw: str) -> list[Envelope] | None:
-        surface_id = self.current_surface_id or self.opts.surface_id()
+        surface_id = self.current_surface_id or self.surface_id()
         self.current_surface_id = ''
 
         text = raw.strip()
@@ -191,50 +192,51 @@ class StreamParser:
         if not out:
             return None
 
-        has_create = any('createSurface' in e for e in out)
-        if has_create:
+        if any('createSurface' in e for e in out):
+            # New card. Stamp the minted id so we don't reuse one the model
+            # copied from a prior surface in history.
             for e in out:
                 force_surface_id(envelope=e, surface_id=surface_id)
-            msg = validate_root(envelopes=out)
-            if msg:
-                self.reject(message=msg)
-                return None
+            return self.require_root(envelopes=out)
+
+        existing_id = next((envelope_surface_id(envelope=e) for e in out if envelope_surface_id(envelope=e)), '')
+        if existing_id and existing_id != surface_id:
+            # Update to a surface the model already knows. Don't invent a
+            # createSurface — that would wipe the card the click landed on.
             return out
 
-        target_id = surface_id
-        for e in out:
-            found = envelope_surface_id(envelope=e)
-            if found:
-                target_id = found
-                break
-        if target_id != surface_id:
-            return out
-
-        msg = validate_root(envelopes=out)
-        if msg:
-            self.reject(message=msg)
+        # New card that omitted createSurface. Add one so the client has a
+        # surface to paint before the updates land.
+        if self.require_root(envelopes=out) is None:
             return None
-        catalog_id = self.opts.catalog.id if self.opts.catalog is not None else ''
+        catalog_id = self.catalog.id if self.catalog is not None else ''
         create: Envelope = {
-            'version': self.opts.version,
+            'version': self.version,
             'createSurface': {'surfaceId': surface_id, 'catalogId': catalog_id},
         }
         return [create, *out]
 
+    def require_root(self, *, envelopes: list[Envelope]) -> list[Envelope] | None:
+        msg = validate_root(envelopes=envelopes)
+        if msg:
+            self.reject(message=msg)
+            return None
+        return envelopes
+
     def normalize_envelope(self, *, env: object, surface_id: str) -> Envelope | None:
-        payload = as_object_dict(value=env)
-        if payload is None:
+        if not isinstance(env, dict):
             self.reject(message='envelope must be an object.')
             return None
+        payload = cast(dict[str, Any], env)
         raw_version = payload.get('version')
-        version = raw_version if isinstance(raw_version, str) and raw_version else self.opts.version
+        version = raw_version if isinstance(raw_version, str) and raw_version else self.version
 
         for key in SURFACE_KEYS:
-            body = as_object_dict(value=payload.get(key))
-            if body is None:
+            body = payload.get(key)
+            if not isinstance(body, dict):
                 continue
             fill_placeholder_id(body=body, surface_id=surface_id)
-            if key == 'updateComponents' and self.opts.validate != 'off':
+            if key == 'updateComponents' and self.validate != 'off':
                 err = self.validate_components(components=body.get('components'))
                 if err:
                     self.reject(message=err)
@@ -248,17 +250,17 @@ class StreamParser:
         return None
 
     def validate_components(self, *, components: object) -> str:
-        if self.opts.catalog is None:
+        if self.catalog is None:
             return ''
         if not isinstance(components, list):
             return 'updateComponents.components must be an array.'
         for item in components:
-            component = as_object_dict(value=item)
-            name = component.get('component') if component is not None else None
+            row = cast(dict[str, Any], item) if isinstance(item, dict) else None
+            name = row.get('component') if row is not None else None
             if not isinstance(name, str):
                 return 'every component needs a "component" type name.'
             if name not in self.known_components:
-                return f'component {name!r} is not in catalog {self.opts.catalog.id!r}.'
+                return f'component {name!r} is not in catalog {self.catalog.id!r}.'
         return ''
 
 
@@ -300,20 +302,3 @@ def validate_root(*, envelopes: list[Envelope]) -> str:
     if not saw_list:
         return ''
     return 'component list must contain a component id "root".'
-
-
-def new_stream_parser(
-    *,
-    catalog: A2uiCatalog | None,
-    validate: ValidateMode,
-    version: str,
-    surface_id: Callable[[], str],
-) -> StreamParser:
-    return StreamParser(
-        opts=ParserOptions(
-            catalog=catalog,
-            validate=validate or 'warn',
-            version=version or DEFAULT_VERSION,
-            surface_id=surface_id,
-        )
-    )

--- a/py/packages/genkit-a2ui/src/genkit_a2ui/_part.py
+++ b/py/packages/genkit-a2ui/src/genkit_a2ui/_part.py
@@ -1,0 +1,60 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""A2UI data-part helpers."""
+
+from __future__ import annotations
+
+from genkit._core._typing import DataPart, Part
+
+from ._types import A2UI_MIME_TYPE, Envelope
+
+
+def a2ui_part(envelopes: list[Envelope]) -> Part:
+    return Part(DataPart(data={'envelopes': envelopes}, metadata={'mimeType': A2UI_MIME_TYPE}))
+
+
+def has_a2ui_mime(*, part: Part) -> bool:
+    root = part.root
+    if not isinstance(root, DataPart):
+        return False
+    metadata = root.metadata or {}
+    return metadata.get('mimeType') == A2UI_MIME_TYPE
+
+
+def is_a2ui_part(part: Part) -> bool:
+    if not has_a2ui_mime(part=part):
+        return False
+    data = part.root.data
+    return isinstance(data, dict) and 'envelopes' in data
+
+
+def envelopes_from_parts(parts: list[Part] | None) -> list[Envelope]:
+    if not parts:
+        return []
+    out: list[Envelope] = []
+    for part in parts:
+        if not is_a2ui_part(part):
+            continue
+        data = part.root.data
+        assert isinstance(data, dict)
+        raw = data.get('envelopes')
+        if not isinstance(raw, list):
+            continue
+        for item in raw:
+            if isinstance(item, dict):
+                out.append(item)
+    return out

--- a/py/packages/genkit-a2ui/src/genkit_a2ui/_types.py
+++ b/py/packages/genkit-a2ui/src/genkit_a2ui/_types.py
@@ -19,6 +19,8 @@
 from typing import Any, Literal
 
 A2UI_MIME_TYPE = 'application/a2ui+json'
+A2UI_CATALOG_VALUE_TYPE = 'a2ui-catalog'
+DEFAULT_CATALOG_ID = 'basic'
 DEFAULT_VERSION = 'v0.9'
 SupportedVersion = Literal['v0.9', 'v0.9.1']
 BASIC_CATALOG_ID = 'https://a2ui.org/specification/v0_9/catalogs/basic/catalog.json'

--- a/py/packages/genkit-a2ui/src/genkit_a2ui/_types.py
+++ b/py/packages/genkit-a2ui/src/genkit_a2ui/_types.py
@@ -1,0 +1,30 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""A2UI protocol constants and shared shapes."""
+
+from typing import Any, Literal
+
+A2UI_MIME_TYPE = 'application/a2ui+json'
+DEFAULT_VERSION = 'v0.9'
+SupportedVersion = Literal['v0.9', 'v0.9.1']
+BASIC_CATALOG_ID = 'https://a2ui.org/specification/v0_9/catalogs/basic/catalog.json'
+SURFACE_ID_PLACEHOLDER = 'SURFACE_ID'
+
+ValidateMode = Literal['strict', 'warn', 'off']
+Envelope = dict[str, Any]
+
+SURFACE_KEYS = ('createSurface', 'updateComponents', 'updateDataModel', 'deleteSurface')

--- a/py/packages/genkit-a2ui/tests/catalog_loader_test.py
+++ b/py/packages/genkit-a2ui/tests/catalog_loader_test.py
@@ -208,6 +208,32 @@ def test_load_catalog_same_catalog_twice_is_ok() -> None:
     assert load_catalog(ai, BANNER_CATALOG) == BANNER_CATALOG
 
 
+def test_load_catalog_raises_when_id_already_holds_something_else() -> None:
+    ai, _ = setup()
+    ai.registry.register_value(A2UI_CATALOG_VALUE_TYPE, BANNER_CATALOG.id, 'not-a-catalog')
+    with pytest.raises(ValueError, match='is not a catalog'):
+        load_catalog(ai, BANNER_CATALOG)
+
+
+def test_load_catalog_file_names_the_path_when_the_file_is_not_utf8(tmp_path: Path) -> None:
+    ai, _ = setup()
+    path = tmp_path / 'catalog.json'
+    path.write_bytes(b'\xff\xfe not utf-8')
+    with pytest.raises(ValueError, match=str(path)) as exc_info:
+        load_catalog_file(ai, str(path))
+    assert isinstance(exc_info.value.__cause__, UnicodeDecodeError)
+
+
+def test_load_catalog_file_names_the_path_when_a_component_has_no_name(tmp_path: Path) -> None:
+    path = tmp_path / 'catalog.json'
+    path.write_text(
+        json.dumps({'id': BANNER_CATALOG.id, 'components': [{'description': 'no name'}]}),
+        encoding='utf-8',
+    )
+    with pytest.raises(ValueError, match=str(path)):
+        load_catalog_file(setup()[0], str(path))
+
+
 def test_a2ui_catalog_is_a_registry_id_string() -> None:
     assert Surfaces(catalog=BANNER_CATALOG.id).config.catalog == BANNER_CATALOG.id
 

--- a/py/packages/genkit-a2ui/tests/catalog_loader_test.py
+++ b/py/packages/genkit-a2ui/tests/catalog_loader_test.py
@@ -1,0 +1,225 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Pins: load a catalog, generate against it, and list it for the Developer UI."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from genkit_a2ui import (
+    A2UI_CATALOG_VALUE_TYPE,
+    A2uiCatalog,
+    A2uiCatalogComponent,
+    A2uiParseError,
+    Surfaces,
+    SurfacesConfig,
+    load_catalog,
+    load_catalog_file,
+    register_basic_catalog,
+)
+from helpers import (
+    BASIC_CATALOG_ID,
+    assert_finished_message,
+    create_surface_ids,
+    envelopes,
+    fence_block,
+    model_ok,
+    request_system_text,
+    setup,
+    weather_fence,
+)
+from pydantic import ValidationError
+
+BANNER_CATALOG = A2uiCatalog(
+    id='https://example.com/catalogs/banner.json',
+    components=(A2uiCatalogComponent(name='Banner', description='A banner.', props='title: string.'),),
+)
+
+
+def banner_fence(*, catalog_id: str = BANNER_CATALOG.id) -> str:
+    return fence_block([
+        {'createSurface': {'surfaceId': 'SURFACE_ID', 'catalogId': catalog_id}},
+        {
+            'updateComponents': {
+                'surfaceId': 'SURFACE_ID',
+                'components': [{'id': 'root', 'component': 'Banner', 'title': 'hi'}],
+            }
+        },
+    ])
+
+
+@pytest.mark.asyncio
+async def test_generate_uses_the_bundled_catalog_when_nothing_is_registered() -> None:
+    ai, pm = setup()
+    pm.responses = [model_ok(weather_fence())]
+
+    response = await ai.generate(model='programmableModel', prompt='weather', use=[Surfaces()])
+    message = assert_finished_message(response)
+    assert create_surface_ids(message.content)
+    assert '- Text:' in request_system_text(pm)
+    assert '- Banner:' not in request_system_text(pm)
+
+
+@pytest.mark.asyncio
+async def test_generate_uses_a_loaded_catalog() -> None:
+    ai, pm = setup()
+    load_catalog(ai, BANNER_CATALOG)
+    pm.responses = [model_ok(banner_fence())]
+
+    response = await ai.generate(
+        model='programmableModel',
+        prompt='banner',
+        use=[Surfaces(catalog=BANNER_CATALOG.id)],
+    )
+    message = assert_finished_message(response)
+    assert any(env.get('createSurface', {}).get('catalogId') == BANNER_CATALOG.id for env in envelopes(message.content))
+    assert '- Banner:' in request_system_text(pm)
+    assert '- Text:' not in request_system_text(pm)
+
+
+@pytest.mark.asyncio
+async def test_generate_default_stays_basic_when_a_custom_catalog_is_registered() -> None:
+    ai, pm = setup()
+    load_catalog(ai, BANNER_CATALOG)
+    pm.responses = [model_ok(weather_fence())]
+
+    response = await ai.generate(model='programmableModel', prompt='weather', use=[Surfaces()])
+    message = assert_finished_message(response)
+    assert create_surface_ids(message.content)
+    assert '- Text:' in request_system_text(pm)
+    assert '- Banner:' not in request_system_text(pm)
+
+
+@pytest.mark.asyncio
+async def test_generate_unknown_catalog_fails_before_the_model() -> None:
+    ai, pm = setup()
+    pm.responses = [model_ok(weather_fence())]
+
+    with pytest.raises(ValueError, match='no catalog registered'):
+        await ai.generate(
+            model='programmableModel',
+            prompt='banner',
+            use=[Surfaces(catalog=BANNER_CATALOG.id)],
+        )
+    assert pm.last_request is None
+
+
+@pytest.mark.asyncio
+async def test_generate_catalog_basic_falls_back_without_register() -> None:
+    ai, pm = setup()
+    pm.responses = [model_ok(weather_fence())]
+
+    response = await ai.generate(model='programmableModel', prompt='weather', use=[Surfaces(catalog='basic')])
+    message = assert_finished_message(response)
+    assert create_surface_ids(message.content)
+
+
+@pytest.mark.asyncio
+async def test_generate_strict_rejects_a_component_the_loaded_catalog_lacks() -> None:
+    ai, pm = setup()
+    load_catalog(ai, BANNER_CATALOG)
+    pm.responses = [model_ok(weather_fence())]
+
+    with pytest.raises(A2uiParseError, match='not in catalog'):
+        await ai.generate(
+            model='programmableModel',
+            prompt='weather',
+            use=[Surfaces(catalog=BANNER_CATALOG.id, validate='strict')],
+        )
+
+
+@pytest.mark.asyncio
+async def test_generate_warn_drops_a_component_the_loaded_catalog_lacks() -> None:
+    ai, pm = setup()
+    load_catalog(ai, BANNER_CATALOG)
+    pm.responses = [model_ok(weather_fence())]
+
+    response = await ai.generate(
+        model='programmableModel',
+        prompt='weather',
+        use=[Surfaces(catalog=BANNER_CATALOG.id)],
+    )
+    message = assert_finished_message(response)
+    # createSurface can still land; the unknown-component update does not.
+    assert not any('updateComponents' in env for env in envelopes(message.content))
+
+
+def test_load_catalog_appears_in_the_registry_the_dev_ui_lists() -> None:
+    ai, _ = setup()
+    load_catalog(ai, BANNER_CATALOG)
+    listed = ai.registry.list_values(A2UI_CATALOG_VALUE_TYPE)
+    assert BANNER_CATALOG.id in listed
+    assert listed[BANNER_CATALOG.id] == BANNER_CATALOG.as_value()
+
+
+def test_register_basic_catalog_appears_in_the_registry_the_dev_ui_lists() -> None:
+    ai, _ = setup()
+    register_basic_catalog(ai)
+    listed = ai.registry.list_values(A2UI_CATALOG_VALUE_TYPE)
+    assert BASIC_CATALOG_ID in listed
+    basic = listed[BASIC_CATALOG_ID]
+    assert isinstance(basic, dict)
+    components = basic.get('components')
+    assert isinstance(components, list)
+    assert 'Text' in {item['name'] for item in components if isinstance(item, dict)}
+
+
+def test_load_catalog_file_registers_and_returns_the_catalog(tmp_path: Path) -> None:
+    ai, _ = setup()
+    path = tmp_path / 'catalog.json'
+    path.write_text(json.dumps(BANNER_CATALOG.as_value()), encoding='utf-8')
+    loaded = load_catalog_file(ai, str(path))
+    assert loaded == BANNER_CATALOG
+    assert ai.registry.lookup_value(A2UI_CATALOG_VALUE_TYPE, BANNER_CATALOG.id) == BANNER_CATALOG.as_value()
+
+
+def test_load_catalog_same_id_keeps_the_first() -> None:
+    ai, _ = setup()
+    load_catalog(ai, BANNER_CATALOG)
+    other = A2uiCatalog(
+        id=BANNER_CATALOG.id,
+        components=(A2uiCatalogComponent(name='Other', description='x', props='y'),),
+    )
+    kept = load_catalog(ai, other)
+    assert kept == BANNER_CATALOG
+    stored = A2uiCatalog.from_value(ai.registry.lookup_value(A2UI_CATALOG_VALUE_TYPE, BANNER_CATALOG.id))
+    assert stored == BANNER_CATALOG
+
+
+def test_load_catalog_same_catalog_twice_is_ok() -> None:
+    ai, _ = setup()
+    assert load_catalog(ai, BANNER_CATALOG) == BANNER_CATALOG
+    assert load_catalog(ai, BANNER_CATALOG) == BANNER_CATALOG
+
+
+def test_a2ui_catalog_is_a_registry_id_string() -> None:
+    assert Surfaces(catalog=BANNER_CATALOG.id).config.catalog == BANNER_CATALOG.id
+
+
+def test_a2ui_catalog_object_is_not_a_knob() -> None:
+    with pytest.raises(ValidationError):
+        Surfaces(catalog=BANNER_CATALOG)
+
+
+def test_a2ui_config_schema_lists_catalog_as_a_string() -> None:
+    """The Developer UI picks a registered catalog by the same id generate uses."""
+    props = SurfacesConfig.model_json_schema().get('properties', {})
+    schema = props['catalog']
+    types = {schema.get('type')} | {opt.get('type') for opt in schema.get('anyOf', [])}
+    assert 'string' in types

--- a/py/packages/genkit-a2ui/tests/conftest.py
+++ b/py/packages/genkit-a2ui/tests/conftest.py
@@ -1,0 +1,24 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Put this test dir on sys.path so sibling helper imports resolve."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))

--- a/py/packages/genkit-a2ui/tests/generate_a2ui_inbound_test.py
+++ b/py/packages/genkit-a2ui/tests/generate_a2ui_inbound_test.py
@@ -19,7 +19,7 @@
 from __future__ import annotations
 
 import pytest
-from genkit_a2ui import A2UI_MIME_TYPE, A2ui
+from genkit_a2ui import A2UI_MIME_TYPE, Surfaces
 from helpers import (
     A2UI_FENCE,
     BASIC_CATALOG_ID,
@@ -68,7 +68,7 @@ async def test_generate_a2ui_sends_click_to_model_as_text() -> None:
                 ],
             )
         ],
-        use=[A2ui()],
+        use=[Surfaces()],
     )
 
     assert not request_has_a2ui_part(pm)
@@ -113,7 +113,7 @@ async def test_generate_a2ui_replays_prior_surface_as_fence() -> None:
             ),
             Message(role=Role.USER, content=[text_part('thanks')]),
         ],
-        use=[A2ui()],
+        use=[Surfaces()],
     )
 
     assert not request_has_a2ui_part(pm)
@@ -166,7 +166,7 @@ async def test_generate_a2ui_splits_replayed_surfaces_around_a_click() -> None:
                 ],
             )
         ],
-        use=[A2ui()],
+        use=[Surfaces()],
     )
 
     assert not request_has_a2ui_part(pm)
@@ -190,7 +190,7 @@ async def test_generate_a2ui_empty_ui_message_keeps_placeholder_before_model() -
             Message(role=Role.MODEL, content=[a2ui_data_part([])]),
             Message(role=Role.USER, content=[text_part('hi')]),
         ],
-        use=[A2ui()],
+        use=[Surfaces()],
     )
 
     assert not request_has_a2ui_part(pm)
@@ -221,7 +221,7 @@ async def test_generate_a2ui_keeps_neighbor_text_when_rewriting_ui() -> None:
             ),
             Message(role=Role.USER, content=[text_part('thanks')]),
         ],
-        use=[A2ui()],
+        use=[Surfaces()],
     )
 
     assert not request_has_a2ui_part(pm)
@@ -256,7 +256,7 @@ async def test_generate_a2ui_new_surface_does_not_reuse_history_id() -> None:
             ),
             Message(role=Role.USER, content=[text_part(WEATHER_PROMPT)]),
         ],
-        use=[A2ui(surface_id='sfc-new')],
+        use=[Surfaces(surface_id='sfc-new')],
     )
     message = assert_finished_message(response)
     ids = create_surface_ids(message.content)
@@ -281,7 +281,7 @@ async def test_generate_a2ui_drops_bare_a2ui_mime_part() -> None:
                 ],
             )
         ],
-        use=[A2ui()],
+        use=[Surfaces()],
     )
 
     assert not request_has_a2ui_part(pm)

--- a/py/packages/genkit-a2ui/tests/generate_a2ui_inbound_test.py
+++ b/py/packages/genkit-a2ui/tests/generate_a2ui_inbound_test.py
@@ -1,0 +1,289 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""L2 pins: the next model request sees text, never ``application/a2ui+json``."""
+
+from __future__ import annotations
+
+import pytest
+from genkit_a2ui import A2UI_MIME_TYPE, A2ui
+from helpers import (
+    A2UI_FENCE,
+    BASIC_CATALOG_ID,
+    WEATHER_PROMPT,
+    a2ui_data_part,
+    assert_finished_message,
+    create_surface_ids,
+    joined_text,
+    model_ok,
+    request_has_a2ui_part,
+    request_history_messages,
+    request_joined_text,
+    setup,
+    text_part,
+    weather_fence,
+)
+
+from genkit import Message, Part
+from genkit._core._typing import DataPart, Role
+
+
+@pytest.mark.asyncio
+async def test_generate_a2ui_sends_click_to_model_as_text() -> None:
+    """A button click reaches the model as text, not as an A2UI data part."""
+    ai, pm = setup()
+    pm.responses = [model_ok()]
+
+    await ai.generate(
+        model='programmableModel',
+        messages=[
+            Message(
+                role=Role.USER,
+                content=[
+                    text_part('User interacted with the UI…'),
+                    a2ui_data_part([
+                        {
+                            'action': {
+                                'name': 'refresh',
+                                'surfaceId': 's1',
+                                'sourceComponentId': 'btn',
+                                'timestamp': 't',
+                                'context': {'city': 'Tokyo'},
+                            }
+                        }
+                    ]),
+                ],
+            )
+        ],
+        use=[A2ui()],
+    )
+
+    assert not request_has_a2ui_part(pm)
+    joined = request_joined_text(pm)
+    assert 'UI action "refresh"' in joined
+    assert 's1' in joined
+    assert 'Tokyo' in joined
+    for message in request_history_messages(pm):
+        assert message.content
+
+
+@pytest.mark.asyncio
+async def test_generate_a2ui_replays_prior_surface_as_fence() -> None:
+    """A prior surface is replayed as an a2ui fence with the same surface id."""
+    ai, pm = setup()
+    pm.responses = [model_ok()]
+
+    await ai.generate(
+        model='programmableModel',
+        messages=[
+            Message(
+                role=Role.MODEL,
+                content=[
+                    text_part('Here you go:'),
+                    a2ui_data_part([
+                        {
+                            'version': 'v0.9',
+                            'createSurface': {
+                                'surfaceId': 's1',
+                                'catalogId': BASIC_CATALOG_ID,
+                            },
+                        },
+                        {
+                            'version': 'v0.9',
+                            'updateComponents': {
+                                'surfaceId': 's1',
+                                'components': [{'id': 'root', 'component': 'Text', 'text': 'hi'}],
+                            },
+                        },
+                    ]),
+                ],
+            ),
+            Message(role=Role.USER, content=[text_part('thanks')]),
+        ],
+        use=[A2ui()],
+    )
+
+    assert not request_has_a2ui_part(pm)
+    joined = request_joined_text(pm)
+    assert A2UI_FENCE in joined
+    assert 'createSurface' in joined
+    assert 'Here you go:' in joined
+    assert '[rendered UI surface]' not in joined
+    assert 's1' in joined
+    for message in request_history_messages(pm):
+        assert message.content
+
+
+@pytest.mark.asyncio
+async def test_generate_a2ui_splits_replayed_surfaces_around_a_click() -> None:
+    """Surfaces stay one fence until a click; the click is its own text line."""
+    ai, pm = setup()
+    pm.responses = [model_ok()]
+
+    await ai.generate(
+        model='programmableModel',
+        messages=[
+            Message(
+                role=Role.USER,
+                content=[
+                    a2ui_data_part([
+                        {'createSurface': {'surfaceId': 's1', 'catalogId': BASIC_CATALOG_ID}},
+                        {
+                            'updateComponents': {
+                                'surfaceId': 's1',
+                                'components': [{'id': 'root', 'component': 'Text', 'text': 'one'}],
+                            }
+                        },
+                        {
+                            'action': {
+                                'name': 'refresh',
+                                'surfaceId': 's1',
+                                'sourceComponentId': 'btn',
+                                'timestamp': 't',
+                            }
+                        },
+                        {'createSurface': {'surfaceId': 's2', 'catalogId': BASIC_CATALOG_ID}},
+                        {
+                            'updateComponents': {
+                                'surfaceId': 's2',
+                                'components': [{'id': 'root', 'component': 'Text', 'text': 'two'}],
+                            }
+                        },
+                    ])
+                ],
+            )
+        ],
+        use=[A2ui()],
+    )
+
+    assert not request_has_a2ui_part(pm)
+    joined = request_joined_text(pm)
+    assert joined.count(A2UI_FENCE) == 2
+    assert 'UI action "refresh"' in joined
+    assert joined.index(A2UI_FENCE) < joined.index('UI action')
+    for message in request_history_messages(pm):
+        assert message.content
+
+
+@pytest.mark.asyncio
+async def test_generate_a2ui_drops_empty_ui_message_before_model() -> None:
+    """A message that is only an empty A2UI part is omitted, not sent as empty content."""
+    ai, pm = setup()
+    pm.responses = [model_ok()]
+
+    await ai.generate(
+        model='programmableModel',
+        messages=[
+            Message(role=Role.MODEL, content=[a2ui_data_part([])]),
+            Message(role=Role.USER, content=[text_part('hi')]),
+        ],
+        use=[A2ui()],
+    )
+
+    assert not request_has_a2ui_part(pm)
+    messages = request_history_messages(pm)
+    assert all(message.content for message in messages)
+    assert any(joined_text(message.content) == 'hi' for message in messages)
+    assert not any(message.role == Role.MODEL and not joined_text(message.content) for message in messages)
+
+
+@pytest.mark.asyncio
+async def test_generate_a2ui_keeps_neighbor_text_when_rewriting_ui() -> None:
+    """Text on the same message as an A2UI part is kept when the part is rewritten."""
+    ai, pm = setup()
+    pm.responses = [model_ok()]
+
+    await ai.generate(
+        model='programmableModel',
+        messages=[
+            Message(
+                role=Role.MODEL,
+                content=[
+                    text_part('Here you go:'),
+                    a2ui_data_part([
+                        {'createSurface': {'surfaceId': 's1', 'catalogId': BASIC_CATALOG_ID}},
+                    ]),
+                ],
+            ),
+            Message(role=Role.USER, content=[text_part('thanks')]),
+        ],
+        use=[A2ui()],
+    )
+
+    assert not request_has_a2ui_part(pm)
+    joined = request_joined_text(pm)
+    assert 'Here you go:' in joined
+    assert A2UI_FENCE in joined
+    for message in request_history_messages(pm):
+        assert message.content
+
+
+@pytest.mark.asyncio
+async def test_generate_a2ui_new_surface_does_not_reuse_history_id() -> None:
+    """A new card after a prior surface s1 does not reuse s1."""
+    ai, pm = setup()
+    pm.responses = [model_ok(weather_fence())]
+
+    response = await ai.generate(
+        model='programmableModel',
+        messages=[
+            Message(
+                role=Role.MODEL,
+                content=[
+                    a2ui_data_part([
+                        {
+                            'createSurface': {
+                                'surfaceId': 's1',
+                                'catalogId': BASIC_CATALOG_ID,
+                            }
+                        }
+                    ])
+                ],
+            ),
+            Message(role=Role.USER, content=[text_part(WEATHER_PROMPT)]),
+        ],
+        use=[A2ui(surface_id='sfc-new')],
+    )
+    message = assert_finished_message(response)
+    ids = create_surface_ids(message.content)
+    assert ids == ['sfc-new']
+    assert 's1' not in ids
+
+
+@pytest.mark.asyncio
+async def test_generate_a2ui_drops_bare_a2ui_mime_part() -> None:
+    """A data part with the A2UI mime type but no envelopes is not sent to the model."""
+    ai, pm = setup()
+    pm.responses = [model_ok()]
+
+    await ai.generate(
+        model='programmableModel',
+        messages=[
+            Message(
+                role=Role.USER,
+                content=[
+                    text_part('hi'),
+                    Part(DataPart(data={'garbage': True}, metadata={'mimeType': A2UI_MIME_TYPE})),
+                ],
+            )
+        ],
+        use=[A2ui()],
+    )
+
+    assert not request_has_a2ui_part(pm)
+    assert 'hi' in request_joined_text(pm)
+    for message in request_history_messages(pm):
+        assert message.content

--- a/py/packages/genkit-a2ui/tests/generate_a2ui_inbound_test.py
+++ b/py/packages/genkit-a2ui/tests/generate_a2ui_inbound_test.py
@@ -179,8 +179,8 @@ async def test_generate_a2ui_splits_replayed_surfaces_around_a_click() -> None:
 
 
 @pytest.mark.asyncio
-async def test_generate_a2ui_drops_empty_ui_message_before_model() -> None:
-    """A message that is only an empty A2UI part is omitted, not sent as empty content."""
+async def test_generate_a2ui_empty_ui_message_keeps_placeholder_before_model() -> None:
+    """A message that is only an empty A2UI part is preserved with a [UI] placeholder."""
     ai, pm = setup()
     pm.responses = [model_ok()]
 
@@ -196,8 +196,9 @@ async def test_generate_a2ui_drops_empty_ui_message_before_model() -> None:
     assert not request_has_a2ui_part(pm)
     messages = request_history_messages(pm)
     assert all(message.content for message in messages)
+    assert any(joined_text(message.content) == '[UI]' for message in messages)
     assert any(joined_text(message.content) == 'hi' for message in messages)
-    assert not any(message.role == Role.MODEL and not joined_text(message.content) for message in messages)
+    assert len([m for m in messages if m.role == Role.MODEL]) == 1
 
 
 @pytest.mark.asyncio

--- a/py/packages/genkit-a2ui/tests/generate_a2ui_test.py
+++ b/py/packages/genkit-a2ui/tests/generate_a2ui_test.py
@@ -18,6 +18,7 @@
 
 from __future__ import annotations
 
+import json
 from typing import Any
 
 import pytest
@@ -151,11 +152,14 @@ async def test_generate_a2ui_stream_and_final_share_surface_id() -> None:
 async def test_generate_a2ui_flushes_open_fence_at_end_of_turn() -> None:
     """An unterminated fence still reaches the stream when the turn ends."""
     ai, pm = setup()
-    unterminated = (
-        '```a2ui\n'
-        '[{ "updateComponents": { "surfaceId": "SURFACE_ID", '
-        '"components": [{ "id": "root", "component": "Text", "text": "hi" }] } }]'
-    )
+    unterminated = '```a2ui\n' + json.dumps([
+        {
+            'updateComponents': {
+                'surfaceId': 'SURFACE_ID',
+                'components': [{'id': 'root', 'component': 'Text', 'text': 'hi'}],
+            }
+        }
+    ])
     pm.responses = [model_ok(unterminated)]
     pm.chunks = [[ModelResponseChunk(role=Role.MODEL, content=[text_part(unterminated)])]]
 

--- a/py/packages/genkit-a2ui/tests/generate_a2ui_test.py
+++ b/py/packages/genkit-a2ui/tests/generate_a2ui_test.py
@@ -1,0 +1,467 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""L1 pins: a finished ``ai.generate(..., use=[A2ui()])`` returns data parts, not fences."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from genkit_a2ui import A2ui, A2uiParseError
+from helpers import (
+    WEATHER_PROMPT,
+    a2ui_parts,
+    assert_finished_message,
+    assert_no_a2ui_parts,
+    assert_no_fence_in_text,
+    bad_component_fence,
+    broken_fence,
+    create_surface_ids,
+    envelopes,
+    fence_only,
+    joined_text,
+    model_ok,
+    no_root_fence,
+    request_system_text,
+    setup,
+    text_part,
+    weather_fence,
+)
+from pydantic import ValidationError
+
+from genkit import Message, ModelResponse, ModelResponseChunk
+from genkit._core._typing import Candidate, FinishReason, Role
+
+
+@pytest.mark.asyncio
+async def test_generate_a2ui_rewrites_fence_to_data_part() -> None:
+    """A finished weather turn returns a data part; the fence is gone from text."""
+    ai, pm = setup()
+    fence = weather_fence()
+    pm.responses = [model_ok(fence)]
+
+    response = await ai.generate(model='programmableModel', prompt=WEATHER_PROMPT, use=[A2ui()])
+    message = assert_finished_message(response)
+    assert envelopes(message.content)
+    assert create_surface_ids(message.content)
+    assert 'Here is the weather:' in joined_text(message.content)
+    assert_no_fence_in_text(message.content)
+
+
+@pytest.mark.asyncio
+async def test_generate_a2ui_leaves_plain_prose_untouched() -> None:
+    """A turn with no A2UI fence stays plain text and grows no data part."""
+    ai, pm = setup()
+    pm.responses = [model_ok('just chatting')]
+
+    response = await ai.generate(model='programmableModel', prompt='hi', use=[A2ui()])
+    message = assert_finished_message(response)
+    assert_no_a2ui_parts(message.content)
+    assert joined_text(message.content) == 'just chatting'
+    assert response.text == 'just chatting'
+
+
+@pytest.mark.asyncio
+async def test_generate_a2ui_fence_only_returns_data_part() -> None:
+    """A fence with no surrounding prose still becomes a data part."""
+    ai, pm = setup()
+    pm.responses = [model_ok(fence_only())]
+
+    response = await ai.generate(model='programmableModel', prompt=WEATHER_PROMPT, use=[A2ui()])
+    message = assert_finished_message(response)
+    assert envelopes(message.content)
+    assert_no_fence_in_text(message.content)
+
+
+@pytest.mark.asyncio
+async def test_generate_a2ui_stitches_fence_split_across_parts() -> None:
+    """A fence split across several final text parts becomes one data part."""
+    ai, pm = setup()
+    fence = weather_fence()
+    mid = len(fence) // 2
+    pm.responses = [
+        ModelResponse(
+            finish_reason=FinishReason.STOP,
+            message=Message(
+                role=Role.MODEL,
+                content=[text_part(fence[:mid]), text_part(fence[mid:])],
+            ),
+        )
+    ]
+
+    response = await ai.generate(model='programmableModel', prompt=WEATHER_PROMPT, use=[A2ui()])
+    message = assert_finished_message(response)
+    assert len(a2ui_parts(message.content)) == 1
+    assert envelopes(message.content)
+    assert_no_fence_in_text(message.content)
+
+
+@pytest.mark.asyncio
+async def test_generate_a2ui_keeps_prose_on_both_sides_of_part() -> None:
+    """Prose before and after the fence stays in order around the data part."""
+    ai, pm = setup()
+    body = weather_fence().replace('Here is the weather:\n', '')
+    pm.responses = [model_ok(f'intro\n{body}outro')]
+
+    response = await ai.generate(model='programmableModel', prompt=WEATHER_PROMPT, use=[A2ui()])
+    message = assert_finished_message(response)
+    content = message.content
+    assert len(content) == 3
+    assert 'intro' in joined_text([content[0]])
+    assert a2ui_parts([content[1]])
+    assert 'outro' in joined_text([content[2]])
+    assert_no_fence_in_text(message.content)
+
+
+@pytest.mark.asyncio
+async def test_generate_a2ui_stream_and_final_share_surface_id() -> None:
+    """Streamed chunks and the final message mint the same surface id."""
+    ai, pm = setup()
+    fence = weather_fence()
+    pm.responses = [model_ok(fence)]
+    pm.chunks = [[ModelResponseChunk(role=Role.MODEL, content=[text_part(fence)])]]
+
+    stream = ai.generate_stream(model='programmableModel', prompt=WEATHER_PROMPT, use=[A2ui()])
+    streamed: list[str] = []
+    async for chunk in stream.stream:
+        streamed.extend(create_surface_ids(chunk.content))
+    response = await stream.response
+    message = assert_finished_message(response)
+    final_ids = create_surface_ids(message.content)
+    assert streamed
+    assert final_ids
+    assert streamed[0] == final_ids[0]
+
+
+@pytest.mark.asyncio
+async def test_generate_a2ui_flushes_open_fence_at_end_of_turn() -> None:
+    """An unterminated fence still reaches the stream when the turn ends."""
+    ai, pm = setup()
+    unterminated = (
+        '```a2ui\n'
+        '[{ "updateComponents": { "surfaceId": "SURFACE_ID", '
+        '"components": [{ "id": "root", "component": "Text", "text": "hi" }] } }]'
+    )
+    pm.responses = [model_ok(unterminated)]
+    pm.chunks = [[ModelResponseChunk(role=Role.MODEL, content=[text_part(unterminated)])]]
+
+    stream = ai.generate_stream(
+        model='programmableModel',
+        prompt=WEATHER_PROMPT,
+        use=[A2ui(surface_id='sfc')],
+    )
+    streamed_envs: list[dict[str, Any]] = []
+    async for chunk in stream.stream:
+        streamed_envs.extend(envelopes(chunk.content))
+    response = await stream.response
+    assert_finished_message(response)
+    assert any('updateComponents' in env for env in streamed_envs)
+
+
+@pytest.mark.asyncio
+async def test_generate_a2ui_flushes_withheld_prose_at_end_of_turn() -> None:
+    """Trailing prose held back for a possible fence still reaches the stream."""
+    ai, pm = setup()
+    full = 'Hello there, friend!'
+    pm.responses = [model_ok(full)]
+    pm.chunks = [[ModelResponseChunk(role=Role.MODEL, content=[text_part(ch)]) for ch in full]]
+
+    stream = ai.generate_stream(model='programmableModel', prompt='hi', use=[A2ui()])
+    streamed = ''
+    async for chunk in stream.stream:
+        streamed += joined_text(chunk.content)
+    response = await stream.response
+    assert_finished_message(response)
+    assert streamed == full
+    assert response.text == full
+
+
+@pytest.mark.asyncio
+async def test_generate_a2ui_drops_bad_block_and_keeps_prose() -> None:
+    """Default warn drops an unknown component and keeps the surrounding prose."""
+    ai, pm = setup()
+    pm.responses = [model_ok(bad_component_fence())]
+
+    response = await ai.generate(model='programmableModel', prompt=WEATHER_PROMPT, use=[A2ui()])
+    message = assert_finished_message(response)
+    assert_no_a2ui_parts(message.content)
+    assert_no_fence_in_text(message.content)
+    assert 'oops' in joined_text(message.content)
+
+
+@pytest.mark.asyncio
+async def test_generate_a2ui_strict_raises_on_bad_block() -> None:
+    """Strict mode fails the generate call when the fence names an unknown component."""
+    ai, pm = setup()
+    pm.responses = [model_ok(bad_component_fence())]
+
+    with pytest.raises(A2uiParseError):
+        await ai.generate(
+            model='programmableModel',
+            prompt=WEATHER_PROMPT,
+            use=[A2ui(validate='strict')],
+        )
+
+
+@pytest.mark.asyncio
+async def test_generate_stream_strict_raises_on_bad_block() -> None:
+    """Strict mode fails generate_stream with A2uiParseError when the fence names an unknown component."""
+    ai, pm = setup()
+    fence = bad_component_fence()
+    pm.responses = [model_ok(fence)]
+    pm.chunks = [[ModelResponseChunk(role=Role.MODEL, content=[text_part(fence)])]]
+
+    stream = ai.generate_stream(
+        model='programmableModel',
+        prompt=WEATHER_PROMPT,
+        use=[A2ui(validate='strict')],
+    )
+    with pytest.raises(A2uiParseError, match='NotAThing'):
+        async for _chunk in stream.stream:
+            pass
+        await stream.response
+
+
+@pytest.mark.asyncio
+async def test_generate_a2ui_skips_rewrite_when_blocked_or_aborted() -> None:
+    """A stopped turn keeps the finish reason and does not salvage a card."""
+    for reason in (FinishReason.BLOCKED, FinishReason.ABORTED, FinishReason.INTERRUPTED):
+        ai, pm = setup()
+        raw = broken_fence()
+        pm.responses = [
+            ModelResponse(
+                finish_reason=reason,
+                finish_message='safety',
+                message=Message(role=Role.MODEL, content=[text_part(raw)]),
+            )
+        ]
+
+        response = await ai.generate(
+            model='programmableModel',
+            prompt=WEATHER_PROMPT,
+            use=[A2ui(validate='strict')],
+        )
+        message = assert_finished_message(response, finish_reason=reason)
+        assert response.finish_message == 'safety'
+        assert_no_a2ui_parts(message.content)
+        assert '```a2ui' in joined_text(message.content)
+
+
+@pytest.mark.asyncio
+async def test_generate_a2ui_other_keeps_raw_fence() -> None:
+    """A turn that finished other keeps the finish reason and does not salvage a card."""
+    ai, pm = setup()
+    raw = broken_fence()
+    pm.responses = [
+        ModelResponse(
+            finish_reason=FinishReason.OTHER,
+            finish_message='provider other',
+            message=Message(role=Role.MODEL, content=[text_part(raw)]),
+        )
+    ]
+
+    response = await ai.generate(
+        model='programmableModel',
+        prompt=WEATHER_PROMPT,
+        use=[A2ui(validate='strict')],
+    )
+    message = assert_finished_message(response, finish_reason=FinishReason.OTHER)
+    assert response.finish_message == 'provider other'
+    assert_no_a2ui_parts(message.content)
+    assert '```a2ui' in joined_text(message.content)
+
+
+@pytest.mark.asyncio
+async def test_generate_stream_blocked_paints_card_but_response_keeps_fence() -> None:
+    """A blocked stream may already have painted a card; the response they persist still has the fence."""
+    ai, pm = setup()
+    fence = weather_fence()
+    pm.responses = [
+        ModelResponse(
+            finish_reason=FinishReason.BLOCKED,
+            finish_message='stop',
+            message=Message(role=Role.MODEL, content=[text_part(fence)]),
+        )
+    ]
+    pm.chunks = [[ModelResponseChunk(role=Role.MODEL, content=[text_part(fence)])]]
+
+    stream = ai.generate_stream(
+        model='programmableModel',
+        prompt=WEATHER_PROMPT,
+        use=[A2ui(validate='strict')],
+    )
+    streamed_envs: list[dict[str, Any]] = []
+    async for chunk in stream.stream:
+        streamed_envs.extend(envelopes(chunk.content))
+    response = await stream.response
+    message = assert_finished_message(response, finish_reason=FinishReason.BLOCKED)
+    assert response.finish_message == 'stop'
+    assert streamed_envs
+    assert_no_a2ui_parts(message.content)
+    assert '```a2ui' in joined_text(message.content)
+
+
+@pytest.mark.asyncio
+async def test_generate_stream_other_paints_card_but_response_keeps_fence() -> None:
+    """A stream that finished other may already have painted a card; the response they persist still has the fence."""
+    ai, pm = setup()
+    fence = weather_fence()
+    pm.responses = [
+        ModelResponse(
+            finish_reason=FinishReason.OTHER,
+            finish_message='stop',
+            message=Message(role=Role.MODEL, content=[text_part(fence)]),
+        )
+    ]
+    pm.chunks = [[ModelResponseChunk(role=Role.MODEL, content=[text_part(fence)])]]
+
+    stream = ai.generate_stream(
+        model='programmableModel',
+        prompt=WEATHER_PROMPT,
+        use=[A2ui(validate='strict')],
+    )
+    streamed_envs: list[dict[str, Any]] = []
+    async for chunk in stream.stream:
+        streamed_envs.extend(envelopes(chunk.content))
+    response = await stream.response
+    message = assert_finished_message(response, finish_reason=FinishReason.OTHER)
+    assert response.finish_message == 'stop'
+    assert streamed_envs
+    assert_no_a2ui_parts(message.content)
+    assert '```a2ui' in joined_text(message.content)
+
+
+@pytest.mark.asyncio
+async def test_generate_a2ui_mints_new_surface_id() -> None:
+    """A new createSurface does not keep the model's SURFACE_ID placeholder."""
+    ai, pm = setup()
+    pm.responses = [model_ok(weather_fence())]
+
+    response = await ai.generate(model='programmableModel', prompt=WEATHER_PROMPT, use=[A2ui()])
+    message = assert_finished_message(response)
+    ids = create_surface_ids(message.content)
+    assert ids
+    assert 'SURFACE_ID' not in ids
+
+
+@pytest.mark.asyncio
+async def test_generate_a2ui_injects_catalog_instructions_by_default() -> None:
+    """Default A2ui() tells the model how to emit an A2UI fence."""
+    ai, pm = setup()
+    pm.responses = [model_ok('ok')]
+
+    await ai.generate(model='programmableModel', prompt=WEATHER_PROMPT, use=[A2ui()])
+    assert 'Rendering UI with A2UI' in request_system_text(pm)
+
+
+@pytest.mark.asyncio
+async def test_generate_a2ui_instructions_none_does_not_inject_catalog() -> None:
+    """A2ui(instructions='none') leaves the system prompt without catalog instructions."""
+    ai, pm = setup()
+    pm.responses = [model_ok('ok')]
+
+    await ai.generate(
+        model='programmableModel',
+        prompt=WEATHER_PROMPT,
+        use=[A2ui(instructions='none')],
+    )
+    assert 'Rendering UI with A2UI' not in request_system_text(pm)
+
+
+@pytest.mark.asyncio
+async def test_generate_a2ui_rewrites_candidates_message_too() -> None:
+    """A finished turn rewrites candidates[0].message, not only the top-level message."""
+    ai, pm = setup()
+    fence = weather_fence()
+    message = Message(role=Role.MODEL, content=[text_part(fence)])
+    pm.responses = [
+        ModelResponse(
+            finish_reason=FinishReason.STOP,
+            message=message,
+            candidates=[
+                Candidate(index=0, message=message, finish_reason=FinishReason.STOP),
+            ],
+        )
+    ]
+
+    response = await ai.generate(model='programmableModel', prompt=WEATHER_PROMPT, use=[A2ui()])
+    finished = assert_finished_message(response)
+    assert envelopes(finished.content)
+    assert_no_fence_in_text(finished.content)
+    assert response.candidates
+    candidate_message = response.candidates[0].message
+    assert envelopes(candidate_message.content)
+    assert_no_fence_in_text(candidate_message.content)
+
+
+@pytest.mark.asyncio
+async def test_generate_a2ui_rewrites_candidates_when_message_missing() -> None:
+    """A finished turn that only carries candidates[0] still becomes a data part."""
+    ai, pm = setup()
+    fence = weather_fence()
+    message = Message(role=Role.MODEL, content=[text_part(fence)])
+    pm.responses = [
+        ModelResponse(
+            finish_reason=FinishReason.STOP,
+            message=None,
+            candidates=[
+                Candidate(index=0, message=message, finish_reason=FinishReason.STOP),
+            ],
+        )
+    ]
+
+    response = await ai.generate(model='programmableModel', prompt=WEATHER_PROMPT, use=[A2ui()])
+    finished = assert_finished_message(response)
+    assert envelopes(finished.content)
+    assert_no_fence_in_text(finished.content)
+    assert response.candidates
+    candidate_message = response.candidates[0].message
+    assert envelopes(candidate_message.content)
+    assert_no_fence_in_text(candidate_message.content)
+
+
+@pytest.mark.asyncio
+async def test_generate_a2ui_off_drops_block_without_root() -> None:
+    """validate='off' drops a surface that has no root and does not raise."""
+    ai, pm = setup()
+    pm.responses = [model_ok(no_root_fence())]
+
+    response = await ai.generate(
+        model='programmableModel',
+        prompt=WEATHER_PROMPT,
+        use=[A2ui(validate='off')],
+    )
+    message = assert_finished_message(response)
+    assert_no_a2ui_parts(message.content)
+    assert_no_fence_in_text(message.content)
+
+
+def test_a2ui_rejects_unknown_catalog_kwarg() -> None:
+    """A2ui(catalog=...) is not a knob; construction fails."""
+    with pytest.raises(ValidationError):
+        A2ui(catalog='basic')
+
+
+def test_a2ui_accepts_camel_surface_id() -> None:
+    """surfaceId= is the same knob as surface_id=."""
+    assert A2ui(surfaceId='sfc').config.surface_id == 'sfc'
+
+
+def test_a2ui_rejects_unknown_version() -> None:
+    """A typo version is rejected so it cannot stamp envelopes the renderer will drop."""
+    with pytest.raises(ValidationError):
+        A2ui(version='v9')

--- a/py/packages/genkit-a2ui/tests/generate_a2ui_test.py
+++ b/py/packages/genkit-a2ui/tests/generate_a2ui_test.py
@@ -14,7 +14,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""L1 pins: a finished ``ai.generate(..., use=[A2ui()])`` returns data parts, not fences."""
+"""L1 pins: a finished ``ai.generate(..., use=[Surfaces()])`` returns data parts, not fences."""
 
 from __future__ import annotations
 
@@ -22,7 +22,7 @@ import json
 from typing import Any
 
 import pytest
-from genkit_a2ui import A2ui, A2uiParseError
+from genkit_a2ui import A2uiParseError, Surfaces
 from helpers import (
     WEATHER_PROMPT,
     a2ui_parts,
@@ -55,7 +55,7 @@ async def test_generate_a2ui_rewrites_fence_to_data_part() -> None:
     fence = weather_fence()
     pm.responses = [model_ok(fence)]
 
-    response = await ai.generate(model='programmableModel', prompt=WEATHER_PROMPT, use=[A2ui()])
+    response = await ai.generate(model='programmableModel', prompt=WEATHER_PROMPT, use=[Surfaces()])
     message = assert_finished_message(response)
     assert envelopes(message.content)
     assert create_surface_ids(message.content)
@@ -69,7 +69,7 @@ async def test_generate_a2ui_leaves_plain_prose_untouched() -> None:
     ai, pm = setup()
     pm.responses = [model_ok('just chatting')]
 
-    response = await ai.generate(model='programmableModel', prompt='hi', use=[A2ui()])
+    response = await ai.generate(model='programmableModel', prompt='hi', use=[Surfaces()])
     message = assert_finished_message(response)
     assert_no_a2ui_parts(message.content)
     assert joined_text(message.content) == 'just chatting'
@@ -82,7 +82,7 @@ async def test_generate_a2ui_fence_only_returns_data_part() -> None:
     ai, pm = setup()
     pm.responses = [model_ok(fence_only())]
 
-    response = await ai.generate(model='programmableModel', prompt=WEATHER_PROMPT, use=[A2ui()])
+    response = await ai.generate(model='programmableModel', prompt=WEATHER_PROMPT, use=[Surfaces()])
     message = assert_finished_message(response)
     assert envelopes(message.content)
     assert_no_fence_in_text(message.content)
@@ -104,7 +104,7 @@ async def test_generate_a2ui_stitches_fence_split_across_parts() -> None:
         )
     ]
 
-    response = await ai.generate(model='programmableModel', prompt=WEATHER_PROMPT, use=[A2ui()])
+    response = await ai.generate(model='programmableModel', prompt=WEATHER_PROMPT, use=[Surfaces()])
     message = assert_finished_message(response)
     assert len(a2ui_parts(message.content)) == 1
     assert envelopes(message.content)
@@ -118,7 +118,7 @@ async def test_generate_a2ui_keeps_prose_on_both_sides_of_part() -> None:
     body = weather_fence().replace('Here is the weather:\n', '')
     pm.responses = [model_ok(f'intro\n{body}outro')]
 
-    response = await ai.generate(model='programmableModel', prompt=WEATHER_PROMPT, use=[A2ui()])
+    response = await ai.generate(model='programmableModel', prompt=WEATHER_PROMPT, use=[Surfaces()])
     message = assert_finished_message(response)
     content = message.content
     assert len(content) == 3
@@ -136,7 +136,7 @@ async def test_generate_a2ui_stream_and_final_share_surface_id() -> None:
     pm.responses = [model_ok(fence)]
     pm.chunks = [[ModelResponseChunk(role=Role.MODEL, content=[text_part(fence)])]]
 
-    stream = ai.generate_stream(model='programmableModel', prompt=WEATHER_PROMPT, use=[A2ui()])
+    stream = ai.generate_stream(model='programmableModel', prompt=WEATHER_PROMPT, use=[Surfaces()])
     streamed: list[str] = []
     async for chunk in stream.stream:
         streamed.extend(create_surface_ids(chunk.content))
@@ -166,7 +166,7 @@ async def test_generate_a2ui_flushes_open_fence_at_end_of_turn() -> None:
     stream = ai.generate_stream(
         model='programmableModel',
         prompt=WEATHER_PROMPT,
-        use=[A2ui(surface_id='sfc')],
+        use=[Surfaces(surface_id='sfc')],
     )
     streamed_envs: list[dict[str, Any]] = []
     async for chunk in stream.stream:
@@ -184,7 +184,7 @@ async def test_generate_a2ui_flushes_withheld_prose_at_end_of_turn() -> None:
     pm.responses = [model_ok(full)]
     pm.chunks = [[ModelResponseChunk(role=Role.MODEL, content=[text_part(ch)]) for ch in full]]
 
-    stream = ai.generate_stream(model='programmableModel', prompt='hi', use=[A2ui()])
+    stream = ai.generate_stream(model='programmableModel', prompt='hi', use=[Surfaces()])
     streamed = ''
     async for chunk in stream.stream:
         streamed += joined_text(chunk.content)
@@ -200,7 +200,7 @@ async def test_generate_a2ui_drops_bad_block_and_keeps_prose() -> None:
     ai, pm = setup()
     pm.responses = [model_ok(bad_component_fence())]
 
-    response = await ai.generate(model='programmableModel', prompt=WEATHER_PROMPT, use=[A2ui()])
+    response = await ai.generate(model='programmableModel', prompt=WEATHER_PROMPT, use=[Surfaces()])
     message = assert_finished_message(response)
     assert_no_a2ui_parts(message.content)
     assert_no_fence_in_text(message.content)
@@ -217,7 +217,7 @@ async def test_generate_a2ui_strict_raises_on_bad_block() -> None:
         await ai.generate(
             model='programmableModel',
             prompt=WEATHER_PROMPT,
-            use=[A2ui(validate='strict')],
+            use=[Surfaces(validate='strict')],
         )
 
 
@@ -232,7 +232,7 @@ async def test_generate_stream_strict_raises_on_bad_block() -> None:
     stream = ai.generate_stream(
         model='programmableModel',
         prompt=WEATHER_PROMPT,
-        use=[A2ui(validate='strict')],
+        use=[Surfaces(validate='strict')],
     )
     with pytest.raises(A2uiParseError, match='NotAThing'):
         async for _chunk in stream.stream:
@@ -257,7 +257,7 @@ async def test_generate_a2ui_skips_rewrite_when_blocked_or_aborted() -> None:
         response = await ai.generate(
             model='programmableModel',
             prompt=WEATHER_PROMPT,
-            use=[A2ui(validate='strict')],
+            use=[Surfaces(validate='strict')],
         )
         message = assert_finished_message(response, finish_reason=reason)
         assert response.finish_message == 'safety'
@@ -281,7 +281,7 @@ async def test_generate_a2ui_other_keeps_raw_fence() -> None:
     response = await ai.generate(
         model='programmableModel',
         prompt=WEATHER_PROMPT,
-        use=[A2ui(validate='strict')],
+        use=[Surfaces(validate='strict')],
     )
     message = assert_finished_message(response, finish_reason=FinishReason.OTHER)
     assert response.finish_message == 'provider other'
@@ -306,7 +306,7 @@ async def test_generate_stream_blocked_paints_card_but_response_keeps_fence() ->
     stream = ai.generate_stream(
         model='programmableModel',
         prompt=WEATHER_PROMPT,
-        use=[A2ui(validate='strict')],
+        use=[Surfaces(validate='strict')],
     )
     streamed_envs: list[dict[str, Any]] = []
     async for chunk in stream.stream:
@@ -336,7 +336,7 @@ async def test_generate_stream_other_paints_card_but_response_keeps_fence() -> N
     stream = ai.generate_stream(
         model='programmableModel',
         prompt=WEATHER_PROMPT,
-        use=[A2ui(validate='strict')],
+        use=[Surfaces(validate='strict')],
     )
     streamed_envs: list[dict[str, Any]] = []
     async for chunk in stream.stream:
@@ -355,7 +355,7 @@ async def test_generate_a2ui_mints_new_surface_id() -> None:
     ai, pm = setup()
     pm.responses = [model_ok(weather_fence())]
 
-    response = await ai.generate(model='programmableModel', prompt=WEATHER_PROMPT, use=[A2ui()])
+    response = await ai.generate(model='programmableModel', prompt=WEATHER_PROMPT, use=[Surfaces()])
     message = assert_finished_message(response)
     ids = create_surface_ids(message.content)
     assert ids
@@ -364,24 +364,24 @@ async def test_generate_a2ui_mints_new_surface_id() -> None:
 
 @pytest.mark.asyncio
 async def test_generate_a2ui_injects_catalog_instructions_by_default() -> None:
-    """Default A2ui() tells the model how to emit an A2UI fence."""
+    """Default Surfaces() tells the model how to emit an A2UI fence."""
     ai, pm = setup()
     pm.responses = [model_ok('ok')]
 
-    await ai.generate(model='programmableModel', prompt=WEATHER_PROMPT, use=[A2ui()])
+    await ai.generate(model='programmableModel', prompt=WEATHER_PROMPT, use=[Surfaces()])
     assert 'Rendering UI with A2UI' in request_system_text(pm)
 
 
 @pytest.mark.asyncio
 async def test_generate_a2ui_instructions_none_does_not_inject_catalog() -> None:
-    """A2ui(instructions='none') leaves the system prompt without catalog instructions."""
+    """Surfaces(instructions='none') leaves the system prompt without catalog instructions."""
     ai, pm = setup()
     pm.responses = [model_ok('ok')]
 
     await ai.generate(
         model='programmableModel',
         prompt=WEATHER_PROMPT,
-        use=[A2ui(instructions='none')],
+        use=[Surfaces(instructions='none')],
     )
     assert 'Rendering UI with A2UI' not in request_system_text(pm)
 
@@ -402,7 +402,7 @@ async def test_generate_a2ui_rewrites_candidates_message_too() -> None:
         )
     ]
 
-    response = await ai.generate(model='programmableModel', prompt=WEATHER_PROMPT, use=[A2ui()])
+    response = await ai.generate(model='programmableModel', prompt=WEATHER_PROMPT, use=[Surfaces()])
     finished = assert_finished_message(response)
     assert envelopes(finished.content)
     assert_no_fence_in_text(finished.content)
@@ -428,7 +428,7 @@ async def test_generate_a2ui_rewrites_candidates_when_message_missing() -> None:
         )
     ]
 
-    response = await ai.generate(model='programmableModel', prompt=WEATHER_PROMPT, use=[A2ui()])
+    response = await ai.generate(model='programmableModel', prompt=WEATHER_PROMPT, use=[Surfaces()])
     finished = assert_finished_message(response)
     assert envelopes(finished.content)
     assert_no_fence_in_text(finished.content)
@@ -447,25 +447,24 @@ async def test_generate_a2ui_off_drops_block_without_root() -> None:
     response = await ai.generate(
         model='programmableModel',
         prompt=WEATHER_PROMPT,
-        use=[A2ui(validate='off')],
+        use=[Surfaces(validate='off')],
     )
     message = assert_finished_message(response)
     assert_no_a2ui_parts(message.content)
     assert_no_fence_in_text(message.content)
 
 
-def test_a2ui_rejects_unknown_catalog_kwarg() -> None:
-    """A2ui(catalog=...) is not a knob; construction fails."""
-    with pytest.raises(ValidationError):
-        A2ui(catalog='basic')
+def test_a2ui_catalog_string_is_the_lookup_id() -> None:
+    """catalog= is the registry id generate and the Developer UI look up."""
+    assert Surfaces(catalog='basic').config.catalog == 'basic'
 
 
 def test_a2ui_accepts_camel_surface_id() -> None:
     """surfaceId= is the same knob as surface_id=."""
-    assert A2ui(surfaceId='sfc').config.surface_id == 'sfc'
+    assert Surfaces(surfaceId='sfc').config.surface_id == 'sfc'
 
 
 def test_a2ui_rejects_unknown_version() -> None:
     """A typo version is rejected so it cannot stamp envelopes the renderer will drop."""
     with pytest.raises(ValidationError):
-        A2ui(version='v9')
+        Surfaces(version='v9')

--- a/py/packages/genkit-a2ui/tests/generate_a2ui_test.py
+++ b/py/packages/genkit-a2ui/tests/generate_a2ui_test.py
@@ -243,7 +243,13 @@ async def test_generate_stream_strict_raises_on_bad_block() -> None:
 @pytest.mark.asyncio
 async def test_generate_a2ui_skips_rewrite_when_blocked_or_aborted() -> None:
     """A stopped turn keeps the finish reason and does not salvage a card."""
-    for reason in (FinishReason.BLOCKED, FinishReason.ABORTED, FinishReason.INTERRUPTED):
+    for reason in (
+        FinishReason.BLOCKED,
+        FinishReason.ABORTED,
+        FinishReason.INTERRUPTED,
+        FinishReason.FAILED,
+        FinishReason.UNKNOWN,
+    ):
         ai, pm = setup()
         raw = broken_fence()
         pm.responses = [
@@ -439,8 +445,8 @@ async def test_generate_a2ui_rewrites_candidates_when_message_missing() -> None:
 
 
 @pytest.mark.asyncio
-async def test_generate_a2ui_off_drops_block_without_root() -> None:
-    """validate='off' drops a surface that has no root and does not raise."""
+async def test_generate_a2ui_off_keeps_surface_without_root() -> None:
+    """validate='off' still returns the surface when the component list has no root."""
     ai, pm = setup()
     pm.responses = [model_ok(no_root_fence())]
 
@@ -450,8 +456,63 @@ async def test_generate_a2ui_off_drops_block_without_root() -> None:
         use=[Surfaces(validate='off')],
     )
     message = assert_finished_message(response)
+    assert envelopes(message.content)
+    assert_no_fence_in_text(message.content)
+
+
+@pytest.mark.asyncio
+async def test_generate_a2ui_warn_drops_surface_without_root() -> None:
+    """Default warn drops a surface that has no root and keeps no fence."""
+    ai, pm = setup()
+    pm.responses = [model_ok(no_root_fence())]
+
+    response = await ai.generate(model='programmableModel', prompt=WEATHER_PROMPT, use=[Surfaces()])
+    message = assert_finished_message(response)
     assert_no_a2ui_parts(message.content)
     assert_no_fence_in_text(message.content)
+
+
+@pytest.mark.asyncio
+async def test_generate_a2ui_empty_text_part_mid_fence_still_returns_a_card() -> None:
+    """An empty text part in the middle of a fence does not drop the card."""
+    ai, pm = setup()
+    fence = weather_fence()
+    mid = len(fence) // 2
+    pm.responses = [
+        ModelResponse(
+            finish_reason=FinishReason.STOP,
+            message=Message(
+                role=Role.MODEL,
+                content=[text_part(fence[:mid]), text_part(''), text_part(fence[mid:])],
+            ),
+        )
+    ]
+
+    response = await ai.generate(model='programmableModel', prompt=WEATHER_PROMPT, use=[Surfaces()])
+    message = assert_finished_message(response)
+    assert envelopes(message.content)
+    assert_no_fence_in_text(message.content)
+
+
+@pytest.mark.asyncio
+async def test_generate_a2ui_truncated_fence_on_length_stays_as_prose() -> None:
+    """A length-stopped turn keeps the unfinished fence as text instead of dropping it."""
+    ai, pm = setup()
+    raw = 'Here is the weather:\n```a2ui\n[{"createSurface":'
+    pm.responses = [
+        ModelResponse(
+            finish_reason=FinishReason.LENGTH,
+            finish_message='max tokens',
+            message=Message(role=Role.MODEL, content=[text_part(raw)]),
+        )
+    ]
+
+    response = await ai.generate(model='programmableModel', prompt=WEATHER_PROMPT, use=[Surfaces()])
+    message = assert_finished_message(response, finish_reason=FinishReason.LENGTH)
+    assert response.finish_message == 'max tokens'
+    assert_no_a2ui_parts(message.content)
+    assert '```a2ui' in joined_text(message.content)
+    assert 'createSurface' in joined_text(message.content)
 
 
 def test_a2ui_catalog_string_is_the_lookup_id() -> None:

--- a/py/packages/genkit-a2ui/tests/helpers.py
+++ b/py/packages/genkit-a2ui/tests/helpers.py
@@ -1,0 +1,179 @@
+# Copyright 2026 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared helpers for A2UI generate pins."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from genkit_a2ui import A2UI_MIME_TYPE
+
+from genkit import Genkit, Message, ModelResponse
+from genkit._ai._testing import ProgrammableModel, define_programmable_model
+from genkit._core._typing import DataPart, FinishReason, Part, Role, TextPart
+
+BASIC_CATALOG_ID = 'https://a2ui.org/specification/v0_9/catalogs/basic/catalog.json'
+A2UI_FENCE = '```a2ui'
+WEATHER_PROMPT = 'Show me the weather in Tokyo'
+
+
+def weather_fence(*, catalog_id: str = BASIC_CATALOG_ID, text: str = 'hi') -> str:
+    return (
+        'Here is the weather:\n'
+        f'{A2UI_FENCE}\n'
+        '['
+        f'{{ "createSurface": {{ "surfaceId": "SURFACE_ID", "catalogId": "{catalog_id}" }} }}, '
+        '{ "updateComponents": { "surfaceId": "SURFACE_ID", "components": ['
+        f'{{ "id": "root", "component": "Text", "text": "{text}" }}'
+        '] } }'
+        ']\n'
+        '```\n'
+    )
+
+
+def fence_only(*, catalog_id: str = BASIC_CATALOG_ID) -> str:
+    return (
+        f'{A2UI_FENCE}\n'
+        '['
+        f'{{ "createSurface": {{ "surfaceId": "SURFACE_ID", "catalogId": "{catalog_id}" }} }}, '
+        '{ "updateComponents": { "surfaceId": "SURFACE_ID", "components": ['
+        '{ "id": "root", "component": "Text", "text": "hi" }'
+        '] } }'
+        ']\n'
+        '```\n'
+    )
+
+
+def bad_component_fence() -> str:
+    return (
+        'oops:\n'
+        f'{A2UI_FENCE}\n'
+        '[{ "updateComponents": { "surfaceId": "SURFACE_ID", "components": ['
+        '{ "id": "root", "component": "NotAThing" }'
+        '] } }]\n'
+        '```\n'
+    )
+
+
+def broken_fence() -> str:
+    return 'partial ```a2ui\n[{"createSurface": bad'
+
+
+def no_root_fence(*, catalog_id: str = BASIC_CATALOG_ID) -> str:
+    return (
+        f'{A2UI_FENCE}\n'
+        '['
+        f'{{ "createSurface": {{ "surfaceId": "SURFACE_ID", "catalogId": "{catalog_id}" }} }}, '
+        '{ "updateComponents": { "surfaceId": "SURFACE_ID", "components": ['
+        '{ "id": "leaf", "component": "Text", "text": "hi" }'
+        '] } }'
+        ']\n'
+        '```\n'
+    )
+
+
+def a2ui_data_part(envelopes: list[dict[str, Any]]) -> Part:
+    return Part(DataPart(data={'envelopes': envelopes}, metadata={'mimeType': A2UI_MIME_TYPE}))
+
+
+def text_part(text: str) -> Part:
+    return Part(TextPart(text=text))
+
+
+def model_ok(text: str = 'ok') -> ModelResponse:
+    return ModelResponse(
+        finish_reason=FinishReason.STOP,
+        message=Message(role=Role.MODEL, content=[text_part(text)]),
+    )
+
+
+def setup() -> tuple[Genkit, ProgrammableModel]:
+    ai = Genkit()
+    pm, _ = define_programmable_model(ai)
+    return ai, pm
+
+
+def roots(content: list[Part]) -> list[object]:
+    return [part.root for part in content]
+
+
+def a2ui_parts(content: list[Part]) -> list[DataPart]:
+    out: list[DataPart] = []
+    for root in roots(content):
+        if not isinstance(root, DataPart):
+            continue
+        metadata = root.metadata or {}
+        if metadata.get('mimeType') == A2UI_MIME_TYPE:
+            out.append(root)
+    return out
+
+
+def joined_text(content: list[Part]) -> str:
+    bits: list[str] = []
+    for root in roots(content):
+        if isinstance(root, TextPart) and root.text:
+            bits.append(root.text)
+    return ''.join(bits)
+
+
+def envelopes(content: list[Part]) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    for part in a2ui_parts(content):
+        data = part.data
+        if not isinstance(data, dict):
+            continue
+        raw = data.get('envelopes')
+        if isinstance(raw, list):
+            out.extend(env for env in raw if isinstance(env, dict))
+    return out
+
+
+def create_surface_ids(content: list[Part]) -> list[str]:
+    ids: list[str] = []
+    for env in envelopes(content):
+        payload = env.get('createSurface')
+        if isinstance(payload, dict) and isinstance(payload.get('surfaceId'), str):
+            ids.append(payload['surfaceId'])
+    return ids
+
+
+def assert_finished_message(
+    response: ModelResponse,
+    *,
+    finish_reason: FinishReason = FinishReason.STOP,
+) -> Message:
+    assert response.finish_reason == finish_reason
+    assert response.message is not None
+    assert response.messages[-1] == response.message
+    return response.message
+
+
+def assert_no_a2ui_parts(content: list[Part]) -> None:
+    assert a2ui_parts(content) == []
+
+
+def assert_no_fence_in_text(content: list[Part]) -> None:
+    assert A2UI_FENCE not in joined_text(content)
+
+
+def request_messages(pm: ProgrammableModel) -> list[Message]:
+    assert pm.last_request is not None
+    return list(pm.last_request.messages)
+
+
+def request_has_a2ui_part(pm: ProgrammableModel) -> bool:
+    return any(a2ui_parts(message.content) for message in request_messages(pm))
+
+
+def request_history_messages(pm: ProgrammableModel) -> list[Message]:
+    """Conversation leftover the model sees — not the injected catalog prompt."""
+    return [message for message in request_messages(pm) if message.role != Role.SYSTEM]
+
+
+def request_joined_text(pm: ProgrammableModel) -> str:
+    return '\n'.join(joined_text(message.content) for message in request_history_messages(pm))
+
+
+def request_system_text(pm: ProgrammableModel) -> str:
+    return '\n'.join(joined_text(message.content) for message in request_messages(pm) if message.role == Role.SYSTEM)

--- a/py/packages/genkit-a2ui/tests/helpers.py
+++ b/py/packages/genkit-a2ui/tests/helpers.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import json
 from typing import Any
 
 from genkit_a2ui import A2UI_MIME_TYPE
@@ -18,42 +19,39 @@ A2UI_FENCE = '```a2ui'
 WEATHER_PROMPT = 'Show me the weather in Tokyo'
 
 
+def fence_block(envelopes: list[dict[str, Any]]) -> str:
+    return f'{A2UI_FENCE}\n{json.dumps(envelopes, indent=2)}\n```\n'
+
+
+def weather_surface(*, catalog_id: str = BASIC_CATALOG_ID, text: str = 'hi') -> list[dict[str, Any]]:
+    return [
+        {'createSurface': {'surfaceId': 'SURFACE_ID', 'catalogId': catalog_id}},
+        {
+            'updateComponents': {
+                'surfaceId': 'SURFACE_ID',
+                'components': [{'id': 'root', 'component': 'Text', 'text': text}],
+            }
+        },
+    ]
+
+
 def weather_fence(*, catalog_id: str = BASIC_CATALOG_ID, text: str = 'hi') -> str:
-    return (
-        'Here is the weather:\n'
-        f'{A2UI_FENCE}\n'
-        '['
-        f'{{ "createSurface": {{ "surfaceId": "SURFACE_ID", "catalogId": "{catalog_id}" }} }}, '
-        '{ "updateComponents": { "surfaceId": "SURFACE_ID", "components": ['
-        f'{{ "id": "root", "component": "Text", "text": "{text}" }}'
-        '] } }'
-        ']\n'
-        '```\n'
-    )
+    return 'Here is the weather:\n' + fence_block(weather_surface(catalog_id=catalog_id, text=text))
 
 
 def fence_only(*, catalog_id: str = BASIC_CATALOG_ID) -> str:
-    return (
-        f'{A2UI_FENCE}\n'
-        '['
-        f'{{ "createSurface": {{ "surfaceId": "SURFACE_ID", "catalogId": "{catalog_id}" }} }}, '
-        '{ "updateComponents": { "surfaceId": "SURFACE_ID", "components": ['
-        '{ "id": "root", "component": "Text", "text": "hi" }'
-        '] } }'
-        ']\n'
-        '```\n'
-    )
+    return fence_block(weather_surface(catalog_id=catalog_id))
 
 
 def bad_component_fence() -> str:
-    return (
-        'oops:\n'
-        f'{A2UI_FENCE}\n'
-        '[{ "updateComponents": { "surfaceId": "SURFACE_ID", "components": ['
-        '{ "id": "root", "component": "NotAThing" }'
-        '] } }]\n'
-        '```\n'
-    )
+    return 'oops:\n' + fence_block([
+        {
+            'updateComponents': {
+                'surfaceId': 'SURFACE_ID',
+                'components': [{'id': 'root', 'component': 'NotAThing'}],
+            }
+        }
+    ])
 
 
 def broken_fence() -> str:
@@ -61,16 +59,15 @@ def broken_fence() -> str:
 
 
 def no_root_fence(*, catalog_id: str = BASIC_CATALOG_ID) -> str:
-    return (
-        f'{A2UI_FENCE}\n'
-        '['
-        f'{{ "createSurface": {{ "surfaceId": "SURFACE_ID", "catalogId": "{catalog_id}" }} }}, '
-        '{ "updateComponents": { "surfaceId": "SURFACE_ID", "components": ['
-        '{ "id": "leaf", "component": "Text", "text": "hi" }'
-        '] } }'
-        ']\n'
-        '```\n'
-    )
+    return fence_block([
+        {'createSurface': {'surfaceId': 'SURFACE_ID', 'catalogId': catalog_id}},
+        {
+            'updateComponents': {
+                'surfaceId': 'SURFACE_ID',
+                'components': [{'id': 'leaf', 'component': 'Text', 'text': 'hi'}],
+            }
+        },
+    ])
 
 
 def a2ui_data_part(envelopes: list[dict[str, Any]]) -> Part:

--- a/py/packages/genkit/pyproject.toml
+++ b/py/packages/genkit/pyproject.toml
@@ -83,6 +83,7 @@ requires-python = ">=3.10"
 version = "0.11.0"
 
 [project.optional-dependencies]
+a2ui                  = ["genkit-a2ui"]
 amazon-bedrock        = ["genkit-amazon-bedrock"]
 anthropic             = ["genkit-anthropic"]
 django                = ["genkit-django"]
@@ -115,6 +116,7 @@ pythonpath = [".", "src", "tests", "packages/genkit/src"]
 testpaths  = ["tests"]
 
 [tool.uv.sources]
+genkit-a2ui                         = { workspace = true }
 genkit-amazon-bedrock               = { workspace = true }
 genkit-anthropic                    = { workspace = true }
 genkit-django                       = { workspace = true }

--- a/py/packages/genkit/src/genkit/_core/_reflection_v2.py
+++ b/py/packages/genkit/src/genkit/_core/_reflection_v2.py
@@ -696,11 +696,14 @@ class ReflectionServerV2:
         except ValidationError as e:
             await self.send_error(sid, JSON_RPC_INVALID_PARAMS, f'invalid params: {e}')
             return
-        if p.type not in ('defaultModel', 'middleware'):
+        if p.type not in ('defaultModel', 'middleware', 'a2ui-catalog'):
             await self.send_error(
                 sid,
                 JSON_RPC_INVALID_PARAMS,
-                f"'type' {p.type} is not supported. Only 'defaultModel' and 'middleware' are supported",
+                (
+                    f"'type' {p.type} is not supported. "
+                    "Only 'defaultModel', 'middleware', and 'a2ui-catalog' are supported"
+                ),
             )
             return
         mapped: dict[str, Any] = {}
@@ -711,10 +714,12 @@ class ReflectionServerV2:
                     f'registry middleware/{name!r} must be GenerateMiddleware, got {type(value).__name__}'
                 )
                 mapped[name] = value.model_dump(by_alias=True, exclude_none=True, mode='json')
-            else:
+            elif p.type == 'defaultModel':
                 # Dev UI lists a model name. A stored ModelRef is an object;
                 # only the name is JSON-serializable here.
                 mapped[name] = value.name if isinstance(value, ModelRef) else value
+            else:
+                mapped[name] = value
         await self.send_response(sid, {'values': mapped})
 
     def handle_configure(self, params: dict[str, Any]) -> None:

--- a/py/packages/genkit/tests/genkit/core/endpoints/reflection_test.py
+++ b/py/packages/genkit/tests/genkit/core/endpoints/reflection_test.py
@@ -446,6 +446,24 @@ async def test_values_default_model_ref_is_name() -> None:
 
 
 @pytest.mark.asyncio
+async def test_values_lists_a2ui_catalog() -> None:
+    """The Developer UI lists registered A2UI catalogs at /api/values?type=a2ui-catalog."""
+    registry = Registry()
+    catalog = {
+        'id': 'https://example.com/catalogs/banner.json',
+        'components': [{'name': 'Banner', 'description': 'A banner.', 'props': 'title: string.'}],
+    }
+    registry.register_value('a2ui-catalog', catalog['id'], catalog)
+    client = await _registry_asgi_client(registry)
+    try:
+        response = await client.get('/api/values?type=a2ui-catalog')
+        assert response.status_code == 200
+        assert response.json() == {catalog['id']: catalog}
+    finally:
+        await client.aclose()
+
+
+@pytest.mark.asyncio
 async def test_no_cors_headers_returned(asgi_client: AsyncClient) -> None:
     """Test that the reflection server does not return CORS headers, matching JS/Go."""
     response = await asgi_client.get('/api/__health', headers={'Origin': 'https://evil.example'})

--- a/py/packages/genkit/tests/genkit/core/reflection_v2_test.py
+++ b/py/packages/genkit/tests/genkit/core/reflection_v2_test.py
@@ -254,6 +254,38 @@ async def test_reflection_server_v2_list_values(fake_manager: FakeReflectionMana
 
 
 @pytest.mark.asyncio
+async def test_reflection_server_v2_list_values_a2ui_catalog(
+    fake_manager: FakeReflectionManager,
+) -> None:
+    """Developer UI can list registered A2UI catalogs."""
+    registry = Registry()
+    catalog = {
+        'id': 'https://example.com/catalogs/banner.json',
+        'components': [{'name': 'Banner', 'description': 'A banner.', 'props': 'title: string.'}],
+    }
+    registry.register_value('a2ui-catalog', catalog['id'], catalog)
+
+    client, task = await _run_client_lifecycle(registry, fake_manager)
+    try:
+        await ack_register(fake_manager)
+        await fake_manager.write_rpc({
+            'jsonrpc': '2.0',
+            'method': 'listValues',
+            'params': {'type': 'a2ui-catalog'},
+            'id': '2c',
+        })
+        resp = await fake_manager.read_rpc()
+        assert resp.get('id') == '2c'
+        result = resp.get('result')
+        assert isinstance(result, dict)
+        values = result.get('values')
+        assert isinstance(values, dict)
+        assert values.get(catalog['id']) == catalog
+    finally:
+        await _stop_client(client, task)
+
+
+@pytest.mark.asyncio
 async def test_reflection_server_v2_list_values_model_ref_is_name(
     fake_manager: FakeReflectionManager,
 ) -> None:

--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
   "genkit-google-cloud",
   "genkit-google-genai",
   "genkit-middleware",
+  "genkit-a2ui",
   "genkit-ollama",
   "genkit-vertexai",
 ]
@@ -171,6 +172,7 @@ genkit-flask        = { workspace = true }
 genkit-google-cloud  = { workspace = true }
 genkit-google-genai     = { workspace = true }
 genkit-middleware   = { workspace = true }
+genkit-a2ui         = { workspace = true }
 genkit-ollama       = { workspace = true }
 genkit-vertexai     = { workspace = true }
 
@@ -374,6 +376,7 @@ root = [
   "packages/genkit-google-cloud/src",
   "packages/genkit-google-genai/src",
   "packages/genkit-middleware/src",
+  "packages/genkit-a2ui/src",
   "packages/genkit-ollama/src",
   "packages/genkit-vertexai/src",
   ".",  # For samples.shared and other root-level imports
@@ -404,6 +407,7 @@ extraPaths = [
   "packages/genkit-google-cloud/src",
   "packages/genkit-google-genai/src",
   "packages/genkit-middleware/src",
+  "packages/genkit-a2ui/src",
   "packages/genkit-ollama/src",
   "packages/genkit-vertexai/src",
 ]
@@ -447,6 +451,7 @@ search-path = [
   "packages/genkit-google-cloud/src",
   "packages/genkit-google-genai/src",
   "packages/genkit-middleware/src",
+  "packages/genkit-a2ui/src",
   "packages/genkit-ollama/src",
   "packages/genkit-vertexai/src",
 ]

--- a/py/uv.lock
+++ b/py/uv.lock
@@ -23,6 +23,7 @@ members = [
     "gemini-code-execution",
     "gemini-context-caching",
     "genkit",
+    "genkit-a2ui",
     "genkit-amazon-bedrock",
     "genkit-anthropic",
     "genkit-django",
@@ -1701,6 +1702,34 @@ requires-dist = [
 provides-extras = ["amazon-bedrock", "anthropic", "django", "evaluators", "fastapi", "flask", "google-cloud", "google-genai", "middleware", "ollama", "openai", "vertex-ai"]
 
 [[package]]
+name = "genkit-a2ui"
+version = "0.11.0"
+source = { editable = "packages/genkit-a2ui" }
+dependencies = [
+    { name = "genkit" },
+    { name = "pydantic" },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-cov" },
+    { name = "pytest-xdist" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "genkit", editable = "packages/genkit" },
+    { name = "pydantic", specifier = ">=2.10.5" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.3.4" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.25.2" },
+    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=6.0.0" },
+    { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.6.1" },
+]
+provides-extras = ["dev"]
+
+[[package]]
 name = "genkit-amazon-bedrock"
 version = "0.11.0"
 source = { editable = "packages/genkit-amazon-bedrock" }
@@ -1945,6 +1974,7 @@ source = { virtual = "." }
 dependencies = [
     { name = "dotpromptz" },
     { name = "genkit" },
+    { name = "genkit-a2ui" },
     { name = "genkit-amazon-bedrock" },
     { name = "genkit-anthropic" },
     { name = "genkit-django" },
@@ -2011,6 +2041,7 @@ lint = [
 requires-dist = [
     { name = "dotpromptz", specifier = "==0.1.5" },
     { name = "genkit", editable = "packages/genkit" },
+    { name = "genkit-a2ui", editable = "packages/genkit-a2ui" },
     { name = "genkit-amazon-bedrock", editable = "packages/genkit-amazon-bedrock" },
     { name = "genkit-anthropic", editable = "packages/genkit-anthropic" },
     { name = "genkit-django", editable = "packages/genkit-django" },

--- a/py/uv.lock
+++ b/py/uv.lock
@@ -1624,6 +1624,9 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+a2ui = [
+    { name = "genkit-a2ui" },
+]
 amazon-bedrock = [
     { name = "genkit-amazon-bedrock" },
 ]
@@ -1666,6 +1669,7 @@ requires-dist = [
     { name = "anyio", specifier = ">=4.9.0" },
     { name = "asgiref", specifier = ">=3.8.1" },
     { name = "dotpromptz", specifier = ">=0.1.5" },
+    { name = "genkit-a2ui", marker = "extra == 'a2ui'", editable = "packages/genkit-a2ui" },
     { name = "genkit-amazon-bedrock", marker = "extra == 'amazon-bedrock'", editable = "packages/genkit-amazon-bedrock" },
     { name = "genkit-anthropic", marker = "extra == 'anthropic'", editable = "packages/genkit-anthropic" },
     { name = "genkit-django", marker = "extra == 'django'", editable = "packages/genkit-django" },
@@ -1699,7 +1703,7 @@ requires-dist = [
     { name = "uvloop", marker = "sys_platform != 'win32'", specifier = ">=0.21.0" },
     { name = "websockets", specifier = ">=13.0.0" },
 ]
-provides-extras = ["amazon-bedrock", "anthropic", "django", "evaluators", "fastapi", "flask", "google-cloud", "google-genai", "middleware", "ollama", "openai", "vertex-ai"]
+provides-extras = ["a2ui", "amazon-bedrock", "anthropic", "django", "evaluators", "fastapi", "flask", "google-cloud", "google-genai", "middleware", "ollama", "openai", "vertex-ai"]
 
 [[package]]
 name = "genkit-a2ui"


### PR DESCRIPTION
Experimental `genkit-a2ui` middleware: add `Surfaces()` to `use=[...]` on `ai.generate` or `define_agent`. The model may emit a ```a2ui fence. On a finished turn the middleware rewrites that fence into `application/a2ui+json` data parts. `envelopes_from_parts(response.message.content)` is how you pull the UI payload for a renderer.

```python
from genkit_a2ui import Surfaces, envelopes_from_parts

response = await ai.generate(
    model='googleai/gemini-2.5-flash',
    prompt='Show me the weather in Tokyo',
    use=[Surfaces()],
)
envelopes = envelopes_from_parts(response.message.content)
```

Streaming rewrites chunks as fences close. The streamed card and `response.message` share the same surface ids.

On the next generate, those data parts become text again so the model can see what was painted: a prior surface is replayed as a ```a2ui fence, and a button click becomes `[UI action "…" on surface …]`.

A stopped turn (blocked / aborted / interrupted / failed / unknown / other) keeps the raw fence. The stop is the result; the middleware does not turn it into a card.

A length-stopped turn that ends inside a fence keeps the unfinished fence as text (`validate='warn'` / `'off'`). It is not dropped and it is not turned into a card.

Install with `pip install 'genkit[a2ui]'` or `pip install genkit-a2ui`.

## Catalogs

`Surfaces()` and `Surfaces(catalog='basic')` use the bundled basic catalog (Text, Card, Button, and the rest). You do not have to register basic to generate with it.

For your own components, register a catalog and pass its id. Registering a catalog does not change `Surfaces()` — you have to pass `catalog=<id>`.

```python
from genkit_a2ui import Surfaces, A2uiCatalog, A2uiCatalogComponent, load_catalog

catalog = A2uiCatalog(
    id='https://my-app.org/catalogs/custom.json',
    components=(
        A2uiCatalogComponent(name='Banner', description='A prominent alert.', props='title: string.'),
    ),
)
load_catalog(ai, catalog)

response = await ai.generate(
    model='googleai/gemini-2.5-flash',
    prompt='Show a warning banner',
    use=[Surfaces(catalog=catalog.id)],
)
```

`catalog=` is a registry id string, not a catalog object. An unknown id fails before the model runs.

`load_catalog_file(ai, './my-catalog.json')` registers from disk. A file that is not UTF-8, or JSON that is not a catalog (missing id, components, or a component name), fails with a message that names the path. `register_basic_catalog(ai)` puts the bundled catalog on the registry so the Developer UI can list it next to custom ones (`GET /api/values?type=a2ui-catalog`).

Loading the same id twice is fine. A different catalog under an already-used id is ignored; the first stays. If that id already holds a value that is not a catalog, `load_catalog` raises.

## Options

- `validate` (`'warn'` default): `'warn'` drops a bad fence or unknown component and keeps the rest of the turn; `'strict'` raises `A2uiParseError`; `'off'` skips the check. This checks envelope shape and component type names only, not prop values.
- `instructions` (`'system'` default): appends the catalog's capabilities to the system prompt so the model knows how to emit a fence. `'none'` injects nothing.
- `surface_id` / `surfaceId`: a fixed id reused for every surface. Omit it for a fresh UUID per surface.
- `version`: protocol version stamped on emitted envelopes (`'v0.9'` default; `'v0.9.1'` is also accepted). A typo is rejected so a renderer is not handed an unknown version.