### PR TITLE
fix(py/plugins/openai): map max_tokens for reasoning models

### DIFF
--- a/py/packages/genkit-openai/src/genkit_openai/models/model.py
+++ b/py/packages/genkit-openai/src/genkit_openai/models/model.py
@@ -61,7 +61,16 @@ def _uses_max_completion_tokens(model: str | None) -> bool:
     if not model:
         return False
     model_id = model.rsplit('/', 1)[-1].lower()
-    return model_id.startswith(('o1', 'o3', 'o4', 'gpt-5', 'gpt-6'))
+    # Fine-tuned OpenAI model ids are prefixed with ``ft:`` and custom
+    # deployment names may put the base model after an arbitrary prefix.
+    if model_id.startswith('ft:'):
+        parts = model_id.split(':')
+        if len(parts) > 1:
+            model_id = parts[1]
+    reasoning_prefixes = ('o1', 'o3', 'o4', 'gpt-5', 'gpt-6')
+    return model_id.startswith(reasoning_prefixes) or any(
+        f'-{prefix}' in model_id for prefix in reasoning_prefixes
+    )
 
 
 def _openai_create_kwargs(*, config: OpenAIConfig, model: str | None = None) -> dict[str, Any]:

--- a/py/packages/genkit-openai/src/genkit_openai/models/model.py
+++ b/py/packages/genkit-openai/src/genkit_openai/models/model.py
@@ -56,7 +56,15 @@ logger = structlog.get_logger(__name__)
 _GENKIT_ONLY = frozenset({'api_key', 'top_k', 'version', 'max_output_tokens', 'stop_sequences'})
 
 
-def _openai_create_kwargs(*, config: OpenAIConfig) -> dict[str, Any]:
+def _uses_max_completion_tokens(model: str | None) -> bool:
+    """Whether a model requires the reasoning-model token-limit parameter."""
+    if not model:
+        return False
+    model_id = model.rsplit('/', 1)[-1].lower()
+    return model_id.startswith(('o1', 'o3', 'o4', 'gpt-5', 'gpt-6'))
+
+
+def _openai_create_kwargs(*, config: OpenAIConfig, model: str | None = None) -> dict[str, Any]:
     """Kwargs for chat.completions.create().
 
     Peel Genkit-only keys. ``stop_sequences`` becomes ``stop`` when ``stop``
@@ -71,6 +79,15 @@ def _openai_create_kwargs(*, config: OpenAIConfig) -> dict[str, Any]:
             continue
         value = getattr(config, name)
         if value is not None:
+            if name == 'max_tokens':
+                # OpenAI reasoning models reject the deprecated max_tokens
+                # field. Keep the explicit max_completion_tokens value when
+                # both knobs are supplied so the request remains valid.
+                if config.max_completion_tokens is not None:
+                    continue
+                if _uses_max_completion_tokens(model) or config.reasoning_effort is not None:
+                    body['max_completion_tokens'] = value
+                    continue
             body[name] = value
     extras = config.model_extra
     if extras:
@@ -382,7 +399,8 @@ class OpenAIModel:
             )
             if config.version:
                 openai_config['model'] = config.version
-            openai_config.update(_openai_create_kwargs(config=config))
+            effective_model = config.model or config.version or self._model
+            openai_config.update(_openai_create_kwargs(config=config, model=effective_model))
         return openai_config
 
     async def _generate(self, request: ModelRequest) -> ModelResponse:

--- a/py/packages/genkit-openai/tests/openai_model_test.py
+++ b/py/packages/genkit-openai/tests/openai_model_test.py
@@ -132,6 +132,51 @@ async def test_get_openai_config_peels_genkit_keys_and_passes_the_rest() -> None
 
 
 @pytest.mark.asyncio
+async def test_get_openai_config_uses_max_completion_tokens_for_reasoning_models() -> None:
+    """Reasoning models reject the deprecated max_tokens request field."""
+    model = OpenAIModel(model='gpt-6-astra', client=MagicMock())
+    request = ModelRequest(
+        messages=[Message(role=Role.USER, content=[Part(root=TextPart(text='hi'))])],
+        config=OpenAIConfig(max_tokens=32),
+    )
+
+    body = await model._get_openai_request_config(request)
+
+    assert body['max_completion_tokens'] == 32
+    assert 'max_tokens' not in body
+
+
+@pytest.mark.asyncio
+async def test_get_openai_config_keeps_max_tokens_for_legacy_models() -> None:
+    """Legacy OpenAI-compatible models continue to receive max_tokens."""
+    model = OpenAIModel(model='gpt-4o', client=MagicMock())
+    request = ModelRequest(
+        messages=[Message(role=Role.USER, content=[Part(root=TextPart(text='hi'))])],
+        config=OpenAIConfig(max_tokens=32),
+    )
+
+    body = await model._get_openai_request_config(request)
+
+    assert body['max_tokens'] == 32
+    assert 'max_completion_tokens' not in body
+
+
+@pytest.mark.asyncio
+async def test_get_openai_config_prefers_explicit_max_completion_tokens() -> None:
+    """An explicit modern token limit wins when both fields are configured."""
+    model = OpenAIModel(model='gpt-4o', client=MagicMock())
+    request = ModelRequest(
+        messages=[Message(role=Role.USER, content=[Part(root=TextPart(text='hi'))])],
+        config=OpenAIConfig(max_tokens=32, max_completion_tokens=64),
+    )
+
+    body = await model._get_openai_request_config(request)
+
+    assert body['max_completion_tokens'] == 64
+    assert 'max_tokens' not in body
+
+
+@pytest.mark.asyncio
 async def test_get_openai_config_model_field_overrides_version() -> None:
     """OpenAIConfig.model is the create() model id; it wins over version."""
     model = OpenAIModel(model='gpt-4o', client=MagicMock())

--- a/py/packages/genkit-openai/tests/openai_model_test.py
+++ b/py/packages/genkit-openai/tests/openai_model_test.py
@@ -134,16 +134,17 @@ async def test_get_openai_config_peels_genkit_keys_and_passes_the_rest() -> None
 @pytest.mark.asyncio
 async def test_get_openai_config_uses_max_completion_tokens_for_reasoning_models() -> None:
     """Reasoning models reject the deprecated max_tokens request field."""
-    model = OpenAIModel(model='gpt-6-astra', client=MagicMock())
-    request = ModelRequest(
-        messages=[Message(role=Role.USER, content=[Part(root=TextPart(text='hi'))])],
-        config=OpenAIConfig(max_tokens=32),
-    )
+    for model_name in ('gpt-6-astra', 'ft:o1-mini:my-org:custom', 'my-o1-mini-deployment'):
+        model = OpenAIModel(model=model_name, client=MagicMock())
+        request = ModelRequest(
+            messages=[Message(role=Role.USER, content=[Part(root=TextPart(text='hi'))])],
+            config=OpenAIConfig(max_tokens=32),
+        )
 
-    body = await model._get_openai_request_config(request)
+        body = await model._get_openai_request_config(request)
 
-    assert body['max_completion_tokens'] == 32
-    assert 'max_tokens' not in body
+        assert body['max_completion_tokens'] == 32, f'Failed for model: {model_name}'
+        assert 'max_tokens' not in body, f'Failed for model: {model_name}'
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Fixes #6320.

`OpenAIConfig(max_tokens=...)` was forwarded as `max_tokens` for reasoning models, which OpenAI rejects. This maps the deprecated option to `max_completion_tokens` for reasoning-model IDs (`o1`, `o3`, `o4`, `gpt-5*`, and `gpt-6*`) while preserving `max_tokens` for legacy models.

When both options are supplied, the explicit `max_completion_tokens` value wins so mutually exclusive fields are not sent together.

## Tests

- Added async regression coverage for reasoning models, legacy models, and explicit precedence.
- `ruff check` and `ruff format --check` pass on changed files.
- Python compilation passes.
- The focused test file runs 49 passing tests in an isolated dependency environment; one unrelated existing usage assertion fails against the installed OpenAI SDK because `image_tokens` is omitted from its `PromptTokensDetails` model.
- The full workspace environment cannot be resolved on Windows because `dotpromptz-handlebars` currently publishes no Windows wheel.

Google CLA requirements in `CONTRIBUTING.md` noted.