### PR TITLE
feat(py/plugins/google-genai): curate stable Gemini 2.5, flash-lite-latest, TTS, and Gemma 4

### DIFF
--- a/py/packages/genkit-google-genai/src/genkit_google_genai/models/gemini.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/models/gemini.py
@@ -557,6 +557,16 @@ GEMINI_2_5_FLASH_PREVIEW_04_17 = ModelInfo(
     ),
 )
 
+GEMINI_2_5_PRO = ModelInfo(
+    label='Google AI - Gemini 2.5 Pro',
+    supports=GEMINI_TEXT_SUPPORTS,
+)
+
+GEMINI_2_5_FLASH = ModelInfo(
+    label='Google AI - Gemini 2.5 Flash',
+    supports=GEMINI_TEXT_SUPPORTS,
+)
+
 GEMINI_2_5_FLASH_LITE = ModelInfo(
     label='Google AI - Gemini 2.5 Flash Lite',
     supports=Supports(
@@ -672,6 +682,11 @@ GEMINI_3_1_FLASH_LITE = ModelInfo(
     ),
 )
 
+GEMINI_FLASH_LITE_LATEST = ModelInfo(
+    label='Google AI - Gemini Flash Lite Latest',
+    supports=GEMINI_TEXT_SUPPORTS,
+)
+
 GEMINI_IMAGE_SUPPORTS = Supports(
     multiturn=True,
     media=True,
@@ -711,6 +726,50 @@ GEMINI_2_5_FLASH_IMAGE_PREVIEW = ModelInfo(
     supports=GEMINI_IMAGE_SUPPORTS,
 )
 
+GEMINI_TTS_SUPPORTS = Supports(
+    multiturn=False,
+    media=False,
+    tools=False,
+    tool_choice=False,
+    system_role=False,
+    constrained=Constrained.ALL,
+)
+
+GEMINI_2_5_FLASH_PREVIEW_TTS = ModelInfo(
+    label='Google AI - Gemini 2.5 Flash Preview TTS',
+    supports=GEMINI_TTS_SUPPORTS,
+)
+
+GEMINI_2_5_PRO_PREVIEW_TTS = ModelInfo(
+    label='Google AI - Gemini 2.5 Pro Preview TTS',
+    supports=GEMINI_TTS_SUPPORTS,
+)
+
+GEMINI_3_1_FLASH_TTS_PREVIEW = ModelInfo(
+    label='Google AI - Gemini 3.1 Flash TTS Preview',
+    supports=GEMINI_TTS_SUPPORTS,
+)
+
+GEMMA_SUPPORTS = Supports(
+    multiturn=True,
+    media=True,
+    tools=True,
+    tool_choice=True,
+    system_role=True,
+    constrained=Constrained.ALL,
+    output=['text', 'json'],
+)
+
+GEMMA_4_26B_A4B_IT = ModelInfo(
+    label='Google AI - Gemma 4 26B A4B IT',
+    supports=GEMMA_SUPPORTS,
+)
+
+GEMMA_4_31B_IT = ModelInfo(
+    label='Google AI - Gemma 4 31B IT',
+    supports=GEMMA_SUPPORTS,
+)
+
 GENERIC_GEMINI_MODEL = ModelInfo(
     label='Google AI - Gemini',
     supports=Supports(
@@ -726,14 +785,7 @@ GENERIC_GEMINI_MODEL = ModelInfo(
 
 GENERIC_TTS_MODEL = ModelInfo(
     label='Google AI - Gemini TTS',
-    supports=Supports(
-        multiturn=False,
-        media=False,
-        tools=False,
-        tool_choice=False,
-        system_role=True,
-        constrained=Constrained.ALL,
-    ),
+    supports=GEMINI_TTS_SUPPORTS,
 )
 
 GENERIC_IMAGE_MODEL = ModelInfo(
@@ -751,15 +803,7 @@ GENERIC_IMAGE_MODEL = ModelInfo(
 
 GENERIC_GEMMA_MODEL = ModelInfo(
     label='Google AI - Gemma',
-    supports=Supports(
-        multiturn=True,
-        media=True,
-        tools=True,
-        tool_choice=True,
-        system_role=True,
-        constrained=Constrained.ALL,
-        output=['text', 'json'],
-    ),
+    supports=GEMMA_SUPPORTS,
 )
 
 
@@ -778,6 +822,7 @@ class VertexAIGeminiVersion(StrEnum, metaclass=Deprecations):  # pyrefly: ignore
     GEMINI_2_5_FLASH_LITE = 'gemini-2.5-flash-lite'
     GEMINI_2_5_FLASH_PREVIEW_TTS = 'gemini-2.5-flash-preview-tts'
     GEMINI_2_5_PRO_PREVIEW_TTS = 'gemini-2.5-pro-preview-tts'
+    GEMINI_3_1_FLASH_TTS_PREVIEW = 'gemini-3.1-flash-tts-preview'
     GEMINI_3_PRO_IMAGE = 'gemini-3-pro-image'
     GEMINI_3_1_FLASH_IMAGE = 'gemini-3.1-flash-image'
     GEMINI_3_PRO_IMAGE_PREVIEW = 'gemini-3-pro-image-preview'
@@ -793,6 +838,8 @@ class VertexAIGeminiVersion(StrEnum, metaclass=Deprecations):  # pyrefly: ignore
     GEMMA_3_27B_IT = 'gemma-3-27b-it'
     GEMMA_3_4B_IT = 'gemma-3-4b-it'
     GEMMA_3N_E4B_IT = 'gemma-3n-e4b-it'
+    GEMMA_4_26B_A4B_IT = 'gemma-4-26b-a4b-it'
+    GEMMA_4_31B_IT = 'gemma-4-31b-it'
 
 
 class GoogleAIGeminiVersion(StrEnum, metaclass=Deprecations):  # pyrefly: ignore[invalid-inheritance]
@@ -809,6 +856,7 @@ class GoogleAIGeminiVersion(StrEnum, metaclass=Deprecations):  # pyrefly: ignore
     GEMINI_2_5_FLASH_LITE = 'gemini-2.5-flash-lite'
     GEMINI_2_5_FLASH_PREVIEW_TTS = 'gemini-2.5-flash-preview-tts'
     GEMINI_2_5_PRO_PREVIEW_TTS = 'gemini-2.5-pro-preview-tts'
+    GEMINI_3_1_FLASH_TTS_PREVIEW = 'gemini-3.1-flash-tts-preview'
     GEMINI_3_PRO_IMAGE = 'gemini-3-pro-image'
     GEMINI_3_1_FLASH_IMAGE = 'gemini-3.1-flash-image'
     GEMINI_3_1_FLASH_IMAGE_PREVIEW = 'gemini-3.1-flash-image-preview'
@@ -823,6 +871,8 @@ class GoogleAIGeminiVersion(StrEnum, metaclass=Deprecations):  # pyrefly: ignore
     GEMMA_3_27B_IT = 'gemma-3-27b-it'
     GEMMA_3_4B_IT = 'gemma-3-4b-it'
     GEMMA_3N_E4B_IT = 'gemma-3n-e4b-it'
+    GEMMA_4_26B_A4B_IT = 'gemma-4-26b-a4b-it'
+    GEMMA_4_31B_IT = 'gemma-4-31b-it'
 
 
 # Quote autocomplete needs a Literal. The version enums above and the
@@ -833,6 +883,7 @@ KnownGemini: TypeAlias = Literal[
     'gemini-2.5-pro',
     'gemini-2.5-flash-lite',
     'gemini-flash-latest',
+    'gemini-flash-lite-latest',
     'gemini-pro-latest',
     'gemini-3-flash-preview',
     'gemini-3-pro-preview',
@@ -851,6 +902,7 @@ KnownGemini: TypeAlias = Literal[
 KnownGeminiTts: TypeAlias = Literal[
     'gemini-2.5-flash-preview-tts',
     'gemini-2.5-pro-preview-tts',
+    'gemini-3.1-flash-tts-preview',
 ]
 KnownGeminiImage: TypeAlias = Literal[
     'gemini-2.5-flash-image',
@@ -866,6 +918,8 @@ KnownGemma: TypeAlias = Literal[
     'gemma-3-12b-it',
     'gemma-3-27b-it',
     'gemma-3n-e4b-it',
+    'gemma-4-26b-a4b-it',
+    'gemma-4-31b-it',
 ]
 
 
@@ -884,7 +938,10 @@ _add_model(GEMINI_2_5_PRO_EXP_03_25, ['gemini-2.5-pro-exp-03-25'])
 _add_model(GEMINI_2_5_PRO_PREVIEW_03_25, ['gemini-2.5-pro-preview-03-25'])
 _add_model(GEMINI_2_5_PRO_PREVIEW_05_06, ['gemini-2.5-pro-preview-05-06'])
 _add_model(GEMINI_2_5_FLASH_PREVIEW_04_17, ['gemini-2.5-flash-preview-04-17'])
+_add_model(GEMINI_2_5_PRO, ['gemini-2.5-pro'])
+_add_model(GEMINI_2_5_FLASH, ['gemini-2.5-flash'])
 _add_model(GEMINI_2_5_FLASH_LITE, ['gemini-2.5-flash-lite'])
+_add_model(GEMINI_FLASH_LITE_LATEST, ['gemini-flash-lite-latest'])
 _add_model(GEMINI_3_FLASH_PREVIEW, ['gemini-3-flash-preview'])
 _add_model(GEMINI_3_PRO_PREVIEW, ['gemini-3-pro-preview', 'gemini-pro-latest'])
 _add_model(GEMINI_3_5_FLASH, ['gemini-3.5-flash', 'gemini-flash-latest'])
@@ -900,6 +957,11 @@ _add_model(GEMINI_3_1_FLASH_IMAGE_PREVIEW, ['gemini-3.1-flash-image-preview'])
 _add_model(GEMINI_3_PRO_IMAGE_PREVIEW, ['gemini-3-pro-image-preview'])
 _add_model(GEMINI_2_5_FLASH_IMAGE_PREVIEW, ['gemini-2.5-flash-image-preview'])
 _add_model(GEMINI_2_5_FLASH_IMAGE, ['gemini-2.5-flash-image'])
+_add_model(GEMINI_2_5_FLASH_PREVIEW_TTS, ['gemini-2.5-flash-preview-tts'])
+_add_model(GEMINI_2_5_PRO_PREVIEW_TTS, ['gemini-2.5-pro-preview-tts'])
+_add_model(GEMINI_3_1_FLASH_TTS_PREVIEW, ['gemini-3.1-flash-tts-preview'])
+_add_model(GEMMA_4_26B_A4B_IT, ['gemma-4-26b-a4b-it'])
+_add_model(GEMMA_4_31B_IT, ['gemma-4-31b-it'])
 
 # Frozen at import so quote-autocomplete tests do not see ids that
 # resolve() writes into SUPPORTED_MODELS later.

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/models/gemini.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/models/gemini.py
@@ -1419,13 +1419,15 @@ class GeminiModel:
         if is_tts_model(model_name):
             if not request_cfg:
                 request_cfg = genai_types.GenerateContentConfig()
-            request_cfg.response_modalities = ['AUDIO']
+            if not request_cfg.response_modalities:
+                request_cfg.response_modalities = ['AUDIO']
 
         # Image models require response_modalities: ["TEXT", "IMAGE"]
         if is_image_model(model_name):
             if not request_cfg:
                 request_cfg = genai_types.GenerateContentConfig()
-            request_cfg.response_modalities = ['TEXT', 'IMAGE']
+            if not request_cfg.response_modalities:
+                request_cfg.response_modalities = ['TEXT', 'IMAGE']
 
         # Resolve the client before building messages so context-cache
         # operations run against the same (possibly overridden) region as the

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/models/gemini.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/models/gemini.py
@@ -454,11 +454,28 @@ class GeminiConfigSchema(ModelConfig):
     stop_sequences: list[str] | None = Field(default=None, alias='stopSequences', description='Stop sequences.')
 
 
+class SpeakerVoiceConfigSchema(BaseModel):
+    """Speaker voice config schema."""
+
+    model_config = ConfigDict(extra='allow', populate_by_name=True)
+    speaker: str | None = None
+    voice_config: VoiceConfigSchema | None = Field(None, alias='voiceConfig')
+
+
+class MultiSpeakerVoiceConfigSchema(BaseModel):
+    """Multi-speaker voice config schema."""
+
+    model_config = ConfigDict(extra='allow', populate_by_name=True)
+    speaker_voice_configs: list[SpeakerVoiceConfigSchema] | None = Field(None, alias='speakerVoiceConfigs')
+
+
 class SpeechConfigSchema(BaseModel):
     """Speech config schema."""
 
     model_config = ConfigDict(extra='allow', populate_by_name=True)
     voice_config: VoiceConfigSchema | None = Field(None, alias='voiceConfig')
+    language_code: str | None = Field(None, alias='languageCode')
+    multi_speaker_voice_config: MultiSpeakerVoiceConfigSchema | None = Field(None, alias='multiSpeakerVoiceConfig')
 
     http_options: Any | None = Field(None, exclude=True)
     tools: Any | None = Field(None, exclude=True)

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/models/gemini.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/models/gemini.py
@@ -457,6 +457,7 @@ class GeminiConfigSchema(ModelConfig):
 class SpeechConfigSchema(BaseModel):
     """Speech config schema."""
 
+    model_config = ConfigDict(extra='allow', populate_by_name=True)
     voice_config: VoiceConfigSchema | None = Field(None, alias='voiceConfig')
 
     http_options: Any | None = Field(None, exclude=True)

--- a/py/packages/genkit-google-genai/test/models/googlegenai_gemini_test.py
+++ b/py/packages/genkit-google-genai/test/models/googlegenai_gemini_test.py
@@ -1404,3 +1404,39 @@ async def test_gemini_model__unknown_speech_config_key_is_rejected(
 
     assert exc_info.value.status == 'INVALID_ARGUMENT'
     assert 'speech_config' in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_generate_keeps_caller_response_modalities_on_tts_model(mocker: MockerFixture) -> None:
+    """A TTS model keeps the response modalities the caller asked for."""
+    version = 'gemini-2.5-flash-preview-tts'
+    request = ModelRequest(
+        messages=[Message(role=Role.USER, content=[Part(root=TextPart(text='hi'))])],
+        config=GeminiTtsConfigSchema.model_validate({'responseModalities': ['AUDIO', 'TEXT']}),
+    )
+    candidate = genai.types.Candidate(content=genai.types.Content(parts=[genai.types.Part(text='ok')]))
+    client_mock = mocker.AsyncMock()
+    client_mock.aio.models.generate_content.return_value = genai.types.GenerateContentResponse(candidates=[candidate])
+
+    await GeminiModel(version, client_mock).generate(request, ActionRunContext())
+
+    sent_config = client_mock.aio.models.generate_content.call_args.kwargs['config']
+    assert sent_config.response_modalities == ['AUDIO', 'TEXT']
+
+
+@pytest.mark.asyncio
+async def test_generate_keeps_caller_response_modalities_on_image_model(mocker: MockerFixture) -> None:
+    """An image model keeps the response modalities the caller asked for."""
+    version = 'gemini-2.5-flash-image'
+    request = ModelRequest(
+        messages=[Message(role=Role.USER, content=[Part(root=TextPart(text='hi'))])],
+        config=GeminiImageConfigSchema.model_validate({'responseModalities': ['IMAGE']}),
+    )
+    candidate = genai.types.Candidate(content=genai.types.Content(parts=[genai.types.Part(text='ok')]))
+    client_mock = mocker.AsyncMock()
+    client_mock.aio.models.generate_content.return_value = genai.types.GenerateContentResponse(candidates=[candidate])
+
+    await GeminiModel(version, client_mock).generate(request, ActionRunContext())
+
+    sent_config = client_mock.aio.models.generate_content.call_args.kwargs['config']
+    assert sent_config.response_modalities == ['IMAGE']

--- a/py/packages/genkit-google-genai/test/models/googlegenai_gemini_test.py
+++ b/py/packages/genkit-google-genai/test/models/googlegenai_gemini_test.py
@@ -1329,6 +1329,35 @@ def tts_model_instance() -> GeminiModel:
     )
 
 
+def test_speech_config_schema_declares_sdk_fields() -> None:
+    """Language code and multi-speaker voice config validate as typed fields, by name or alias."""
+    config = SpeechConfigSchema.model_validate({
+        'language_code': 'en-US',
+        'multiSpeakerVoiceConfig': {
+            'speakerVoiceConfigs': [
+                {'speaker': 'Alice', 'voice_config': {'prebuilt_voice_config': {'voice_name': 'Kore'}}},
+            ]
+        },
+    })
+
+    assert config.language_code == 'en-US'
+    assert config.multi_speaker_voice_config is not None
+    speakers = config.multi_speaker_voice_config.speaker_voice_configs
+    assert speakers is not None
+    assert speakers[0].speaker == 'Alice'
+    assert speakers[0].voice_config is not None
+    assert speakers[0].voice_config.prebuilt_voice_config is not None
+    assert speakers[0].voice_config.prebuilt_voice_config.voice_name == 'Kore'
+
+
+def test_tts_config_json_schema_exposes_speech_config_fields() -> None:
+    """The Dev UI schema lists every speech config field the SDK accepts."""
+    schema = GeminiTtsConfigSchema.model_json_schema(by_alias=True)
+    speech = schema['$defs']['SpeechConfigSchema']['properties']
+
+    assert {'voiceConfig', 'languageCode', 'multiSpeakerVoiceConfig'} <= set(speech)
+
+
 def test_speech_config_schema_populates_by_field_name() -> None:
     """The speech config validates from snake_case field names, not only aliases."""
     config = SpeechConfigSchema.model_validate({'voice_config': {'prebuilt_voice_config': {'voice_name': 'Kore'}}})

--- a/py/packages/genkit-google-genai/test/models/googlegenai_gemini_test.py
+++ b/py/packages/genkit-google-genai/test/models/googlegenai_gemini_test.py
@@ -36,6 +36,7 @@ from genkit_google_genai.models.gemini import (
     GeminiTtsConfigSchema,
     GemmaConfigSchema,
     GoogleAIGeminiVersion,
+    SpeechConfigSchema,
     VertexAIGeminiVersion,
     _to_finish_reason,
     get_model_config_schema,
@@ -1317,3 +1318,89 @@ def test_to_finish_reason_image_other_and_unexpected_tool() -> None:
     assert _to_finish_reason('NO_IMAGE') == FinishReason.OTHER
     assert _to_finish_reason('IMAGE_OTHER') == FinishReason.OTHER
     assert _to_finish_reason('UNEXPECTED_TOOL_CALL') == FinishReason.OTHER
+
+
+@pytest.fixture
+def tts_model_instance() -> GeminiModel:
+    """Common initialization of a TTS GeminiModel."""
+    return GeminiModel(
+        version='gemini-2.5-flash-preview-tts',
+        client=MagicMock(spec=genai.Client),
+    )
+
+
+def test_speech_config_schema_populates_by_field_name() -> None:
+    """The speech config validates from snake_case field names, not only aliases."""
+    config = SpeechConfigSchema.model_validate({'voice_config': {'prebuilt_voice_config': {'voice_name': 'Kore'}}})
+
+    assert config.voice_config is not None
+    assert config.voice_config.prebuilt_voice_config is not None
+    assert config.voice_config.prebuilt_voice_config.voice_name == 'Kore'
+
+
+@pytest.mark.asyncio
+async def test_gemini_model__speech_config_keeps_language_code(
+    tts_model_instance: GeminiModel,
+) -> None:
+    """A language code on the speech config reaches the SDK config."""
+    request = ModelRequest(
+        messages=[Message(role=Role.USER, content=[Part(root=TextPart(text='hi'))])],
+        config=GeminiTtsConfigSchema.model_validate({
+            'speechConfig': {
+                'languageCode': 'en-US',
+                'voiceConfig': {'prebuiltVoiceConfig': {'voiceName': 'Kore'}},
+            }
+        }),
+    )
+
+    cfg = await tts_model_instance._genkit_to_googleai_cfg(request)
+
+    assert cfg is not None
+    assert isinstance(cfg.speech_config, genai_types.SpeechConfig)
+    assert cfg.speech_config.language_code == 'en-US'
+    assert cfg.speech_config.voice_config is not None
+
+
+@pytest.mark.asyncio
+async def test_gemini_model__speech_config_keeps_multi_speaker_voice_config(
+    tts_model_instance: GeminiModel,
+) -> None:
+    """A multi-speaker voice config on the speech config reaches the SDK config."""
+    request = ModelRequest(
+        messages=[Message(role=Role.USER, content=[Part(root=TextPart(text='hi'))])],
+        config=GeminiTtsConfigSchema.model_validate({
+            'speechConfig': {
+                'multiSpeakerVoiceConfig': {
+                    'speakerVoiceConfigs': [
+                        {'speaker': 'Alice', 'voiceConfig': {'prebuiltVoiceConfig': {'voiceName': 'Kore'}}},
+                    ]
+                }
+            }
+        }),
+    )
+
+    cfg = await tts_model_instance._genkit_to_googleai_cfg(request)
+
+    assert cfg is not None
+    assert isinstance(cfg.speech_config, genai_types.SpeechConfig)
+    assert cfg.speech_config.multi_speaker_voice_config is not None
+    speakers = cfg.speech_config.multi_speaker_voice_config.speaker_voice_configs
+    assert speakers is not None
+    assert [s.speaker for s in speakers] == ['Alice']
+
+
+@pytest.mark.asyncio
+async def test_gemini_model__unknown_speech_config_key_is_rejected(
+    tts_model_instance: GeminiModel,
+) -> None:
+    """An unknown speech config key is reported instead of silently dropped."""
+    request = ModelRequest(
+        messages=[Message(role=Role.USER, content=[Part(root=TextPart(text='hi'))])],
+        config=GeminiTtsConfigSchema.model_validate({'speechConfig': {'languageCodes': 'en-US'}}),
+    )
+
+    with pytest.raises(GenkitError) as exc_info:
+        await tts_model_instance._genkit_to_googleai_cfg(request)
+
+    assert exc_info.value.status == 'INVALID_ARGUMENT'
+    assert 'speech_config' in str(exc_info.value)

--- a/py/packages/genkit-google-genai/test/models/googlegenai_gemini_test.py
+++ b/py/packages/genkit-google-genai/test/models/googlegenai_gemini_test.py
@@ -612,6 +612,87 @@ def test_vertexai_gemini_3_x_text_models_register_real_capabilities(model_name: 
     assert model_info.supports.output == ['text', 'json']
 
 
+@pytest.mark.parametrize(
+    ('model_name', 'expected_label'),
+    [
+        ('gemini-2.5-pro', 'Google AI - Gemini 2.5 Pro'),
+        ('gemini-2.5-flash', 'Google AI - Gemini 2.5 Flash'),
+        ('gemini-flash-lite-latest', 'Google AI - Gemini Flash Lite Latest'),
+    ],
+)
+def test_stable_gemini_text_models_register_real_capabilities(model_name: str, expected_label: str) -> None:
+    """Stable text ids resolve to their own ModelInfo, not the generic fallback.
+
+    The fallback (DEFAULT_SUPPORTS_MODEL) leaves ``output`` unset and labels the id verbatim,
+    so the label and ``output == ['text', 'json']`` together prove real metadata.
+    """
+    model_info = google_model_info(model_name)
+
+    assert model_info.label == expected_label
+    assert model_info.supports is not None
+    assert model_info.supports.tools is True
+    assert model_info.supports.tool_choice is True
+    assert model_info.supports.system_role is True
+    assert model_info.supports.constrained == Constrained.ALL
+    assert model_info.supports.output == ['text', 'json']
+
+
+@pytest.mark.parametrize(
+    ('model_name', 'expected_label'),
+    [
+        ('gemini-2.5-flash-preview-tts', 'Google AI - Gemini 2.5 Flash Preview TTS'),
+        ('gemini-2.5-pro-preview-tts', 'Google AI - Gemini 2.5 Pro Preview TTS'),
+        ('gemini-3.1-flash-tts-preview', 'Google AI - Gemini 3.1 Flash TTS Preview'),
+    ],
+)
+def test_tts_models_register_per_name_capabilities(model_name: str, expected_label: str) -> None:
+    """Each TTS id carries its own label instead of sharing the generic TTS entry."""
+    model_info = google_model_info(model_name)
+
+    assert model_info.label == expected_label
+    assert model_info.supports is not None
+    assert model_info.supports.multiturn is False
+    assert model_info.supports.media is False
+    assert model_info.supports.tools is False
+    assert model_info.supports.tool_choice is False
+    assert model_info.supports.output is None
+    assert get_model_config_schema(model_name) is GeminiTtsConfigSchema
+
+
+@pytest.mark.parametrize(
+    'model_name',
+    [
+        'gemini-2.5-flash-preview-tts',
+        'gemini-2.5-pro-preview-tts',
+        'gemini-3.1-flash-tts-preview',
+        'gemini-9.9-flash-preview-tts',
+    ],
+)
+def test_tts_models_do_not_advertise_system_role(model_name: str) -> None:
+    """TTS ignores system instructions, so no TTS entry advertises a system role."""
+    supports = google_model_info(model_name).supports
+
+    assert supports is not None
+    assert supports.system_role is False
+
+
+@pytest.mark.parametrize(
+    ('model_name', 'expected_label'),
+    [
+        ('gemma-4-26b-a4b-it', 'Google AI - Gemma 4 26B A4B IT'),
+        ('gemma-4-31b-it', 'Google AI - Gemma 4 31B IT'),
+    ],
+)
+def test_gemma_4_models_register_per_name_capabilities(model_name: str, expected_label: str) -> None:
+    """Each gemma-4 id carries its own label instead of sharing the generic Gemma entry."""
+    model_info = google_model_info(model_name)
+
+    assert model_info.label == expected_label
+    assert model_info.supports is not None
+    assert model_info.supports.output == ['text', 'json']
+    assert get_model_config_schema(model_name) is GemmaConfigSchema
+
+
 @pytest.fixture
 def gemini_model_instance() -> GeminiModel:
     """Common initialization of GeminiModel."""
@@ -1106,6 +1187,7 @@ async def test_gemini_model__unknown_extra_rides_on_extra_body(
     ('version', 'expected_schema'),
     [
         ('gemini-2.5-flash-preview-tts', GeminiTtsConfigSchema),
+        ('gemini-3.1-flash-tts-preview', GeminiTtsConfigSchema),
         ('gemini-2.0-flash-preview-image-generation', GeminiImageConfigSchema),
         ('gemini-3-pro-image', GeminiImageConfigSchema),
         ('gemini-3.1-flash-image', GeminiImageConfigSchema),
@@ -1114,6 +1196,7 @@ async def test_gemini_model__unknown_extra_rides_on_extra_body(
         ('gemini-2.5-flash-image', GeminiImageConfigSchema),
         ('gemini-2.5-flash-image-preview', GeminiImageConfigSchema),
         ('gemma-2-27b-it', GemmaConfigSchema),
+        ('gemma-4-31b-it', GemmaConfigSchema),
         ('gemini-2.0-flash-001', GeminiConfigSchema),
     ],
 )

--- a/py/packages/genkit-google-genai/test/models/model_refs_test.py
+++ b/py/packages/genkit-google-genai/test/models/model_refs_test.py
@@ -278,3 +278,16 @@ class TestKnownIdLiterals:
         assert all(is_imagen_model_name(value) for value in get_args(KnownImagen))
         assert set(get_args(KnownVeo)) == {str(member.value) for member in VeoVersion}
         assert all(is_veo_model(value) for value in get_args(KnownVeo))
+
+    def test_latest_aliases_autocomplete_on_gemini_model(self) -> None:
+        """Every rotating ``-latest`` alias is offered by ``gemini_model``."""
+        assert {'gemini-pro-latest', 'gemini-flash-latest', 'gemini-flash-lite-latest'} <= set(get_args(KnownGemini))
+
+    def test_infix_tts_id_autocompletes_on_the_tts_constructor(self) -> None:
+        """A ``-tts`` infix belongs to the TTS constructor, not the text one."""
+        assert 'gemini-3.1-flash-tts-preview' in get_args(KnownGeminiTts)
+        assert 'gemini-3.1-flash-tts-preview' not in get_args(KnownGemini)
+
+    def test_gemma_4_autocompletes_on_gemma_model(self) -> None:
+        """The gemma-4 ids are offered by ``gemma_model``."""
+        assert {'gemma-4-26b-a4b-it', 'gemma-4-31b-it'} <= set(get_args(KnownGemma))


### PR DESCRIPTION
Closes #6178

## Summary

Curates the ids the issue lists: `gemini-2.5-pro`, `gemini-2.5-flash`, the `gemini-flash-lite-latest` alias, per-name entries for `gemini-2.5-flash-preview-tts`, `gemini-2.5-pro-preview-tts` and `gemini-3.1-flash-tts-preview`, and `gemma-4-26b-a4b-it` / `gemma-4-31b-it`. The new ids autocomplete on the typed ref constructors. TTS entries, including the generic fallback, no longer advertise `system_role`.

Two fixes in the TTS request path:

- `SpeechConfigSchema` kept only `voiceConfig` and only in its camelCase form. It now allows extra fields and populates by field name, so `language_code` and `multi_speaker_voice_config` reach the SDK and the snake_case config in the media sample applies. An unknown nested key now fails with `INVALID_ARGUMENT` instead of being dropped.
- `generate()` overwrote a caller-supplied `response_modalities` on TTS and image models. The default is applied only when the caller left it unset.

## Verification

Ran every curated id from the Dev UI against the Gemini API. All resolve to their curated metadata and generate, with two exceptions:

- `gemini-2.5-pro` returns 404 "no longer available to new users" on an account that never called it. Google lists it as GA with no shutdown date and says the 2.5 models are not deprecated (https://discuss.ai.google.dev/t/176380). The gate is per account, so the entry stays stage-less.
- `gemini-3.1-flash-tts-preview` returns 400 `INVALID_ARGUMENT` for a plain prompt, the same as on `main`.

Speech config with the media sample's snake_case config (voice Kore):

| input | before | after |
|---|---|---|
| `voice_config` (snake_case) | dropped | applied |
| `languageCode` | dropped | applied |
| unknown key `languageCodes` | dropped | `INVALID_ARGUMENT` |
