### PR TITLE
fix(js/plugins/compat-oai): omit visualDetailLevel from OpenAI request bodies

### DIFF
--- a/js/plugins/compat-oai/src/model.ts
+++ b/js/plugins/compat-oai/src/model.ts
@@ -578,6 +578,7 @@ export function toOpenAIRequestBody(
     version: modelVersion,
     tools: toolsFromConfig,
     apiKey,
+    visualDetailLevel,
     ...restOfConfig
   } = request.config ?? {};
 

--- a/js/plugins/compat-oai/tests/compat_oai_test.ts
+++ b/js/plugins/compat-oai/tests/compat_oai_test.ts
@@ -1500,6 +1500,47 @@ describe('toOpenAiRequestBody', () => {
       },
     });
   });
+
+  it('applies visualDetailLevel to image URLs without leaking it into the request body', () => {
+    const request = {
+      messages: [
+        {
+          role: 'user',
+          content: [
+            { text: 'describe this image' },
+            {
+              media: {
+                contentType: 'image/jpeg',
+                url: 'https://example.com/image.jpg',
+              },
+            },
+          ],
+        },
+      ],
+      config: {
+        visualDetailLevel: 'high',
+      },
+    } as GenerateRequest;
+
+    const actualOutput = toOpenAIRequestBody('gpt-4o', request);
+
+    expect(actualOutput).not.toHaveProperty('visualDetailLevel');
+    expect(actualOutput.messages).toStrictEqual([
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'describe this image' },
+          {
+            type: 'image_url',
+            image_url: {
+              url: 'https://example.com/image.jpg',
+              detail: 'high',
+            },
+          },
+        ],
+      },
+    ]);
+  });
 });
 
 describe('openAIModelRunner', () => {


### PR DESCRIPTION
`toOpenAIRequestBody()` now omits `visualDetailLevel` in the existing config destructure, the same way `apiKey`, `maxOutputTokens`, `topK`, and `version` are already omitted. Image `detail` mapping is unchanged.

`config.visualDetailLevel` is applied to `image_url.detail` in `toOpenAIMessages()`, but `toOpenAIRequestBody()` did not pull it out of `request.config` before spreading `restOfConfig` into the Chat Completions body. OpenAI then returned `400 Unknown parameter: 'visualDetailLevel'`.

Fixes #4592.

### Checklist
- [x] PR title follows https://www.conventionalcommits.org/en/v1.0.0/
- [x] PR description contains enough context, bug link, code samples for new APIs
- [x] Tested (unit tested)
- [ ] Docs/readmes updated (README already documents `visualDetailLevel`; no doc change)

### Decision
Strip `visualDetailLevel` in the existing destructure list. Alternative: also add it to `ChatCompletionCommonConfigSchema`, or share a denylist with the image/audio/translate converters.

Stripping in the destructure matches `toOpenAIRequestBody()`'s current pattern and the Go adapter (`go/plugins/compat_oai/generate.go` already deletes `visualDetailLevel`). Putting it on the Zod schema would not stop the leak because common config is `.passthrough()`. Can switch to the schema or shared-denylist approach if that is preferred.

### Test plan
- [x] Regression: `toOpenAIRequestBody('gpt-4o', { config: { visualDetailLevel: 'high' }, ...image... })` has no top-level `visualDetailLevel` and still sets `image_url.detail` to `'high'`.
- [x] Test fails without the source change (`Received value: "high"` on `not.toHaveProperty('visualDetailLevel')`) and passes with it.
- [x] `@genkit-ai/compat-oai` unit tests (7 suites, 102 tests).
