### PR TITLE
feat(py): stream tool send_chunk and send_partial on generate

### DIFF
--- a/py/packages/genkit/src/genkit/_ai/_agents/_client.py
+++ b/py/packages/genkit/src/genkit/_ai/_agents/_client.py
@@ -743,6 +743,40 @@ def as_part(part: Any) -> Part:  # noqa: ANN401
     return part if isinstance(part, Part) else Part.model_validate(part)
 
 
+KEEP_IN_HISTORY_CUSTOM_KEY = 'keepInHistory'
+
+
+def chunk_kept_in_history(chunk: AgentStreamChunk) -> bool:
+    """Whether this generate chunk should land in the next turn's history.
+
+    Mid-tool send_chunk / send_partial were for the stream listener. The flag
+    rides ``custom.keepInHistory`` so a dump/validate hop still sees it.
+    """
+    mc = chunk.model_chunk
+    if mc is None:
+        return True
+    if getattr(mc, '_keep_in_history', True) is False:
+        return False
+    custom = mc.custom
+    if isinstance(custom, dict) and custom.get(KEEP_IN_HISTORY_CUSTOM_KEY) is False:
+        return False
+    return True
+
+
+def durable_history_part(*, role: Role | str, part: Part) -> bool:
+    """Whether this streamed part belongs in the next turn's history.
+
+    Mid-tool send_chunk / send_partial were for the stream listener. The next
+    turn should only see completed tool returns, same as generate history.
+    """
+    root = part.root
+    if isinstance(root, ToolResponsePart) and (root.metadata or {}).get('partial') is True:
+        return False
+    if role == Role.TOOL:
+        return isinstance(root, (ToolRequestPart, ToolResponsePart))
+    return True
+
+
 class StreamedMessageAccumulator:
     """Rebuilds a turn's messages from its chunk stream.
 
@@ -750,6 +784,7 @@ class StreamedMessageAccumulator:
     tool-request/tool-response steps; nothing else does. We stitch them back the
     same way the store records them: consecutive model deltas (same role and
     message index) merge into one message; a ``tool`` chunk arrives whole.
+    Mid-tool send_chunk / send_partial stay on the stream and out of this view.
     """
 
     def __init__(self) -> None:
@@ -763,13 +798,17 @@ class StreamedMessageAccumulator:
         mc = chunk.model_chunk
         if mc is None:
             return
+        if not chunk_kept_in_history(chunk):
+            return
         role = mc.role if mc.role is not None else Role.MODEL
         if self.role is not None and (role != self.role or mc.index != self.index):
             self.flush()
         self.role = role
         self.index = mc.index
         for part in mc.content or []:
-            self.parts.append(as_part(part))
+            converted = as_part(part)
+            if durable_history_part(role=role, part=converted):
+                self.parts.append(converted)
 
     def flush(self) -> None:
         if self.role is None:

--- a/py/packages/genkit/src/genkit/_ai/_generate.py
+++ b/py/packages/genkit/src/genkit/_ai/_generate.py
@@ -709,18 +709,24 @@ class ChunkAccumulator:
         """Wrap a raw chunk with metadata and track message index changes."""
         if role != self.chunk_role and len(self.prev_chunks) > 0:
             self.message_index += 1
+            # Same-role sends concatenate; a role change starts a new bucket
+            # so model leftover JSON does not mix into tool parts.
+            self.prev_chunks = []
 
         self.chunk_role = role
 
         prev_to_send = copy.copy(self.prev_chunks)
         self.prev_chunks.append(chunk)
 
+        # Leftover parse is the model's output. Tool-role chunks are the
+        # parts the tool sent, not that schema.
+        apply_schema = role == Role.MODEL
         return ModelResponseChunk(
             chunk,
             index=self.message_index,
             previous_chunks=prev_to_send,
-            chunk_parser=self._chunk_parser,
-            schema_type=self.schema_type,
+            chunk_parser=self._chunk_parser if apply_schema else None,
+            schema_type=self.schema_type if apply_schema else None,
         )
 
     def stream_chunk(
@@ -922,6 +928,58 @@ async def _generate_action_turn(
             turn_options = await apply_resources(registry, turn_options, run_ctx.abort_signal)
         assert_valid_tool_names(turn_tools)
 
+        chunks = ChunkAccumulator(
+            params.message_index,
+            turn.formatter,
+            schema_type=getattr(turn_options.output, 'schema_type', None) if turn_options.output else None,
+        )
+
+        def stream_tool_parts(parts: list[Part]) -> None:
+            """Put one send_chunk onto the generate stream without failing the tool."""
+            try:
+                chunks.stream_chunk(
+                    chunk=ModelResponseChunk(role=Role.TOOL, content=parts),
+                    role=Role.TOOL,
+                    ctx=run_ctx,
+                )
+            except Exception as e:
+                logger.debug(
+                    'tool send_chunk callback failed; dropping update',
+                    error=str(e),
+                )
+
+        def stream_tool_partial(tool_request_part: ToolRequestPart, value: object) -> None:
+            """Put one send_partial onto the generate stream without failing the tool."""
+            try:
+                req = tool_request_part.tool_request
+                chunks.stream_chunk(
+                    chunk=ModelResponseChunk(
+                        role=Role.TOOL,
+                        content=[
+                            Part(
+                                root=ToolResponsePart(
+                                    tool_response=ToolResponse(
+                                        name=req.name,
+                                        ref=req.ref,
+                                        output=value,
+                                    ),
+                                    metadata={'partial': True},
+                                )
+                            )
+                        ],
+                    ),
+                    role=Role.TOOL,
+                    ctx=run_ctx,
+                )
+            except Exception as e:
+                logger.debug(
+                    'tool send_partial callback failed; dropping update',
+                    error=str(e),
+                )
+
+        on_tool_parts = stream_tool_parts if run_ctx.on_chunk is not None else None
+        on_tool_partial = stream_tool_partial if run_ctx.on_chunk is not None else None
+
         (
             revised_request,
             interrupted_response,
@@ -930,6 +988,8 @@ async def _generate_action_turn(
             registry=registry,
             raw_request=turn_options,
             mw_pipeline=mw_pipeline,
+            on_tool_parts=on_tool_parts,
+            on_tool_partial=on_tool_partial,
         )
         # NOTE: in the future we should make it possible to interrupt a restart, but
         # at the moment it's too complicated because it's not clear how to return a
@@ -942,11 +1002,6 @@ async def _generate_action_turn(
             )
         turn_options = revised_request
 
-        chunks = ChunkAccumulator(
-            params.message_index,
-            turn.formatter,
-            schema_type=getattr(turn_options.output, 'schema_type', None) if turn_options.output else None,
-        )
         if resumed_tool_message:
             chunks.stream_chunk(
                 chunk=ModelResponseChunk(
@@ -1112,6 +1167,8 @@ async def _generate_action_turn(
             message=generated_msg,
             mw_pipeline=mw_pipeline,
             abort_signal=ctx.abort_signal,
+            on_tool_parts=on_tool_parts,
+            on_tool_partial=on_tool_partial,
         )
 
         # if an interrupt message is returned, stop the tool loop and return a
@@ -1510,6 +1567,8 @@ async def resolve_tool_requests(
     message: Message,
     abort_signal: asyncio.Event,
     mw_pipeline: _GenerateMiddlewarePipeline | None = None,
+    on_tool_parts: Callable[[list[Part]], None] | None = None,
+    on_tool_partial: Callable[[ToolRequestPart, object], None] | None = None,
 ) -> tuple[Message | None, Message | None]:
     """Execute tool requests in a message, returning responses or interrupt info."""
     tool_dict: dict[str, Action] = {}
@@ -1570,6 +1629,8 @@ async def resolve_tool_requests(
                 tool=p.tool,
                 tool_request_part=p.tool_request_part,
                 ctx=c,
+                on_tool_parts=on_tool_parts,
+                on_tool_partial=on_tool_partial,
             )
 
         try:
@@ -1656,6 +1717,8 @@ async def _resolve_tool_request(
     tool: Action,
     tool_request_part: ToolRequestPart,
     ctx: GenerateMiddlewareContext,
+    on_tool_parts: Callable[[list[Part]], None] | None = None,
+    on_tool_partial: Callable[[ToolRequestPart, object], None] | None = None,
 ) -> MultipartToolResponse:
     """Execute a tool and return its response.
 
@@ -1669,7 +1732,15 @@ async def _resolve_tool_request(
     # the tool. We still watch abort_signal here so a tool that ignores it gets hard
     # cancelled instead of hanging past a client abort.
     abort_signal = ctx.abort_signal
-    tool_task = asyncio.create_task(run_tool_request(tool=tool, tool_request_part=tool_request_part, ctx=ctx))
+    tool_task = asyncio.create_task(
+        run_tool_request(
+            tool=tool,
+            tool_request_part=tool_request_part,
+            ctx=ctx,
+            on_tool_parts=on_tool_parts,
+            on_tool_partial=on_tool_partial,
+        )
+    )
 
     async def watch_abort() -> None:
         await abort_signal.wait()
@@ -1735,6 +1806,8 @@ async def _resolve_resume_options(
     registry: Registry,
     raw_request: GenerateActionOptions,
     mw_pipeline: _GenerateMiddlewarePipeline | None = None,
+    on_tool_parts: Callable[[list[Part]], None] | None = None,
+    on_tool_partial: Callable[[ToolRequestPart, object], None] | None = None,
 ) -> tuple[GenerateActionOptions, ModelResponse | None, Message | None]:
     """Handle resume options by resolving pending tool calls from a previous turn."""
     if not raw_request.resume:
@@ -1767,6 +1840,8 @@ async def _resolve_resume_options(
             raw_request=raw_request,
             tool_request_part=part,
             mw_pipeline=mw_pipeline,
+            on_tool_parts=on_tool_parts,
+            on_tool_partial=on_tool_partial,
         )
         tool_responses.append(Part(root=resumed_response))
         updated_content[i] = Part(root=resumed_request)
@@ -1804,6 +1879,8 @@ async def _resolve_resumed_tool_request(
     raw_request: GenerateActionOptions,
     tool_request_part: Part,
     mw_pipeline: _GenerateMiddlewarePipeline | None = None,
+    on_tool_parts: Callable[[list[Part]], None] | None = None,
+    on_tool_partial: Callable[[ToolRequestPart, object], None] | None = None,
 ) -> tuple[ToolRequestPart, ToolResponsePart]:
     """Resolve a single tool request from pending output, resume.respond, or resume.restart."""
     # Type narrowing: ensure we're working with a ToolRequestPart
@@ -1887,6 +1964,8 @@ async def _resolve_resumed_tool_request(
             tool=tool,
             restart_trp=restart_trp,
             mw_pipeline=mw_pipeline,
+            on_tool_parts=on_tool_parts,
+            on_tool_partial=on_tool_partial,
         )
         metadata = dict(tool_req_root.metadata) if tool_req_root.metadata else {}
         interrupt = metadata.get('interrupt')
@@ -1917,6 +1996,8 @@ async def _run_restart_through_middleware(
     tool: Action,
     restart_trp: ToolRequestPart,
     mw_pipeline: _GenerateMiddlewarePipeline | None,
+    on_tool_parts: Callable[[list[Part]], None] | None = None,
+    on_tool_partial: Callable[[ToolRequestPart, object], None] | None = None,
 ) -> ToolResponsePart:
     """Run a restarted tool through the wrap_tool middleware chain.
 
@@ -1931,6 +2012,8 @@ async def _run_restart_through_middleware(
             tool=tool,
             restart_trp=restart_trp,
             ctx=mw_pipeline.ctx if mw_pipeline is not None else None,
+            on_tool_parts=on_tool_parts,
+            on_tool_partial=on_tool_partial,
         )
 
     params = ToolHookParams(
@@ -1939,7 +2022,13 @@ async def _run_restart_through_middleware(
     )
 
     async def next_fn(p: ToolHookParams, ctx: GenerateMiddlewareContext) -> MultipartToolResponse:
-        executed = await run_tool_after_restart(tool=p.tool, restart_trp=p.tool_request_part, ctx=ctx)
+        executed = await run_tool_after_restart(
+            tool=p.tool,
+            restart_trp=p.tool_request_part,
+            ctx=ctx,
+            on_tool_parts=on_tool_parts,
+            on_tool_partial=on_tool_partial,
+        )
         raw_content = executed.tool_response.content or []
         return MultipartToolResponse(
             output=executed.tool_response.output,

--- a/py/packages/genkit/src/genkit/_ai/_generate.py
+++ b/py/packages/genkit/src/genkit/_ai/_generate.py
@@ -682,6 +682,24 @@ async def generate_with_request(
     )
 
 
+KEEP_IN_HISTORY_CUSTOM_KEY = 'keepInHistory'
+
+
+def empty_chunk_output(_chunk: ModelResponseChunk[Any]) -> None:
+    """Tool-role leftover parse: the parts are the payload, not `.output`."""
+    return None
+
+
+def mark_stream_only(chunk: ModelResponseChunk[Any]) -> None:
+    """Mark a mid-tool update so a wire hop still leaves it off history."""
+    chunk._keep_in_history = False
+    custom = chunk.custom
+    if isinstance(custom, dict):
+        chunk.custom = {**custom, KEEP_IN_HISTORY_CUSTOM_KEY: False}
+    else:
+        chunk.custom = {KEEP_IN_HISTORY_CUSTOM_KEY: False}
+
+
 class ChunkAccumulator:
     """Tracks role and message-index state across a streaming turn's chunks.
 
@@ -719,14 +737,15 @@ class ChunkAccumulator:
         self.prev_chunks.append(chunk)
 
         # Leftover parse is the model's output. Tool-role chunks are the
-        # parts the tool sent, not that schema.
+        # parts the tool sent, so `.output` stays empty.
         apply_schema = role == Role.MODEL
         return ModelResponseChunk(
             chunk,
             index=self.message_index,
             previous_chunks=prev_to_send,
-            chunk_parser=self._chunk_parser if apply_schema else None,
+            chunk_parser=self._chunk_parser if apply_schema else empty_chunk_output,
             schema_type=self.schema_type if apply_schema else None,
+            keep_in_history=getattr(chunk, '_keep_in_history', True),
         )
 
     def stream_chunk(
@@ -735,10 +754,13 @@ class ChunkAccumulator:
         chunk: ModelResponseChunk[Any],
         role: Role,
         ctx: GenerateMiddlewareContext,
+        keep_in_history: bool = True,
     ) -> None:
         """Send one framework-wrapped chunk through the current stream chain."""
         if ctx.on_chunk is None:
             return
+        if keep_in_history is False:
+            mark_stream_only(chunk)
         ctx.on_chunk(self.make(role=role, chunk=chunk))
 
     @contextlib.contextmanager
@@ -941,6 +963,7 @@ async def _generate_action_turn(
                     chunk=ModelResponseChunk(role=Role.TOOL, content=parts),
                     role=Role.TOOL,
                     ctx=run_ctx,
+                    keep_in_history=False,
                 )
             except Exception as e:
                 logger.debug(
@@ -970,6 +993,7 @@ async def _generate_action_turn(
                     ),
                     role=Role.TOOL,
                     ctx=run_ctx,
+                    keep_in_history=False,
                 )
             except Exception as e:
                 logger.debug(

--- a/py/packages/genkit/src/genkit/_ai/_tools.py
+++ b/py/packages/genkit/src/genkit/_ai/_tools.py
@@ -89,6 +89,26 @@ def coerce_part(value: object) -> Part | None:
     return None
 
 
+def normalize_send_chunk_parts(chunk: object) -> list[Part]:
+    """Require a Part or list of Parts for tool ``send_chunk``."""
+    if isinstance(chunk, Part):
+        return [chunk]
+    if isinstance(chunk, list):
+        out: list[Part] = []
+        for item in chunk:
+            if not isinstance(item, Part):
+                raise GenkitError(
+                    status='INVALID_ARGUMENT',
+                    message=f'send_chunk parts must be Part values, got {type(item).__name__}.',
+                )
+            out.append(item)
+        return out
+    raise GenkitError(
+        status='INVALID_ARGUMENT',
+        message=f'send_chunk expects a Part or list of Parts, got {type(chunk).__name__}.',
+    )
+
+
 def normalize_response_parts(parts: Sequence[Part] | None) -> list[Part] | None:
     if parts is None:
         return None
@@ -345,6 +365,14 @@ class Tool:
 _tool_resumed_metadata: ContextVar[dict[str, Any] | None] = ContextVar('tool_resumed_metadata', default=None)
 # Stashed copy of tool_request.input when restart replaces input (JSON; shape is per tool).
 _tool_original_input: ContextVar[Any | None] = ContextVar('tool_original_input', default=None)  # noqa: ANN401
+# Generate-only sink: wraps send_chunk parts as a tool-role stream chunk.
+_tool_generate_chunk_sender: ContextVar[Callable[[list[Part]], None] | None] = ContextVar(
+    'tool_generate_chunk_sender', default=None
+)
+# Generate-only sink: wraps send_partial as a stamped tool-response part.
+_tool_generate_partial_sender: ContextVar[Callable[[object], None] | None] = ContextVar(
+    'tool_generate_partial_sender', default=None
+)
 
 
 class ToolRunContext(ActionRunContext):
@@ -370,6 +398,33 @@ class ToolRunContext(ActionRunContext):
         )
         self.resumed_metadata = resumed_metadata
         self.original_input = original_input
+
+    def send_chunk(self, chunk: Part | list[Part]) -> None:  # type: ignore[override]
+        """Stream parts from this tool.
+
+        During ``generate_stream`` the parts become one tool-role
+        ``ModelResponseChunk``. On ``tool.stream()`` the same call still
+        delivers the ``Part`` or list you passed. With no listener this
+        validates and returns.
+        """
+        parts = normalize_send_chunk_parts(chunk)
+        sender = _tool_generate_chunk_sender.get()
+        if sender is not None:
+            sender(parts)
+            return
+        super().send_chunk(chunk)
+
+    def send_partial(self, value: object) -> None:
+        """Stream a progress value from this tool.
+
+        During ``generate_stream`` the value becomes one tool-role
+        ``ToolResponsePart`` with this call's name and ref and
+        ``metadata.partial``. On ``tool.stream()`` or with no listener
+        this is a no-op.
+        """
+        sender = _tool_generate_partial_sender.get()
+        if sender is not None:
+            sender(value)
 
     def is_resumed(self) -> bool:
         """Return True if this execution is resuming after an interrupt."""
@@ -505,6 +560,8 @@ async def run_tool_request(
     tool: Action,
     tool_request_part: ToolRequestPart,
     ctx: GenerateMiddlewareContext | None = None,
+    on_tool_parts: Callable[[list[Part]], None] | None = None,
+    on_tool_partial: Callable[[ToolRequestPart, object], None] | None = None,
 ) -> Any:  # noqa: ANN401 - tool output follows registered handler
     """Execute a tool request with generate-scoped context and resume metadata.
 
@@ -515,6 +572,13 @@ async def run_tool_request(
     resumed_meta, original_input = _resume_context_from_tool_request_part(tool_request_part)
     token_meta = _tool_resumed_metadata.set(resumed_meta)
     token_input = _tool_original_input.set(original_input)
+    token_sender = _tool_generate_chunk_sender.set(on_tool_parts)
+
+    def send_partial_value(value: object) -> None:
+        if on_tool_partial is not None:
+            on_tool_partial(tool_request_part, value)
+
+    token_partial = _tool_generate_partial_sender.set(send_partial_value if on_tool_partial is not None else None)
     run_context = dict(ctx.custom_context) if ctx and ctx.custom_context else None
     telemetry_labels = cast(dict[str, object], dict(ctx.telemetry_labels)) if ctx and ctx.telemetry_labels else None
     try:
@@ -527,6 +591,8 @@ async def run_tool_request(
             )
         ).response
     finally:
+        _tool_generate_partial_sender.reset(token_partial)
+        _tool_generate_chunk_sender.reset(token_sender)
         _tool_resumed_metadata.reset(token_meta)
         _tool_original_input.reset(token_input)
 
@@ -559,6 +625,8 @@ async def run_tool_after_restart(
     tool: Action,
     restart_trp: ToolRequestPart,
     ctx: GenerateMiddlewareContext | None = None,
+    on_tool_parts: Callable[[list[Part]], None] | None = None,
+    on_tool_partial: Callable[[ToolRequestPart, object], None] | None = None,
 ) -> ToolResponsePart:
     """Run a tool for ``resume_restart``: applies ``resumed`` / ``replacedInput`` from metadata.
 
@@ -566,7 +634,13 @@ async def run_tool_after_restart(
     a resumed run. A tool cannot raise another interrupt while it is being restarted.
     """
     try:
-        raw = await run_tool_request(tool=tool, tool_request_part=restart_trp, ctx=ctx)
+        raw = await run_tool_request(
+            tool=tool,
+            tool_request_part=restart_trp,
+            ctx=ctx,
+            on_tool_parts=on_tool_parts,
+            on_tool_partial=on_tool_partial,
+        )
     except (GenkitError, Interrupt) as e:
         intr = (
             e.cause

--- a/py/packages/genkit/src/genkit/_core/_model.py
+++ b/py/packages/genkit/src/genkit/_core/_model.py
@@ -701,6 +701,9 @@ class ModelResponseChunk(ModelResponseChunkSchema, Generic[OutputT]):
     previous_chunks: list[ModelResponseChunk[Any]] = Field(default_factory=list, exclude=True)
     chunk_parser: Callable[[ModelResponseChunk[Any]], object] | None = Field(None, exclude=True)
     schema_type: type[BaseModel] | None = Field(None, exclude=True)
+    # Mid-tool send_chunk / send_partial stay on the stream; the next turn
+    # should only see completed tool returns.
+    _keep_in_history: bool = PrivateAttr(default=True)
 
     def __init__(
         self,
@@ -709,6 +712,7 @@ class ModelResponseChunk(ModelResponseChunkSchema, Generic[OutputT]):
         index: int | float | None = None,
         chunk_parser: Callable[[ModelResponseChunk[Any]], object] | None = None,
         schema_type: type[BaseModel] | None = None,
+        keep_in_history: bool | None = None,
         **kwargs: Any,  # noqa: ANN401
     ) -> None:
         """Initialize from a chunk or keyword arguments."""
@@ -727,6 +731,10 @@ class ModelResponseChunk(ModelResponseChunkSchema, Generic[OutputT]):
         self.previous_chunks = previous_chunks or []
         self.chunk_parser = chunk_parser
         self.schema_type = schema_type
+        if keep_in_history is not None:
+            self._keep_in_history = keep_in_history
+        elif chunk is not None:
+            self._keep_in_history = getattr(chunk, '_keep_in_history', True)
 
     def __eq__(self, other: object) -> bool:
         """Check equality."""

--- a/py/packages/genkit/tests/genkit/ai/streaming_tool_send_chunk_test.py
+++ b/py/packages/genkit/tests/genkit/ai/streaming_tool_send_chunk_test.py
@@ -1,0 +1,796 @@
+#!/usr/bin/env python3
+#
+# Copyright 2026 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Pins ``ToolRunContext.send_chunk`` during ``generate_stream``.
+
+``send_chunk(Part | list[Part])`` shows up as a tool-role
+``ModelResponseChunk`` on ``generate_stream``. History only keeps the
+tool's return. ``tool.stream()`` still yields the Part you sent.
+"""
+
+from collections.abc import Sequence
+
+import pytest
+from pydantic import BaseModel
+
+from genkit import Genkit, Message, ModelResponse, ModelResponseChunk, restart_tool
+from genkit._ai._testing import define_programmable_model
+from genkit._ai._tools import Interrupt, ToolRunContext, normalize_send_chunk_parts
+from genkit._core._action import ActionRunContext
+from genkit._core._error import GenkitError
+from genkit._core._middleware import BaseMiddleware, GenerateHookParams, GenerateMiddlewareContext
+from genkit._core._typing import (
+    FinishReason,
+    Media,
+    MediaPart,
+    Part,
+    Role,
+    TextPart,
+    ToolRequest,
+    ToolRequestPart,
+    ToolResponse,
+    ToolResponsePart,
+)
+
+
+class Recipe(BaseModel):
+    title: str
+    steps: list[str]
+
+
+def _text_part(text: str) -> Part:
+    return Part(TextPart(text=text))
+
+
+def _model_calls(*tools: tuple[str, str]) -> ModelResponse:
+    return ModelResponse(
+        finish_reason=FinishReason.STOP,
+        message=Message(
+            role=Role.MODEL,
+            content=[
+                Part(root=ToolRequestPart(tool_request=ToolRequest(name=name, ref=ref, input={})))
+                for name, ref in tools
+            ],
+        ),
+    )
+
+
+def _model_says(text: str) -> ModelResponse:
+    return ModelResponse(
+        finish_reason=FinishReason.STOP,
+        message=Message(role=Role.MODEL, content=[_text_part(text)]),
+    )
+
+
+def _message_texts(messages: Sequence[Message]) -> list[str]:
+    texts: list[str] = []
+    for msg in messages:
+        for part in msg.content:
+            text_val = getattr(part.root, 'text', None)
+            if text_val:
+                texts.append(str(text_val))
+    return texts
+
+
+def _tool_outputs(messages: Sequence[Message]) -> list[object]:
+    out: list[object] = []
+    for msg in messages:
+        if msg.role != Role.TOOL:
+            continue
+        for part in msg.content:
+            root = part.root
+            if isinstance(root, ToolResponsePart):
+                out.append(root.tool_response.output)
+    return out
+
+
+def _send_chunks(chunks: Sequence[ModelResponseChunk]) -> list[ModelResponseChunk]:
+    return [
+        chunk
+        for chunk in chunks
+        if chunk.role == Role.TOOL and any(isinstance(p.root, TextPart) for p in chunk.content)
+    ]
+
+
+async def _collect_stream(ai: Genkit, **kwargs: object) -> tuple[list[ModelResponseChunk], ModelResponse]:
+    stream = ai.generate_stream(**kwargs)  # type: ignore[arg-type]
+    chunks: list[ModelResponseChunk] = []
+    async for chunk in stream.stream:
+        chunks.append(chunk)
+    return chunks, await stream.response
+
+
+@pytest.mark.asyncio
+async def test_generate_stream_send_chunk_one_text_part_is_tool_role_text() -> None:
+    """Tool send_chunk of one text part is a tool-role chunk with that text."""
+    ai = Genkit(model='programmableModel')
+    pm, _ = define_programmable_model(ai)
+
+    @ai.tool(name='deploy')
+    async def deploy(_req: dict, ctx: ToolRunContext) -> str:
+        ctx.send_chunk(_text_part('svc-00042 is live'))
+        return 'done'
+
+    pm.responses = [_model_calls(('deploy', 'r1')), _model_says('ok')]
+    chunks, response = await _collect_stream(ai, prompt='go', tools=[deploy])
+
+    sent = _send_chunks(chunks)
+    assert len(sent) == 1
+    assert sent[0].role == Role.TOOL
+    assert sent[0].text == 'svc-00042 is live'
+    assert 'svc-00042 is live' not in _message_texts(response.messages)
+    assert _tool_outputs(response.messages) == ['done']
+
+
+@pytest.mark.asyncio
+async def test_generate_stream_send_chunk_list_keeps_every_part() -> None:
+    """send_chunk([text, media]) is one tool-role chunk with both parts."""
+    ai = Genkit(model='programmableModel')
+    pm, _ = define_programmable_model(ai)
+
+    media = Part(root=MediaPart(media=Media(url='data:image/png;base64,QQ==', content_type='image/png')))
+
+    @ai.tool(name='deploy')
+    async def deploy(_req: dict, ctx: ToolRunContext) -> str:
+        ctx.send_chunk([_text_part('chart:'), media])
+        return 'done'
+
+    pm.responses = [_model_calls(('deploy', 'r1')), _model_says('ok')]
+    chunks, response = await _collect_stream(ai, prompt='go', tools=[deploy])
+
+    sent = _send_chunks(chunks)
+    assert len(sent) == 1
+    assert sent[0].text == 'chart:'
+    assert len(sent[0].content) == 2
+    assert isinstance(sent[0].content[1].root, MediaPart)
+    assert 'chart:' not in _message_texts(response.messages)
+    assert _tool_outputs(response.messages) == ['done']
+
+
+@pytest.mark.asyncio
+async def test_generate_stream_return_still_streams_final_tool_response() -> None:
+    """After send_chunk, the return still streams as a later tool-role response."""
+    ai = Genkit(model='programmableModel')
+    pm, _ = define_programmable_model(ai)
+
+    @ai.tool(name='deploy')
+    async def deploy(_req: dict, ctx: ToolRunContext) -> str:
+        ctx.send_chunk(_text_part('live'))
+        return 'done'
+
+    pm.responses = [_model_calls(('deploy', 'r1')), _model_says('ok')]
+    chunks, response = await _collect_stream(ai, prompt='go', tools=[deploy])
+
+    finals = [
+        chunk
+        for chunk in chunks
+        if chunk.role == Role.TOOL and any(isinstance(p.root, ToolResponsePart) for p in chunk.content)
+    ]
+    assert finals
+    assert finals[0].text == ''
+    assert _tool_outputs(response.messages) == ['done']
+    assert response.messages[-1].role in {Role.MODEL, Role.TOOL}
+
+
+@pytest.mark.asyncio
+async def test_generate_stream_after_a_finished_tool_round_send_chunk_still_tool_role() -> None:
+    """A later tool's send_chunk is still role=tool; the first closed round stays."""
+    ai = Genkit(model='programmableModel')
+    pm, _ = define_programmable_model(ai)
+
+    @ai.tool(name='weather')
+    async def weather(_req: dict) -> str:
+        return '72F'
+
+    @ai.tool(name='deploy')
+    async def deploy(_req: dict, ctx: ToolRunContext) -> str:
+        ctx.send_chunk(_text_part('live'))
+        return 'done'
+
+    pm.responses = [
+        _model_calls(('weather', 'w1')),
+        _model_calls(('deploy', 'd1')),
+        _model_says('ok'),
+    ]
+    chunks, response = await _collect_stream(ai, prompt='do both', tools=[weather, deploy])
+
+    sent = _send_chunks(chunks)
+    assert sent[0].role == Role.TOOL
+    assert sent[0].text == 'live'
+    assert [m.role for m in response.messages[:3]] == [Role.USER, Role.MODEL, Role.TOOL]
+    assert _tool_outputs(response.messages)[0] == '72F'
+    assert 'live' not in _message_texts(response.messages)
+
+
+@pytest.mark.asyncio
+async def test_tool_stream_send_chunk_one_part_is_the_part() -> None:
+    """tool.stream() yields the Part you sent, not a generate ModelResponseChunk."""
+    ai = Genkit()
+
+    @ai.tool(name='deploy')
+    async def deploy(_req: dict, ctx: ToolRunContext) -> str:
+        ctx.send_chunk(_text_part('live'))
+        return 'done'
+
+    stream = deploy.action().stream({})
+    got: list[object] = []
+    async for chunk in stream.stream:
+        got.append(chunk)
+    assert len(got) == 1
+    assert isinstance(got[0], Part)
+    assert got[0].root.text == 'live'
+    assert (await stream.response).output == 'done'
+
+
+@pytest.mark.asyncio
+async def test_generate_stream_send_chunk_media_only_has_empty_text() -> None:
+    """A media-only send_chunk has empty .text and keeps the media part."""
+    ai = Genkit(model='programmableModel')
+    pm, _ = define_programmable_model(ai)
+    media = Part(root=MediaPart(media=Media(url='https://example.com/a.png', content_type='image/png')))
+
+    @ai.tool(name='deploy')
+    async def deploy(_req: dict, ctx: ToolRunContext) -> str:
+        ctx.send_chunk(media)
+        return 'done'
+
+    pm.responses = [_model_calls(('deploy', 'r1')), _model_says('ok')]
+    chunks, _response = await _collect_stream(ai, prompt='go', tools=[deploy])
+
+    tool_chunks = [c for c in chunks if c.role == Role.TOOL]
+    sent = [c for c in tool_chunks if any(isinstance(p.root, MediaPart) for p in c.content)]
+    assert sent[0].text == ''
+    assert isinstance(sent[0].content[0].root, MediaPart)
+
+
+@pytest.mark.asyncio
+async def test_generate_stream_send_chunk_tool_response_part_is_forwarded() -> None:
+    """A ToolResponsePart is a legal send_chunk part and shows up as-is."""
+    ai = Genkit(model='programmableModel')
+    pm, _ = define_programmable_model(ai)
+    stamped = Part(
+        root=ToolResponsePart(tool_response=ToolResponse(name='deploy', ref='mine', output='uploading')),
+    )
+
+    @ai.tool(name='deploy')
+    async def deploy(_req: dict, ctx: ToolRunContext) -> str:
+        ctx.send_chunk(stamped)
+        return 'done'
+
+    pm.responses = [_model_calls(('deploy', 'r1')), _model_says('ok')]
+    chunks, response = await _collect_stream(ai, prompt='go', tools=[deploy])
+
+    sent = [c for c in chunks if c.role == Role.TOOL and any(isinstance(p.root, ToolResponsePart) for p in c.content)]
+    first = sent[0].content[0].root
+    assert isinstance(first, ToolResponsePart)
+    assert first.tool_response.name == 'deploy'
+    assert first.tool_response.ref == 'mine'
+    assert first.tool_response.output == 'uploading'
+    assert _tool_outputs(response.messages) == ['done']
+
+
+@pytest.mark.asyncio
+async def test_generate_stream_two_send_chunks_accumulated_text_is_hello() -> None:
+    """Two text send_chunks concatenate on .accumulated_text."""
+    ai = Genkit(model='programmableModel')
+    pm, _ = define_programmable_model(ai)
+
+    @ai.tool(name='deploy')
+    async def deploy(_req: dict, ctx: ToolRunContext) -> str:
+        ctx.send_chunk(_text_part('hel'))
+        ctx.send_chunk(_text_part('lo'))
+        return 'done'
+
+    pm.responses = [_model_calls(('deploy', 'r1')), _model_says('ok')]
+    chunks, response = await _collect_stream(ai, prompt='go', tools=[deploy])
+
+    sent = _send_chunks(chunks)
+    assert sent[0].text == 'hel'
+    assert sent[1].text == 'lo'
+    assert sent[1].accumulated_text == 'hello'
+    assert 'hel' not in _message_texts(response.messages)
+    assert _tool_outputs(response.messages) == ['done']
+
+
+@pytest.mark.asyncio
+async def test_generate_stream_two_tools_send_chunk_chunks_have_no_tool_name() -> None:
+    """Two tools send_chunk text; generate does not stamp name or ref."""
+    ai = Genkit(model='programmableModel')
+    pm, _ = define_programmable_model(ai)
+
+    @ai.tool(name='alpha')
+    async def alpha(_req: dict, ctx: ToolRunContext) -> str:
+        ctx.send_chunk(_text_part('from-alpha'))
+        return 'a'
+
+    @ai.tool(name='beta')
+    async def beta(_req: dict, ctx: ToolRunContext) -> str:
+        ctx.send_chunk(_text_part('from-beta'))
+        return 'b'
+
+    pm.responses = [_model_calls(('alpha', 'a1'), ('beta', 'b1')), _model_says('ok')]
+    chunks, response = await _collect_stream(ai, prompt='go', tools=[alpha, beta])
+
+    sent = _send_chunks(chunks)
+    assert {c.text for c in sent} == {'from-alpha', 'from-beta'}
+    for chunk in sent:
+        for part in chunk.content:
+            root = part.root
+            if isinstance(root, ToolResponsePart):
+                raise AssertionError('send_chunk text must not be stamped as a tool response')
+    assert _tool_outputs(response.messages) == ['a', 'b'] or set(_tool_outputs(response.messages)) == {'a', 'b'}
+
+
+@pytest.mark.asyncio
+async def test_generate_stream_two_tools_send_chunk_accumulated_text_includes_both() -> None:
+    """The later tool-role send_chunk's accumulated_text includes both tools."""
+    ai = Genkit(model='programmableModel')
+    pm, _ = define_programmable_model(ai)
+
+    @ai.tool(name='alpha')
+    async def alpha(_req: dict, ctx: ToolRunContext) -> str:
+        ctx.send_chunk(_text_part('from-alpha'))
+        return 'a'
+
+    @ai.tool(name='beta')
+    async def beta(_req: dict, ctx: ToolRunContext) -> str:
+        ctx.send_chunk(_text_part('from-beta'))
+        return 'b'
+
+    pm.responses = [_model_calls(('alpha', 'a1'), ('beta', 'b1')), _model_says('ok')]
+    chunks, response = await _collect_stream(ai, prompt='go', tools=[alpha, beta])
+
+    sent = _send_chunks(chunks)
+    later = sent[-1]
+    assert 'from-alpha' in later.accumulated_text
+    assert 'from-beta' in later.accumulated_text
+    assert set(_tool_outputs(response.messages)) == {'a', 'b'}
+
+
+@pytest.mark.asyncio
+async def test_generate_send_chunk_does_not_appear_on_the_stream() -> None:
+    """await generate() has no stream; send_chunk is a no-op and messages have the return."""
+    ai = Genkit(model='programmableModel')
+    pm, _ = define_programmable_model(ai)
+
+    @ai.tool(name='deploy')
+    async def deploy(_req: dict, ctx: ToolRunContext) -> str:
+        ctx.send_chunk(_text_part('live'))
+        return 'done'
+
+    pm.responses = [_model_calls(('deploy', 'r1')), _model_says('ok')]
+    response = await ai.generate(prompt='go', tools=[deploy])
+    assert 'live' not in _message_texts(response.messages)
+    assert _tool_outputs(response.messages) == ['done']
+
+
+@pytest.mark.asyncio
+async def test_tool_run_send_chunk_without_a_stream_is_noop() -> None:
+    """deploy.run() with no on_chunk: send_chunk does not error; return is unchanged."""
+    ai = Genkit()
+
+    @ai.tool(name='deploy')
+    async def deploy(_req: dict, ctx: ToolRunContext) -> str:
+        ctx.send_chunk(_text_part('live'))
+        return 'done'
+
+    assert (await deploy({})).output == 'done'
+
+
+@pytest.mark.asyncio
+async def test_generate_stream_send_chunk_text_is_not_in_response_messages() -> None:
+    """No message in the finished response contains the send_chunk string."""
+    ai = Genkit(model='programmableModel')
+    pm, _ = define_programmable_model(ai)
+
+    @ai.tool(name='deploy')
+    async def deploy(_req: dict, ctx: ToolRunContext) -> str:
+        ctx.send_chunk(_text_part('not-in-history'))
+        return 'done'
+
+    pm.responses = [_model_calls(('deploy', 'r1')), _model_says('ok')]
+    _chunks, response = await _collect_stream(ai, prompt='go', tools=[deploy])
+    assert 'not-in-history' not in _message_texts(response.messages)
+    assert _tool_outputs(response.messages) == ['done']
+
+
+@pytest.mark.asyncio
+async def test_generate_stream_return_tool_requests_never_runs_send_chunk() -> None:
+    """return_tool_requests=True does not run the tool, so send_chunk never fires."""
+    ai = Genkit(model='programmableModel')
+    pm, _ = define_programmable_model(ai)
+    ran = {'n': 0}
+
+    @ai.tool(name='deploy')
+    async def deploy(_req: dict, ctx: ToolRunContext) -> str:
+        ran['n'] += 1
+        ctx.send_chunk(_text_part('live'))
+        return 'done'
+
+    pm.responses = [_model_calls(('deploy', 'r1'))]
+    chunks, response = await _collect_stream(ai, prompt='go', tools=[deploy], return_tool_requests=True)
+    assert ran['n'] == 0
+    assert _send_chunks(chunks) == []
+    assert response.message is not None
+    assert response.message.tool_requests
+
+
+@pytest.mark.asyncio
+async def test_generate_stream_recipe_schema_does_not_apply_to_send_chunk() -> None:
+    """output_schema=Recipe does not turn a tool send_chunk into a Recipe."""
+    ai = Genkit(model='programmableModel')
+    pm, _ = define_programmable_model(ai)
+
+    @ai.tool(name='deploy')
+    async def deploy(_req: dict, ctx: ToolRunContext) -> str:
+        ctx.send_chunk(_text_part('live'))
+        return 'done'
+
+    recipe_json = '{"title": "Pie", "steps": ["bake"]}'
+    pm.chunks = [[ModelResponseChunk(role=Role.MODEL, content=[_text_part(recipe_json)])]]
+    pm.responses = [
+        ModelResponse(
+            finish_reason=FinishReason.STOP,
+            message=Message(
+                role=Role.MODEL,
+                content=[
+                    _text_part(recipe_json),
+                    Part(root=ToolRequestPart(tool_request=ToolRequest(name='deploy', ref='r1', input={}))),
+                ],
+            ),
+        ),
+        ModelResponse(
+            finish_reason=FinishReason.STOP,
+            message=Message(role=Role.MODEL, content=[_text_part(recipe_json)]),
+        ),
+    ]
+    chunks, response = await _collect_stream(ai, prompt='go', tools=[deploy], output_schema=Recipe)
+
+    sent = _send_chunks(chunks)
+    assert sent
+    assert not isinstance(sent[0].output, Recipe)
+    assert 'live' not in _message_texts(response.messages)
+
+
+@pytest.mark.asyncio
+async def test_generate_stream_model_chunks_are_still_recipe_next_to_send_chunk() -> None:
+    """Model-role chunks are still leftover Recipe beside a tool send_chunk."""
+    ai = Genkit(model='programmableModel')
+    pm, _ = define_programmable_model(ai)
+
+    @ai.tool(name='deploy')
+    async def deploy(_req: dict, ctx: ToolRunContext) -> str:
+        ctx.send_chunk(_text_part('live'))
+        return 'done'
+
+    recipe_json = '{"title": "Pie", "steps": ["bake"]}'
+    pm.chunks = [[ModelResponseChunk(role=Role.MODEL, content=[_text_part(recipe_json)])]]
+    pm.responses = [
+        ModelResponse(
+            finish_reason=FinishReason.STOP,
+            message=Message(
+                role=Role.MODEL,
+                content=[
+                    _text_part(recipe_json),
+                    Part(root=ToolRequestPart(tool_request=ToolRequest(name='deploy', ref='r1', input={}))),
+                ],
+            ),
+        ),
+        ModelResponse(
+            finish_reason=FinishReason.STOP,
+            message=Message(role=Role.MODEL, content=[_text_part(recipe_json)]),
+        ),
+    ]
+    chunks, response = await _collect_stream(ai, prompt='go', tools=[deploy], output_schema=Recipe)
+
+    model_chunks = [c for c in chunks if c.role == Role.MODEL]
+    assert model_chunks
+    assert isinstance(model_chunks[0].output, Recipe)
+    assert model_chunks[0].output.title == 'Pie'
+    assert _tool_outputs(response.messages) == ['done']
+
+
+@pytest.mark.asyncio
+async def test_generate_stream_interrupt_after_send_chunk_streamed_but_not_in_messages() -> None:
+    """send_chunk then Interrupt: the chunk was streamed; messages do not keep it."""
+    ai = Genkit(model='programmableModel')
+    pm, _ = define_programmable_model(ai)
+
+    @ai.tool(name='deploy')
+    async def deploy(_req: dict, ctx: ToolRunContext) -> str:
+        ctx.send_chunk(_text_part('live'))
+        raise Interrupt({'hold': True})
+
+    pm.responses = [_model_calls(('deploy', 'r1'))]
+    chunks, response = await _collect_stream(ai, prompt='go', tools=[deploy])
+
+    assert _send_chunks(chunks)[0].text == 'live'
+    assert response.finish_reason == FinishReason.INTERRUPTED
+    assert 'live' not in _message_texts(response.messages)
+
+
+@pytest.mark.asyncio
+async def test_generate_stream_resume_does_not_replay_send_chunk() -> None:
+    """Resume after interrupt does not replay the first run's send_chunk text."""
+    ai = Genkit(model='programmableModel')
+    pm, _ = define_programmable_model(ai)
+    runs = {'n': 0}
+
+    @ai.tool(name='pay')
+    async def pay(inp: dict, ctx: ToolRunContext) -> str:
+        runs['n'] += 1
+        if not inp.get('ok'):
+            ctx.send_chunk(_text_part('first-run'))
+            raise Interrupt({'hold': True})
+        return 'paid'
+
+    pm.responses = [_model_calls(('pay', 'p1')), _model_says('final')]
+    first_chunks, first = await _collect_stream(ai, prompt='go', tools=[pay])
+    assert _send_chunks(first_chunks)[0].text == 'first-run'
+
+    restart = restart_tool(interrupt=first.interrupts[0], replace_input={'ok': True})
+    second_chunks, second = await _collect_stream(
+        ai,
+        messages=list(first.messages),
+        tools=[pay],
+        resume_restart=restart,
+    )
+    assert all(c.text != 'first-run' for c in _send_chunks(second_chunks))
+    assert 'first-run' not in _message_texts(second.messages)
+    assert runs['n'] == 2
+
+
+@pytest.mark.asyncio
+async def test_generate_stream_restarted_tool_send_chunk_is_a_new_chunk() -> None:
+    """A restarted tool's send_chunk is new text, not a replay of the first run."""
+    ai = Genkit(model='programmableModel')
+    pm, _ = define_programmable_model(ai)
+
+    @ai.tool(name='pay')
+    async def pay(inp: dict, ctx: ToolRunContext) -> str:
+        if not inp.get('ok'):
+            ctx.send_chunk(_text_part('first-run'))
+            raise Interrupt({'hold': True})
+        ctx.send_chunk(_text_part('second-run'))
+        return 'paid'
+
+    pm.responses = [_model_calls(('pay', 'p1')), _model_says('final')]
+    _first_chunks, first = await _collect_stream(ai, prompt='go', tools=[pay])
+    restart = restart_tool(interrupt=first.interrupts[0], replace_input={'ok': True})
+    second_chunks, second = await _collect_stream(
+        ai,
+        messages=list(first.messages),
+        tools=[pay],
+        resume_restart=restart,
+    )
+    sent = _send_chunks(second_chunks)
+    assert any(c.text == 'second-run' for c in sent)
+    assert all(c.text != 'first-run' for c in sent)
+    assert 'second-run' not in _message_texts(second.messages)
+    assert _tool_outputs(second.messages)[-1] == 'paid'
+
+
+@pytest.mark.asyncio
+async def test_generate_stream_abort_after_send_chunk_keeps_chunk_off_messages() -> None:
+    """Abort after send_chunk: the chunk was streamed; messages do not contain it."""
+    ai = Genkit(model='programmableModel')
+    pm, _ = define_programmable_model(ai)
+
+    @ai.tool(name='deploy')
+    async def deploy(_req: dict, ctx: ToolRunContext) -> str:
+        ctx.send_chunk(_text_part('live'))
+        ctx.abort_signal.set()
+        return 'done'
+
+    pm.responses = [_model_calls(('deploy', 'r1')), _model_says('ok')]
+    chunks: list[ModelResponseChunk] = []
+    stream = ai.generate_stream(prompt='go', tools=[deploy])
+    with pytest.raises(GenkitError) as ei:
+        async for chunk in stream.stream:
+            chunks.append(chunk)
+        await stream.response
+    assert ei.value.status == 'ABORTED'
+    assert _send_chunks(chunks)[0].text == 'live'
+
+
+@pytest.mark.asyncio
+async def test_generate_stream_max_turns_after_send_chunk_keeps_chunk_off_messages() -> None:
+    """Hitting max turns after send_chunk keeps the chunk off messages."""
+    ai = Genkit(model='programmableModel')
+    pm, _ = define_programmable_model(ai)
+
+    @ai.tool(name='lookup')
+    async def lookup(_req: dict, ctx: ToolRunContext) -> str:
+        ctx.send_chunk(_text_part('live'))
+        return '72F'
+
+    pm.responses = [_model_calls(('lookup', 'r1')), _model_calls(('lookup', 'r2'))]
+    chunks, response = await _collect_stream(ai, prompt='keep going', tools=[lookup], max_turns=1)
+    assert _send_chunks(chunks)[0].text == 'live'
+    assert 'live' not in _message_texts(response.messages)
+    assert _tool_outputs(response.messages) == ['72F']
+
+
+@pytest.mark.asyncio
+async def test_define_prompt_stream_send_chunk_is_tool_role_text() -> None:
+    """define_prompt(...).stream() + send_chunk is the same tool-role text."""
+    ai = Genkit(model='programmableModel')
+    pm, _ = define_programmable_model(ai)
+
+    @ai.tool(name='deploy')
+    async def deploy(_req: dict, ctx: ToolRunContext) -> str:
+        ctx.send_chunk(_text_part('live'))
+        return 'done'
+
+    pm.responses = [_model_calls(('deploy', 'r1')), _model_says('ok')]
+    prompt = ai.define_prompt(prompt='go', tools=[deploy])
+    stream = prompt.stream()
+    chunks: list[ModelResponseChunk] = []
+    async for chunk in stream.stream:
+        chunks.append(chunk)
+    response = await stream.response
+    assert _send_chunks(chunks)[0].text == 'live'
+    assert 'live' not in _message_texts(response.messages)
+
+
+@pytest.mark.asyncio
+async def test_agent_send_stream_includes_tool_send_chunk() -> None:
+    """Agent send_stream surfaces the generate tool-role send_chunk as that same chunk."""
+    ai = Genkit(model='programmableModel')
+    pm, _ = define_programmable_model(ai)
+
+    @ai.tool(name='deploy')
+    async def deploy(_req: dict, ctx: ToolRunContext) -> str:
+        ctx.send_chunk(_text_part('live'))
+        return 'done'
+
+    ai.define_prompt(name='shipAgent', model='programmableModel', tools=[deploy])
+    agent = ai.define_prompt_agent(name='shipAgent')
+    pm.responses = [_model_calls(('deploy', 'r1')), _model_says('ok')]
+
+    turn = agent.chat().send_stream('go')
+    texts: list[str] = []
+    async for item in turn.stream:
+        raw = item.raw
+        model_chunk = raw.model_chunk if raw is not None else None
+        if model_chunk is not None and model_chunk.role == Role.TOOL and item.text:
+            texts.append(item.text)
+    await turn.response
+    assert 'live' in texts
+
+
+@pytest.mark.asyncio
+async def test_send_chunk_dict_raises_invalid_argument() -> None:
+    """send_chunk({'percent': 50}) raises INVALID_ARGUMENT."""
+    ctx = ToolRunContext(ActionRunContext())
+    with pytest.raises(GenkitError) as ei:
+        ctx.send_chunk({'percent': 50})  # type: ignore[arg-type]
+    assert ei.value.status == 'INVALID_ARGUMENT'
+
+
+@pytest.mark.asyncio
+async def test_send_chunk_model_response_chunk_raises_invalid_argument() -> None:
+    """Passing a ModelResponseChunk to send_chunk raises INVALID_ARGUMENT."""
+    ctx = ToolRunContext(ActionRunContext())
+    with pytest.raises(GenkitError) as ei:
+        ctx.send_chunk(ModelResponseChunk(role=Role.TOOL, content=[_text_part('x')]))  # type: ignore[arg-type]
+    assert ei.value.status == 'INVALID_ARGUMENT'
+
+
+@pytest.mark.asyncio
+async def test_send_chunk_none_raises_invalid_argument() -> None:
+    """send_chunk(None) raises INVALID_ARGUMENT."""
+    ctx = ToolRunContext(ActionRunContext())
+    with pytest.raises(GenkitError) as ei:
+        ctx.send_chunk(None)  # type: ignore[arg-type]
+    assert ei.value.status == 'INVALID_ARGUMENT'
+
+
+@pytest.mark.asyncio
+async def test_send_chunk_empty_list_is_a_tool_role_chunk_with_no_parts() -> None:
+    """send_chunk([]) is a tool-role chunk with empty content."""
+    ai = Genkit(model='programmableModel')
+    pm, _ = define_programmable_model(ai)
+
+    @ai.tool(name='deploy')
+    async def deploy(_req: dict, ctx: ToolRunContext) -> str:
+        ctx.send_chunk([])
+        return 'done'
+
+    pm.responses = [_model_calls(('deploy', 'r1')), _model_says('ok')]
+    chunks, response = await _collect_stream(ai, prompt='go', tools=[deploy])
+    empty = [c for c in chunks if c.role == Role.TOOL and c.content == []]
+    assert empty
+    assert empty[0].text == ''
+    assert _tool_outputs(response.messages) == ['done']
+
+
+@pytest.mark.asyncio
+async def test_generate_stream_error_during_send_chunk_tool_still_returns() -> None:
+    """A listener error on the send_chunk chunk is dropped; the return still lands."""
+
+    class BoomOnSend(BaseMiddleware):
+        async def wrap_generate(
+            self,
+            params: GenerateHookParams,
+            ctx: GenerateMiddlewareContext,
+            next_fn,
+        ) -> ModelResponse:
+            downstream = ctx.on_chunk
+
+            def handler(chunk: ModelResponseChunk) -> None:
+                if chunk.role == Role.TOOL and chunk.text == 'live':
+                    raise RuntimeError('sink')
+                if downstream is not None:
+                    downstream(chunk)
+
+            previous = ctx.replace_on_chunk(handler)
+            try:
+                return await next_fn(params, ctx)
+            finally:
+                ctx.replace_on_chunk(previous)
+
+    ai = Genkit(model='programmableModel')
+    pm, _ = define_programmable_model(ai)
+
+    @ai.tool(name='deploy')
+    async def deploy(_req: dict, ctx: ToolRunContext) -> str:
+        ctx.send_chunk(_text_part('live'))
+        return 'done'
+
+    pm.responses = [_model_calls(('deploy', 'r1')), _model_says('ok')]
+    _chunks, response = await _collect_stream(ai, prompt='go', tools=[deploy], use=[BoomOnSend()])
+    assert _tool_outputs(response.messages) == ['done']
+    assert response.finish_reason == FinishReason.STOP
+
+
+@pytest.mark.asyncio
+async def test_generate_stream_error_on_final_tool_response_fails_generate() -> None:
+    """A listener error on the return tool-role chunk fails generate."""
+
+    class BoomOnFinal(BaseMiddleware):
+        async def wrap_generate(
+            self,
+            params: GenerateHookParams,
+            ctx: GenerateMiddlewareContext,
+            next_fn,
+        ) -> ModelResponse:
+            downstream = ctx.on_chunk
+
+            def handler(chunk: ModelResponseChunk) -> None:
+                if chunk.role == Role.TOOL and any(isinstance(p.root, ToolResponsePart) for p in chunk.content):
+                    raise RuntimeError('final sink')
+                if downstream is not None:
+                    downstream(chunk)
+
+            previous = ctx.replace_on_chunk(handler)
+            try:
+                return await next_fn(params, ctx)
+            finally:
+                ctx.replace_on_chunk(previous)
+
+    ai = Genkit(model='programmableModel')
+    pm, _ = define_programmable_model(ai)
+
+    @ai.tool(name='deploy')
+    async def deploy(_req: dict, ctx: ToolRunContext) -> str:
+        ctx.send_chunk(_text_part('live'))
+        return 'done'
+
+    pm.responses = [_model_calls(('deploy', 'r1')), _model_says('ok')]
+    stream = ai.generate_stream(prompt='go', tools=[deploy], use=[BoomOnFinal()])
+    with pytest.raises(RuntimeError, match='final sink'):
+        async for _chunk in stream.stream:
+            pass
+        await stream.response
+    with pytest.raises(RuntimeError, match='final sink'):
+        await stream.response
+
+
+def test_normalize_send_chunk_parts_accepts_part_and_list() -> None:
+    """normalize_send_chunk_parts turns one Part into a one-item list."""
+    part = _text_part('x')
+    assert normalize_send_chunk_parts(part) == [part]
+    assert normalize_send_chunk_parts([part, part]) == [part, part]

--- a/py/packages/genkit/tests/genkit/ai/streaming_tool_send_chunk_test.py
+++ b/py/packages/genkit/tests/genkit/ai/streaming_tool_send_chunk_test.py
@@ -268,6 +268,7 @@ async def test_generate_stream_send_chunk_tool_response_part_is_forwarded() -> N
     assert first.tool_response.name == 'deploy'
     assert first.tool_response.ref == 'mine'
     assert first.tool_response.output == 'uploading'
+    assert (sent[0].custom or {}).get('keepInHistory') is False
     assert _tool_outputs(response.messages) == ['done']
 
 
@@ -450,7 +451,7 @@ async def test_generate_stream_recipe_schema_does_not_apply_to_send_chunk() -> N
 
     sent = _send_chunks(chunks)
     assert sent
-    assert not isinstance(sent[0].output, Recipe)
+    assert sent[0].output is None
     assert 'live' not in _message_texts(response.messages)
 
 
@@ -489,6 +490,47 @@ async def test_generate_stream_model_chunks_are_still_recipe_next_to_send_chunk(
     assert model_chunks
     assert isinstance(model_chunks[0].output, Recipe)
     assert model_chunks[0].output.title == 'Pie'
+    assert _tool_outputs(response.messages) == ['done']
+
+
+@pytest.mark.asyncio
+async def test_generate_stream_json_send_chunk_does_not_leave_output_on_later_tool_chunks() -> None:
+    """A json-looking send_chunk does not become leftover chunk.output on later tool-role chunks."""
+    ai = Genkit(model='programmableModel')
+    pm, _ = define_programmable_model(ai)
+    leftover = '{"title": "Pie", "steps": ["mix"]}'
+    recipe_json = '{"title": "Pie", "steps": ["bake"]}'
+
+    @ai.tool(name='deploy')
+    async def deploy(_req: dict, ctx: ToolRunContext) -> str:
+        ctx.send_chunk(_text_part(leftover))
+        return 'done'
+
+    pm.chunks = [[ModelResponseChunk(role=Role.MODEL, content=[_text_part(recipe_json)])]]
+    pm.responses = [
+        ModelResponse(
+            finish_reason=FinishReason.STOP,
+            message=Message(
+                role=Role.MODEL,
+                content=[
+                    _text_part(recipe_json),
+                    Part(root=ToolRequestPart(tool_request=ToolRequest(name='deploy', ref='r1', input={}))),
+                ],
+            ),
+        ),
+        ModelResponse(
+            finish_reason=FinishReason.STOP,
+            message=Message(role=Role.MODEL, content=[_text_part(recipe_json)]),
+        ),
+    ]
+    chunks, response = await _collect_stream(ai, prompt='go', tools=[deploy], output_schema=Recipe)
+    tool_chunks = [chunk for chunk in chunks if chunk.role == Role.TOOL]
+    assert tool_chunks
+    for chunk in tool_chunks:
+        assert chunk.output is None
+    model_chunks = [chunk for chunk in chunks if chunk.role == Role.MODEL]
+    assert isinstance(model_chunks[-1].output, Recipe)
+    assert model_chunks[-1].output.steps == ['bake']
     assert _tool_outputs(response.messages) == ['done']
 
 

--- a/py/packages/genkit/tests/genkit/ai/streaming_tool_send_partial_test.py
+++ b/py/packages/genkit/tests/genkit/ai/streaming_tool_send_partial_test.py
@@ -18,17 +18,21 @@ import pytest
 from pydantic import BaseModel
 
 from genkit import Genkit, Message, ModelResponse, ModelResponseChunk, restart_tool
+from genkit._ai._agents._client import StreamedMessageAccumulator
+from genkit._ai._generate import mark_stream_only
 from genkit._ai._testing import define_programmable_model
 from genkit._ai._tools import Interrupt, ToolRunContext
 from genkit._core._error import GenkitError
 from genkit._core._middleware import BaseMiddleware, GenerateHookParams, GenerateMiddlewareContext
 from genkit._core._typing import (
+    AgentStreamChunk,
     FinishReason,
     Part,
     Role,
     TextPart,
     ToolRequest,
     ToolRequestPart,
+    ToolResponse,
     ToolResponsePart,
 )
 
@@ -65,6 +69,16 @@ def _model_says(text: str) -> ModelResponse:
         finish_reason=FinishReason.STOP,
         message=Message(role=Role.MODEL, content=[_text_part(text)]),
     )
+
+
+def _message_texts(messages: Sequence[Message]) -> list[str]:
+    texts: list[str] = []
+    for msg in messages:
+        for part in msg.content:
+            text_val = getattr(part.root, 'text', None)
+            if text_val:
+                texts.append(str(text_val))
+    return texts
 
 
 def _tool_outputs(messages: Sequence[Message]) -> list[object]:
@@ -325,8 +339,7 @@ async def test_generate_stream_send_partial_chunk_output_is_not_the_progress() -
         if chunk.role == Role.TOOL and any((p.root.metadata or {}).get('partial') is True for p in chunk.content)
     ]
     assert sent_chunks
-    assert not isinstance(sent_chunks[0].output, Progress)
-    assert sent_chunks[0].output != progress
+    assert sent_chunks[0].output is None
     _assert_stamped(_partials(chunks)[0], name='deploy', ref='r1', output=progress)
     assert _tool_outputs(response.messages) == ['done']
 
@@ -785,6 +798,165 @@ async def test_agent_send_stream_includes_tool_send_partial() -> None:
                 found.append(root)
     await turn.response
     _assert_stamped(found[0], name='deploy', ref='r1', output=progress)
+
+
+@pytest.mark.asyncio
+async def test_agent_chat_messages_keep_return_not_mid_tool_updates() -> None:
+    """After send, chat.messages has the return; the next turn does not see mid-tool parts."""
+    ai = Genkit(model='programmableModel')
+    pm, _ = define_programmable_model(ai)
+    progress = Progress(step='uploading', percent=50)
+
+    @ai.tool(name='deploy')
+    async def deploy(_req: dict, ctx: ToolRunContext) -> str:
+        ctx.send_chunk(_text_part('svc-00042 is live'))
+        ctx.send_partial(progress)
+        return 'done'
+
+    ai.define_prompt(name='shipAgent', model='programmableModel', tools=[deploy])
+    agent = ai.define_prompt_agent(name='shipAgent')
+    pm.responses = [
+        _model_calls(('deploy', 'r1')),
+        _model_says('ok'),
+        _model_says('again-ok'),
+    ]
+
+    chat = agent.chat()
+    await chat.send('go')
+    assert _tool_outputs(chat.messages) == ['done']
+    assert not _has_partial_part(chat.messages)
+    assert 'svc-00042 is live' not in _message_texts(chat.messages)
+
+    turn = chat.send_stream('again')
+    async for _item in turn.stream:
+        pass
+    await turn.response
+    req = pm.last_request
+    assert req is not None
+    assert 'svc-00042 is live' not in _message_texts(req.messages)
+    assert not _has_partial_part(req.messages)
+    assert _tool_outputs(req.messages) == ['done']
+
+
+@pytest.mark.asyncio
+async def test_agent_next_turn_drops_send_chunk_tool_response_part() -> None:
+    """send_chunk(ToolResponsePart) is streamed; chat.messages and the next turn keep only the return."""
+    ai = Genkit(model='programmableModel')
+    pm, _ = define_programmable_model(ai)
+    stamped = Part(
+        root=ToolResponsePart(tool_response=ToolResponse(name='deploy', ref='mine', output='uploading')),
+    )
+
+    @ai.tool(name='deploy')
+    async def deploy(_req: dict, ctx: ToolRunContext) -> str:
+        ctx.send_chunk(stamped)
+        return 'done'
+
+    ai.define_prompt(name='shipAgent', model='programmableModel', tools=[deploy])
+    agent = ai.define_prompt_agent(name='shipAgent')
+    pm.responses = [
+        _model_calls(('deploy', 'r1')),
+        _model_says('ok'),
+        _model_says('again-ok'),
+    ]
+
+    chat = agent.chat()
+    await chat.send('go')
+    assert _tool_outputs(chat.messages) == ['done']
+
+    turn = chat.send_stream('again')
+    async for _item in turn.stream:
+        pass
+    await turn.response
+    req = pm.last_request
+    assert req is not None
+    assert _tool_outputs(req.messages) == ['done']
+    assert _tool_outputs(chat.messages) == ['done']
+
+
+@pytest.mark.asyncio
+async def test_agent_next_turn_drops_send_chunk_tool_request_part() -> None:
+    """send_chunk(ToolRequestPart) is streamed; the next turn does not replay it."""
+    ai = Genkit(model='programmableModel')
+    pm, _ = define_programmable_model(ai)
+    sneak = Part(root=ToolRequestPart(tool_request=ToolRequest(name='sneak', ref='x', input={})))
+
+    @ai.tool(name='deploy')
+    async def deploy(_req: dict, ctx: ToolRunContext) -> str:
+        ctx.send_chunk(sneak)
+        return 'done'
+
+    ai.define_prompt(name='shipAgent', model='programmableModel', tools=[deploy])
+    agent = ai.define_prompt_agent(name='shipAgent')
+    pm.responses = [
+        _model_calls(('deploy', 'r1')),
+        _model_says('ok'),
+        _model_says('again-ok'),
+    ]
+
+    chat = agent.chat()
+    await chat.send('go')
+    sneak_names = [
+        part.root.tool_request.name
+        for msg in chat.messages
+        for part in msg.content
+        if isinstance(part.root, ToolRequestPart)
+    ]
+    assert 'sneak' not in sneak_names
+
+    turn = chat.send_stream('again')
+    async for _item in turn.stream:
+        pass
+    await turn.response
+    req = pm.last_request
+    assert req is not None
+    req_names = [
+        part.root.tool_request.name
+        for msg in req.messages
+        for part in msg.content
+        if isinstance(part.root, ToolRequestPart)
+    ]
+    assert 'sneak' not in req_names
+
+
+def test_agent_history_still_drops_send_chunk_tool_response_after_wire_hop() -> None:
+    """After dump/validate, send_chunk(ToolResponsePart) still stays off history."""
+    mid = ModelResponseChunk(
+        role=Role.TOOL,
+        content=[
+            Part(root=ToolResponsePart(tool_response=ToolResponse(name='deploy', ref='mine', output='uploading'))),
+        ],
+    )
+    mark_stream_only(mid)
+    dumped = AgentStreamChunk.model_validate(
+        AgentStreamChunk(model_chunk=mid).model_dump(by_alias=True, exclude_none=True)
+    )
+    acc = StreamedMessageAccumulator()
+    acc.add(dumped)
+    assert _tool_outputs(acc.messages()) == []
+
+
+@pytest.mark.asyncio
+async def test_generate_stream_json_send_chunk_then_send_partial_output_stays_empty() -> None:
+    """After a json-looking send_chunk, send_partial and the return have chunk.output None."""
+    ai = Genkit(model='programmableModel')
+    pm, _ = define_programmable_model(ai)
+    leftover = '{"title": "Pie", "steps": ["mix"]}'
+    progress = Progress(step='uploading', percent=50)
+
+    @ai.tool(name='deploy')
+    async def deploy(_req: dict, ctx: ToolRunContext) -> str:
+        ctx.send_chunk(_text_part(leftover))
+        ctx.send_partial(progress)
+        return 'done'
+
+    pm.responses = [_model_calls(('deploy', 'r1')), _model_says('ok')]
+    chunks, response = await _collect_stream(ai, prompt='go', tools=[deploy], output_schema=Recipe)
+    for chunk in chunks:
+        if chunk.role == Role.TOOL:
+            assert chunk.output is None
+    _assert_stamped(_partials(chunks)[0], name='deploy', ref='r1', output=progress)
+    assert _tool_outputs(response.messages) == ['done']
 
 
 @pytest.mark.asyncio

--- a/py/packages/genkit/tests/genkit/ai/streaming_tool_send_partial_test.py
+++ b/py/packages/genkit/tests/genkit/ai/streaming_tool_send_partial_test.py
@@ -1,0 +1,871 @@
+#!/usr/bin/env python3
+#
+# Copyright 2026 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Pins ``ToolRunContext.send_partial`` during ``generate_stream``.
+
+``send_partial(value)`` shows up as a tool-role chunk with one
+``ToolResponsePart``: this tool's name and ref, ``metadata.partial is True``,
+and ``output`` is the value they passed. History only keeps the return.
+``chunk.output`` is not that Progress. ``tool.stream()`` does not yield it.
+Agent ``send_stream`` carries the same generate chunk (walk its parts).
+"""
+
+from collections.abc import Sequence
+
+import pytest
+from pydantic import BaseModel
+
+from genkit import Genkit, Message, ModelResponse, ModelResponseChunk, restart_tool
+from genkit._ai._testing import define_programmable_model
+from genkit._ai._tools import Interrupt, ToolRunContext
+from genkit._core._error import GenkitError
+from genkit._core._middleware import BaseMiddleware, GenerateHookParams, GenerateMiddlewareContext
+from genkit._core._typing import (
+    FinishReason,
+    Part,
+    Role,
+    TextPart,
+    ToolRequest,
+    ToolRequestPart,
+    ToolResponsePart,
+)
+
+
+class Progress(BaseModel):
+    step: str
+    percent: int
+
+
+class Recipe(BaseModel):
+    title: str
+    steps: list[str]
+
+
+def _text_part(text: str) -> Part:
+    return Part(TextPart(text=text))
+
+
+def _model_calls(*tools: tuple[str, str]) -> ModelResponse:
+    return ModelResponse(
+        finish_reason=FinishReason.STOP,
+        message=Message(
+            role=Role.MODEL,
+            content=[
+                Part(root=ToolRequestPart(tool_request=ToolRequest(name=name, ref=ref, input={})))
+                for name, ref in tools
+            ],
+        ),
+    )
+
+
+def _model_says(text: str) -> ModelResponse:
+    return ModelResponse(
+        finish_reason=FinishReason.STOP,
+        message=Message(role=Role.MODEL, content=[_text_part(text)]),
+    )
+
+
+def _tool_outputs(messages: Sequence[Message]) -> list[object]:
+    out: list[object] = []
+    for msg in messages:
+        if msg.role != Role.TOOL:
+            continue
+        for part in msg.content:
+            root = part.root
+            if isinstance(root, ToolResponsePart):
+                out.append(root.tool_response.output)
+    return out
+
+
+def _has_partial_part(messages: Sequence[Message]) -> bool:
+    for msg in messages:
+        for part in msg.content:
+            root = part.root
+            if isinstance(root, ToolResponsePart) and (root.metadata or {}).get('partial') is True:
+                return True
+    return False
+
+
+def _partials(chunks: Sequence[ModelResponseChunk]) -> list[ToolResponsePart]:
+    out: list[ToolResponsePart] = []
+    for chunk in chunks:
+        if chunk.role != Role.TOOL:
+            continue
+        for part in chunk.content:
+            root = part.root
+            if isinstance(root, ToolResponsePart) and (root.metadata or {}).get('partial') is True:
+                out.append(root)
+    return out
+
+
+def _assert_stamped(part: ToolResponsePart, *, name: str, ref: str, output: object) -> None:
+    assert part.tool_response.name == name
+    assert part.tool_response.ref == ref
+    assert (part.metadata or {}).get('partial') is True
+    assert part.tool_response.output == output
+
+
+async def _collect_stream(ai: Genkit, **kwargs: object) -> tuple[list[ModelResponseChunk], ModelResponse]:
+    stream = ai.generate_stream(**kwargs)  # type: ignore[arg-type]
+    chunks: list[ModelResponseChunk] = []
+    async for chunk in stream.stream:
+        chunks.append(chunk)
+    return chunks, await stream.response
+
+
+@pytest.mark.asyncio
+async def test_generate_stream_send_partial_progress_is_tool_role_stamped_part() -> None:
+    """send_partial(Progress) is a tool-role chunk with name, ref, and partial metadata."""
+    ai = Genkit(model='programmableModel')
+    pm, _ = define_programmable_model(ai)
+    progress = Progress(step='uploading', percent=50)
+
+    @ai.tool(name='deploy')
+    async def deploy(_req: dict, ctx: ToolRunContext) -> str:
+        ctx.send_partial(progress)
+        return 'done'
+
+    pm.responses = [_model_calls(('deploy', 'r1')), _model_says('ok')]
+    chunks, response = await _collect_stream(ai, prompt='go', tools=[deploy])
+    sent = _partials(chunks)
+    assert len(sent) == 1
+    _assert_stamped(sent[0], name='deploy', ref='r1', output=progress)
+    assert not _has_partial_part(response.messages)
+    assert _tool_outputs(response.messages) == ['done']
+
+
+@pytest.mark.asyncio
+async def test_generate_stream_two_send_partials_are_two_progress_values() -> None:
+    """Two send_partial calls are two chunks: 50 then 100, not one merged Progress."""
+    ai = Genkit(model='programmableModel')
+    pm, _ = define_programmable_model(ai)
+    first = Progress(step='uploading', percent=50)
+    second = Progress(step='health', percent=100)
+
+    @ai.tool(name='deploy')
+    async def deploy(_req: dict, ctx: ToolRunContext) -> str:
+        ctx.send_partial(first)
+        ctx.send_partial(second)
+        return 'done'
+
+    pm.responses = [_model_calls(('deploy', 'r1')), _model_says('ok')]
+    chunks, response = await _collect_stream(ai, prompt='go', tools=[deploy])
+    sent = _partials(chunks)
+    assert len(sent) == 2
+    _assert_stamped(sent[0], name='deploy', ref='r1', output=first)
+    _assert_stamped(sent[1], name='deploy', ref='r1', output=second)
+    assert _tool_outputs(response.messages) == ['done']
+
+
+@pytest.mark.asyncio
+async def test_generate_stream_return_still_streams_final_tool_response() -> None:
+    """After send_partial, the return still streams as a later tool-role response without partial."""
+    ai = Genkit(model='programmableModel')
+    pm, _ = define_programmable_model(ai)
+
+    @ai.tool(name='deploy')
+    async def deploy(_req: dict, ctx: ToolRunContext) -> str:
+        ctx.send_partial(Progress(step='uploading', percent=50))
+        return 'done'
+
+    pm.responses = [_model_calls(('deploy', 'r1')), _model_says('ok')]
+    chunks, response = await _collect_stream(ai, prompt='go', tools=[deploy])
+    finals = [
+        chunk
+        for chunk in chunks
+        if chunk.role == Role.TOOL
+        and any(
+            isinstance(p.root, ToolResponsePart) and (p.root.metadata or {}).get('partial') is not True
+            for p in chunk.content
+        )
+    ]
+    assert finals
+    assert _tool_outputs(response.messages) == ['done']
+    assert not _has_partial_part(response.messages)
+
+
+@pytest.mark.asyncio
+async def test_generate_stream_after_a_finished_tool_round_send_partial_is_still_stamped() -> None:
+    """A later tool's send_partial is still stamped; the first closed round stays."""
+    ai = Genkit(model='programmableModel')
+    pm, _ = define_programmable_model(ai)
+    progress = Progress(step='uploading', percent=50)
+
+    @ai.tool(name='weather')
+    async def weather(_req: dict) -> str:
+        return '72F'
+
+    @ai.tool(name='deploy')
+    async def deploy(_req: dict, ctx: ToolRunContext) -> str:
+        ctx.send_partial(progress)
+        return 'done'
+
+    pm.responses = [
+        _model_calls(('weather', 'w1')),
+        _model_calls(('deploy', 'd1')),
+        _model_says('ok'),
+    ]
+    chunks, response = await _collect_stream(ai, prompt='do both', tools=[weather, deploy])
+    sent = _partials(chunks)
+    _assert_stamped(sent[0], name='deploy', ref='d1', output=progress)
+    assert _tool_outputs(response.messages)[0] == '72F'
+    assert not _has_partial_part(response.messages)
+
+
+@pytest.mark.asyncio
+async def test_generate_stream_send_partial_dict_stays_a_dict() -> None:
+    """send_partial({'percent': 50}) puts that dict on the part; it is not a Progress."""
+    ai = Genkit(model='programmableModel')
+    pm, _ = define_programmable_model(ai)
+    payload = {'percent': 50}
+
+    @ai.tool(name='deploy')
+    async def deploy(_req: dict, ctx: ToolRunContext) -> str:
+        ctx.send_partial(payload)
+        return 'done'
+
+    pm.responses = [_model_calls(('deploy', 'r1')), _model_says('ok')]
+    chunks, response = await _collect_stream(ai, prompt='go', tools=[deploy])
+    sent = _partials(chunks)
+    _assert_stamped(sent[0], name='deploy', ref='r1', output=payload)
+    assert isinstance(sent[0].tool_response.output, dict)
+    assert not isinstance(sent[0].tool_response.output, Progress)
+    assert _tool_outputs(response.messages) == ['done']
+
+
+@pytest.mark.asyncio
+async def test_generate_stream_send_partial_number_is_the_number() -> None:
+    """send_partial(50) puts 50 on the part."""
+    ai = Genkit(model='programmableModel')
+    pm, _ = define_programmable_model(ai)
+
+    @ai.tool(name='deploy')
+    async def deploy(_req: dict, ctx: ToolRunContext) -> str:
+        ctx.send_partial(50)
+        return 'done'
+
+    pm.responses = [_model_calls(('deploy', 'r1')), _model_says('ok')]
+    chunks, response = await _collect_stream(ai, prompt='go', tools=[deploy])
+    _assert_stamped(_partials(chunks)[0], name='deploy', ref='r1', output=50)
+    assert _tool_outputs(response.messages) == ['done']
+
+
+@pytest.mark.asyncio
+async def test_generate_stream_send_partial_none_is_a_partial_with_no_output() -> None:
+    """send_partial(None) is still a stamped partial; output is None."""
+    ai = Genkit(model='programmableModel')
+    pm, _ = define_programmable_model(ai)
+
+    @ai.tool(name='deploy')
+    async def deploy(_req: dict, ctx: ToolRunContext) -> str:
+        ctx.send_partial(None)
+        return 'done'
+
+    pm.responses = [_model_calls(('deploy', 'r1')), _model_says('ok')]
+    chunks, response = await _collect_stream(ai, prompt='go', tools=[deploy])
+    _assert_stamped(_partials(chunks)[0], name='deploy', ref='r1', output=None)
+    assert _tool_outputs(response.messages) == ['done']
+
+
+@pytest.mark.asyncio
+async def test_generate_stream_send_partial_part_is_the_part_on_output() -> None:
+    """send_partial(Part(...)) puts that Part on output; it does not raise."""
+    ai = Genkit(model='programmableModel')
+    pm, _ = define_programmable_model(ai)
+    part = _text_part('live')
+
+    @ai.tool(name='deploy')
+    async def deploy(_req: dict, ctx: ToolRunContext) -> str:
+        ctx.send_partial(part)
+        return 'done'
+
+    pm.responses = [_model_calls(('deploy', 'r1')), _model_says('ok')]
+    chunks, response = await _collect_stream(ai, prompt='go', tools=[deploy])
+    _assert_stamped(_partials(chunks)[0], name='deploy', ref='r1', output=part)
+    assert _tool_outputs(response.messages) == ['done']
+
+
+@pytest.mark.asyncio
+async def test_generate_stream_send_partial_model_response_chunk_is_on_output() -> None:
+    """send_partial(ModelResponseChunk(...)) puts that chunk on output; it does not raise."""
+    ai = Genkit(model='programmableModel')
+    pm, _ = define_programmable_model(ai)
+    payload = ModelResponseChunk(role=Role.TOOL, content=[_text_part('x')])
+
+    @ai.tool(name='deploy')
+    async def deploy(_req: dict, ctx: ToolRunContext) -> str:
+        ctx.send_partial(payload)
+        return 'done'
+
+    pm.responses = [_model_calls(('deploy', 'r1')), _model_says('ok')]
+    chunks, response = await _collect_stream(ai, prompt='go', tools=[deploy])
+    _assert_stamped(_partials(chunks)[0], name='deploy', ref='r1', output=payload)
+    assert _tool_outputs(response.messages) == ['done']
+
+
+@pytest.mark.asyncio
+async def test_generate_stream_send_partial_chunk_output_is_not_the_progress() -> None:
+    """chunk.output is not the Progress they sent; the Progress is on the part."""
+    ai = Genkit(model='programmableModel')
+    pm, _ = define_programmable_model(ai)
+    progress = Progress(step='uploading', percent=50)
+
+    @ai.tool(name='deploy')
+    async def deploy(_req: dict, ctx: ToolRunContext) -> str:
+        ctx.send_partial(progress)
+        return 'done'
+
+    pm.responses = [_model_calls(('deploy', 'r1')), _model_says('ok')]
+    chunks, response = await _collect_stream(ai, prompt='go', tools=[deploy])
+    sent_chunks = [
+        chunk
+        for chunk in chunks
+        if chunk.role == Role.TOOL and any((p.root.metadata or {}).get('partial') is True for p in chunk.content)
+    ]
+    assert sent_chunks
+    assert not isinstance(sent_chunks[0].output, Progress)
+    assert sent_chunks[0].output != progress
+    _assert_stamped(_partials(chunks)[0], name='deploy', ref='r1', output=progress)
+    assert _tool_outputs(response.messages) == ['done']
+
+
+@pytest.mark.asyncio
+async def test_generate_stream_send_chunk_then_send_partial_keeps_both() -> None:
+    """send_chunk text then send_partial Progress: both show up; only the second is stamped."""
+    ai = Genkit(model='programmableModel')
+    pm, _ = define_programmable_model(ai)
+    progress = Progress(step='uploading', percent=50)
+
+    @ai.tool(name='deploy')
+    async def deploy(_req: dict, ctx: ToolRunContext) -> str:
+        ctx.send_chunk(_text_part('svc-00042 is live'))
+        ctx.send_partial(progress)
+        return 'done'
+
+    pm.responses = [_model_calls(('deploy', 'r1')), _model_says('ok')]
+    chunks, response = await _collect_stream(ai, prompt='go', tools=[deploy])
+    text_chunks = [
+        chunk
+        for chunk in chunks
+        if chunk.role == Role.TOOL and any(isinstance(p.root, TextPart) for p in chunk.content)
+    ]
+    assert text_chunks[0].text == 'svc-00042 is live'
+    for part in text_chunks[0].content:
+        assert not isinstance(part.root, ToolResponsePart)
+    _assert_stamped(_partials(chunks)[0], name='deploy', ref='r1', output=progress)
+    assert _tool_outputs(response.messages) == ['done']
+
+
+@pytest.mark.asyncio
+async def test_generate_stream_send_chunk_still_has_no_tool_name() -> None:
+    """A send_chunk next to send_partial still has no name or ref."""
+    ai = Genkit(model='programmableModel')
+    pm, _ = define_programmable_model(ai)
+
+    @ai.tool(name='deploy')
+    async def deploy(_req: dict, ctx: ToolRunContext) -> str:
+        ctx.send_chunk(_text_part('live'))
+        ctx.send_partial(Progress(step='uploading', percent=50))
+        return 'done'
+
+    pm.responses = [_model_calls(('deploy', 'r1')), _model_says('ok')]
+    chunks, _response = await _collect_stream(ai, prompt='go', tools=[deploy])
+    text_chunks = [
+        chunk
+        for chunk in chunks
+        if chunk.role == Role.TOOL and any(isinstance(p.root, TextPart) for p in chunk.content)
+    ]
+    for part in text_chunks[0].content:
+        root = part.root
+        if isinstance(root, ToolResponsePart):
+            raise AssertionError('send_chunk text must not be stamped as a tool response')
+
+
+@pytest.mark.asyncio
+async def test_generate_stream_two_tools_send_partial_parts_have_name_and_ref() -> None:
+    """Two tools send_partial; each part has that tool's name and ref."""
+    ai = Genkit(model='programmableModel')
+    pm, _ = define_programmable_model(ai)
+    a_val = Progress(step='alpha', percent=1)
+    b_val = Progress(step='beta', percent=2)
+
+    @ai.tool(name='alpha')
+    async def alpha(_req: dict, ctx: ToolRunContext) -> str:
+        ctx.send_partial(a_val)
+        return 'a'
+
+    @ai.tool(name='beta')
+    async def beta(_req: dict, ctx: ToolRunContext) -> str:
+        ctx.send_partial(b_val)
+        return 'b'
+
+    pm.responses = [_model_calls(('alpha', 'a1'), ('beta', 'b1')), _model_says('ok')]
+    chunks, response = await _collect_stream(ai, prompt='go', tools=[alpha, beta])
+    sent = _partials(chunks)
+    by_name = {p.tool_response.name: p for p in sent}
+    _assert_stamped(by_name['alpha'], name='alpha', ref='a1', output=a_val)
+    _assert_stamped(by_name['beta'], name='beta', ref='b1', output=b_val)
+    assert set(_tool_outputs(response.messages)) == {'a', 'b'}
+
+
+@pytest.mark.asyncio
+async def test_generate_stream_two_tools_send_partial_can_tell_them_apart() -> None:
+    """Two tools send_partial; you can tell which progress is which from name and ref."""
+    ai = Genkit(model='programmableModel')
+    pm, _ = define_programmable_model(ai)
+
+    @ai.tool(name='alpha')
+    async def alpha(_req: dict, ctx: ToolRunContext) -> str:
+        ctx.send_partial({'who': 'alpha'})
+        return 'a'
+
+    @ai.tool(name='beta')
+    async def beta(_req: dict, ctx: ToolRunContext) -> str:
+        ctx.send_partial({'who': 'beta'})
+        return 'b'
+
+    pm.responses = [_model_calls(('alpha', 'a1'), ('beta', 'b1')), _model_says('ok')]
+    chunks, response = await _collect_stream(ai, prompt='go', tools=[alpha, beta])
+    sent = _partials(chunks)
+    named = {(p.tool_response.name, p.tool_response.ref) for p in sent}
+    assert named == {('alpha', 'a1'), ('beta', 'b1')}
+    by_name = {p.tool_response.name: p.tool_response.output for p in sent}
+    assert by_name['alpha'] == {'who': 'alpha'}
+    assert by_name['beta'] == {'who': 'beta'}
+    assert set(_tool_outputs(response.messages)) == {'a', 'b'}
+
+
+@pytest.mark.asyncio
+async def test_generate_send_partial_does_not_appear_on_the_stream() -> None:
+    """await generate() has no stream; send_partial is a no-op and messages have the return."""
+    ai = Genkit(model='programmableModel')
+    pm, _ = define_programmable_model(ai)
+
+    @ai.tool(name='deploy')
+    async def deploy(_req: dict, ctx: ToolRunContext) -> str:
+        ctx.send_partial(Progress(step='uploading', percent=50))
+        return 'done'
+
+    pm.responses = [_model_calls(('deploy', 'r1')), _model_says('ok')]
+    response = await ai.generate(prompt='go', tools=[deploy])
+    assert not _has_partial_part(response.messages)
+    assert _tool_outputs(response.messages) == ['done']
+
+
+@pytest.mark.asyncio
+async def test_tool_stream_send_partial_does_not_yield() -> None:
+    """tool.stream() does not yield the Progress; only send_chunk Parts if any."""
+    ai = Genkit()
+    progress = Progress(step='uploading', percent=50)
+
+    @ai.tool(name='deploy')
+    async def deploy(_req: dict, ctx: ToolRunContext) -> str:
+        ctx.send_chunk(_text_part('live'))
+        ctx.send_partial(progress)
+        return 'done'
+
+    stream = deploy.action().stream({})
+    got: list[object] = []
+    async for chunk in stream.stream:
+        got.append(chunk)
+    assert len(got) == 1
+    assert isinstance(got[0], Part)
+    assert got[0].root.text == 'live'
+    assert (await stream.response).output == 'done'
+
+
+@pytest.mark.asyncio
+async def test_tool_run_send_partial_without_a_stream_is_noop() -> None:
+    """deploy.run() with no listener: send_partial does not error; return is unchanged."""
+    ai = Genkit()
+
+    @ai.tool(name='deploy')
+    async def deploy(_req: dict, ctx: ToolRunContext) -> str:
+        ctx.send_partial(Progress(step='uploading', percent=50))
+        return 'done'
+
+    assert (await deploy({})).output == 'done'
+
+
+@pytest.mark.asyncio
+async def test_generate_stream_send_partial_progress_is_not_in_response_messages() -> None:
+    """No message in the finished response contains the Progress or a partial part."""
+    ai = Genkit(model='programmableModel')
+    pm, _ = define_programmable_model(ai)
+    progress = Progress(step='uploading', percent=50)
+
+    @ai.tool(name='deploy')
+    async def deploy(_req: dict, ctx: ToolRunContext) -> str:
+        ctx.send_partial(progress)
+        return 'done'
+
+    pm.responses = [_model_calls(('deploy', 'r1')), _model_says('ok')]
+    _chunks, response = await _collect_stream(ai, prompt='go', tools=[deploy])
+    assert not _has_partial_part(response.messages)
+    assert progress not in _tool_outputs(response.messages)
+    assert _tool_outputs(response.messages) == ['done']
+
+
+@pytest.mark.asyncio
+async def test_generate_stream_return_tool_requests_never_runs_send_partial() -> None:
+    """return_tool_requests=True does not run the tool, so send_partial never fires."""
+    ai = Genkit(model='programmableModel')
+    pm, _ = define_programmable_model(ai)
+    ran = {'n': 0}
+
+    @ai.tool(name='deploy')
+    async def deploy(_req: dict, ctx: ToolRunContext) -> str:
+        ran['n'] += 1
+        ctx.send_partial(Progress(step='uploading', percent=50))
+        return 'done'
+
+    pm.responses = [_model_calls(('deploy', 'r1'))]
+    chunks, response = await _collect_stream(ai, prompt='go', tools=[deploy], return_tool_requests=True)
+    assert ran['n'] == 0
+    assert _partials(chunks) == []
+    assert response.message is not None
+    assert response.message.tool_requests
+
+
+@pytest.mark.asyncio
+async def test_generate_stream_recipe_schema_does_not_apply_to_send_partial() -> None:
+    """output_schema=Recipe does not turn a send_partial chunk into a Recipe."""
+    ai = Genkit(model='programmableModel')
+    pm, _ = define_programmable_model(ai)
+    progress = Progress(step='uploading', percent=50)
+    recipe_json = '{"title": "Pie", "steps": ["bake"]}'
+
+    @ai.tool(name='deploy')
+    async def deploy(_req: dict, ctx: ToolRunContext) -> str:
+        ctx.send_partial(progress)
+        return 'done'
+
+    pm.chunks = [[ModelResponseChunk(role=Role.MODEL, content=[_text_part(recipe_json)])]]
+    pm.responses = [
+        ModelResponse(
+            finish_reason=FinishReason.STOP,
+            message=Message(
+                role=Role.MODEL,
+                content=[
+                    _text_part(recipe_json),
+                    Part(root=ToolRequestPart(tool_request=ToolRequest(name='deploy', ref='r1', input={}))),
+                ],
+            ),
+        ),
+        ModelResponse(
+            finish_reason=FinishReason.STOP,
+            message=Message(role=Role.MODEL, content=[_text_part(recipe_json)]),
+        ),
+    ]
+    chunks, response = await _collect_stream(ai, prompt='go', tools=[deploy], output_schema=Recipe)
+    sent_chunks = [
+        chunk
+        for chunk in chunks
+        if chunk.role == Role.TOOL and any((p.root.metadata or {}).get('partial') is True for p in chunk.content)
+    ]
+    assert sent_chunks
+    assert not isinstance(sent_chunks[0].output, Recipe)
+    _assert_stamped(_partials(chunks)[0], name='deploy', ref='r1', output=progress)
+    assert not _has_partial_part(response.messages)
+
+
+@pytest.mark.asyncio
+async def test_generate_stream_model_chunks_are_still_recipe_next_to_send_partial() -> None:
+    """Model-role chunks are still Recipe beside a send_partial."""
+    ai = Genkit(model='programmableModel')
+    pm, _ = define_programmable_model(ai)
+    recipe_json = '{"title": "Pie", "steps": ["bake"]}'
+
+    @ai.tool(name='deploy')
+    async def deploy(_req: dict, ctx: ToolRunContext) -> str:
+        ctx.send_partial(Progress(step='uploading', percent=50))
+        return 'done'
+
+    pm.chunks = [[ModelResponseChunk(role=Role.MODEL, content=[_text_part(recipe_json)])]]
+    pm.responses = [
+        ModelResponse(
+            finish_reason=FinishReason.STOP,
+            message=Message(
+                role=Role.MODEL,
+                content=[
+                    _text_part(recipe_json),
+                    Part(root=ToolRequestPart(tool_request=ToolRequest(name='deploy', ref='r1', input={}))),
+                ],
+            ),
+        ),
+        ModelResponse(
+            finish_reason=FinishReason.STOP,
+            message=Message(role=Role.MODEL, content=[_text_part(recipe_json)]),
+        ),
+    ]
+    chunks, response = await _collect_stream(ai, prompt='go', tools=[deploy], output_schema=Recipe)
+    model_chunks = [c for c in chunks if c.role == Role.MODEL]
+    assert model_chunks
+    assert isinstance(model_chunks[0].output, Recipe)
+    assert model_chunks[0].output.title == 'Pie'
+    assert _tool_outputs(response.messages) == ['done']
+
+
+@pytest.mark.asyncio
+async def test_generate_stream_interrupt_after_send_partial_streamed_but_not_in_messages() -> None:
+    """send_partial then Interrupt: the progress was streamed; messages do not keep it."""
+    ai = Genkit(model='programmableModel')
+    pm, _ = define_programmable_model(ai)
+    progress = Progress(step='uploading', percent=50)
+
+    @ai.tool(name='deploy')
+    async def deploy(_req: dict, ctx: ToolRunContext) -> str:
+        ctx.send_partial(progress)
+        raise Interrupt({'hold': True})
+
+    pm.responses = [_model_calls(('deploy', 'r1'))]
+    chunks, response = await _collect_stream(ai, prompt='go', tools=[deploy])
+    _assert_stamped(_partials(chunks)[0], name='deploy', ref='r1', output=progress)
+    assert response.finish_reason == FinishReason.INTERRUPTED
+    assert not _has_partial_part(response.messages)
+
+
+@pytest.mark.asyncio
+async def test_generate_stream_resume_does_not_replay_send_partial() -> None:
+    """Resume after interrupt does not replay the first run's Progress."""
+    ai = Genkit(model='programmableModel')
+    pm, _ = define_programmable_model(ai)
+    first = Progress(step='first', percent=10)
+    runs = {'n': 0}
+
+    @ai.tool(name='pay')
+    async def pay(inp: dict, ctx: ToolRunContext) -> str:
+        runs['n'] += 1
+        if not inp.get('ok'):
+            ctx.send_partial(first)
+            raise Interrupt({'hold': True})
+        return 'paid'
+
+    pm.responses = [_model_calls(('pay', 'p1')), _model_says('final')]
+    first_chunks, first_resp = await _collect_stream(ai, prompt='go', tools=[pay])
+    _assert_stamped(_partials(first_chunks)[0], name='pay', ref='p1', output=first)
+    restart = restart_tool(interrupt=first_resp.interrupts[0], replace_input={'ok': True})
+    second_chunks, second = await _collect_stream(
+        ai,
+        messages=list(first_resp.messages),
+        tools=[pay],
+        resume_restart=restart,
+    )
+    assert all(p.tool_response.output != first for p in _partials(second_chunks))
+    assert not _has_partial_part(second.messages)
+    assert runs['n'] == 2
+
+
+@pytest.mark.asyncio
+async def test_generate_stream_restarted_tool_send_partial_is_a_new_chunk() -> None:
+    """A restarted tool's send_partial is new Progress, not a replay of the first run."""
+    ai = Genkit(model='programmableModel')
+    pm, _ = define_programmable_model(ai)
+    first = Progress(step='first', percent=10)
+    second = Progress(step='second', percent=90)
+
+    @ai.tool(name='pay')
+    async def pay(inp: dict, ctx: ToolRunContext) -> str:
+        if not inp.get('ok'):
+            ctx.send_partial(first)
+            raise Interrupt({'hold': True})
+        ctx.send_partial(second)
+        return 'paid'
+
+    pm.responses = [_model_calls(('pay', 'p1')), _model_says('final')]
+    _first_chunks, first_resp = await _collect_stream(ai, prompt='go', tools=[pay])
+    restart = restart_tool(interrupt=first_resp.interrupts[0], replace_input={'ok': True})
+    second_chunks, second_resp = await _collect_stream(
+        ai,
+        messages=list(first_resp.messages),
+        tools=[pay],
+        resume_restart=restart,
+    )
+    sent = _partials(second_chunks)
+    assert any(p.tool_response.output == second for p in sent)
+    assert all(p.tool_response.output != first for p in sent)
+    assert not _has_partial_part(second_resp.messages)
+    assert _tool_outputs(second_resp.messages)[-1] == 'paid'
+
+
+@pytest.mark.asyncio
+async def test_generate_stream_abort_after_send_partial_keeps_progress_off_messages() -> None:
+    """Abort after send_partial: the progress was streamed; messages do not contain it."""
+    ai = Genkit(model='programmableModel')
+    pm, _ = define_programmable_model(ai)
+    progress = Progress(step='uploading', percent=50)
+
+    @ai.tool(name='deploy')
+    async def deploy(_req: dict, ctx: ToolRunContext) -> str:
+        ctx.send_partial(progress)
+        ctx.abort_signal.set()
+        return 'done'
+
+    pm.responses = [_model_calls(('deploy', 'r1')), _model_says('ok')]
+    chunks: list[ModelResponseChunk] = []
+    stream = ai.generate_stream(prompt='go', tools=[deploy])
+    with pytest.raises(GenkitError) as ei:
+        async for chunk in stream.stream:
+            chunks.append(chunk)
+        await stream.response
+    assert ei.value.status == 'ABORTED'
+    _assert_stamped(_partials(chunks)[0], name='deploy', ref='r1', output=progress)
+
+
+@pytest.mark.asyncio
+async def test_generate_stream_max_turns_after_send_partial_keeps_progress_off_messages() -> None:
+    """Hitting max turns after send_partial keeps the Progress off messages."""
+    ai = Genkit(model='programmableModel')
+    pm, _ = define_programmable_model(ai)
+    progress = Progress(step='uploading', percent=50)
+
+    @ai.tool(name='lookup')
+    async def lookup(_req: dict, ctx: ToolRunContext) -> str:
+        ctx.send_partial(progress)
+        return '72F'
+
+    pm.responses = [_model_calls(('lookup', 'r1')), _model_calls(('lookup', 'r2'))]
+    chunks, response = await _collect_stream(ai, prompt='keep going', tools=[lookup], max_turns=1)
+    _assert_stamped(_partials(chunks)[0], name='lookup', ref='r1', output=progress)
+    assert not _has_partial_part(response.messages)
+    assert _tool_outputs(response.messages) == ['72F']
+
+
+@pytest.mark.asyncio
+async def test_define_prompt_stream_send_partial_is_stamped_progress() -> None:
+    """define_prompt(...).stream() + send_partial is the same stamped tool-role part."""
+    ai = Genkit(model='programmableModel')
+    pm, _ = define_programmable_model(ai)
+    progress = Progress(step='uploading', percent=50)
+
+    @ai.tool(name='deploy')
+    async def deploy(_req: dict, ctx: ToolRunContext) -> str:
+        ctx.send_partial(progress)
+        return 'done'
+
+    pm.responses = [_model_calls(('deploy', 'r1')), _model_says('ok')]
+    prompt = ai.define_prompt(prompt='go', tools=[deploy])
+    stream = prompt.stream()
+    chunks: list[ModelResponseChunk] = []
+    async for chunk in stream.stream:
+        chunks.append(chunk)
+    response = await stream.response
+    _assert_stamped(_partials(chunks)[0], name='deploy', ref='r1', output=progress)
+    assert not _has_partial_part(response.messages)
+
+
+@pytest.mark.asyncio
+async def test_agent_send_stream_includes_tool_send_partial() -> None:
+    """Agent send_stream has the same stamped generate chunk; walk the parts."""
+    ai = Genkit(model='programmableModel')
+    pm, _ = define_programmable_model(ai)
+    progress = Progress(step='uploading', percent=50)
+
+    @ai.tool(name='deploy')
+    async def deploy(_req: dict, ctx: ToolRunContext) -> str:
+        ctx.send_partial(progress)
+        return 'done'
+
+    ai.define_prompt(name='shipAgent', model='programmableModel', tools=[deploy])
+    agent = ai.define_prompt_agent(name='shipAgent')
+    pm.responses = [_model_calls(('deploy', 'r1')), _model_says('ok')]
+
+    turn = agent.chat().send_stream('go')
+    found: list[ToolResponsePart] = []
+    async for item in turn.stream:
+        raw = item.raw
+        model_chunk = raw.model_chunk if raw is not None else None
+        if model_chunk is None:
+            continue
+        for part in model_chunk.content:
+            root = part.root
+            if isinstance(root, ToolResponsePart) and (root.metadata or {}).get('partial') is True:
+                found.append(root)
+    await turn.response
+    _assert_stamped(found[0], name='deploy', ref='r1', output=progress)
+
+
+@pytest.mark.asyncio
+async def test_generate_stream_error_during_send_partial_tool_still_returns() -> None:
+    """A listener error on the send_partial chunk is dropped; the return still lands."""
+
+    class BoomOnPartial(BaseMiddleware):
+        async def wrap_generate(
+            self,
+            params: GenerateHookParams,
+            ctx: GenerateMiddlewareContext,
+            next_fn,
+        ) -> ModelResponse:
+            downstream = ctx.on_chunk
+
+            def handler(chunk: ModelResponseChunk) -> None:
+                if any((p.root.metadata or {}).get('partial') is True for p in chunk.content):
+                    raise RuntimeError('sink')
+                if downstream is not None:
+                    downstream(chunk)
+
+            previous = ctx.replace_on_chunk(handler)
+            try:
+                return await next_fn(params, ctx)
+            finally:
+                ctx.replace_on_chunk(previous)
+
+    ai = Genkit(model='programmableModel')
+    pm, _ = define_programmable_model(ai)
+
+    @ai.tool(name='deploy')
+    async def deploy(_req: dict, ctx: ToolRunContext) -> str:
+        ctx.send_partial(Progress(step='uploading', percent=50))
+        return 'done'
+
+    pm.responses = [_model_calls(('deploy', 'r1')), _model_says('ok')]
+    _chunks, response = await _collect_stream(ai, prompt='go', tools=[deploy], use=[BoomOnPartial()])
+    assert _tool_outputs(response.messages) == ['done']
+    assert response.finish_reason == FinishReason.STOP
+
+
+@pytest.mark.asyncio
+async def test_generate_stream_error_on_final_tool_response_fails_generate() -> None:
+    """A listener error on the return tool-role chunk fails generate."""
+
+    class BoomOnFinal(BaseMiddleware):
+        async def wrap_generate(
+            self,
+            params: GenerateHookParams,
+            ctx: GenerateMiddlewareContext,
+            next_fn,
+        ) -> ModelResponse:
+            downstream = ctx.on_chunk
+
+            def handler(chunk: ModelResponseChunk) -> None:
+                if chunk.role == Role.TOOL and any(
+                    isinstance(p.root, ToolResponsePart) and (p.root.metadata or {}).get('partial') is not True
+                    for p in chunk.content
+                ):
+                    raise RuntimeError('final sink')
+                if downstream is not None:
+                    downstream(chunk)
+
+            previous = ctx.replace_on_chunk(handler)
+            try:
+                return await next_fn(params, ctx)
+            finally:
+                ctx.replace_on_chunk(previous)
+
+    ai = Genkit(model='programmableModel')
+    pm, _ = define_programmable_model(ai)
+
+    @ai.tool(name='deploy')
+    async def deploy(_req: dict, ctx: ToolRunContext) -> str:
+        ctx.send_partial(Progress(step='uploading', percent=50))
+        return 'done'
+
+    pm.responses = [_model_calls(('deploy', 'r1')), _model_says('ok')]
+    stream = ai.generate_stream(prompt='go', tools=[deploy], use=[BoomOnFinal()])
+    with pytest.raises(RuntimeError, match='final sink'):
+        async for _chunk in stream.stream:
+            pass
+    with pytest.raises(RuntimeError, match='final sink'):
+        await stream.response


### PR DESCRIPTION
During `generate_stream`, a tool can push mid-run updates two ways.
`ctx.send_chunk(...)` takes a `Part` or list of `Part`s. Each call arrives as a `ModelResponseChunk` with `role='tool'` and those parts.
`ctx.send_partial(value)` takes any value. Each call arrives as a tool-role chunk with one `ToolResponsePart`: this tool request's name and ref, `metadata.partial` True, and `output` set to the value you passed.
History and the next Agent turn keep only the completed tool return, including after a wire hop. `tool.stream()` yields `send_chunk` Parts only. Tool-role `chunk.output` stays empty.

```python
# before — mid-tool updates during generate_stream were not stream events
@ai.tool(name='deploy')
async def deploy(_req: dict, ctx: ToolRunContext) -> str:
    ctx.send_chunk(Part(TextPart(text='svc-00042 is live')))
    ctx.send_partial({'step': 'uploading', 'percent': 50})
    return 'done'


stream = ai.generate_stream(prompt='deploy it', tools=[deploy])
async for chunk in stream.stream:
    print(chunk.role, chunk.text)
# only model chunks; the live text and the progress never appear

# after
@ai.tool(name='deploy')
async def deploy(_req: dict, ctx: ToolRunContext) -> str:
    ctx.send_chunk(Part(TextPart(text='svc-00042 is live')))
    ctx.send_partial({'step': 'uploading', 'percent': 50})
    return 'done'


stream = ai.generate_stream(prompt='deploy it', tools=[deploy])
async for chunk in stream.stream:
    if chunk.role != 'tool':
        continue
    for part in chunk.content:
        if (part.metadata or {}).get('partial'):
            print(part.tool_response.name, part.tool_response.output)
        else:
            print(chunk.text)
resp = await stream.response
# resp.messages has the tool return ("done"), not the mid-run updates
```

## Decisions
- `send_chunk` takes a `Part` or `list[Part]`. Each call is one tool-role `ModelResponseChunk` with those parts. `send_chunk` is unstamped (no name or ref).
- `send_partial(value)` takes any value. Each call is one tool-role chunk with one `ToolResponsePart`: this tool request's name and ref, `metadata.partial` True, output is the value you passed. Two tools sending at once each stamp their own name and ref.
- History and the next Agent turn keep only the completed tool return, including after a wire hop. Mid-tool updates are not replayed on resume.
- `tool.stream()` yields `send_chunk` Parts only. `send_partial` does not appear there.
- Tool-role `chunk.output` stays empty. Read text or `part.tool_response.output` from the parts.
- `await generate(...)` / no listener: `send_chunk` validates then no-ops; `send_partial` no-ops.
- A listener error on a mid-tool update is dropped (the tool still returns). A listener error on the final tool-response chunk fails `generate`.
- Agent `send_stream` carries the same generate chunks. Walk the parts (`metadata.partial` / text) the same way.